### PR TITLE
Add complete how-to guides for all 23 skills (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.8.1 — 2026-04-09
+
+### Complete How-To Guides
+
+- Fill 5 stub how-to guides: add a constraint, add fitness functions,
+  run a harness audit, set up auto-enforcer, sync conventions
+- Add 16 new how-to guides covering all remaining skills: run an
+  assessment, extract conventions, set up context engineering, review
+  code with CUPID, audit dependencies, audit Docker images, harden
+  GitHub Actions, set up garbage collection, write literate code,
+  set up verification slots, set up model routing, run portfolio
+  assessment, generate improvement plan, orchestrate across repos,
+  create team API, understand harness engineering
+- Total: 23 how-to guides (was 7, of which 5 were stubs)
+
 ## 0.8.0 — 2026-04-09
 
 ### Team API Skill

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-23-2E8B57?style=flat-square)](#skills-23)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-14-2E8B57?style=flat-square)](#commands-14)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/docs/how-to/add-a-constraint.md
+++ b/docs/how-to/add-a-constraint.md
@@ -7,6 +7,94 @@ nav_order: 2
 
 # Add a Constraint
 
-How to add or promote a constraint in HARNESS.md. Use `/harness-constrain` to start a guided session that captures the constraint, its current enforcement state, and the verification command. Once added, you can promote it from advisory to deterministic as enforcement tooling is put in place.
+Add or promote a constraint in HARNESS.md using `/harness-constrain` to capture the rule,
+its enforcement state, and the verification command.
 
-{: .label .label-yellow } Coming Soon
+---
+
+## 1. Open a guided session
+
+Run the command in Claude Code:
+
+```text
+/harness-constrain
+```
+
+The agent will ask you to describe what must be true. Write the rule precisely enough that
+a reviewer — human or agent — could check it without ambiguity.
+
+---
+
+## 2. Choose an enforcement type
+
+When prompted, select one of three enforcement types:
+
+| Type | When to use |
+| ------ | ------------- |
+| `deterministic` | A tool exists that produces a clear pass/fail result |
+| `agent` | The rule requires judgement but is precise enough for consistent LLM review |
+| `unverified` | No tool yet; constraint is declared but not mechanically checked |
+
+Start with `unverified` if you are unsure. Promote later when tooling is ready.
+
+---
+
+## 3. Set the scope
+
+| Scope | When it runs | Use for |
+| ------- | ------------- | ------- |
+| `commit` | PreToolUse hook (advisory) | Fast checks — formatting, naming |
+| `pr` | CI pipeline (strict) | Thorough checks — tests, secrets |
+| `weekly` | Scheduled GC run | Slow checks — dependency audits |
+| `manual` | `/harness-audit` only | New rules being calibrated |
+
+Use `pr` for most constraints. Move to `commit` only for checks that run in under a second.
+
+---
+
+## 4. Confirm the HARNESS.md entry
+
+After the guided session, verify the new constraint appears in `HARNESS.md`:
+
+```markdown
+## No direct database calls from controllers
+
+- **Rule**: Controller classes may not import repository or ORM packages directly
+- **Enforcement**: deterministic
+- **Tool**: npx dependency-cruiser --validate .dependency-cruiser.js src/
+- **Scope**: pr
+```
+
+If the entry looks wrong, edit `HARNESS.md` directly — the format is plain markdown.
+
+---
+
+## 5. Promote an existing constraint
+
+To move a constraint from `unverified` to `deterministic`:
+
+1. Add the tool command to the constraint's `Tool` field in `HARNESS.md`
+2. Change the `Enforcement` field from `unverified` to `deterministic`
+3. Run the tool command manually to confirm it exits non-zero on a real violation:
+
+   ```bash
+   # Example: run the tool against the current codebase
+   npx dependency-cruiser --validate .dependency-cruiser.js src/
+   ```
+
+4. Wire the command into CI (see [Set Up Auto-Enforcer](set-up-auto-enforcer.md))
+
+The promotion ladder is: `unverified` → `agent` → `deterministic`. You can skip steps
+if tooling is immediately available.
+
+---
+
+## 6. Verify with `/harness-status`
+
+```text
+/harness-status
+```
+
+The output lists all constraints grouped by enforcement type. Confirm your new constraint
+appears in the correct tier. If it shows as `unverified` when you expect `deterministic`,
+check that the `Enforcement` field in `HARNESS.md` is spelled correctly.

--- a/docs/how-to/add-fitness-functions.md
+++ b/docs/how-to/add-fitness-functions.md
@@ -2,11 +2,125 @@
 title: Add Fitness Functions
 layout: default
 parent: How-to Guides
-nav_order: 6
+nav_order: 3
 ---
 
 # Add Fitness Functions
 
-How to add architectural fitness functions. Fitness functions are automated checks that measure whether the system continues to satisfy an architectural property — test coverage thresholds, dependency rules, bundle size limits, and similar constraints that degrade quietly without active monitoring.
+Add architectural fitness functions to HARNESS.md as weekly GC rules that detect system-wide
+degradation — layer boundary violations, rising coupling, and complexity hotspots — that
+per-change constraints miss.
 
-{: .label .label-yellow } Coming Soon
+---
+
+## 1. Identify what to measure
+
+Fitness functions answer "Is the system still healthy?" at a system-wide level. Pick checks
+from these categories:
+
+| Category | Examples |
+| -------- | -------- |
+| Structural | Layer boundary violations, circular dependencies |
+| Coupling | Fan-in/fan-out growth, instability index changes |
+| Complexity | Files with high churn correlated with growing complexity |
+| Coverage | Test coverage declining in architecturally important layers |
+
+Start with one structural check. Add coupling or complexity checks after the first is
+running reliably.
+
+---
+
+## 2. Pick a tool for your stack
+
+| Stack | Tool | Install |
+| ----- | ---- | ------- |
+| JavaScript/TypeScript | dependency-cruiser | `npm install --save-dev dependency-cruiser` |
+| Java/Kotlin | ArchUnit | Add to build dependencies |
+| Go | go-cleanarch | `go install github.com/roblaszczak/go-cleanarch@latest` |
+| Python | import-linter | `pip install import-linter` |
+| Any language | semgrep | `brew install semgrep` |
+
+Verify the tool works against your codebase before wiring it into the harness:
+
+```bash
+# JavaScript example
+npx dependency-cruiser --validate .dependency-cruiser.js src/
+
+# Go example
+go-cleanarch -application app -domain domain -infrastructure infra ./...
+```
+
+The tool should exit non-zero when a violation is present.
+
+---
+
+## 3. Add a GC rule to HARNESS.md
+
+Open `HARNESS.md` and add an entry to the Garbage Collection section. Use
+`deterministic` when the tool produces a clear pass/fail, and `agent` when
+results need trend interpretation:
+
+```markdown
+### Layer boundary compliance
+
+- **What it checks**: No imports crossing declared architectural boundaries
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: npx dependency-cruiser --validate .dependency-cruiser.js src/
+- **Auto-fix**: false
+```
+
+For checks that produce metrics rather than pass/fail (coupling trends, complexity scores),
+use agent enforcement:
+
+```markdown
+### Coupling trend
+
+- **What it checks**: Inter-module coupling has not increased since last snapshot
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: npx dependency-cruiser --output-type metrics src/
+- **Auto-fix**: false
+```
+
+Keep `Auto-fix` as `false` for all fitness functions. Architectural issues require
+human judgement about the right fix.
+
+---
+
+## 4. Run the fitness function manually
+
+Before relying on the scheduled GC run, confirm the rule works:
+
+```text
+/harness-gc
+```
+
+The GC agent reads the weekly rules from `HARNESS.md`, executes each tool command,
+and reports findings. Review the output to confirm your new rule fires correctly.
+
+---
+
+## 5. Interpret the results
+
+Fitness functions produce trend data, not binary pass/fail. Use this table:
+
+| Trend | Action |
+| ----- | ------ |
+| Stable or improving | Record the snapshot, no action needed |
+| Slow decline (1-2 snapshots) | Note it; watch next week |
+| Sustained decline (3+ snapshots) | Create an issue with the trend data |
+| Sudden spike | Investigate commits since the last snapshot |
+
+---
+
+## 6. Promote to a constraint if needed
+
+If the same violation appears in three or more consecutive weekly snapshots, promote
+it to a per-PR constraint so it blocks new violations at merge time:
+
+1. Extract the specific pattern from the fitness function
+2. Run `/harness-constrain` to add a targeted constraint in HARNESS.md
+3. Set scope to `pr` and enforcement to `deterministic`
+4. Keep the broader fitness function running — it catches drift the narrower
+   constraint does not

--- a/docs/how-to/audit-dependencies.md
+++ b/docs/how-to/audit-dependencies.md
@@ -1,0 +1,205 @@
+---
+title: Audit Dependencies
+layout: default
+parent: How-to Guides
+nav_order: 13
+---
+
+# Audit Dependencies
+
+This guide walks you through auditing your project dependencies for known vulnerabilities, supply chain risk, and staleness — covering Go modules and Maven/JVM projects.
+
+**Never judge a dependency as safe based on your knowledge of its version number. Version numbers in training data are stale. Always run the tools.**
+
+---
+
+## 1. Install the scanner for your ecosystem
+
+**Go — govulncheck:**
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@latest
+```
+
+**Maven/JVM — OWASP Dependency-Check** is run via Maven plugin (no separate install needed). Add it to `pom.xml` under `<build><plugins>`:
+
+```xml
+<plugin>
+  <groupId>org.owasp</groupId>
+  <artifactId>dependency-check-maven</artifactId>
+  <version>9.0.9</version>
+  <executions>
+    <execution>
+      <goals><goal>check</goal></goals>
+    </execution>
+  </executions>
+  <configuration>
+    <failBuildOnCVSS>7</failBuildOnCVSS>
+  </configuration>
+</plugin>
+```
+
+---
+
+## 2. Run the vulnerability scanner
+
+**Go:**
+
+```bash
+# Run from the module root
+govulncheck ./...
+```
+
+`govulncheck` cross-references the Go vulnerability database against the specific functions your code actually calls — not just which modules are present. This means fewer false positives than tools that flag any version of a module.
+
+**Maven/JVM:**
+
+```bash
+# Downloads NVD data on first run — takes ~5 minutes
+mvn org.owasp:dependency-check-maven:check
+# HTML report generated at: target/dependency-check-report.html
+```
+
+---
+
+## 3. Verify module integrity (Go)
+
+```bash
+# Confirms every module matches its go.sum hash
+go mod verify
+```
+
+A failure here means a module has been tampered with or `go.sum` is stale. Do not proceed with a failing integrity check.
+
+---
+
+## 4. Check for supply chain red flags
+
+**Go — look for suspicious replace directives:**
+
+```bash
+grep -A1 "^replace" go.mod
+```
+
+A `replace` directive pointing to a local path or private fork bypasses the module proxy and checksum verification. Treat any such entry as a supply chain risk until you can verify it is intentional.
+
+**Go — list all transitive modules:**
+
+```bash
+go list -m all
+```
+
+Review for unfamiliar or unexpected module paths.
+
+**Maven — check for version ranges:**
+
+```bash
+grep -E "\[|,|\)" pom.xml
+```
+
+Any match is a risk: Maven may silently resolve a different version than was tested.
+
+**Maven — review the full dependency tree:**
+
+```bash
+mvn dependency:tree
+```
+
+Look for unexpectedly old versions, multiple conflicting versions of the same library, and unfamiliar group IDs.
+
+---
+
+## 5. Check dependency age with libyear
+
+CVE scanners report known vulnerabilities. They do not measure overall staleness. Use libyear to get the full picture:
+
+**npm:**
+
+```bash
+npx libyear
+```
+
+**Go:**
+
+```bash
+go list -m -u all
+```
+
+Flags modules with available updates. Calculate years manually by comparing release dates.
+
+Recommended thresholds:
+
+| Project size | Budget |
+| --- | --- |
+| Fewer than 20 direct dependencies | < 10 libyears |
+| 20 or more direct dependencies | < 20 libyears |
+
+---
+
+## 6. Add the scanner to CI
+
+**Go:**
+
+```yaml
+- name: Run vulnerability scan
+  run: |
+    go install golang.org/x/vuln/cmd/govulncheck@latest
+    govulncheck ./...
+```
+
+**Maven:**
+
+```yaml
+- name: Run OWASP dependency scan
+  run: mvn -B org.owasp:dependency-check-maven:check
+```
+
+---
+
+## 7. Enable Dependabot for automatic update PRs
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+---
+
+## 8. Record findings
+
+Produce a findings table to track what was discovered and what needs fixing:
+
+```markdown
+## Dependency Audit
+
+| Ecosystem | Finding | Severity | Fix |
+| --- | --- | --- | --- |
+| Go | govulncheck not in CI | Medium | Add govulncheck step to workflow |
+| Maven | OWASP Dependency-Check not in CI | Medium | Add plugin and CI step |
+| All | No dependabot.yml | Medium | Add gomod and maven ecosystems |
+```
+
+Severity guide: **Critical** — actively exploited CVE in a direct dependency. **High** — CVE with CVSS ≥ 7. **Medium** — no scanner in CI; unverified provenance; unpinned dependency. **Low** — legacy group ID with no known CVE.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A vulnerability scan run against actual code call paths, not just module presence
+- Module integrity verified against go.sum hashes
+- Supply chain red flags identified and documented
+- A libyear staleness baseline
+- Automated scanning in CI that fails the build on high-severity CVEs
+- Dependabot configured to keep dependencies current

--- a/docs/how-to/audit-docker-images.md
+++ b/docs/how-to/audit-docker-images.md
@@ -1,0 +1,162 @@
+---
+title: Audit Docker Images
+layout: default
+parent: How-to Guides
+nav_order: 14
+---
+
+# Audit Docker Images
+
+This guide walks you through using Docker Scout to audit your Docker images for CVEs, assess base image staleness, and apply hardening recommendations.
+
+**Never assert that a base image version is safe based on training knowledge. Tag aliases like `alpine:3.21` can float. Always run Scout to get the current state.**
+
+---
+
+## 1. Build the image locally
+
+Docker Scout analyses image layers, not Dockerfiles. Build before scanning:
+
+```bash
+docker build -t my-app:local .
+```
+
+If you have multiple images, build all of them before starting the audit.
+
+---
+
+## 2. Get a quick overview
+
+```bash
+docker scout quickview my-app:local
+```
+
+This prints a one-line summary such as `5C  3H  6M  63L` (Critical / High / Medium / Low), plus whether a base image refresh or update is available. Run this first for every image to triage where to spend time.
+
+---
+
+## 3. List actionable CVEs
+
+Limit the output to CVEs that have a known patch and are high severity or above — the immediately actionable set:
+
+```bash
+docker scout cves \
+  --only-severity critical,high \
+  --only-fixed \
+  my-app:local
+```
+
+Drop `--only-fixed` to see the full picture including CVEs with no available patch.
+
+---
+
+## 4. Separate base image CVEs from your own package CVEs
+
+```bash
+docker scout cves --ignore-base my-app:local
+```
+
+This shows only CVEs introduced by packages your Dockerfile installs, not the base image itself. Use it to separate "update the FROM line" work from "change our installed packages" work.
+
+---
+
+## 5. Get base image recommendations
+
+```bash
+docker scout recommendations my-app:local
+```
+
+Shows whether a patch refresh of the same base tag or an update to a newer tag would eliminate CVEs, with a count for each option.
+
+If the image uses a hardened base (distroless, chiseled), Scout may error with `image has no base image`. This is expected. In CI, add `continue-on-error: true` to that step.
+
+---
+
+## 6. Follow the triage workflow
+
+Work through each image in this order:
+
+1. `quickview` — is there anything worth fixing?
+2. `recommendations` — can a base image bump fix most of it?
+3. `cves --only-fixed --only-severity critical,high` — what must be fixed now?
+4. `cves --ignore-base` — anything in our own installed packages?
+
+Act on base image CVEs first. A single `FROM` line update often eliminates tens of vulnerabilities in one commit.
+
+---
+
+## 7. Apply Alpine runtime hardening
+
+For Alpine-based runtime stages, use `apk upgrade --no-cache` rather than upgrading specific packages. A targeted upgrade can silently no-op if the fixed version is not yet in the current Alpine repo index:
+
+```dockerfile
+RUN apk add --no-cache bash \
+    && apk upgrade --no-cache
+```
+
+---
+
+## 8. Consider hardened base images
+
+Where a hardened base is available, prefer it over patching individual packages:
+
+| Use case | Hardened base | Why |
+| --- | --- | --- |
+| Go static binary | `gcr.io/distroless/static:nonroot` | No shell, no libc, no package manager |
+| .NET app | `mcr.microsoft.com/dotnet/runtime:8.0-jammy-chiseled` | Ubuntu Chiseled strips shell and package manager |
+
+---
+
+## 9. Add a `.dockerignore` to prevent false positives
+
+`COPY . .` in a Dockerfile copies development artefacts (`.venv`, `node_modules`) that Scout will scan and report CVEs against — even though they are unreachable at runtime. Exclude them:
+
+```text
+.venv
+node_modules
+.pytest_cache
+__pycache__
+*.pyc
+```
+
+---
+
+## 10. Add Scout to CI
+
+Block merges with critical or high CVEs that have available fixes:
+
+```yaml
+- name: Scan for critical/high CVEs
+  run: |
+    docker scout cves \
+      --only-severity critical,high \
+      --only-fixed \
+      --exit-code \
+      my-app:local
+```
+
+`--exit-code` returns `2` if any matching CVEs are found, failing the CI job. Pair with `--only-fixed` so builds are not blocked by CVEs with no available patch.
+
+---
+
+## 11. Compare before and after a base image change
+
+After updating a `FROM` line, quantify the security improvement before committing:
+
+```bash
+docker scout compare \
+  --to my-app:new \
+  my-app:old
+```
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A CVE baseline for every image, separated into base image and own-package findings
+- Base image recommendations reviewed and applied where available
+- Alpine runtime stages hardened with `apk upgrade --no-cache`
+- A `.dockerignore` that prevents development artefacts from inflating scan results
+- CI configured to block merges with fixable critical or high CVEs

--- a/docs/how-to/create-team-api.md
+++ b/docs/how-to/create-team-api.md
@@ -1,0 +1,153 @@
+---
+title: Create a Team API
+layout: default
+parent: How-to Guides
+nav_order: 23
+---
+
+# Create a Team API
+
+Generate or update a Team Topologies Team API document populated with AI
+literacy data from a portfolio assessment.
+
+---
+
+## 1. Run a portfolio assessment first
+
+The Team API skill reads from the most recent portfolio assessment
+document. If you have not run one yet:
+
+```bash
+/portfolio-assess --local ~/code/myteam/
+```
+
+This writes `assessments/YYYY-MM-DD-portfolio-assessment.md` to the
+current directory. The Team API command reads this file for literacy
+levels, discipline scores, shared gaps, and the improvement plan.
+
+---
+
+## 2. Invoke the Team API skill
+
+From the directory that contains your `assessments/` folder:
+
+```bash
+/team-api
+```
+
+The skill finds the most recent portfolio assessment automatically:
+
+```bash
+ls assessments/*-portfolio-assessment.md | sort | tail -1
+```
+
+If no portfolio assessment exists, the skill stops and asks you to run
+`/portfolio-assess` first.
+
+---
+
+## 3. Choose: update existing or generate new
+
+The skill asks whether you have an existing Team API document:
+
+```text
+Do you have an existing Team API document to update?
+
+1. Yes — provide the file path
+2. No — generate a new one from the template
+```
+
+**Updating an existing file:** The skill reads the file, locates the
+`## AI Literacy` or `## AI Engineering Maturity` section, and replaces it
+with fresh data from the portfolio assessment. All other sections of your
+existing Team API are preserved exactly.
+
+**Generating a new file:** The skill asks for your team name and team type
+(stream-aligned, enabling, complicated-subsystem, or platform), then
+produces a `team-api.md` with the AI literacy section populated and
+placeholder sections for you to complete.
+
+---
+
+## 4. Review what gets populated
+
+The skill maps portfolio data into the Team API as follows:
+
+| Portfolio field | Team API section |
+| --- | --- |
+| Portfolio median level | AI Literacy header |
+| Assessment coverage | AI Literacy header |
+| Repo detail table | Repo Levels table |
+| Discipline scores | Discipline Scores table |
+| Shared gaps | Active Shared Gaps table |
+| Organisation-wide improvements | Current Improvement Focus |
+| Next assessment date | Next assessment due |
+
+The resulting AI Literacy section looks like this:
+
+```markdown
+## AI Literacy
+
+**Portfolio median level**: L3 — Habitat Engineering
+**Assessment coverage**: 80% of repos fully assessed
+**Last portfolio assessment**: 2026-04-08
+**Next assessment due**: 2026-07-08
+
+### Repo Levels
+
+| Repo | Level | Confidence | Last Assessed |
+| --- | --- | --- | --- |
+| api-gateway | L3 | assessed | 2026-04-01 |
+| billing-service | L2 | assessed | 2026-03-15 |
+
+### Active Shared Gaps
+
+| Gap | Repos Affected | Recommended Action |
+| --- | --- | --- |
+| No harness GC rules | 4/5 | Run /harness-gc to add rules |
+```
+
+---
+
+## 5. Complete the non-AI sections
+
+The skill does not fill in the rest of the Team API — those sections are
+your team's responsibility. For a new document, the generated file
+contains clearly marked placeholders for:
+
+- Communication preferences
+- Service offerings and interaction modes
+- Team dependencies
+- Working agreements
+
+Edit these sections directly in `team-api.md`.
+
+---
+
+## 6. Find the output
+
+The skill reports what it produced:
+
+```text
+Team API updated: team-api.md
+
+  AI Literacy section: populated from portfolio assessment (2026-04-08)
+  Portfolio median: L3
+  Repos covered: 5
+  Shared gaps: 2
+  Next assessment: 2026-07-08
+```
+
+Check the file into your team repository so it is visible to the rest of
+the organisation.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A Team API document with an up-to-date AI literacy section
+- Literacy levels, discipline scores, and shared gaps visible to other teams
+- A documented next assessment date that keeps the data fresh
+- Non-AI sections ready for the team to complete

--- a/docs/how-to/extract-conventions.md
+++ b/docs/how-to/extract-conventions.md
@@ -1,0 +1,120 @@
+---
+title: Extract Conventions
+layout: default
+parent: How-to Guides
+nav_order: 10
+---
+
+# Extract Conventions
+
+Run a guided convention extraction session to surface tacit team knowledge and encode
+it as enforceable artefacts in CLAUDE.md and HARNESS.md.
+
+---
+
+## When to do this
+
+| Situation | Signal |
+| --------- | ------ |
+| New project setup | CLAUDE.md and HARNESS.md are empty or boilerplate |
+| AI output quality varies | Same codebase, different developers get different results |
+| After team changes | A key engineer joined or left |
+| Post-incident | A production incident revealed a convention that was never written down |
+| Quarterly cadence | Review whether encoded conventions still match practice |
+
+Teams of five often do not need formal extraction — conversations happen naturally.
+Teams of fifteen almost certainly do — tacit knowledge diverges without intervention.
+
+---
+
+## 1. Start the session
+
+```text
+/extract-conventions
+```
+
+The agent walks through five structured questions conversationally. Run this in a
+mob session with senior engineers, or use the transcript as an interview guide for
+one-on-one conversations.
+
+---
+
+## 2. Answer the five questions
+
+The session covers these questions in order:
+
+1. **What architectural decisions should never be left to individual judgment?**
+   Surfaces non-negotiable patterns — dependency direction, module boundaries,
+   API design rules.
+
+2. **Which conventions are corrected most often in AI-generated code?**
+   Surfaces the gap between what AI produces by default and what the team expects.
+   These are your highest-value conventions to encode.
+
+3. **Which security checks are applied instinctively?**
+   Surfaces embodied security knowledge — input validation, auth patterns,
+   secrets handling.
+
+4. **What triggers an immediate rejection in code review?**
+   Surfaces hard boundaries — things that are never acceptable regardless of context.
+
+5. **What separates a clean refactoring from an over-engineered one?**
+   Surfaces judgment about abstraction thresholds and YAGNI boundaries.
+
+If the answer to a question is always "it depends on context," that convention needs
+decomposition into specific, observable cases before it can be encoded. "It depends"
+is a signal to keep digging, not a failure.
+
+---
+
+## 3. Review the artefact mapping
+
+The agent maps each answer to the appropriate artefact:
+
+| Answer category | Artefact type | Where it lives |
+| --------------- | ------------- | -------------- |
+| Non-negotiable patterns | Constraint | HARNESS.md |
+| Frequent corrections | Convention | CLAUDE.md |
+| Security instincts | Constraint or threat-model item | HARNESS.md |
+| Review rejections | Critical check | HARNESS.md or reviewer agent |
+| Refactoring philosophy | Style preference | CLAUDE.md |
+| "It depends" answers | Not encodable yet | Backlog for decomposition |
+
+Review the mapping before the agent writes anything. Correct any misclassifications.
+
+---
+
+## 4. Confirm the written artefacts
+
+The agent updates CLAUDE.md with new conventions and runs `/harness-constrain` to add
+constraints to HARNESS.md. After each update, verify:
+
+- The rule is precise enough to check without ambiguity
+- The enforcement type matches what tooling you have available
+- The scope matches when you need the check to run
+
+---
+
+## 5. Avoid common mistakes
+
+| Anti-pattern | Fix |
+| ------------ | --- |
+| Over-prescriptive instructions | Test each instruction against real code before committing |
+| Encoding aspirations ("write clean code") | Decompose into observable properties |
+| Starting with ten conventions | Adopt one, then expand |
+| Skipping disagreement between seniors | The disagreement is the point — resolve it before encoding |
+
+---
+
+## 6. Schedule a re-extraction
+
+Add a re-extraction cadence to `CLAUDE.md`:
+
+```markdown
+## Operating Cadence
+
+- Quarterly: review CLAUDE.md conventions against current practice
+- After team composition changes: run `/extract-conventions`
+```
+
+Conventions drift. What the team encoded six months ago may not match what they do today.

--- a/docs/how-to/generate-improvement-plan.md
+++ b/docs/how-to/generate-improvement-plan.md
@@ -1,0 +1,153 @@
+---
+title: Generate an Improvement Plan
+layout: default
+parent: How-to Guides
+nav_order: 21
+---
+
+# Generate an Improvement Plan
+
+Generate a prioritised improvement plan from assessment gaps and work
+through it item by item, accepting, skipping, or deferring each action.
+
+---
+
+## 1. Run an assessment first (if you haven't already)
+
+The improvement plan works best when it has an existing assessment to draw
+gaps from. If you haven't assessed the repository yet:
+
+```bash
+/assess
+```
+
+The assessment identifies your current level (L0–L5) and lists specific
+gaps. The improvement skill uses these gaps to filter the plan to only
+what is actually missing.
+
+If you already know your level, you can skip the assessment and invoke
+the improvement skill directly.
+
+---
+
+## 2. Start the improvement plan
+
+The improvement skill is invoked automatically at the end of `/assess`.
+To run it standalone:
+
+```bash
+/literacy-improvements
+```
+
+If invoked standalone, the skill asks for your current level:
+
+```text
+What is your current AI literacy level?
+
+1. Level 0 — Awareness
+2. Level 1 — Prompting
+3. Level 2 — Verification
+4. Level 3 — Habitat Engineering
+5. Level 4 — Specification Architecture
+```
+
+---
+
+## 3. Choose a target level
+
+The skill presents the levels above your current one:
+
+```text
+You're currently at Level 2 (Verification).
+
+How far would you like to improve?
+
+1. Level 3 — Habitat Engineering (recommended next step)
+2. Level 4 — Specification Architecture
+3. Level 5 — Platform Engineering
+```
+
+The default recommendation is always the next level. Choosing a higher
+target includes all intermediate levels — the plan works through each
+level transition in order.
+
+---
+
+## 4. Work through the plan item by item
+
+For each gap, the skill presents one item at a time with its priority and
+recommended action:
+
+```text
+Improvement 1/6 (Level 2 → Level 3):
+  Gap: No HARNESS.md
+  Action: Run /harness-init
+  Priority: High — foundational; nothing else at L3 works without it
+
+  Accept / Skip / Defer?
+```
+
+Respond to each item:
+
+- **Accept** — the command or skill runs immediately. Wait for it to
+  complete before the next item appears.
+- **Skip** — removes the item from the plan for this session.
+- **Defer** — keeps the item in the plan but does not execute it now. The
+  next assessment picks it up.
+
+If an accepted command opens its own interactive flow (for example,
+`/harness-init` asks which features to enable), let it run naturally. The
+improvement plan resumes after the command completes.
+
+---
+
+## 5. Understand priority levels
+
+| Priority | Criteria | Examples |
+| --- | --- | --- |
+| High | Foundational — other items depend on it | HARNESS.md for L3, CI pipeline for L2 |
+| Medium | Closes a real gap independently | Secret scanning, GC rules |
+| Low | Conditional on project context | Docker scanning when no Docker is used |
+
+Work through High items first. Medium and Low items can be deferred if
+resources are constrained.
+
+---
+
+## 6. Find the output document
+
+After working through all items, the skill appends an Improvement Plan
+section to today's assessment document if one exists:
+
+```text
+assessments/YYYY-MM-DD-assessment.md
+```
+
+If no assessment exists for today, it writes a standalone file:
+
+```text
+assessments/YYYY-MM-DD-improvements.md
+```
+
+The document records which improvements were accepted, skipped, or
+deferred, and what commands ran.
+
+---
+
+## 7. Re-run after completing deferred items
+
+Deferred items are not lost — they appear again at the next assessment.
+When you have capacity to address them, re-run `/assess` or invoke
+`/literacy-improvements` directly to resume the plan.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A prioritised list of improvements mapped to your specific gaps
+- Commands executed for accepted improvements
+- A record of accepted, skipped, and deferred items in the assessment
+  document
+- A clear target level and a path to reach it

--- a/docs/how-to/harden-github-actions.md
+++ b/docs/how-to/harden-github-actions.md
@@ -1,0 +1,181 @@
+---
+title: Harden GitHub Actions
+layout: default
+parent: How-to Guides
+nav_order: 15
+---
+
+# Harden GitHub Actions
+
+This guide walks you through reviewing and hardening your GitHub Actions workflows against supply chain attacks — covering SHA pinning, permissions scoping, and automated update configuration.
+
+**Never rely on your knowledge of whether an action version is safe. Run the checklist.**
+
+---
+
+## 1. List your workflow files
+
+```bash
+ls .github/workflows/
+```
+
+Work through every file in the directory. A finding in one workflow is often present in others.
+
+---
+
+## 2. Check every `uses:` reference for SHA pinning
+
+A mutable tag (`@v4`) can be silently repointed to a different commit by anyone with push access to that repository. The `tj-actions/changed-files` incident (March 2025) demonstrated this at scale — a compromised action exfiltrated secrets from thousands of repositories.
+
+Every `uses:` reference must be pinned to a full 40-character commit SHA.
+
+**Find unpinned references:**
+
+```bash
+grep -r "uses:" .github/workflows/ | grep -v "@[0-9a-f]\{40\}"
+```
+
+Any output is a finding.
+
+---
+
+## 3. Resolve the SHA for each action
+
+```bash
+# Get the SHA for a tag — replace owner, repo, and tag as needed
+gh api repos/actions/checkout/git/ref/refs/tags/v4 --jq '.object.sha'
+
+# If the tag points to a tag object rather than a commit, dereference it:
+gh api repos/actions/checkout/git/tags/<sha-from-above> --jq '.object.sha'
+```
+
+---
+
+## 4. Pin every reference and add a comment
+
+```yaml
+# Before (mutable tag):
+uses: actions/checkout@v4
+
+# After (pinned SHA with tag as comment):
+uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+```
+
+Always leave the tag as a comment. A bare SHA is unreadable to humans.
+
+Apply the same treatment to third-party actions — any namespace outside `actions/` and `github/` is high risk:
+
+| Action namespace | Risk level |
+| --- | --- |
+| `actions/*` | Medium — GitHub-owned; employee accounts can be compromised |
+| `github/*` | Medium — same as above |
+| Any other owner | High — no privileged relationship; pin and verify provenance |
+
+---
+
+## 5. Add a `permissions:` block to every workflow
+
+Without an explicit `permissions:` block, a workflow inherits the repository's default token permissions, which may include write access to contents, pull requests, or packages.
+
+**Most CI workflows (read-only):**
+
+```yaml
+permissions:
+  contents: read
+```
+
+**Workflows that post PR comments:**
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+**Workflows that upload release artifacts:**
+
+```yaml
+permissions:
+  contents: write
+```
+
+Apply the block at the job level when different jobs need different scopes. Apply at the workflow level when all jobs share the same scope.
+
+---
+
+## 6. Check for `pull_request_target` misuse
+
+`pull_request_target` runs with write permissions and access to secrets. If used with `actions/checkout` of the PR head, it allows a fork to run arbitrary code with those permissions.
+
+```bash
+grep -r "pull_request_target" .github/workflows/
+```
+
+Any match warrants careful review. If the trigger is needed, ensure the checkout step checks out the base branch, not the PR head.
+
+---
+
+## 7. Check for script injection
+
+User-controlled input flowing into `run:` shell commands is a script injection risk:
+
+```bash
+grep -r "\${{ github.event" .github/workflows/
+```
+
+Review every match. Values like `github.event.pull_request.title` or `github.event.issue.body` are attacker-controlled and must not be interpolated directly into shell commands. Use an environment variable intermediary instead:
+
+```yaml
+- name: Safe interpolation
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "$PR_TITLE"
+```
+
+---
+
+## 8. Configure Dependabot to keep pinned SHAs current
+
+A pinned SHA that never updates is worse than a mutable tag once a CVE lands in the pinned version. Add a `dependabot.yml` entry for GitHub Actions:
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+```
+
+---
+
+## 9. Produce a findings table
+
+```markdown
+## Supply Chain Assessment — .github/workflows/
+
+| File | Finding | Severity | Fix |
+| --- | --- | --- | --- |
+| lint.yml | Third-party action not SHA-pinned | High | Pin to commit SHA |
+| build.yml | No permissions block | Medium | Add permissions: contents: read |
+| All files | No dependabot.yml for actions | Medium | Add .github/dependabot.yml |
+```
+
+Severity guide: **High** — third-party action not SHA-pinned; `pull_request_target` misuse; script injection. **Medium** — first-party action not SHA-pinned; no `permissions:` block; no Dependabot. **Low** — minor hygiene.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- Every `uses:` reference pinned to a full commit SHA with a human-readable comment
+- Third-party actions identified and risk-rated
+- Minimal `permissions:` blocks on every workflow
+- No `pull_request_target` misuse or unguarded script injection
+- Dependabot configured to keep pinned SHAs current automatically

--- a/docs/how-to/orchestrate-across-repos.md
+++ b/docs/how-to/orchestrate-across-repos.md
@@ -1,0 +1,170 @@
+---
+title: Orchestrate Changes Across Repos
+layout: default
+parent: How-to Guides
+nav_order: 22
+---
+
+# Orchestrate Changes Across Repos
+
+Coordinate changes — skills, templates, hooks, and harness policies —
+across multiple repositories using the pattern appropriate to your scale.
+
+---
+
+## 1. Choose the right pattern
+
+| Situation | Pattern |
+| --- | --- |
+| Syncing skills or hooks from an upstream repo to 2–5 downstream repos | Git-mediated (Level 4) |
+| Propagating harness policy changes to downstream consumers | Git-mediated (Level 4) |
+| Managing shared standards across 10+ repos | Specification-mediated (Level 5) |
+| Aggregating health snapshots across an organisation | Specification-mediated (Level 5) |
+
+Start with git-mediated. Graduate to specification-mediated when the
+portfolio grows beyond what a single agent or team can manage manually.
+
+---
+
+## 2. Git-mediated coordination (Level 4)
+
+This pattern uses the standard git workflow: identify what changed
+upstream, then apply those changes to each downstream repo via a branch
+and PR.
+
+### Declare what the upstream repo exports
+
+Document the exported artefacts in the upstream README or a manifest
+section. At minimum, state:
+
+- Which directories contain reusable artefacts
+- What the downstream repos are
+- What triggers a sync (for example, "after any PR that modifies `skills/`")
+
+### What to sync — and what not to
+
+| Sync | Do not sync |
+| --- | --- |
+| Skills (tool-agnostic knowledge) | HARNESS.md (project-specific constraints) |
+| Agent definitions | AGENTS.md (project-specific learnings) |
+| Hook scripts and `hooks.json` | REFLECTION_LOG.md (project-specific reflections) |
+| CI workflow templates | Project source code |
+| Templates (starting points) | Specs and plans |
+
+### Apply changes to each downstream repo
+
+For each downstream repo:
+
+```bash
+cd /path/to/downstream-repo
+git checkout main && git pull
+git checkout -b sync/upstream-skills-YYYY-MM-DD
+
+# Copy the changed artefacts from upstream
+cp -r /path/to/upstream/skills/ ./skills/
+# or use rsync for selective updates
+rsync -av --include='*.md' --exclude='*' /path/to/upstream/skills/ ./skills/
+
+# Run lint and verify
+npx markdownlint-cli2 "skills/**/*.md"
+
+git add skills/
+git commit -m "sync: update skills from upstream (YYYY-MM-DD)"
+git push -u origin sync/upstream-skills-YYYY-MM-DD
+gh pr create --title "Sync skills from upstream" --body "..."
+```
+
+Watch CI checks and merge when green.
+
+---
+
+## 3. Specification-mediated orchestration (Level 5)
+
+At organisational scale, each repo declares its dependencies through a
+manifest file, and a platform orchestrator resolves and propagates changes
+automatically.
+
+### Create a repo manifest
+
+Add `.repo-manifest.yml` to the upstream repo:
+
+```yaml
+name: my-platform-repo
+version: 0.1.0
+
+exports:
+  skills:
+    - harness-engineering
+    - verification-slots
+  hooks:
+    - constraint-gate
+    - drift-check
+
+imports: []
+```
+
+Downstream repos declare what they consume:
+
+```yaml
+name: my-service-repo
+version: 0.1.0
+
+imports:
+  - source: my-platform-repo
+    version: ">=0.1.0"
+    artefacts:
+      - skills/*
+      - hooks/*
+```
+
+### Let the platform orchestrator propagate changes
+
+When the platform repo changes a harness policy, the orchestrator:
+
+1. Reads all downstream manifests
+2. Identifies which repos consume the changed artefact
+3. Opens sync PRs in each affected repo
+4. Reports sync status to the portfolio dashboard
+
+---
+
+## 4. Avoid common anti-patterns
+
+| Anti-pattern | Problem | Fix |
+| --- | --- | --- |
+| Sync without contracts | Nobody knows what should flow where | Declare exports in README or manifest |
+| Bidirectional sync | Changes flow both ways, causing conflicts | One direction only — upstream is authoritative |
+| Sync everything | Downstream repos lose their identity | Only sync declared exports |
+| Manual ad-hoc copies | Drift accumulates silently | Use a documented sync command or workflow |
+| Sync without CI | Broken changes propagate downstream | Every sync goes through a PR with CI checks |
+
+---
+
+## 5. Monitor portfolio health
+
+For specification-mediated orchestration, aggregate health snapshots give
+a portfolio-wide view:
+
+```text
+Portfolio Health — 2026-04-08
+
+Repos: 12
+At L3+: 9 (75%)
+Below threshold: 3 (api-gateway, legacy-auth, billing-service)
+Enforcement average: 84%
+Mutation score average: 76%
+Repos with stale snapshots: 1 (legacy-auth, 45 days)
+```
+
+Run `/portfolio-assess` to generate the current portfolio view.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A documented contract between upstream and downstream repos
+- A repeatable sync workflow that goes through PRs and CI
+- Clear boundaries around what flows downstream and what stays local
+- A monitoring approach scaled to the size of your portfolio

--- a/docs/how-to/review-code-with-cupid.md
+++ b/docs/how-to/review-code-with-cupid.md
@@ -1,0 +1,137 @@
+---
+title: Review Code with CUPID
+layout: default
+parent: How-to Guides
+nav_order: 12
+---
+
+# Review Code with CUPID
+
+This guide walks you through reviewing code using the five CUPID properties — Composable, Unix philosophy, Predictable, Idiomatic, Domain-based — as a structured lens for surfacing improvement opportunities.
+
+---
+
+## 1. Invoke the skill
+
+Open the file or function you want to review and run:
+
+```bash
+/cupid-code-review
+```
+
+The skill applies each of the five CUPID properties in turn to the code you provide. You can also invoke it on a specific file or a PR diff.
+
+---
+
+## 2. Work through each property in order
+
+For each of the five properties, ask the review questions and note findings before moving to the next. Do not try to evaluate all five simultaneously.
+
+### C — Composable: can I use this anywhere without baggage?
+
+Key questions:
+
+- Can this function or module be used independently, without pulling in unrelated state?
+- Are dependencies explicit (passed in) rather than implicit (global or ambient)?
+- Is the API surface the minimum needed?
+
+Signals of weak composability: hidden global state, "god object" arguments, functions that only make sense when called in a specific order.
+
+### U — Unix philosophy: does it do one thing completely?
+
+Key questions:
+
+- Can I describe what this does in one short sentence without using "and"?
+- Does the name match what it actually does?
+- Are multiple abstraction levels mixed together?
+
+Signals of weak Unix philosophy: "and" or "or" in function names, section comments inside a function body, functions that compute, persist, and notify.
+
+### P — Predictable: does it behave as its name suggests?
+
+Key questions:
+
+- Given only the name, would a reader expect the observed behaviour?
+- Are there hidden side effects beyond what the signature suggests?
+- Does it fail loudly or silently?
+
+Signals of weak predictability: boolean parameters that change behaviour significantly, swallowed exceptions, names that understate what the function does (a "get" that also writes).
+
+### I — Idiomatic: does it feel natural here?
+
+Key questions:
+
+- Would an experienced developer in this language find this familiar?
+- Are language features used as intended, not fought against?
+- Is anything reimplementing what the standard library provides?
+
+Signals of weak idiom: manual iteration where a higher-order function is conventional, inconsistent style compared to surrounding code.
+
+### D — Domain-based: does it speak the domain's language?
+
+Key questions:
+
+- Do the names appear in conversations with domain experts?
+- Are there technical names where domain names exist?
+- Does the structure mirror the structure of the domain?
+
+Signals of weak domain language: generic names (`data`, `manager`, `handler`, `util`), technical names for business concepts (`UserRecord` instead of `Customer`).
+
+---
+
+## 3. Rate each property
+
+After working through the questions, give each property a loose rating:
+
+| Property | Strength | Top opportunity |
+| --- | --- | --- |
+| Composable | Strong / Weak / Absent | One concrete improvement |
+| Unix philosophy | Strong / Weak / Absent | One concrete improvement |
+| Predictable | Strong / Weak / Absent | One concrete improvement |
+| Idiomatic | Strong / Weak / Absent | One concrete improvement |
+| Domain-based | Strong / Weak / Absent | One concrete improvement |
+
+Do not frame this as pass/fail. The goal is to identify where the code sits on each dimension and what a move in the right direction looks like.
+
+---
+
+## 4. Prioritise and act
+
+When deciding where to start:
+
+1. Identify the weakest one or two properties.
+2. Check whether improving the weakest property makes the others easier — improving Domain-based often makes the right structure obvious; improving Composable makes the code testable and movable.
+3. Describe one concrete change per weak property. Keep it specific enough to be actionable.
+
+Avoid trying to improve all five at once. That leads to over-engineering.
+
+---
+
+## 5. Optionally add a CUPID Status section to the README
+
+After a full five-property assessment, the skill will offer to add a CUPID Status section to the project README. Accept this if you want to track quality state over time. The section uses this format:
+
+```markdown
+## CUPID Status
+
+Last assessed: YYYY-MM-DD
+
+| Property | Strength | Top opportunity |
+| --- | --- | --- |
+| Composable | ★★★★☆ | Brief description |
+| Unix philosophy | ★★★☆☆ | Brief description |
+| Predictable | ★★★★★ | — |
+| Idiomatic | ★★★☆☆ | Brief description |
+| Domain-based | ★★★★☆ | Brief description |
+```
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A structured assessment of the code across all five CUPID properties
+- A prioritised list of improvement opportunities
+- A concrete action for each weak property
+- Optionally, a documented CUPID Status in the README for tracking over time

--- a/docs/how-to/run-a-harness-audit.md
+++ b/docs/how-to/run-a-harness-audit.md
@@ -2,11 +2,114 @@
 title: Run a Harness Audit
 layout: default
 parent: How-to Guides
-nav_order: 5
+nav_order: 4
 ---
 
 # Run a Harness Audit
 
-How to verify harness health. Running `/harness-audit` produces a full meta-verification of the harness: it checks that every DETERMINISTIC constraint has a working enforcement mechanism, identifies constraints that have drifted to advisory in practice, and surfaces gaps between what HARNESS.md claims and what is actually enforced.
+Run `/harness-audit` to produce a full meta-verification of the harness and generate
+a health snapshot with trend data.
 
-{: .label .label-yellow } Coming Soon
+---
+
+## 1. Run the audit command
+
+```text
+/harness-audit
+```
+
+The audit agent checks four things:
+
+1. Every `deterministic` constraint has a working enforcement mechanism
+2. No constraint has silently drifted to advisory in practice
+3. The GC rules are configured and have run within their declared cadence
+4. The snapshot currency is within 30 days
+
+---
+
+## 2. Review the snapshot output
+
+The audit writes a timestamped snapshot to your project. It includes:
+
+- **Constraint inventory**: each constraint with its current enforcement status
+- **Cadence compliance**: whether audit, GC, and reflection reviews are on schedule
+- **Trend section**: deltas from the previous snapshot (if one exists)
+- **Meta-health checks**: five signals that indicate whether the harness itself is working
+
+The five meta-health checks are:
+
+| Check | What it means if stale or failing |
+| ----- | ---------------------------------- |
+| Snapshot currency | The outer loop is not running |
+| Cadence compliance | Declared practices are not being followed |
+| Learning flow | Compound learning from sessions is broken |
+| GC effectiveness | GC rules may be misconfigured or never firing |
+| Trend direction | Architectural drift is going unnoticed |
+
+---
+
+## 3. Check the README health badge
+
+After the audit, `/harness-audit` updates the README health badge. Confirm the badge
+colour reflects the current state:
+
+| Colour | Condition |
+| ------ | --------- |
+| Green | All layers operating, no overdue cadences |
+| Amber | One layer degraded or outer loop overdue |
+| Red | Multiple layers degraded or no snapshot in 30+ days |
+
+If the badge is amber or red, address the flagged items before the next session.
+
+---
+
+## 4. Resolve flagged constraints
+
+If the audit flags constraints as unverified in practice:
+
+1. Open `HARNESS.md` and locate the constraint
+2. Run its `Tool` command manually to confirm it works:
+
+   ```bash
+   # Run whatever tool command is declared in the Tool field
+   gitleaks detect --source . --no-banner
+   ```
+
+3. If the tool is missing or broken, either fix the tool or demote the enforcement
+   field from `deterministic` to `unverified` until the tool is restored
+4. Re-run `/harness-audit` to confirm the constraint passes
+
+---
+
+## 5. Set up a recurring cadence
+
+The audit is most useful on a regular schedule. Add the cadence to `CLAUDE.md`:
+
+```markdown
+## Operating Cadence
+
+- Monthly: run `/harness-health` to generate a health snapshot
+- Quarterly: run `/harness-audit` for full meta-verification
+- Quarterly: run `/assess` to re-assess AI literacy level
+```
+
+A Stop hook in the plugin nudges you when the last snapshot is older than 30 days.
+
+---
+
+## 6. Run a deep check when the harness feels stale
+
+For a more thorough investigation than the standard audit:
+
+```text
+/harness-health --deep
+```
+
+For a multi-period trend view across all stored snapshots:
+
+```text
+/harness-health --trends
+```
+
+Use `--trends` at the start of quarterly reviews to see whether constraint coverage
+and enforcement ratios have improved or declined over time.

--- a/docs/how-to/run-an-assessment.md
+++ b/docs/how-to/run-an-assessment.md
@@ -1,0 +1,118 @@
+---
+title: Run an Assessment
+layout: default
+parent: How-to Guides
+nav_order: 9
+---
+
+# Run an Assessment
+
+Run an AI literacy assessment to determine where your team sits on the ALCI framework,
+get a timestamped evidence document, and apply immediate habitat improvements.
+
+---
+
+## 1. Start the assessment
+
+```text
+/assess
+```
+
+The agent scans the repository for observable evidence, then asks 3-5 clarifying questions
+to fill gaps that file inspection cannot answer.
+
+---
+
+## 2. Answer the clarifying questions
+
+The agent asks one question at a time. Questions focus on:
+
+- Whether you write specs before code or after
+- How systematically you verify AI output
+- Whether your team has shared AI conventions or each developer works independently
+- Whether you track what AI tools cost per month
+- Whether you capture lessons from AI sessions
+
+Answer honestly — the assessment is most useful when it reflects actual practice,
+not aspirations.
+
+---
+
+## 3. Review the assessment document
+
+The agent creates `assessments/YYYY-MM-DD-assessment.md` with:
+
+1. Team name, date, and assessed level
+2. Observable evidence found (with file paths)
+3. Summary of your answers
+4. Level assessment with rationale
+5. Discipline maturity ratings (context engineering, constraints, guardrail design)
+6. Strengths at your current level
+7. Gaps preventing the next level
+8. 3-5 specific recommendations
+
+The assessed level is the highest level where you have substantial evidence across all
+three disciplines. The weakest discipline is the ceiling.
+
+| Level | Minimum evidence required |
+| ----- | ------------------------- |
+| L0 | Repo exists, team is aware of AI tools |
+| L1 | Some AI tool usage, basic prompting |
+| L2 | Automated tests in CI, systematic verification of AI output |
+| L3 | CLAUDE.md + 3 or more enforced harness constraints + custom agents or skills |
+| L4 | Specifications before code + agent pipeline with safety gates |
+| L5 | Platform-level governance + cross-team standards + observability |
+
+---
+
+## 4. Accept or decline immediate adjustments
+
+The agent identifies habitat hygiene fixes that can be applied without team discussion:
+
+- Stale constraint counts in HARNESS.md
+- Outdated README badges
+- Missing entries in AGENTS.md GOTCHAS
+- Mechanism map gaps
+
+For each adjustment, the agent describes the change and asks before applying it.
+Accepted changes are applied immediately and recorded in the assessment document.
+
+---
+
+## 5. Accept or decline workflow recommendations
+
+Based on the gaps found, the agent recommends changes to how existing artifacts are
+operated (not what to build next). For each recommendation:
+
+- The agent explains what to change and why
+- You respond yes or no
+- Accepted recommendations are applied immediately — cadences added to CLAUDE.md,
+  constraints promoted in HARNESS.md, notes added to AGENTS.md
+
+---
+
+## 6. Check the README badge
+
+After the assessment, the agent adds or updates a badge in the README:
+
+```text
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_N-COLOUR?style=flat-square)](assessments/YYYY-MM-DD-assessment.md)
+```
+
+The badge links to the assessment document. Anyone who clicks it sees the full
+evidence and rationale.
+
+---
+
+## 7. Re-assess quarterly
+
+AI literacy changes as the team's practices evolve. Run `/assess` quarterly to track
+progress and catch practices that have drifted from what the harness declares.
+
+Add this to your `CLAUDE.md` operating cadence:
+
+```markdown
+## Operating Cadence
+
+- Quarterly: run `/assess` to re-assess AI literacy level
+```

--- a/docs/how-to/run-portfolio-assessment.md
+++ b/docs/how-to/run-portfolio-assessment.md
@@ -1,0 +1,153 @@
+---
+title: Run a Portfolio Assessment
+layout: default
+parent: How-to Guides
+nav_order: 20
+---
+
+# Run a Portfolio Assessment
+
+Aggregate AI literacy assessments across multiple repositories into an
+organisational portfolio view showing level distribution, shared gaps,
+outliers, and a prioritised improvement plan.
+
+---
+
+## 1. Decide how to discover repos
+
+The `/portfolio-assess` command discovers repos through three modes, which
+can be combined:
+
+| Flag | What it does |
+| --- | --- |
+| `--local <path>` | Scan subdirectories under `<path>` for `.git` directories |
+| `--org <name>` | List repos in a GitHub organisation via the GitHub CLI |
+| `--topic <tag>` | Filter repos by GitHub topic tag |
+
+At least one flag is required. If you omit all flags the command will ask
+you to choose.
+
+---
+
+## 2. Pre-assess individual repos (recommended)
+
+The portfolio assessment reads existing assessment documents. Run
+`/assess` in each repo before running the portfolio command to get full
+discipline scores and gap data:
+
+```bash
+cd /path/to/repo
+/assess
+```
+
+Repos without existing assessments are handled by a lightweight evidence
+scan that estimates a level but does not produce discipline scores. Pass
+`--no-scan-unassessed` to skip the scan and mark those repos as "not
+assessed" instead.
+
+---
+
+## 3. Run `/portfolio-assess`
+
+From a portfolio or platform repo (where you want the output written):
+
+```bash
+# Scan a local directory of repos
+/portfolio-assess --local ~/code/myorg/
+
+# Scan a GitHub organisation
+/portfolio-assess --org my-github-org
+
+# Filter by topic tag
+/portfolio-assess --org my-github-org --topic ai-literacy
+
+# Combine local and org, skip unevaluated repos
+/portfolio-assess --local ~/code/myorg/ --org my-github-org --no-scan-unassessed
+```
+
+The command reports progress as it works through discovery, gathering,
+and aggregation:
+
+```text
+Discovered 12 repos:
+  Local: 8 (from ~/code/myorg/)
+  GitHub org: 6 (from my-github-org)
+  Total after deduplication: 12
+
+Gathering assessments...
+  api-gateway: L3 (assessed 2026-04-01)
+  billing-service: L2 (assessed 2026-03-15)
+  new-service: L1 (estimated — no prior assessment)
+  legacy-auth: not assessed (--no-scan-unassessed)
+```
+
+---
+
+## 4. Review the portfolio view
+
+After gathering, the command computes portfolio metrics and identifies
+patterns:
+
+- **Level distribution** — count of repos at each level (assessed vs estimated)
+- **Portfolio median level** — median across all repos
+- **Weakest discipline** — lowest average discipline score across assessed repos
+- **Assessment coverage** — percentage of repos with full assessments
+- **Shared gaps** — gaps appearing in 3 or more repos (organisational problems)
+- **Outliers** — repos significantly above or below the median
+- **Stale assessments** — repos not assessed in more than 90 days
+
+Shared gaps drive the improvement plan because fixing them once lifts
+multiple repos.
+
+---
+
+## 5. Review the improvement plan
+
+The command generates a prioritised improvement plan grouped by impact
+scope:
+
+| Scope | Criteria | Typical actions |
+| --- | --- | --- |
+| Organisation-wide | Gap in 50%+ of repos | Deploy shared CI templates, establish org-wide cadences |
+| Cluster | Gap in 2–4 related repos | Roll out a specific tool, share a constraint pattern |
+| Individual | Gap unique to one repo | Defer to that repo's own improvement plan |
+
+Organisation-wide items get highest priority because one action lifts
+many repos.
+
+---
+
+## 6. Find the output document
+
+The command writes its output to the current directory:
+
+```text
+assessments/YYYY-MM-DD-portfolio-assessment.md
+```
+
+Open this file to see the full portfolio view, repo table, shared gap
+analysis, and improvement plan. This document is the input for
+`/team-api` when updating your Team API with AI literacy data.
+
+---
+
+## 7. Re-run on a schedule
+
+Stale assessments (older than 90 days) reduce the reliability of the
+portfolio view. Schedule a regular portfolio assessment — quarterly is a
+reasonable default for most organisations.
+
+When individual repos are re-assessed, run `/portfolio-assess` again to
+refresh the portfolio view with updated data.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A portfolio view of AI literacy levels across your repos
+- Shared gaps identified at the organisational level
+- A prioritised improvement plan grouped by impact scope
+- A dated `assessments/YYYY-MM-DD-portfolio-assessment.md` document to
+  drive team planning

--- a/docs/how-to/set-up-auto-enforcer.md
+++ b/docs/how-to/set-up-auto-enforcer.md
@@ -2,11 +2,126 @@
 title: Set Up Auto-Enforcer
 layout: default
 parent: How-to Guides
-nav_order: 4
+nav_order: 5
 ---
 
 # Set Up Auto-Enforcer
 
-How to set up automatic PR constraint checking. The auto-enforcer agent reviews every pull request against the constraints in HARNESS.md and posts a structured report, blocking merge if any DETERMINISTIC constraint is violated.
+Wire the auto-enforcer GitHub Action to check every PR against the constraints in
+HARNESS.md — blocking on deterministic failures and posting advisory comments for
+agent-based constraints.
 
-{: .label .label-yellow } Coming Soon
+---
+
+## Prerequisites
+
+- `HARNESS.md` exists at the project root with at least one PR-scoped constraint
+- Repository is hosted on GitHub
+
+---
+
+## 1. Copy the workflow template
+
+```bash
+cp .claude/plugins/ai-literacy-superpowers/templates/ci-auto-enforcer.yml \
+   .github/workflows/auto-enforcer.yml
+```
+
+---
+
+## 2. Add the API key secret
+
+The auto-enforcer uses the Claude API to evaluate agent-based constraints. Add the key
+in your repository settings:
+
+1. Go to **Settings > Secrets and variables > Actions**
+2. Click **New repository secret**
+3. Name: `ANTHROPIC_API_KEY`
+4. Value: your Anthropic API key
+
+Deterministic constraints run without the API key. If you have no agent constraints,
+you can skip this step.
+
+---
+
+## 3. Commit and push the workflow
+
+```bash
+git add .github/workflows/auto-enforcer.yml
+git commit -m "Add auto-enforcer workflow for PR constraint checking"
+git push
+```
+
+On the next pull request, the workflow runs automatically.
+
+---
+
+## 4. Read the PR comment
+
+When agent findings exist, the auto-enforcer posts a comment on the PR:
+
+```markdown
+## Auto-Enforcer Results
+
+| Constraint | Type | Status | Findings |
+|---|---|---|---|
+| No secrets in source | deterministic | PASS | -- |
+| All frontmatter complete | agent | ADVISORY | 2 files missing description |
+| Consistent formatting | deterministic | FAIL | 3 files need formatting |
+```
+
+| Status | Meaning |
+| ------ | ------- |
+| `PASS` | Check succeeded with no findings |
+| `FAIL` | Deterministic constraint failed — blocks merge |
+| `ADVISORY` | Agent constraint found issues — informational only |
+| `SKIP` | Constraint excluded by configuration |
+
+A red CI check always means a deterministic failure. Agent findings never block merge.
+
+---
+
+## 5. Configure optional filtering
+
+Edit the workflow file to include or exclude specific constraints:
+
+```yaml
+env:
+  # Run only these constraints (comma-separated):
+  INCLUDE_CONSTRAINTS: "no-secrets,frontmatter-complete"
+
+  # Skip these constraints (comma-separated):
+  EXCLUDE_CONSTRAINTS: "slow-integration-check"
+
+  # Claude model for agent constraints:
+  AGENT_MODEL: "claude-sonnet-4-20250514"
+
+  # Post comment even when all constraints pass:
+  COMMENT_MODE: "always"
+```
+
+---
+
+## 6. Avoid duplicate checks
+
+If your existing `harness.yml` already runs some deterministic constraints, avoid
+running them twice:
+
+```yaml
+env:
+  EXCLUDE_CONSTRAINTS: "no-secrets,test-suite"
+```
+
+Or migrate all PR constraints to the auto-enforcer and simplify `harness.yml` to
+remove the duplicates. Both workflows run independently as separate CI jobs.
+
+---
+
+## Known limitations
+
+- Agent constraints see only changed files and surrounding context, not the full
+  codebase. Some rules may need full-repo context to evaluate accurately.
+- Diffs larger than 50 KB fall back to a summary — agent accuracy decreases in
+  this mode.
+- GitHub Actions only. For other CI platforms, adapt the shell logic from the
+  template to your platform's format.

--- a/docs/how-to/set-up-context-engineering.md
+++ b/docs/how-to/set-up-context-engineering.md
@@ -1,0 +1,139 @@
+---
+title: Set Up Context Engineering
+layout: default
+parent: How-to Guides
+nav_order: 11
+---
+
+# Set Up Context Engineering
+
+This guide walks you through writing enforceable conventions for the Context section of your `HARNESS.md` so that LLMs and new team members work from the same shared understanding of your codebase.
+
+---
+
+## 1. Open the Context section of HARNESS.md
+
+The Context section has two parts: a Stack Declaration and a Conventions block. If your `HARNESS.md` was created by `/harness-init`, the Stack Declaration should already be populated. If not, add a factual summary of your languages, build system, test framework, and container strategy:
+
+```markdown
+## Context
+
+### Stack
+
+- Language: Go 1.22
+- Build: `make build`
+- Tests: `go test ./...`
+- Containers: Docker multi-stage builds, Alpine runtime
+```
+
+Keep this section factual — describe what is true today, not aspirations.
+
+---
+
+## 2. Identify your conventions
+
+Before writing anything, gather what the team actually values. Ask:
+
+- What do code reviewers comment on most often?
+- What patterns does the codebase already follow consistently?
+- What rules exist informally ("we always do X") but are not written down?
+
+List them as rough aspirations first. You will make them enforceable in the next step.
+
+---
+
+## 3. Apply the enforceability test to each convention
+
+For each aspiration, ask three questions:
+
+1. Can I describe what code that **follows** this convention looks like?
+2. Can I describe what code that **violates** it looks like?
+3. Could a tool or agent check this without ambiguity?
+
+If any answer is no, rewrite the convention until all three are yes.
+
+Use this table as a guide:
+
+| Aspiration | Not enforceable | Enforceable convention |
+| --- | --- | --- |
+| Write clean code | Too broad | Decompose into specific rules below |
+| Keep functions short | Vague | Functions must not exceed 40 lines |
+| Use meaningful names | Subjective | Variables must be 3+ characters except `i`, `j`, `k`, `err` |
+| Handle errors properly | Unverifiable | Every returned error must be wrapped with context |
+
+---
+
+## 4. Organise conventions by category
+
+Group your conventions under these headings in the Context section:
+
+```markdown
+### Conventions
+
+#### Naming
+- Variables must be 3+ characters except loop indices (`i`, `j`, `k`) and `err`
+- Exported types use PascalCase; unexported identifiers use camelCase
+
+#### File structure
+- One type per file; file name matches the primary type name
+- Tests co-located with source: `foo.go` + `foo_test.go`
+
+#### Error handling
+- Every returned error must be wrapped with `fmt.Errorf("context: %w", err)`
+- No `panic` outside of `main` or init functions
+
+#### Testing
+- Test function names follow `Test<Function>_<scenario>` pattern
+- Table-driven tests for functions with more than two distinct input cases
+```
+
+Adjust categories to match your stack. Omit empty categories rather than leaving placeholder headings.
+
+---
+
+## 5. Remove convention anti-patterns
+
+Before saving, check each entry against these anti-patterns and rewrite or remove anything that matches:
+
+- **Implementation instructions** — "use dependency injection" is an instruction. Replace with the observable outcome: "dependencies are passed as constructor parameters, not retrieved from globals."
+- **Tool configuration** — linter rules belong in the linter config file, not in `HARNESS.md`.
+- **Aspirational quality statements** — "write readable code" cannot be checked. Decompose it.
+- **Temporary rules** — if a rule will expire, add it as a constraint with a scope, not a convention.
+
+---
+
+## 6. Verify conventions against the existing codebase
+
+A convention that the codebase already violates in many places is worse than no convention — it creates noise for LLM agents and erodes trust. Before committing each convention:
+
+```bash
+# Example: check whether error wrapping is already in use
+grep -r "fmt.Errorf" . --include="*.go" | wc -l
+grep -r 'errors.New' . --include="*.go" | wc -l
+```
+
+If the convention is not yet followed consistently, note it as a target state and create a constraint to enforce it going forward rather than pretending it is already the case.
+
+---
+
+## 7. Run `/harness-audit` to detect stale context
+
+After adding or updating conventions, run the harness audit to cross-reference your context against the project's actual state:
+
+```bash
+/harness-audit
+```
+
+The audit flags conventions that reference functions, files, or patterns that no longer exist. Address each finding before declaring the context section complete.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A Stack Declaration that reflects the actual project configuration
+- A Conventions section where every entry passes the enforceability test
+- Conventions grouped by category with no anti-patterns
+- A verified baseline — conventions that match the codebase as it stands
+- A living context section maintained by `/harness-audit` on an ongoing basis

--- a/docs/how-to/set-up-garbage-collection.md
+++ b/docs/how-to/set-up-garbage-collection.md
@@ -1,0 +1,170 @@
+---
+title: Set Up Garbage Collection
+layout: default
+parent: How-to Guides
+nav_order: 16
+---
+
+# Set Up Garbage Collection
+
+This guide walks you through designing and adding garbage collection (GC) rules to your `HARNESS.md` — periodic checks that fight the entropy that real-time hooks and PR gates cannot catch.
+
+---
+
+## 1. Understand what GC rules catch
+
+GC rules target slow drift: documentation going stale, conventions eroding, dead code accumulating, dependencies falling behind. They complement your deterministic constraints — where constraints fire at commit or PR time, GC rules run on a schedule.
+
+Each GC rule has five fields:
+
+| Field | Description |
+| --- | --- |
+| What it checks | The specific entropy being detected |
+| Frequency | `daily`, `weekly`, or `manual` |
+| Enforcement | `deterministic` (tool) or `agent` (reasoning required) |
+| Tool | What runs the check |
+| Auto-fix | `true` (agent fixes and commits) or `false` (creates an issue) |
+
+---
+
+## 2. Identify the entropy in your codebase
+
+Before writing rules, answer these questions:
+
+- What goes stale fastest in this codebase? (Documentation? Dependency versions? API references?)
+- What conventions drift in code review? (Naming? File structure? Error handling?)
+- What accumulates silently? (Unused exports? Orphaned test fixtures? Stale TODO comments?)
+- What slows down teams when it drifts? (Prioritise by impact.)
+
+List your answers. Each answer is a candidate GC rule.
+
+---
+
+## 3. Choose frequency for each rule
+
+| Frequency | Use for |
+| --- | --- |
+| `daily` | Fast-moving codebases with high entropy rate |
+| `weekly` | Most rules — documentation, dependencies, dead code |
+| `manual` | Checks not yet calibrated for automation |
+
+Start with `weekly` for everything. Only move to `daily` if the entropy rate justifies the cost.
+
+---
+
+## 4. Apply the auto-fix decision
+
+Auto-fix is safe when the fix is **deterministic, local, verifiable, and reversible**. It is not safe when the fix requires judgement, has ripple effects, or is destructive.
+
+| Condition | Auto-fix |
+| --- | --- |
+| Running `go mod tidy` to clean unused dependencies | `true` — deterministic and reversible |
+| Removing a dead function used nowhere | `false` — needs human judgement about intent |
+| Updating a version number in a docs file | `true` — local and verifiable |
+| Refactoring a naming violation across many files | `false` — ripple effects |
+
+When auto-fix is `false`, the `harness-gc` agent creates a GitHub issue with file and line references and a suggested fix.
+
+---
+
+## 5. Add GC rules to HARNESS.md
+
+Open `HARNESS.md` and find or create the Garbage Collection section. Add one row per rule:
+
+```markdown
+## Garbage Collection
+
+| What it checks | Frequency | Enforcement | Tool | Auto-fix |
+| --- | --- | --- | --- | --- |
+| Stale doc references to deleted files | weekly | agent | harness-gc | false |
+| Unused Go exports | weekly | deterministic | deadcode ./... | false |
+| Dependency CVEs | weekly | deterministic | govulncheck ./... | false |
+| Convention drift — error wrapping | weekly | deterministic | custom lint rule | false |
+| go.mod tidiness | weekly | deterministic | go mod tidy | true |
+```
+
+---
+
+## 6. Run the GC agent
+
+```bash
+/harness-gc
+```
+
+The `harness-gc` agent reads your GC rules, runs each check, and either applies auto-fixes (with your confirmation in interactive mode) or creates GitHub issues for findings that require human attention.
+
+To run a single rule by name:
+
+```bash
+/harness-gc --rule "Unused Go exports"
+```
+
+---
+
+## 7. Add common GC rules by category
+
+Use these as a starting point and adapt to your codebase:
+
+**Documentation entropy:**
+
+```markdown
+| HARNESS.md references non-existent files | weekly | agent | harness-gc | false |
+| Stack declaration version mismatch | weekly | agent | harness-gc | false |
+```
+
+**Convention drift:**
+
+```markdown
+| Naming convention violations | weekly | deterministic | custom linter | false |
+| Error wrapping missing context | weekly | deterministic | errcheck | false |
+```
+
+**Dead code:**
+
+```markdown
+| Unused exported functions | weekly | deterministic | deadcode ./... | false |
+| Orphaned test fixtures | weekly | agent | harness-gc | false |
+```
+
+**Dependency entropy:**
+
+```markdown
+| Known CVEs in dependencies | weekly | deterministic | govulncheck ./... | false |
+| Dependencies > 2 major versions behind | weekly | agent | harness-gc | false |
+```
+
+---
+
+## 8. Schedule GC in CI
+
+Run the deterministic GC checks on a weekly schedule in GitHub Actions:
+
+```yaml
+name: Harness GC
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
+
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run dependency CVE check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+```
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- GC rules that target the entropy specific to your codebase
+- Frequency and auto-fix decisions applied using the safety rubric
+- A Garbage Collection section in `HARNESS.md` with structured rule entries
+- The `harness-gc` agent wired up to run checks and create issues
+- Deterministic GC checks scheduled in CI to run weekly

--- a/docs/how-to/set-up-model-routing.md
+++ b/docs/how-to/set-up-model-routing.md
@@ -1,0 +1,162 @@
+---
+title: Set Up Model Routing
+layout: default
+parent: How-to Guides
+nav_order: 19
+---
+
+# Set Up Model Routing
+
+Decide which models handle which workloads, document those routing rules
+in `MODEL_ROUTING.md`, and evaluate your sovereignty position.
+
+---
+
+## 1. Understand the decision hierarchy
+
+Exhaust simpler approaches before escalating complexity. Each step adds
+maintenance burden:
+
+1. **Prompting + context engineering** — the default. Most teams
+   underestimate how far this carries them.
+2. **RAG** — when the limitation is knowledge that is volatile, large, or
+   frequently changing.
+3. **Fine-tuning (LoRA/QLoRA)** — when the limitation is behaviour:
+   consistent domain-specific patterns at scale.
+4. **Distillation** — when the limitation is size or speed (edge
+   deployment, latency-sensitive workloads).
+5. **Local hosting** — when the limitation is privacy, cost at scale, or
+   independence from vendor defaults.
+
+---
+
+## 2. Classify your data
+
+List every type of data that flows through your AI interactions. Classify
+each as one of:
+
+| Class | Description | Default routing |
+| --- | --- | --- |
+| Public | No restrictions | Cloud API |
+| Internal | Business context, non-sensitive | Cloud API |
+| Sensitive | PII, financial, health | Local or private cloud |
+| Restricted | Regulated, trade secret, residency-bound | Local only |
+
+If any data is Sensitive or Restricted, local hosting is non-negotiable
+for those interactions. Consult your legal and compliance teams before
+routing Restricted data to any external API.
+
+---
+
+## 3. Answer the routing decision questions
+
+Work through these questions in order. Stop at the first "yes."
+
+**Does your data require local processing?**
+PII, regulated data, trade secrets, or data subject to residency
+requirements means local hosting is required for those interactions.
+
+**Does knowledge change frequently?**
+Information changing weekly or monthly — add a RAG layer regardless of
+hosting choice. RAG updates instantly; fine-tuning requires retraining.
+
+**Does the model need consistent domain behaviour at scale?**
+Reliable format compliance, style consistency, or decision logic across
+thousands of requests — evaluate fine-tuning with LoRA/QLoRA.
+
+**Is baseline load above the break-even threshold?**
+Approximately 30M tokens per day sustained makes self-hosted inference
+economically justified within four months.
+
+**None of the above?**
+Use cloud API models with good prompting and context engineering.
+
+---
+
+## 4. Create `MODEL_ROUTING.md`
+
+Create a `MODEL_ROUTING.md` file at the repository root that documents
+your routing decisions:
+
+```markdown
+# Model Routing
+
+## Data Classification
+
+| Data type | Class | Routing |
+| --- | --- | --- |
+| Source code context | Internal | Cloud API (Claude) |
+| User PII in prompts | Sensitive | Blocked — strip before sending |
+| Internal docs | Internal | Cloud API (Claude) |
+
+## Routing Rules
+
+| Workload | Model | Reason |
+| --- | --- | --- |
+| Code generation | Claude Sonnet (cloud) | Reasoning quality required |
+| Doc generation | Claude Haiku (cloud) | Cost-sensitive, lower stakes |
+| On-device inference | Ollama (local) | Sensitive internal data |
+
+## Fallback
+
+If the primary model API is unavailable:
+1. [Alternative model or provider]
+2. Degrade to [manual process]
+
+## Sovereignty Test
+
+If our primary API provider changed pricing, rate-limited us, or
+discontinued our model tomorrow:
+- Fallback model identified: [yes/no — model name]
+- Specifications precise enough to regenerate with another model: [yes/no]
+- Local alternative evaluated: [yes/no — tool name]
+- Data classification covering all flows: [yes/no]
+```
+
+---
+
+## 5. Evaluate local hosting options
+
+If local hosting is needed for any workload, evaluate your options:
+
+**Ollama** — simplest local inference, good for development and
+privacy-sensitive workloads:
+
+```bash
+brew install ollama
+ollama pull llama3
+ollama run llama3
+```
+
+**vLLM** — production-grade inference server for GPU-backed deployments:
+
+```bash
+pip install vllm
+python -m vllm.entrypoints.openai.api_server --model mistralai/Mistral-7B-v0.1
+```
+
+Test that local inference meets your quality bar before committing to it
+for production workloads.
+
+---
+
+## 6. Plan maintenance cadence
+
+Custom models accumulate maintenance debt. Document the cadence in
+`MODEL_ROUTING.md`:
+
+- **Version pinning** — pin model versions and test before updating
+- **Retraining** — quarterly for fine-tuned models
+- **Drift detection** — monitor output quality metrics over time
+- **Exit strategy** — every custom model needs a cloud fallback
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- Data classified by sensitivity and routed accordingly
+- `MODEL_ROUTING.md` documenting routing rules and fallback options
+- A completed sovereignty test showing your vendor dependency position
+- A maintenance plan for any custom or local models in use

--- a/docs/how-to/set-up-verification-slots.md
+++ b/docs/how-to/set-up-verification-slots.md
@@ -1,0 +1,150 @@
+---
+title: Set Up Verification Slots
+layout: default
+parent: How-to Guides
+nav_order: 18
+---
+
+# Set Up Verification Slots
+
+Integrate a deterministic tool into a harness constraint so the enforcer
+can run it automatically at commit time and in CI.
+
+---
+
+## 1. Understand the slot contract
+
+Every constraint in HARNESS.md is backed by a verification slot. The
+enforcer reads each constraint and dispatches verification based on its
+`enforcement` field:
+
+| Enforcement | What happens |
+| --- | --- |
+| `deterministic` | Execute the `tool` command; interpret exit code |
+| `agent` | Read the rule text; review files; produce findings |
+| `deterministic + agent` | Run both; merge findings |
+| `unverified` | Skip — log as unchecked |
+
+The slot contract is always the same regardless of what backs it:
+
+- **Input:** constraint definition, scope, and file set
+- **Output:** `pass` or `fail` with a list of `{file, line, message}` findings
+
+---
+
+## 2. Choose a tool for the slot
+
+Identify a tool that checks your constraint — a linter, formatter,
+scanner, or custom script. Confirm it runs locally and exits non-zero on
+violations:
+
+```bash
+# Example: run ESLint on staged files
+npx eslint --max-warnings 0 src/
+
+# Example: run Prettier in check mode
+npx prettier --check "src/**/*.ts"
+
+# Example: run a custom script
+./scripts/check-no-console.sh
+```
+
+The tool must:
+
+- Accept a file path or directory as an argument, or scan by default
+- Exit `0` on pass, non-zero on failure
+- Produce output that helps a developer understand what to fix
+
+---
+
+## 3. Update the constraint in HARNESS.md
+
+Open `HARNESS.md` and find the constraint row to harden. Change the
+`enforcement` field to `deterministic` and set the `tool` field to the
+exact command the enforcer will run:
+
+```markdown
+<!-- Before: agent or unverified -->
+| No console.log in production code | AGENT | prose rule | none |
+
+<!-- After: deterministic -->
+| No console.log in production code | DETERMINISTIC | ESLint no-console | npx eslint --max-warnings 0 src/ |
+```
+
+If the constraint does not yet exist, run `/harness-constrain` to add it
+through the guided flow, then edit the enforcement details by hand.
+
+---
+
+## 4. Run `/harness-audit` to confirm the slot works
+
+```bash
+/harness-audit
+```
+
+The audit agent reads every constraint, executes deterministic tools, and
+reports whether each slot produces a usable result. Look for your
+constraint in the output:
+
+```text
+Constraint: No console.log in production code
+  Enforcement: deterministic
+  Tool: npx eslint --max-warnings 0 src/
+  Result: PASS (exit 0)
+```
+
+If the tool fails to run, the audit reports the error. Fix the command
+and re-run the audit until the slot reports cleanly.
+
+---
+
+## 5. Set up mixed enforcement (optional)
+
+Some constraints benefit from both a deterministic check and an agent
+review. For example, a linter can verify that doc comments exist while an
+agent reviews whether those comments explain the reasoning rather than
+restating the signature.
+
+Set the `enforcement` field to `deterministic + agent` and list both tools:
+
+```markdown
+| Doc comments explain reasoning | DETERMINISTIC + AGENT | ESLint + agent review | npx eslint --rule 'valid-jsdoc: error' src/ |
+```
+
+The enforcer runs both, merges the findings, and reports a combined
+result.
+
+---
+
+## 6. Verify enforcement timing
+
+Slots run at three timescales. Check that your constraint appears at the
+right level:
+
+| Loop | Trigger | Strictness |
+| --- | --- | --- |
+| Inner | PreToolUse hook | Advisory |
+| Middle | CI on PR | Strict |
+| Outer | Scheduled GC + audit | Investigative |
+
+Run `/harness-status` to confirm the constraint is active in the correct
+enforcement tier:
+
+```bash
+/harness-status
+```
+
+The output shows each constraint with its enforcement type and last
+verification result.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A deterministic tool wired into a constraint's verification slot
+- Confirmation via `/harness-audit` that the slot runs and produces results
+- The constraint enforced at the appropriate timing tiers
+- A clear path to mixed enforcement if the constraint also benefits from
+  agent-based review

--- a/docs/how-to/sync-conventions.md
+++ b/docs/how-to/sync-conventions.md
@@ -2,11 +2,95 @@
 title: Sync Conventions
 layout: default
 parent: How-to Guides
-nav_order: 3
+nav_order: 6
 ---
 
 # Sync Conventions
 
-How to sync conventions to Cursor, Copilot, and Windsurf. The harness maintains a single source of truth in HARNESS.md and CLAUDE.md; this guide covers how to propagate those conventions to other AI coding assistants so that all tools work from the same rules.
+Propagate HARNESS.md conventions to Cursor, Copilot, and Windsurf so all AI coding
+tools work from the same rules.
 
-{: .label .label-yellow } Coming Soon
+---
+
+## 1. Run the sync command
+
+```text
+/convention-sync
+```
+
+The agent reads the Context and Constraints sections of `HARNESS.md`, generates the
+target files for each tool, and reports what changed in a summary table.
+
+HARNESS.md is the single source of truth. Sync is one-way: HARNESS.md drives the other
+files. Do not edit the generated files directly — changes will be overwritten on the
+next sync.
+
+---
+
+## 2. Review the generated files
+
+The sync creates or updates these files:
+
+| Tool | File | Contents |
+| ---- | ---- | -------- |
+| Cursor | `.cursor/rules/conventions.mdc` | Context section (stack, conventions) |
+| Cursor | `.cursor/rules/constraints.mdc` | One rule block per constraint |
+| Copilot | `.github/copilot-instructions.md` | Context and constraints combined |
+| Windsurf | `.windsurf/rules/conventions.md` | Context section (no frontmatter) |
+| Windsurf | `.windsurf/rules/constraints.md` | One rule block per constraint |
+
+Open each file and confirm that every constraint from HARNESS.md appears. If a
+constraint is missing, the generation has a bug — report it rather than adding the
+entry by hand.
+
+---
+
+## 3. Handle conflicts
+
+When a target file already exists, the agent diffs the generated content against
+the existing file:
+
+- **Identical**: reports "unchanged" and moves on
+- **Different**: shows the diff and asks before overwriting
+- **Declined**: reports "skipped" for that file
+
+If you have tool-specific rules that should not be in HARNESS.md, add them in a
+separate file that the sync does not manage. For example, a Cursor-only rule about
+a third-party IDE extension belongs in `.cursor/rules/ide-specific.mdc`, not in
+`.cursor/rules/conventions.mdc`.
+
+---
+
+## 4. Commit the generated files
+
+```bash
+git add .cursor/rules/ .github/copilot-instructions.md .windsurf/rules/
+git commit -m "Sync conventions from HARNESS.md to Cursor, Copilot, Windsurf"
+```
+
+---
+
+## 5. Re-sync after HARNESS.md changes
+
+Run `/convention-sync` whenever you add or promote a constraint in HARNESS.md. The
+sync is fast — it reads HARNESS.md and regenerates only files that have changed.
+
+A good practice is to add convention sync to your PR checklist:
+
+```markdown
+- [ ] Run `/convention-sync` if HARNESS.md was modified
+```
+
+---
+
+## What gets synced
+
+| HARNESS.md section | What it becomes |
+| ------------------- | --------------- |
+| Context > Stack | Tool description block in each file |
+| Context > Conventions | Convention rules in each file |
+| Each constraint entry | One rule block per constraint |
+| Constraint `Scope` field | Cursor glob pattern (defaults to `**/*`) |
+
+The Garbage Collection and Status sections are not synced — they are harness-internal
+and have no equivalent in other tools.

--- a/docs/how-to/understand-harness-engineering.md
+++ b/docs/how-to/understand-harness-engineering.md
@@ -1,0 +1,160 @@
+---
+title: Understand Harness Engineering
+layout: default
+parent: How-to Guides
+nav_order: 24
+---
+
+# Understand Harness Engineering
+
+Apply the harness engineering framework to your project — understand the
+three components, set up the living harness document, and harden
+constraints over time.
+
+---
+
+## 1. Understand the three components
+
+A harness is the combined set of deterministic tooling and LLM-based
+agents that keeps AI-generated code trustworthy and maintainable. Three
+components form a complete harness:
+
+**Context engineering** — the knowledge an LLM needs to work effectively
+in your codebase. This includes explicit documentation (conventions,
+constraints, stack declarations) and implicit context (the code design
+itself). In this plugin, context engineering lives in HARNESS.md's
+Context section.
+
+**Architectural constraints** — rules that must be enforced, not
+suggestions. Each constraint is backed by a verification slot that can be
+filled by a deterministic tool (linter, formatter, structural test) or an
+agent-based review. Constraints live in HARNESS.md's Constraints section
+and are enforced at three timescales.
+
+**Garbage collection** — periodic checks that fight entropy. Documentation
+goes stale, conventions erode, dead code accumulates. GC agents run on a
+schedule to find and fix these issues. GC rules live in HARNESS.md's
+Garbage Collection section.
+
+---
+
+## 2. Initialise the harness
+
+If your project does not yet have a `HARNESS.md`, run:
+
+```bash
+/harness-init
+```
+
+This creates a `HARNESS.md` with starter sections for Context,
+Constraints, and Garbage Collection. It also installs the pre-commit hook
+and sets up the CI workflow step if you confirm those options.
+
+---
+
+## 3. Add context to HARNESS.md
+
+Open `HARNESS.md` and fill in the Context section. Useful entries:
+
+- Stack declaration (language, framework, key libraries)
+- Conventions that AI tools should follow
+- Constraints that govern code structure
+- Any project-specific knowledge that shapes how code should be written
+
+The more precise the context, the more accurate AI-generated code will be.
+
+---
+
+## 4. Understand the constraint promotion ladder
+
+Constraints follow a three-stage promotion ladder:
+
+| Stage | Meaning |
+| --- | --- |
+| `unverified` | Declared intent — no automation yet |
+| `agent` | LLM-based review against the constraint's prose rule |
+| `deterministic` | Tool-backed enforcement (linter, formatter, test) |
+
+Start by declaring what should be true. Automate when you are ready. The
+harness improves over time without restructuring.
+
+To add a new constraint through the guided flow:
+
+```bash
+/harness-constrain
+```
+
+---
+
+## 5. Understand the three enforcement loops
+
+Constraints are checked at three timescales — inner, middle, and outer:
+
+| Loop | Trigger | Strictness | Purpose |
+| --- | --- | --- | --- |
+| Inner | PreToolUse hook | Advisory | Catch issues while context is fresh |
+| Middle | CI on PR | Strict | Prevent violations reaching main |
+| Outer | Scheduled GC + audit | Investigative | Fight slow entropy |
+
+The inner loop gives fast feedback without blocking. The middle loop
+blocks merges on violations. The outer loop catches slow drift that neither
+hook nor PR gate sees.
+
+---
+
+## 6. Check harness health
+
+Run the health command to see the current state of every constraint:
+
+```bash
+/harness-status
+```
+
+This shows each constraint's enforcement type, last verification result,
+and whether it is active in the hook and CI layers.
+
+For a deeper audit — including running every deterministic tool and
+reporting which constraints are drifting from their declared state:
+
+```bash
+/harness-audit
+```
+
+---
+
+## 7. Run garbage collection
+
+GC checks run on a schedule to catch entropy that accumulates between
+PRs. To run them manually:
+
+```bash
+/harness-gc
+```
+
+The GC agent reads every rule in HARNESS.md's Garbage Collection section
+and reports findings. Common GC rules include stale documentation checks,
+dead code detection, and dependency freshness checks.
+
+---
+
+## 8. Understand the living harness principle
+
+HARNESS.md is a living document — it declares what should be true and
+the plugin's agents check whether it is true. The Status section reflects
+the gap between declared and actual enforcement.
+
+When the Status section shows drift, the team knows where to invest next.
+This self-referential loop is the central design principle: the harness
+is harnessed by its own document.
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- A `HARNESS.md` with Context, Constraints, and GC sections
+- An understanding of the three-component harness model
+- Constraints on the promotion ladder, hardening over time
+- Three enforcement loops active at commit, PR, and schedule timescales
+- Harness health visible via `/harness-status` and `/harness-audit`

--- a/docs/how-to/write-literate-code.md
+++ b/docs/how-to/write-literate-code.md
@@ -1,0 +1,158 @@
+---
+title: Write Literate Code
+layout: default
+parent: How-to Guides
+nav_order: 17
+---
+
+# Write Literate Code
+
+This guide walks you through applying the literate programming discipline to your code — writing files whose structure and documentation make the reasoning visible to the next reader.
+
+---
+
+## 1. Invoke the skill
+
+When creating a new file, writing a new function or type, or significantly rewriting existing code, invoke the skill:
+
+```bash
+/literate-programming
+```
+
+The skill applies five rules to every file it produces or reviews.
+
+---
+
+## 2. Open every file with a narrative preamble
+
+The preamble goes in the package or module comment block, before any imports. It answers three questions:
+
+1. Why does this file exist? What problem does it solve?
+2. What are the key design decisions? Not a list of functions — the choices that shaped the structure.
+3. What does this file deliberately NOT do? Explicit scope exclusions are as informative as inclusions.
+
+**Before (no preamble):**
+
+```go
+package cache
+
+import (
+    "sync"
+    "time"
+)
+
+type Cache struct { ... }
+```
+
+**After (with preamble):**
+
+```go
+// Package cache provides a short-lived, in-process store for rendered page
+// fragments. Its only job is to reduce redundant template execution on
+// repeated requests for the same URL within a single deploy.
+//
+// We deliberately avoid distributed caching here. The fragments are cheap
+// to recompute, the deploy cadence is high, and the operational burden of
+// a networked cache is not justified at current traffic.
+//
+// We do not attempt cache invalidation on content change — that problem
+// belongs to the deployment pipeline, not the request path.
+package cache
+```
+
+If you cannot state the file's single concern in the preamble's first sentence, the file has too many concerns and should be split.
+
+---
+
+## 3. Write documentation that explains reasoning, not signatures
+
+A comment that restates the function name or its parameter types adds no value. The code already shows WHAT. Documentation's job is to explain WHY.
+
+**Before (restates the signature):**
+
+```go
+// getUserByID returns the user with the given ID from the database.
+func getUserByID(id string) (*User, error) {
+```
+
+**After (explains reasoning):**
+
+```go
+// getUserByID loads from the read replica, not the primary. For the auth
+// hot-path this is acceptable because user records change rarely and a
+// replication lag of a few seconds is not observable by a human login flow.
+// Write operations that need immediate consistency call the primary directly.
+func getUserByID(id string) (*User, error) {
+```
+
+Apply the same standard to type definitions: explain why the type exists and what invariants it maintains.
+
+---
+
+## 4. Order presentation for understanding, not compiler convention
+
+Arrange code so that a reader encounters concepts in the order needed to build understanding:
+
+- High-level orchestration before low-level detail — the function that calls helpers should appear before the helpers.
+- Domain model before mechanics — the type that represents the problem before the functions that manipulate it.
+- Purpose before implementation — what something is for before how it works.
+
+In Go and Kotlin this sometimes means forward references. That is fine. Readability for the human outweighs compiler convention.
+
+---
+
+## 5. Write inline comments that explain WHY, not WHAT
+
+| Describes WHAT (avoid) | Explains WHY (use) |
+| --- | --- |
+| `// increment counter` | `// counter is used by the rate limiter, not just for metrics` |
+| `// check if user is nil` | `// nil user is valid here — unauthenticated requests are allowed` |
+| `// loop over items` | `// process in reverse so removals don't shift the indices we haven't visited` |
+| `// return error` | `// surface the parse error; callers need the line number to show a useful message` |
+
+---
+
+## 6. Check for red flags before committing
+
+Before every commit, scan for these signs that literate programming discipline has slipped:
+
+- File opens with `import` or a type declaration — no preamble
+- Any function comment that could be auto-generated from its signature
+- Helper functions defined before the code that calls them
+- A preamble that lists what the file contains rather than why it exists
+- An inline comment that starts with "this" and restates the next line
+
+If you find any of these, stop and rewrite before continuing.
+
+---
+
+## 7. Add a convention to HARNESS.md
+
+To make literate programming enforceable across the team, add a convention to the Context section of `HARNESS.md`:
+
+```markdown
+#### Documentation
+- Every new file must open with a narrative preamble answering: why this file exists,
+  key design decisions, and what it deliberately does not do
+- Function comments must explain the reasoning behind the approach, not restate the signature
+- Inline comments explain WHY, not WHAT — comments that restate the next line are prohibited
+```
+
+Then add it as a constraint to enforce it in code review:
+
+```markdown
+| Literate preamble on new files | PROBABILISTIC | code review | manual |
+```
+
+---
+
+## Summary
+
+After completing these steps you have:
+
+- Every new file opening with a preamble that states its purpose and key decisions
+- Function and type comments that explain reasoning rather than restating signatures
+- Code ordered for human understanding rather than compiler convention
+- Inline comments that explain why, not what
+- Red flag checks embedded in your commit workflow
+- A HARNESS.md convention that makes the discipline visible to the whole team


### PR DESCRIPTION
## Summary

Every skill in the plugin now has a corresponding practical how-to guide:

- **5 stubs filled**: add a constraint, add fitness functions, run a harness audit, set up auto-enforcer, sync conventions
- **16 new guides**: run an assessment, extract conventions, set up context engineering, review code with CUPID, audit dependencies, audit Docker images, harden GitHub Actions, set up garbage collection, write literate code, set up verification slots, set up model routing, run portfolio assessment, generate improvement plan, orchestrate across repos, create team API, understand harness engineering
- **Total**: 23 how-to guides (was 2 complete + 5 stubs)
- All guides follow the existing style (numbered steps, code blocks, direct tone)
- All pass markdownlint with 0 errors

## Test plan

- [ ] Verify 23 how-to files exist in docs/how-to/ (excluding index.md)
- [ ] Verify no "Coming Soon" stubs remain
- [ ] Verify all guides have correct Jekyll frontmatter
- [ ] Verify markdownlint passes on all files