### PR TITLE
Add reflection: gitleaks skill and harness initialization

### DIFF
--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -1,0 +1,31 @@
+# Reflection Log
+
+<!-- Each entry is appended by integration-agent at the end of a pipeline run.
+     Entries capture what was surprising, what went wrong, and what should be
+     proposed for addition to AGENTS.md.
+
+     Do NOT modify AGENTS.md directly from this log — only propose. Humans
+     curate AGENTS.md. The value of this log is that it provides the raw
+     material for curation, not that it auto-populates memory.
+
+     Entry format:
+
+     ---
+
+     - **Date**: YYYY-MM-DD
+     - **Agent**: integration-agent
+     - **Task**: [one-sentence summary]
+     - **Surprise**: [anything unexpected during the pipeline run]
+     - **Proposal**: [pattern or gotcha to consider for AGENTS.md, or "none"]
+     - **Improvement**: [what would make the pipeline smoother next time]
+
+     -->
+
+---
+
+- **Date**: 2026-04-06
+- **Agent**: orchestrator (opus)
+- **Task**: Added gitleaks secret detection skill and harness integration, then initialized the project's own harness with 6 constraints and promoted ShellCheck to deterministic
+- **Surprise**: ShellCheck found 4 issues in existing scripts including `secrets-check.sh` which had just been created and passed both implementer and spec compliance review — the unused variable (`output`) and sed-vs-parameter-expansion patterns were invisible to the subagent reviewers because the spec review checked structure and behaviour, not shell idioms
+- **Proposal**: When adding a new deterministic constraint (like ShellCheck), always run a test pass against the full codebase before promoting — including files created earlier in the same session. Consider adding ShellCheck to the default harness template alongside gitleaks so new projects get it from the start.
+- **Improvement**: The spec reviewer subagent should be briefed to run ShellCheck (or equivalent linters) as part of its verification when reviewing shell scripts, rather than only checking structural requirements against the spec. Deterministic tools catch what LLM review misses.


### PR DESCRIPTION
## Summary

- Initialize REFLECTION_LOG.md from template
- Capture session reflection covering gitleaks skill creation, harness init, and ShellCheck promotion
- Key learning: deterministic tools (ShellCheck) caught issues that subagent LLM reviewers missed in shell scripts

## Test Plan

- [ ] markdownlint passes on REFLECTION_LOG.md
- [ ] Harness constraints pass