### PR TITLE
Add Tier 2 design proposals for future features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 2026-04-07
 
+### Tier 2 Design Proposals
+
+- Add design proposal for complexity hotspot detection — weekly GC rule
+  correlating git churn with cognitive complexity to find decay hotspots
+- Add design proposal for dependency age budget (libyear) — aggregate
+  staleness metric complementing CVE scanning
+- Add design proposal for executable spec integration — making specs
+  load-bearing by wiring test suites into the constraint system
+
 ### Tier 1 Feature: Auto-Enforcer GitHub Action
 
 - Add `auto-enforcer-action` skill for setting up automatic PR constraint

--- a/docs/superpowers/specs/2026-04-07-tier2-complexity-hotspots-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-complexity-hotspots-design.md
@@ -1,0 +1,57 @@
+# Complexity Hotspot Detection — Design Proposal (Tier 2)
+
+## Problem
+
+The GC system catches dead code and stale docs but not *quality decay* —
+files that are growing more complex over time without being "dead." The
+code-maat / CodeScene pattern (git churn correlated with complexity)
+identifies these decay hotspots: files that change often AND are growing
+in complexity are the most expensive to maintain.
+
+## Proposal
+
+A new GC rule pattern: "Complexity Hotspots" — weekly check that
+correlates file churn (from `git log`) with complexity metrics (from
+a tool appropriate to the stack). Agent enforcement — the deterministic
+tool produces data, the agent interprets the trend. Auto-fix: false.
+
+### Artifacts
+
+1. **GC rule entry** for HARNESS.md:
+
+```markdown
+### Complexity hotspots
+
+- **What it checks**: Whether any files show increasing cognitive
+  complexity correlated with high git churn (decay hotspots)
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent (using git log + complexity metrics)
+- **Auto-fix**: false
+```
+
+2. **Guidance in the fitness-functions skill** — already added as part
+   of Tier 1. The fitness catalogue includes a complexity hotspots entry
+   with tool commands for multiple ecosystems.
+
+### Tools by Ecosystem
+
+- JavaScript/TypeScript: `eslint --rule 'complexity: error'` + `git log`
+- Python: `radon cc` (cognitive complexity) + `git log`
+- Go: `gocyclo` or `gocognit` + `git log`
+- Java/Kotlin: SonarQube or PMD complexity rules + `git log`
+- Any language: `scc` for file-level metrics + `git log --format='%H' --follow`
+
+### Interpretation
+
+The agent compares the current snapshot's hotspot list against the
+previous snapshot. A file is a hotspot if it is in the top 10% by churn
+AND the top 10% by complexity. The finding is actionable when a file
+appears as a hotspot across 3+ consecutive snapshots — at that point,
+it warrants refactoring attention.
+
+## Status
+
+Partially addressed by the fitness-functions skill (Tier 1). This
+proposal adds the specific GC rule and interpretation guidance. Ready
+for implementation when a project with application code needs it.

--- a/docs/superpowers/specs/2026-04-07-tier2-dependency-age-budget-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-dependency-age-budget-design.md
@@ -1,0 +1,61 @@
+# Dependency Age Budget (libyear) — Design Proposal (Tier 2)
+
+## Problem
+
+Dependency checks currently cover CVEs (`govulncheck`, OWASP
+Dependency-Check) and major version lag. But they miss *aggregate
+staleness* — the total age of all dependencies as a single number.
+
+The libyear metric (sum of years each direct dependency is behind
+latest) gives a clear, trending measure of dependency health. A project
+with 2 libyears is reasonably current; a project with 15 libyears has
+significant staleness risk even if no individual dependency has a CVE.
+
+## Proposal
+
+Add libyear as a complementary metric to the `dependency-vulnerability-audit`
+skill, and add a GC rule for weekly tracking with a configurable
+threshold.
+
+### Artifacts
+
+1. **Update to `dependency-vulnerability-audit` skill** — add a
+   "Dependency Age" section covering:
+   - What libyear measures and why it matters beyond CVE scanning
+   - Commands per ecosystem:
+     - npm: `npx libyear`
+     - Ruby: `bundle exec libyear-bundler`
+     - Python: `pip list --outdated` (manual calculation)
+     - Go: `go list -m -u all` (manual calculation from update availability)
+   - How to read the output and set a threshold
+   - Recommended budget: <10 libyears for small projects, <20 for large
+
+2. **GC rule entry** for HARNESS.md:
+
+```markdown
+### Dependency age budget
+
+- **What it checks**: Whether the total dependency age (libyear score)
+  exceeds the project's declared threshold or has increased since the
+  last snapshot
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: npx libyear (or ecosystem equivalent)
+- **Auto-fix**: false
+```
+
+3. **Health snapshot integration** — add a libyear metric to the
+   snapshot format so it trends over time alongside enforcement ratio
+   and mutation kill rate.
+
+### Interpretation
+
+The GC agent flags when:
+- Total libyears exceed the declared threshold
+- Total libyears increased week-over-week (staleness is accumulating)
+- A single dependency accounts for >3 libyears (concentrated risk)
+
+## Status
+
+Ready for implementation. Requires a project with npm/Ruby/Python
+dependencies to be useful — not applicable to this plugin itself.

