### PR TITLE
Sync: add framework-change-prompt Stop hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations, drift check and reflection prompt (Stop) nudge at session end",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; drift check, reflection prompt, and framework-change prompt (Stop) nudge at session end",
   "hooks": {
     "PreToolUse": [
       {
@@ -25,6 +25,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/reflection-prompt.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/framework-change-prompt.sh",
             "timeout": 10
           }
         ]

--- a/hooks/scripts/framework-change-prompt.sh
+++ b/hooks/scripts/framework-change-prompt.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Framework change prompt — runs at session end (Stop hook).
+#
+# Checks whether framework/framework.md was modified during this session.
+# If so, nudges three actions:
+#   1. Run /reflect to capture learnings
+#   2. Run /sync-repos to roll out changes to downstream repos
+#   3. Check whether downstream READMEs need updating
+#
+# This script is advisory only — it never blocks.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+FRAMEWORK_FILE="${PROJECT_DIR}/framework/framework.md"
+
+# If no framework.md exists, nothing to check
+if [ ! -f "$FRAMEWORK_FILE" ]; then
+  exit 0
+fi
+
+# Check if framework.md was modified in commits made in the last 4 hours
+framework_changed=$(git log --oneline --since="4 hours ago" -- framework/framework.md 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$framework_changed" -gt 0 ]; then
+  message="framework.md was modified in ${framework_changed} commit(s) this session. Three actions needed:"
+  message="${message}\n1. Run /reflect to capture what changed and why"
+  message="${message}\n2. Run /sync-repos to roll out changes to ai-literacy-superpowers and ai-literacy-exemplar"
+  message="${message}\n3. Check whether downstream READMEs need updating (new themes, appendices, or cross-cutting concepts)"
+
+  printf '{"systemMessage": "%s"}' "$(echo -e "$message" | sed 's/"/\\"/g')"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Synced from ai-literacy-for-software-engineers: adds the framework-change-prompt.sh Stop hook that detects framework.md modifications and nudges reflections + repo sync. hooks.json updated to include all four Stop hooks.

## Test plan

- [ ] Verify markdownlint passes
- [ ] Confirm hooks.json has four hooks