### PR TITLE
Add team-api skill (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.8.0 — 2026-04-09
+
+### Team API Skill
+
+- Add team-api skill — create or update Team Topologies Team API
+  documents with AI literacy portfolio assessment data
+- Template mode generates a full Team API with AI Literacy section,
+  communication preferences, services, dependencies, and ways of
+  working
+- Update mode adds or refreshes the AI Literacy section in an existing
+  Team API document, preserving all other sections
+- Includes Team API template in references/team-api-template.md
+
 ## 0.7.1 — 2026-04-09
 
 ### Agent Harness Enabled Topic Tag

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.7.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
-[![Skills](https://img.shields.io/badge/Skills-22-2E8B57?style=flat-square)](#skills-22)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Skills](https://img.shields.io/badge/Skills-23-2E8B57?style=flat-square)](#skills-23)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-14-2E8B57?style=flat-square)](#commands-14)
 [![Harness](https://img.shields.io/badge/Harness-6%2F6_enforced-2E8B57?style=flat-square)](HARNESS.md)
@@ -81,7 +81,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 ## What You Get
 
-### Skills (22)
+### Skills (23)
 
 Code quality and harness engineering knowledge that agents read when working in your codebase.
 
@@ -109,6 +109,7 @@ Code quality and harness engineering knowledge that agents read when working in 
 | literacy-improvements | Prioritised improvement plan mapping assessment gaps to plugin commands and skills |
 | portfolio-assessment | Multi-repo assessment aggregation — level distribution, shared gaps, and portfolio improvement plans |
 | portfolio-dashboard | Generate a self-contained HTML dashboard from portfolio assessment data with trend visualisation |
+| team-api | Create or update a Team Topologies Team API document with AI literacy portfolio data |
 
 ### Agents (10)
 
@@ -289,7 +290,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (22)                     Domain knowledge for agents
+│   └── Skills (23)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/team-api/SKILL.md
+++ b/ai-literacy-superpowers/skills/team-api/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: team-api
+description: Use when the user wants to create or update a Team Topologies Team API document with AI literacy portfolio assessment data — generates a template Team API with literacy levels, discipline scores, shared gaps, and improvement plans, or updates an existing Team API with the latest assessment data
+---
+
+# Team API
+
+Generate or update a Team Topologies Team API document enriched with
+AI literacy portfolio assessment data. The Team API is a document
+that describes a team's capabilities, communication preferences, and
+service offerings — adding AI literacy data makes the team's
+engineering maturity visible to the rest of the organisation.
+
+This skill works in two modes:
+
+- **Update mode**: reads an existing Team API document and adds or
+  refreshes the AI literacy section using the latest portfolio
+  assessment data
+- **Template mode**: generates a new Team API document from the
+  template in `references/team-api-template.md`, populated with
+  portfolio assessment data
+
+## Input
+
+The skill needs:
+
+- **Portfolio assessment file** — the most recent
+  `assessments/*-portfolio-assessment.md`. If none exists, tell the
+  user to run `/portfolio-assess` first.
+- **Existing Team API file** (optional) — if the user provides a path
+  to an existing Team API document, update it. If not, generate from
+  the template.
+- **Team directory** (optional) — where to write the output. Defaults
+  to the current directory.
+
+## Process
+
+### Step 1: Find Portfolio Assessment Data
+
+```bash
+ls assessments/*-portfolio-assessment.md 2>/dev/null | sort | tail -1
+```
+
+If no file exists, stop and suggest running `/portfolio-assess`.
+
+Read the most recent portfolio assessment and extract:
+
+- Portfolio median level
+- Assessment coverage percentage
+- Repo detail table (each repo with level and discipline scores)
+- Shared gaps
+- Improvement plan (organisation-wide items)
+- Next assessment date
+
+### Step 2: Check for Existing Team API
+
+Ask the user:
+
+```text
+Do you have an existing Team API document to update?
+
+1. Yes — provide the file path
+2. No — generate a new one from the template
+```
+
+### Step 3a: Update Existing Team API
+
+If the user provides an existing file, read it and look for an
+`## AI Literacy` or `## AI Engineering Maturity` section. If found,
+replace it with fresh data. If not found, append the section before
+the last section of the document (typically "Further Information" or
+similar).
+
+The AI Literacy section to insert:
+
+```markdown
+## AI Literacy
+
+**Portfolio median level**: LN — Level Name
+**Assessment coverage**: N% of repos fully assessed
+**Last portfolio assessment**: YYYY-MM-DD
+**Next assessment due**: YYYY-MM-DD
+
+### Repo Levels
+
+| Repo | Level | Confidence | Last Assessed |
+| --- | --- | --- | --- |
+| repo-name | LN | assessed/estimated | YYYY-MM-DD |
+
+### Discipline Scores (assessed repos only)
+
+| Repo | Context | Constraints | Guardrails |
+| --- | --- | --- | --- |
+| repo-name | N/5 | N/5 | N/5 |
+
+### Active Shared Gaps
+
+| Gap | Repos Affected | Recommended Action |
+| --- | --- | --- |
+| gap description | N/M | action |
+
+### Current Improvement Focus
+
+[Organisation-wide improvement items from the portfolio assessment,
+presented as the team's current AI engineering priorities]
+```
+
+Preserve all other sections of the existing Team API untouched.
+
+### Step 3b: Generate New Team API from Template
+
+If no existing file, read `references/team-api-template.md` and
+populate it with:
+
+- Team name (ask the user)
+- Team type (ask: stream-aligned, enabling, complicated-subsystem,
+  or platform)
+- The AI Literacy section populated from portfolio assessment data
+- Placeholder sections for the user to fill in (communication
+  preferences, service offerings, dependencies)
+
+Write to the team directory as `team-api.md`.
+
+### Step 4: Summary
+
+Report what was done:
+
+```text
+Team API [created/updated]: path/to/team-api.md
+
+  AI Literacy section: populated from portfolio assessment (YYYY-MM-DD)
+  Portfolio median: LN
+  Repos covered: N
+  Shared gaps: N
+  Next assessment: YYYY-MM-DD
+```
+
+## What Gets Pulled from Portfolio Assessment
+
+| Portfolio field | Team API field |
+| --- | --- |
+| Portfolio median level | AI Literacy header |
+| Assessment coverage | AI Literacy header |
+| Repo detail table | Repo Levels table (simplified) |
+| Discipline scores | Discipline Scores table |
+| Shared gaps | Active Shared Gaps table |
+| Organisation-wide improvements | Current Improvement Focus |
+| Next assessment date | Next assessment due |
+
+## What This Skill Does NOT Do
+
+- Does not run `/portfolio-assess` — the data must already exist
+- Does not modify the portfolio assessment — it reads, not writes
+- Does not fill in non-AI sections of the Team API — those are the
+  team's responsibility
+- Does not enforce Team Topologies practices — it provides the
+  document structure, the team decides how to use it

--- a/ai-literacy-superpowers/skills/team-api/references/team-api-template.md
+++ b/ai-literacy-superpowers/skills/team-api/references/team-api-template.md
@@ -1,0 +1,91 @@
+# Team API — {{TEAM_NAME}}
+
+**Team type**: {{stream-aligned | enabling | complicated-subsystem | platform}}
+**Last updated**: {{YYYY-MM-DD}}
+
+---
+
+## Team Mission
+
+{{One or two sentences describing the team's purpose — what value
+they deliver and to whom.}}
+
+## AI Literacy
+
+**Portfolio median level**: {{LN — Level Name}}
+**Assessment coverage**: {{N%}} of repos fully assessed
+**Last portfolio assessment**: {{YYYY-MM-DD}}
+**Next assessment due**: {{YYYY-MM-DD}}
+
+### Repo Levels
+
+| Repo | Level | Confidence | Last Assessed |
+| --- | --- | --- | --- |
+| {{repo}} | {{LN}} | {{assessed/estimated}} | {{YYYY-MM-DD}} |
+
+### Discipline Scores (assessed repos only)
+
+| Repo | Context | Constraints | Guardrails |
+| --- | --- | --- | --- |
+| {{repo}} | {{N/5}} | {{N/5}} | {{N/5}} |
+
+### Active Shared Gaps
+
+| Gap | Repos Affected | Recommended Action |
+| --- | --- | --- |
+| {{gap}} | {{N/M}} | {{action}} |
+
+### Current Improvement Focus
+
+{{Organisation-wide improvement items from the portfolio assessment.
+These are the team's current AI engineering priorities — the actions
+that would lift the most repos toward the next literacy level.}}
+
+---
+
+## Services We Provide
+
+{{What this team offers to other teams — APIs, libraries, platforms,
+documentation, support channels. Be specific about what others can
+depend on.}}
+
+## Services We Consume
+
+{{What this team depends on from other teams — upstream APIs, shared
+infrastructure, platform services, data sources.}}
+
+## Communication Preferences
+
+| Channel | Use for | Response time |
+| --- | --- | --- |
+| {{Slack channel}} | {{day-to-day questions}} | {{hours}} |
+| {{GitHub issues}} | {{feature requests, bug reports}} | {{days}} |
+| {{email}} | {{formal requests, escalations}} | {{days}} |
+
+## Ways of Working
+
+{{How the team operates — meeting cadence, decision-making process,
+on-call rotation, deployment practices. Include anything that helps
+other teams interact with you effectively.}}
+
+## Dependencies
+
+### Upstream (we depend on)
+
+| Team/Service | What we need | Interaction mode |
+| --- | --- | --- |
+| {{team}} | {{what}} | {{X-as-a-Service / collaboration / facilitation}} |
+
+### Downstream (depends on us)
+
+| Team/Service | What they need | Interaction mode |
+| --- | --- | --- |
+| {{team}} | {{what}} | {{X-as-a-Service / collaboration / facilitation}} |
+
+---
+
+## Further Information
+
+- Portfolio assessment: `assessments/YYYY-MM-DD-portfolio-assessment.md`
+- Individual assessments: `assessments/YYYY-MM-DD-assessment.md` per repo
+- AI Literacy framework: [ai-literacy-superpowers plugin](https://github.com/Habitat-Thinking/ai-literacy-superpowers)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ stays trustworthy at scale.
 
 It gives you:
 
-- **22 skills** — domain knowledge for security auditing, constraint
+- **23 skills** — domain knowledge for security auditing, constraint
   design, context engineering, fitness functions, model sovereignty, and more
 - **10 agents** — autonomous workers for orchestration, enforcement,
   garbage collection, code review, and TDD

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Skills
 
-The plugin ships 22 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 23 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -111,7 +111,11 @@ Multi-repo assessment aggregation.
 
 ### portfolio-dashboard
 
-Self-contained HTML dashboard from portfolio assessment data. Covers generating a shareable dashboard with level distribution, repo table, shared gaps, improvement plan, and trend visualisation from multiple quarterly assessments. Output is a single HTML file with no external dependencies. Covers discovering repos from local paths, GitHub orgs, or topic tags, reading or estimating individual assessment levels, aggregating into a portfolio view with level distribution, shared gaps, and outliers, and generating improvement plans grouped by organisational impact.
+Self-contained HTML dashboard from portfolio assessment data.
+
+### team-api
+
+Team Topologies Team API document generation and update. Covers creating a new Team API from a template or updating an existing one with AI literacy portfolio data — repo levels, discipline scores, shared gaps, and improvement priorities. Bridges portfolio assessment into organisational communication artifacts. Covers generating a shareable dashboard with level distribution, repo table, shared gaps, improvement plan, and trend visualisation from multiple quarterly assessments. Output is a single HTML file with no external dependencies. Covers discovering repos from local paths, GitHub orgs, or topic tags, reading or estimating individual assessment levels, aggregating into a portfolio view with level distribution, shared gaps, and outliers, and generating improvement plans grouped by organisational impact.
 
 ### auto-enforcer-action
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -39,7 +39,7 @@ should see output similar to:
 ```text
 Installing ai-literacy-superpowers from marketplace Habitat-Thinking...
 Plugin installed: ai-literacy-superpowers
-  22 skills
+  23 skills
   10 agents
   14 commands
 ```


### PR DESCRIPTION
## Summary

- Add `team-api` skill — create or update Team Topologies Team API documents with AI literacy portfolio assessment data
- **Template mode**: generates a full Team API with AI Literacy section (repo levels, discipline scores, shared gaps, improvement focus), plus standard Team API sections (mission, services, communication, dependencies)
- **Update mode**: adds or refreshes the AI Literacy section in an existing Team API, preserving all other content
- Includes `references/team-api-template.md` with the full document template
- Update counts: skills 22→23, version 0.7.1→0.8.0

## Test plan

- [ ] Verify SKILL.md has both update and template mode processes
- [ ] Verify template has all Team API sections plus AI Literacy section with portfolio data fields
- [ ] Verify the mapping table shows which portfolio fields populate which Team API fields
- [ ] Verify all count and version locations show 23 skills / v0.8.0