### PR TITLE
Add marketplace manifest and installation instructions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-literacy-superpowers",
+  "owner": {
+    "name": "Russ Miles"
+  },
+  "plugins": [
+    {
+      "name": "ai-literacy-superpowers",
+      "source": ".",
+      "description": "AI Literacy framework development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,40 @@ Install the plugin, run `/superpowers-init`, and get a fully operational habitat
 
 ---
 
+## Installation
+
+Add the marketplace and install the plugin:
+
+```bash
+# Add the marketplace
+claude plugin marketplace add russmiles/ai-literacy-superpowers
+
+# Install the plugin
+claude plugin install ai-literacy-superpowers
+```
+
+Once installed, the plugin's skills, agents, commands, and hooks are available in any Claude Code session within your project.
+
+### Quick start
+
+After installation, run these commands to set up your project:
+
+```bash
+# Initialize a harness for your project
+/harness-init
+
+# Check the status of your harness
+/harness-status
+
+# Run a health check
+/harness-health
+
+# Run an AI literacy assessment
+/assess
+```
+
+---
+
 ## What You Get
 
 ### Skills (12)


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` for marketplace discovery
- Add Installation section to README with quick start commands

Users can now install via:
```bash
claude plugin marketplace add russmiles/ai-literacy-superpowers
claude plugin install ai-literacy-superpowers
```