### PR TITLE
Add AI literacy assessment components

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install the plugin, run `/superpowers-init`, and get a fully operational habitat
 
 ## What You Get
 
-### Skills (10)
+### Skills (11)
 
 Code quality and harness engineering knowledge that agents read when working in your codebase.
 
@@ -24,8 +24,9 @@ Code quality and harness engineering knowledge that agents read when working in 
 | constraint-design | Designing enforceable constraints with the verification slot model |
 | garbage-collection | Entropy-fighting patterns and the auto-fix safety rubric |
 | verification-slots | The unified interface for deterministic and agent-based checks |
+| ai-literacy-assessment | Assessment instrument — scan repo, ask questions, produce timestamped assessment with remediation |
 
-### Agents (9)
+### Agents (10)
 
 A coordinated team that handles the full development lifecycle.
 
@@ -40,8 +41,9 @@ A coordinated team that handles the full development lifecycle.
 | harness-enforcer | Unified verification engine for all constraint types | Read + Bash |
 | harness-gc | Periodic entropy fighter | Read + Write |
 | harness-auditor | Meta-agent — checks whether the harness matches reality | Write to Status only |
+| assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 
-### Commands (9)
+### Commands (10)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -54,6 +56,7 @@ A coordinated team that handles the full development lifecycle.
 | `/harness-audit` | Full meta-verification of the harness |
 | `/reflect` | Capture a post-task reflection |
 | `/worktree` | Git worktree lifecycle — spin, merge, clean |
+| `/assess` | AI literacy assessment with immediate fixes and workflow recommendations |
 
 ### Templates (8)
 

--- a/agents/assessor.md
+++ b/agents/assessor.md
@@ -1,0 +1,138 @@
+---
+name: assessor
+description: Use this agent to run an AI literacy assessment — scans the repository for observable evidence, asks clarifying questions, and produces a timestamped assessment document with a README badge. Examples:
+
+ <example>
+ Context: User wants to know their team's AI literacy level
+ user: "Where are we on the AI literacy framework?"
+ assistant: "I'll use the assessor agent to run a full assessment."
+ <commentary>
+ The assessor scans the repo, asks clarifying questions, and produces an evidence-based level assessment.
+ </commentary>
+ </example>
+
+ <example>
+ Context: User runs /assess command
+ user: "/assess"
+ assistant: "Starting the AI literacy assessment."
+ <commentary>
+ The /assess command dispatches the assessor agent.
+ </commentary>
+ </example>
+
+model: inherit
+color: yellow
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+---
+
+# Assessor Agent
+
+You assess a team's AI collaboration literacy level by combining
+observable evidence from the repository with clarifying questions.
+
+## Before doing anything
+
+Read the `ai-literacy-assessment` skill from `.claude/skills/ai-literacy-assessment/SKILL.md`.
+Read the assessment template from `.claude/skills/ai-literacy-assessment/references/assessment-template.md`.
+
+## Your process
+
+### Phase 1: Scan the repository
+
+Search for observable evidence of each framework level. Check for:
+
+**L2 signals** (verification):
+
+```bash
+ls .github/workflows/*.yml 2>/dev/null        # CI workflows
+grep -r "coverage" .github/workflows/ 2>/dev/null  # Coverage enforcement
+grep -r "govulncheck\|owasp\|scout" .github/workflows/ 2>/dev/null  # Security scanning
+ls **/mutation* .github/workflows/mutation* 2>/dev/null  # Mutation testing
+```
+
+**L3 signals** (habitat):
+
+```bash
+ls CLAUDE.md HARNESS.md AGENTS.md MODEL_ROUTING.md REFLECTION_LOG.md 2>/dev/null
+ls .claude/skills/*/SKILL.md 2>/dev/null       # Custom skills
+ls .claude/agents/*.md 2>/dev/null             # Custom agents
+ls .claude/commands/*.md 2>/dev/null           # Custom commands
+cat harness-engineering/hooks/hooks.json 2>/dev/null  # Hooks
+```
+
+**L4 signals** (specification):
+
+```bash
+ls specs/*/spec.md 2>/dev/null                 # Specifications
+ls specs/*/plan*.md 2>/dev/null                # Implementation plans
+grep -l "GATE\|GUARDRAIL\|MAX_REVIEW" .claude/agents/orchestrator.md 2>/dev/null
+```
+
+**L5 signals** (sovereign):
+
+```bash
+ls harness-engineering/.claude-plugin/plugin.json 2>/dev/null  # Plugin
+grep -r "OTEL\|otel\|telemetry" . --include="*.yml" --include="*.json" 2>/dev/null
+```
+
+Record every signal found with its file path. Also record signals NOT found.
+
+### Phase 2: Present findings and ask clarifying questions
+
+Present what you found to the user in a structured summary. Then ask
+3-5 clarifying questions to fill gaps. Focus on:
+
+- Workflow habits that aren't observable in files
+- Team practices vs individual practices
+- How consistently the observable tools are actually used
+- Cost awareness and spend tracking
+- Whether specifications are written before or after code
+
+Ask ONE question at a time. Wait for the answer before asking the next.
+
+### Phase 3: Assess the level
+
+Apply the scoring heuristic from the skill:
+
+- The assessed level is the highest level where the team has
+  substantial evidence across ALL THREE disciplines
+- The weakest discipline is the ceiling
+- Map each piece of evidence to context engineering, architectural
+  constraints, or guardrail design
+
+### Phase 4: Generate the assessment document
+
+Create `assessments/` directory if it doesn't exist. Write the
+assessment document using the template from the skill's references.
+
+File path: `assessments/YYYY-MM-DD-assessment.md`
+
+Fill in every section with specific evidence and rationale. Do not
+use placeholders or generic statements — every claim should
+reference a specific file, configuration, or response.
+
+### Phase 5: Update the README badge
+
+Check if the README has an AI Literacy badge. If it does, update it.
+If it doesn't, add one after the existing badges.
+
+Badge format:
+
+```markdown
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_N_{{LEVEL_NAME}}-COLOUR?style=flat-square)](assessments/YYYY-MM-DD-assessment.md)
+```
+
+Colour by level: L0=808080, L1=87CEEB, L2=4682B4, L3=20B2AA, L4=2E8B57, L5=DAA520
+
+### Phase 6: Commit
+
+```bash
+git add assessments/ README.md
+git commit -m "AI Literacy Assessment: Level N — {{LEVEL_NAME}} (YYYY-MM-DD)"
+```
+
+## What you do NOT do
+
+- You do not change any code or configuration based on the assessment
+- You do not modify HARNESS.md, CLAUDE.md, or any enforcement files
+- You assess and report. Improvement actions are for the team to decide.