--- a/docs/superpowers/specs/2026-04-07-tier2-executable-spec-integration-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-executable-spec-integration-design.md
@@ -1,0 +1,83 @@
+# Executable Spec Integration — Design Proposal (Tier 2)
+
+## Problem
+
+The plugin has a `spec-writer` agent and `writing-plans` skill, but
+the connection between specs and verification is informal. A spec
+describes what should be built; tests verify it was built correctly.
+But there is no harness-level mechanism ensuring that generated code
+passes the spec's tests before other constraint checks run.
+
+Birgitta Boeckeler's article names functional verification as a
+"missing piece" in AI harnesses — the gap between "the code looks
+right" (constraint checks) and "the code does the right thing"
+(spec conformance).
+
+## Proposal
+
+A constraint pattern (documented in the `constraint-design` skill)
+that makes specs load-bearing: when a spec file exists with executable
+tests, generated code must pass those tests before the harness-enforcer
+runs other constraints.
+
+### Artifacts
+
+1. **Update to `constraint-design` skill** — add an "Executable Spec
+   Constraint" section covering:
+   - The pattern: a constraint whose tool command is "run the spec's
+     tests"
+   - HARNESS.md entry format:
+
+```markdown
+### Spec conformance
+
+- **Rule**: All code changes covered by a spec in `docs/superpowers/specs/`
+  must pass the spec's associated test suite before merge
+- **Enforcement**: deterministic
+- **Tool**: <project test runner command>
+- **Scope**: pr
+```
+
+   - How to link specs to tests (naming convention: spec at
+     `specs/YYYY-MM-DD-feature-design.md` → tests at
+     `tests/feature/` or `tests/feature_test.go`)
+   - The distinction: this constraint runs the test suite, not the
+     spec itself. The spec is the human-readable requirement; the
+     tests are the executable verification.
+
+2. **Update to `writing-plans` skill** — add guidance that every
+   implementation plan should declare where its tests live, so the
+   spec conformance constraint knows what to run.
+
+3. **Update to TDD agent** — reinforce that specs produce tests first,
+   and those tests are the executable contract that the spec
+   conformance constraint will verify.
+
+### How It Works in the Enforcement Loop
+
+| Timescale | What happens |
+|-----------|-------------|
+| Edit (PreToolUse) | Agent warns if changes touch spec-covered code without tests passing |
+| PR (CI) | Test suite runs as a deterministic constraint — blocks merge on failure |
+| PR (auto-enforcer) | Agent reviews whether the implementation matches the spec's intent |
+
+The deterministic test gate catches "code doesn't work." The agent
+review catches "code works but doesn't match what was specified." Both
+are needed — this is the `deterministic + agent` enforcement pattern.
+
+### Connection to BDD/Cucumber
+
+For teams using BDD, the executable spec pattern is natural — Gherkin
+scenarios ARE the spec AND the test. The constraint design skill should
+note this as the gold standard: when the spec is the test, there is
+zero drift between intent and verification.
+
+For teams not using BDD, the naming convention approach (spec file →
+test directory) is the pragmatic alternative.
+
+## Status
+
+Ready for implementation. This is primarily a documentation/guidance
+change — updating existing skills to articulate a pattern, not building
+new tools. The constraint itself is just a test suite runner, which
+every project already has.


### PR DESCRIPTION
## Summary

- Add design proposal: Complexity hotspot detection (churn x complexity GC rule)
- Add design proposal: Dependency age budget (libyear metric for aggregate staleness)
- Add design proposal: Executable spec integration (making specs load-bearing via test constraints)
- Update CHANGELOG

All three are documented proposals ready for implementation when needed by projects with application code.

## Test Plan

- [ ] Passes markdownlint and harness constraints