### PR TITLE
Document harness observability in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Without observability, cost discipline is aspirational, mutation testing is a on
 The plugin includes a four-layer observability model for monitoring harness health over time:
 
 | Layer | Question | How |
-|-------|----------|-----|
+| ----- | -------- | --- |
 | Operational cadence | Is the harness running? | `/harness-health` generates snapshots; a Stop hook nudges when the last snapshot is older than 30 days |
 | Trend visibility | How has the harness changed? | Snapshots are diffed to show deltas; `--trends` produces multi-period views |
 | Telemetry export | Can I visualise this externally? | Snapshot data can be exported as OpenTelemetry metrics to any OTLP-compatible backend |


### PR DESCRIPTION
Add four-layer observability model, health snapshots, README badge, and telemetry export documentation.

Adds a dedicated **Harness Observability** section covering:
- The four-layer observability model (operational cadence, trend visibility, telemetry export, meta-observability)
- Health snapshot structure and storage location
- README health badge semantics (Healthy / Attention / Degraded)
- Telemetry export as an optional layer
- Related plugin component cross-references (skill, command, references, hook, script)

Inserted between the "Observability as the Enabling Layer" subsection and "The Agent Pipeline" section.