--- a/commands/assess.md
+++ b/commands/assess.md
@@ -1,0 +1,136 @@
+---
+name: assess
+description: Run an AI literacy assessment — scan the repo for evidence, ask clarifying questions, produce a timestamped assessment document, apply immediate habitat fixes, recommend workflow changes, capture a reflection, and add a literacy level badge to the README
+---
+
+# /assess
+
+Run an AI literacy assessment for this project.
+
+Read the `ai-literacy-assessment` skill before proceeding — it contains
+the scoring heuristic, evidence signals, assessment template, and the
+immediate adjustment and workflow recommendation phases.
+
+## Process
+
+### 1. Scan
+
+Scan the repository for observable evidence of each framework level.
+Check for CI workflows, test coverage, vulnerability scanning, mutation
+testing, CLAUDE.md, HARNESS.md, AGENTS.md, MODEL_ROUTING.md, custom
+skills, agents, commands, hooks, specifications, implementation plans,
+orchestrator safety gates, and platform-level tooling.
+
+Record every signal found (with file path) and every signal not found.
+
+### 2. Present and Question
+
+Present what the scan found in a structured summary. Then ask 3-5
+clarifying questions to fill gaps — focus on workflow habits, team
+practices, cost awareness, and how consistently the observable tools
+are actually used.
+
+Ask ONE question at a time. Wait for each answer.
+
+### 3. Assess
+
+Apply the scoring heuristic: the assessed level is the highest level
+where the team has substantial evidence across all three disciplines
+(context engineering, architectural constraints, guardrail design).
+The weakest discipline is the ceiling.
+
+### 4. Document
+
+Create `assessments/YYYY-MM-DD-assessment.md` using the template from
+the skill's references. Fill every section with specific evidence.
+
+### 5. Immediate Habitat Adjustments
+
+Identify and apply fixes that require no team discussion — habitat
+hygiene that should always be current:
+
+- **Stale HARNESS.md Status**: If the constraint count, enforcement
+  ratio, or GC count doesn't match the actual declarations, update it
+- **Stale README badges**: If harness badge, mutation testing badge,
+  or AI Literacy badge show outdated numbers, update them
+- **Stale README mechanism map**: If new agents, commands, hooks,
+  skills, or CI workflows exist but aren't in the map, add them
+- **Stale README enforcement table**: If constraint type counts are
+  wrong, fix them
+- **Stale README framework document section**: If new appendices or
+  themes exist but aren't listed, add them
+- **Empty AGENTS.md sections**: If the assessment revealed gotchas
+  or patterns that should be in AGENTS.md, propose additions
+
+Present each adjustment. Apply immediately. Record what was changed
+in the assessment document.
+
+### 6. Workflow Operation Recommendations
+
+Based on gaps identified, recommend changes to how existing artifacts
+are *operated* (not built — they exist, they just need different usage
+patterns). Present each recommendation ONE at a time. For each:
+
+- Describe the recommendation
+- Explain why it matters (which gap it closes)
+- Ask: "Accept this change?" (yes/no)
+
+If accepted, apply immediately:
+
+- **Operating cadences** → add to CLAUDE.md as a workflow rule
+- **Harness constraint promotions** → update HARNESS.md enforcement
+  field from unverified to agent or deterministic
+- **Artifact activation** → add operating notes to AGENTS.md or
+  CLAUDE.md
+- **Habit recommendations** → add to AGENTS.md GOTCHAS
+
+Record accepted and rejected recommendations in the assessment
+document.
+
+### 7. Assessment Reflection
+
+Append a structured reflection to REFLECTION_LOG.md:
+
+- **Date**: today
+- **Agent**: assessor (via /assess)
+- **Task**: AI literacy assessment
+- **Surprise**: what the scan revealed vs what was expected
+- **Proposal**: any patterns to add to AGENTS.md
+- **Improvement**: what would make the next assessment better
+
+### 8. Check README for broader updates
+
+Beyond the specific adjustments in step 5, do a final check:
+has anything else in the README become stale? Update if needed.
+
+### 9. Badge
+
+Add or update an AI Literacy badge in the README:
+
+```text
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_N-COLOUR?style=flat-square)](assessments/YYYY-MM-DD-assessment.md)
+```
+
+Colours: L0=808080, L1=87CEEB, L2=4682B4, L3=20B2AA, L4=2E8B57, L5=DAA520
+
+### 10. Commit
+
+```bash
+mkdir -p assessments
+git add assessments/ README.md HARNESS.md AGENTS.md CLAUDE.md REFLECTION_LOG.md
+git commit -m "AI Literacy Assessment: Level N — LEVEL_NAME (YYYY-MM-DD)
+
+Assessment with immediate adjustments and accepted workflow changes."
+```
+
+### 11. Report
+
+Present a summary to the user:
+
+- Assessed level with one-line rationale
+- Top 3 strengths
+- Top 3 gaps
+- Immediate adjustments applied (count and summary)
+- Workflow changes accepted vs rejected
+- Top 3 recommendations for longer-term work
+- Link to the full assessment document

--- a/skills/ai-literacy-assessment/SKILL.md
+++ b/skills/ai-literacy-assessment/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: ai-literacy-assessment
+description: This skill should be used when the user asks to "assess AI literacy", "run an assessment", "check literacy level", "evaluate our AI collaboration", "where are we on the framework", or wants to determine their team's AI literacy level using the ALCI instrument.
+---
+
+# AI Literacy Assessment
+
+Assess a team's AI collaboration literacy level by combining observable
+evidence from the repository with clarifying questions, then produce a
+timestamped assessment document and a README badge.
+
+## The Assessment Process
+
+### Phase 1: Observable Evidence
+
+Scan the repository for signals that indicate which framework level the
+team is operating at. Each signal maps to a specific level:
+
+**Level 0-1 indicators (awareness + prompting)**:
+
+- Does the repo exist and contain code? (baseline)
+- Are there any AI-related configuration files at all?
+
+**Level 2 indicators (verification)**:
+
+- CI workflows that run tests (`*.yml` in `.github/workflows/`)
+- Test coverage enforcement (coverage thresholds in CI or build files)
+- Vulnerability scanning (govulncheck, OWASP, Docker Scout)
+- Markdownlint or other linting in CI
+- Mutation testing configuration
+
+**Level 3 indicators (habitat engineering)**:
+
+- `CLAUDE.md` or equivalent context engineering file
+- `HARNESS.md` with declared constraints
+- `AGENTS.md` compound learning memory
+- `MODEL_ROUTING.md` model-tier guidance
+- `.claude/skills/` project-local skills
+- `.claude/agents/` custom agent definitions
+- `.claude/commands/` custom commands
+- Hooks configuration (`hooks.json`)
+- `REFLECTION_LOG.md` with entries
+- `.markdownlint.json` or equivalent config
+
+**Level 4 indicators (specification architecture)**:
+
+- `specs/` directory with specification files
+- Implementation plans (`plan.md`, `plan-*.md`)
+- Agent pipeline with orchestrator
+- Plan approval gate in orchestrator
+- Loop guardrails (MAX_REVIEW_CYCLES)
+
+**Level 5 indicators (sovereign engineering)**:
+
+- Platform-level tooling (reusable plugins)
+- Cross-team harness templates
+- OpenTelemetry configuration
+- Organisational governance documentation
+- Multiple agent teams or cloud async agents
+
+### Phase 2: Clarifying Questions
+
+After scanning, ask questions to fill gaps that observable evidence
+cannot answer. Focus on:
+
+- **Workflow habits**: "Do you write specs before code, or after?"
+- **Verification practices**: "Do you verify AI output systematically
+  or trust it if it looks right?"
+- **Cost awareness**: "Do you know what your AI tools cost per month?"
+- **Team practices**: "Does your team have shared AI conventions, or
+  does each developer work differently?"
+- **Learning**: "Do you capture what you learn from AI sessions?"
+
+Ask 3-5 questions maximum. Each question should disambiguate between
+adjacent levels.
+
+### Phase 3: Assessment Document
+
+Produce a timestamped Markdown document at
+`assessments/YYYY-MM-DD-assessment.md` with:
+
+1. **Header**: team name, date, assessor, assessed level
+2. **Observable evidence**: what was found in the repo (with file paths)
+3. **Clarifying responses**: summary of answers
+4. **Level assessment**: primary level with rationale
+5. **Discipline maturity**: context engineering, architectural
+   constraints, guardrail design — each rated
+6. **Strengths**: what the team does well at their current level
+7. **Gaps**: what's missing for the next level
+8. **Recommendations**: 3-5 specific actions to progress
+9. **Immediate adjustments applied**: what was fixed during this assessment
+10. **Workflow operation changes**: accepted changes to how artifacts are used
+11. **Reflection**: what the assessment itself revealed
+12. **Next assessment date**: suggested quarterly re-assessment
+
+### Phase 4: Immediate Habitat Adjustments
+
+After documenting the assessment, identify adjustments that can be
+made immediately — without changing any application code or
+requiring team discussion. These are habitat hygiene fixes:
+
+**Stale counts**: If HARNESS.md Status section shows outdated counts,
+update them. If README badges show old numbers, update them.
+
+**Missing entries**: If AGENTS.md GOTCHAS is empty but the assessment
+revealed gotchas, add them. If REFLECTION_LOG.md has no entries from
+this assessment, add one.
+
+**Drift detection**: If HARNESS.md declares constraints that no longer
+match reality (tools removed, workflows renamed), update the
+declarations.
+
+**Mechanism map staleness**: If the README mechanism map is missing
+components that the scan found (new agents, commands, hooks, skills),
+update it.
+
+Present each adjustment to the user and apply it immediately. Record
+what was adjusted in the assessment document.
+
+### Phase 5: Workflow Operation Recommendations
+
+Based on the gaps identified, recommend specific changes to how
+existing workflows and artifacts are *operated* (not built — the
+infrastructure exists, it just needs to be used differently):
+
+**Operating rhythm**: Recommend cadences for harness audits, reflection
+reviews, mutation score checks, and cost monitoring. Suggest adding
+these to a calendar or checklist.
+
+**Habit formation**: Identify which framework habits (from Part VII)
+are not yet automatic and suggest specific practice exercises.
+
+**Artifact activation**: Identify artifacts that exist but are not
+actively used (e.g., AGENTS.md that isn't read at session start,
+MODEL_ROUTING.md that isn't consulted when dispatching agents) and
+recommend how to activate them.
+
+**Promotion opportunities**: Identify unverified HARNESS.md constraints
+that could be promoted to agent or deterministic with available tooling.
+
+Present each recommendation to the user. For accepted recommendations,
+apply the change (update CLAUDE.md with new cadences, promote
+HARNESS.md constraints, add operating notes to AGENTS.md). Record
+accepted and rejected recommendations in the assessment document.
+
+### Phase 6: Assessment Reflection
+
+Capture a reflection on the assessment itself:
+
+- What did the scan reveal that was surprising?
+- Where did observable evidence diverge from the team's self-perception?
+- What should future assessments pay attention to?
+
+Append this to REFLECTION_LOG.md as a structured entry.
+
+### Phase 7: README Badge
+
+Add or update a badge in the project's README showing the assessed
+level:
+
+```text
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_N-COLOUR?style=flat-square)](assessments/YYYY-MM-DD-assessment.md)
+```
+
+Colour coding:
+
+| Level | Colour | Hex |
+| --- | --- | --- |
+| L0 | Grey | `808080` |
+| L1 | Light blue | `87CEEB` |
+| L2 | Blue | `4682B4` |
+| L3 | Teal | `20B2AA` |
+| L4 | Green | `2E8B57` |
+| L5 | Gold | `DAA520` |
+
+Link target: the assessment document, so anyone who clicks the badge
+sees the full assessment with evidence and rationale.
+
+## Scoring Heuristic
+
+The assessed level is the **highest level where the team has
+substantial evidence across all three disciplines**. A team with L3
+context engineering but L1 verification is assessed at L1 — the
+weakest discipline is the ceiling.
+
+| Level | Minimum evidence required |
+| --- | --- |
+| L0 | Repo exists, team is aware of AI tools |
+| L1 | Some AI tool usage, basic prompting |
+| L2 | Automated tests in CI, systematic verification of AI output |
+| L3 | CLAUDE.md + at least 3 harness constraints enforced + custom agents or skills |
+| L4 | Specifications before code + agent pipeline with safety gates |
+| L5 | Platform-level governance + cross-team standards + observability |

--- a/skills/ai-literacy-assessment/references/assessment-template.md
+++ b/skills/ai-literacy-assessment/references/assessment-template.md
@@ -1,0 +1,90 @@
+# AI Literacy Assessment Template
+
+Use this template when generating the assessment document.
+
+```markdown
+# AI Literacy Assessment — {{TEAM_NAME}}
+
+**Date**: {{YYYY-MM-DD}}
+**Assessed by**: {{ASSESSOR}}
+**Assessed level**: Level {{N}} — {{LEVEL_NAME}}
+
+---
+
+## Observable Evidence
+
+### Repository Signals
+
+| Signal | Found | Level indicator |
+| --- | --- | --- |
+| CI workflows | {{yes/no — list workflows}} | L2 |
+| Test coverage enforcement | {{yes/no — threshold}} | L2 |
+| Vulnerability scanning | {{yes/no — tools}} | L2 |
+| Mutation testing | {{yes/no — tool and cadence}} | L2 |
+| CLAUDE.md | {{yes/no — line count}} | L3 |
+| HARNESS.md | {{yes/no — constraint count}} | L3 |
+| AGENTS.md | {{yes/no — entry count}} | L3 |
+| MODEL_ROUTING.md | {{yes/no}} | L3 |
+| Custom skills | {{yes/no — count}} | L3 |
+| Custom agents | {{yes/no — count}} | L3 |
+| Custom commands | {{yes/no — count}} | L3 |
+| Hooks configured | {{yes/no — count}} | L3 |
+| REFLECTION_LOG.md | {{yes/no — entry count}} | L3 |
+| Specifications directory | {{yes/no — spec count}} | L4 |
+| Implementation plans | {{yes/no}} | L4 |
+| Orchestrator with safety gates | {{yes/no}} | L4 |
+| Plugin/platform tooling | {{yes/no}} | L5 |
+| OTel configuration | {{yes/no}} | L5 |
+
+### Evidence Summary
+
+{{Brief narrative of what the repo scan revealed — what's strong,
+what's present but thin, what's absent.}}
+
+## Clarifying Responses
+
+{{Summary of the team's answers to clarifying questions, noting
+any differences between observable evidence and self-report.}}
+
+## Level Assessment
+
+### Primary Level: {{N}} — {{LEVEL_NAME}}
+
+{{Rationale — why this level and not the one above or below.
+Reference specific evidence.}}
+
+### Discipline Maturity
+
+| Discipline | Strength (1-5) | Evidence |
+| --- | --- | --- |
+| Context Engineering | {{1-5}} | {{What context artifacts exist and how current they are}} |
+| Architectural Constraints | {{1-5}} | {{What enforcement exists — deterministic, agent, unverified}} |
+| Guardrail Design | {{1-5}} | {{What feedback loops exist — tests, hooks, CI, mutation}} |
+
+### The Weakest Discipline
+
+{{Identify which discipline is the ceiling — the one holding
+the team at this level rather than the next.}}
+
+## Strengths
+
+{{3-5 bullet points — what the team does well at their current
+level. Be specific, reference evidence.}}
+
+## Gaps
+
+{{3-5 bullet points — what's missing for the next level.
+Reference the framework's level descriptions.}}
+
+## Recommendations
+
+{{3-5 specific, actionable recommendations. Each should name:
+what to do, why it matters, and which framework concept it
+addresses. Order by impact.}}
+
+## Next Assessment
+
+Suggested re-assessment date: {{YYYY-MM-DD}} (quarterly)
+
+Previous assessment: {{link to previous if exists, or "first assessment"}}
+```


### PR DESCRIPTION
Synced from source: assessment skill (with template), assessor agent, /assess command. README updated: 11 skills (was 10), 10 agents (was 9), 10 commands (was 9).