### PR TITLE
Add complete tutorial set (v0.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.2 — 2026-04-09
+
+### Complete Tutorial Set
+
+- Fill 2 tutorial stubs: Harness for an Existing Codebase, Creating
+  Your First Skill
+- Add 3 new tutorials: Your First Assessment, From Assessment to
+  Dashboard, The Improvement Cycle
+- Total: 6 tutorials covering the full journey from setup through
+  measurement, scaling, and improvement
+
 ## 0.8.1 — 2026-04-09
 
 ### Complete How-To Guides

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-23-2E8B57?style=flat-square)](#skills-23)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-14-2E8B57?style=flat-square)](#commands-14)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/docs/tutorials/from-assessment-to-dashboard.md
+++ b/docs/tutorials/from-assessment-to-dashboard.md
@@ -1,0 +1,467 @@
+---
+title: From Assessment to Dashboard
+layout: default
+parent: Tutorials
+nav_order: 5
+---
+
+# From Assessment to Dashboard
+
+This tutorial walks you through running a portfolio assessment across
+multiple repositories and generating a shareable HTML dashboard from
+the results. By the end you will have a self-contained dashboard file
+that shows AI literacy levels, shared gaps, and improvement priorities
+across your whole organisation — shareable by email, Slack, or GitHub
+Pages.
+
+Plan for about thirty minutes, including time to work through the
+discovery conversation and review the dashboard output.
+
+---
+
+## Prerequisites
+
+You need:
+
+- Claude Code with the ai-literacy-superpowers plugin installed
+- Two or more repositories to assess
+- At least one of those repositories already assessed with `/assess`
+  (this gives you full discipline scores rather than estimates)
+- The GitHub CLI (`gh`) if you want to discover repos by organisation
+  or topic tag — optional if you are scanning a local directory
+
+If you haven't run a single-repo assessment yet, follow the
+[Getting Started](getting-started) tutorial first to install the
+plugin and run `/harness-init`, then use `/assess` to get an
+assessment document in at least one repo before continuing here.
+
+---
+
+## Step 1: Choose a Discovery Mode
+
+The `/portfolio-assess` command needs to know which repositories to
+include. It supports three discovery modes, and you can combine them.
+
+### Local mode
+
+If your repositories are all cloned on your machine under a shared
+parent directory:
+
+```text
+/portfolio-assess --local ~/code/myorg/
+```
+
+The command scans every subdirectory under that path that contains a
+`.git` directory. This is the fastest option — no network calls, no
+authentication required.
+
+### GitHub organisation mode
+
+If your repositories live in a GitHub organisation and you have the
+GitHub CLI authenticated:
+
+```text
+/portfolio-assess --org my-github-org
+```
+
+The command calls `gh repo list` to enumerate up to 200 repositories
+in the organisation. Useful when you don't have all repos cloned
+locally.
+
+### GitHub topic mode
+
+If your organisation uses topic tags to mark which repositories are
+AI-literacy-tracked:
+
+```text
+/portfolio-assess --topic ai-literacy
+```
+
+Or combine with `--org` to scope to one organisation:
+
+```text
+/portfolio-assess --org my-github-org --topic ai-literacy
+```
+
+### Combining modes
+
+Local repos take precedence when modes are combined — already-cloned
+repos are not re-fetched from GitHub. Duplicates are removed by repo
+name.
+
+For this tutorial, pick the mode that matches your setup. If you're
+not sure, start with `--local` pointed at the directory where you keep
+your projects.
+
+---
+
+## Step 2: Run `/portfolio-assess`
+
+Open Claude Code in the repo where you want the portfolio output
+written — typically a platform repo or a dedicated `assessments` repo.
+Then run the command with your chosen mode:
+
+```text
+/portfolio-assess --local ~/code/myorg/
+```
+
+The command works in three phases, reporting progress as it goes.
+
+### Discovery
+
+```text
+Discovered 8 repos:
+  Local: 8 (from ~/code/myorg/)
+  Total after deduplication: 8
+```
+
+If you see fewer repos than expected, check that each one has a `.git`
+directory at its root. Subdirectories of monorepos are not counted as
+separate repos.
+
+### Gathering assessments
+
+The command checks each repo for an existing `assessments/` directory
+and reads the most recent assessment file it finds:
+
+```text
+Gathering assessments...
+  api-gateway:       L3 (assessed 2026-04-01)
+  billing-service:   L2 (assessed 2026-03-15)
+  auth-service:      L2 (assessed 2026-02-28)
+  frontend:          L1 (estimated — no prior assessment)
+  legacy-payments:   L1 (estimated — no prior assessment)
+  data-pipeline:     L2 (assessed 2026-03-20)
+  infra-modules:     L1 (estimated — no prior assessment)
+  docs-site:         L0 (estimated — no prior assessment)
+```
+
+Repos marked `estimated` were scanned for observable evidence
+(CI workflows, CLAUDE.md, HARNESS.md, test configuration) and given
+an estimated level. Estimates lack discipline scores, so they appear
+in the dashboard with lower confidence than fully assessed repos.
+
+To get full scores for estimated repos, run `/assess` in each one
+before re-running the portfolio command. For now, continue with the
+mix — the dashboard distinguishes assessed from estimated.
+
+If you want to skip estimated repos entirely, add
+`--no-scan-unassessed` to the command. Those repos appear as "not
+assessed" in the output.
+
+### Completion summary
+
+```text
+Portfolio assessment complete.
+
+  Repos: 8 total (4 assessed, 4 estimated, 0 not assessed)
+  Median level: L2
+  Shared gaps: 3 (affecting 3+ repos)
+  Stale assessments: 1 (older than 90 days)
+  Organisation-wide improvements: 2
+  Document: assessments/2026-04-08-portfolio-assessment.md
+```
+
+---
+
+## Step 3: Understand the Portfolio Assessment Document
+
+Open the file the command just wrote:
+
+```bash
+open assessments/2026-04-08-portfolio-assessment.md
+```
+
+The document has four key sections you will use to understand where
+the organisation stands.
+
+### Level distribution
+
+A table showing how many repos are at each level, split by confidence:
+
+```text
+| Level | Assessed | Estimated | Total |
+|-------|----------|-----------|-------|
+| L0    | 0        | 1         | 1     |
+| L1    | 0        | 3         | 3     |
+| L2    | 3        | 0         | 3     |
+| L3    | 1        | 0         | 1     |
+| L4    | 0        | 0         | 0     |
+| L5    | 0        | 0         | 0     |
+
+Portfolio median: L2
+Assessment coverage: 50% (4/8 repos fully assessed)
+```
+
+The median level is the single most useful number for an organisation.
+A median of L2 means most teams have systematic verification in place
+but haven't yet invested in habitat engineering — CLAUDE.md, harness
+constraints, and custom skills are the next frontier.
+
+### Repo table
+
+Each repo as a row with level, discipline scores (where available),
+last assessed date, and a note for stale assessments:
+
+```text
+| Repo             | Level | Context | Constraints | Guardrails | Assessed     |
+|------------------|-------|---------|-------------|------------|--------------|
+| api-gateway      | L3    | 4/5     | 3/5         | 4/5        | 2026-04-01   |
+| billing-service  | L2    | 3/5     | 2/5         | 3/5        | 2026-03-15   |
+| auth-service     | L2    | 2/5     | 2/5         | 2/5        | 2026-02-28 ⚠ |
+| data-pipeline    | L2    | 3/5     | 3/5         | 2/5        | 2026-03-20   |
+| frontend         | L1    | —       | —           | —          | estimated    |
+| legacy-payments  | L1    | —       | —           | —          | estimated    |
+| infra-modules    | L1    | —       | —           | —          | estimated    |
+| docs-site        | L0    | —       | —           | —          | estimated    |
+```
+
+The warning flag on `auth-service` indicates a stale assessment
+(older than 90 days). Its data is less reliable for decisions.
+
+### Shared gaps
+
+Gaps that appear in three or more repos are organisational problems,
+not individual repo problems. Fixing them once — through a shared CI
+template, a skill library, or a team-wide cadence — lifts multiple
+repos at the same time:
+
+```text
+Shared gaps (affecting 3+ repos):
+
+1. No HARNESS.md or equivalent context file
+   Repos affected: 6 (all estimated + auth-service, billing-service)
+   Recommended action: /harness-init (run in each affected repo)
+   Organisation-wide impact: High — HARNESS.md is the L3 foundation
+
+2. No secret scanning
+   Repos affected: 5
+   Recommended action: /harness-constrain (add gitleaks constraint)
+
+3. Tests not enforced in CI
+   Repos affected: 4 (estimated repos)
+   Recommended action: Add test step to CI workflow
+```
+
+### Improvement plan
+
+The plan is grouped by impact scope:
+
+**Organisation-wide (50%+ of repos):** One action lifts many repos.
+These are your highest-leverage investments. In this example, rolling
+out HARNESS.md through a shared template would move six repos toward L3
+at once.
+
+**Cluster (2-4 related repos):** Share a specific tool or constraint
+pattern across a small group of related repos.
+
+**Individual:** Unique to one repo. The plan defers these to each
+repo's own assessment improvement plan.
+
+---
+
+## Step 4: Generate the HTML Dashboard
+
+Now convert the portfolio assessment into a shareable dashboard. Ask
+Claude Code directly:
+
+```text
+Read all portfolio assessment files in assessments/ (matching
+*-portfolio-assessment.md) and generate a self-contained HTML
+dashboard (inline CSS, no external dependencies) that visualises:
+
+1. Summary header — portfolio name, date, repo count, median level
+2. Level distribution — colour-coded showing how many repos at each
+   level (L0 grey, L1 light blue, L2 blue, L3 teal, L4 green, L5 gold)
+3. Repo table — each repo with level, confidence, discipline scores,
+   last assessed date. Colour-code the level cells.
+4. Shared gaps — table of gaps affecting 3+ repos with repo count
+   and recommended action
+5. Improvement plan — organisation-wide actions first, then cluster,
+   then individual
+
+Save to assessments/portfolio-dashboard.html
+```
+
+The `portfolio-dashboard` skill handles this end to end. Claude reads
+every file matching `*-portfolio-assessment.md` in the `assessments/`
+directory, parses the data, and produces the dashboard. When it
+finishes:
+
+```text
+Dashboard generated: assessments/portfolio-dashboard.html
+
+  Repos: 8 (4 assessed, 4 estimated, 0 not assessed)
+  Median level: L2
+  Trend data: 1 quarterly assessment (no trend yet)
+  Shared gaps: 3
+
+Open with: open assessments/portfolio-dashboard.html
+```
+
+---
+
+## Step 5: Review the Dashboard Panels
+
+Open the dashboard:
+
+```bash
+open assessments/portfolio-dashboard.html
+```
+
+The dashboard has six panels.
+
+**Summary header.** Portfolio name (derived from your discovery
+source), date, total repos, and median level shown prominently. This
+is the one-line answer to "where are we?"
+
+**Level distribution.** A colour-coded bar or grid showing the count
+of repos at each level. Grey for L0, light blue for L1, blue for L2,
+teal for L3, green for L4, gold for L5. Estimated repos are shown
+with a lighter tint to distinguish them from fully assessed ones.
+
+**Trends.** With only one assessment file, this section reads "no
+trend data yet." After you run a second quarterly assessment and
+regenerate the dashboard, it will show a median level trend line,
+the count of repos at L3+ over time, and per-repo level trajectories.
+This is the panel that makes the quarterly cadence worth maintaining.
+
+**Repo table.** Each repo as a row. Level cells are colour-coded.
+Discipline score columns (context, constraints, guardrails) show
+numerical scores for assessed repos and "—" for estimated ones. A
+warning icon marks stale assessments.
+
+**Shared gaps.** The same gap table from the assessment document, now
+formatted as a clickable reference. Each row shows the gap, the number
+of repos affected, and the recommended command or action.
+
+**Improvement plan.** Organisation-wide items first, in a highlighted
+section. Cluster and individual items follow. The grouping makes it
+easy to see which actions to prioritise when planning a quarterly
+improvement sprint.
+
+---
+
+## Step 6: Customise the Dashboard
+
+The dashboard is a generated HTML file — ask Claude to refine it after
+generation. Each refinement is a follow-up prompt. Common requests:
+
+**Filter to a subset of repos:**
+
+```text
+Rewrite the dashboard to only include repos tagged `backend`
+```
+
+**Highlight repos below a threshold:**
+
+```text
+Add red highlighting to any repo in the table that is below L2
+```
+
+**Add dark mode:**
+
+```text
+Add a dark mode toggle button to the dashboard
+```
+
+**Make the table sortable:**
+
+```text
+Make the repo table sortable by clicking any column header
+```
+
+**Collapse the improvement plan:**
+
+```text
+Make the improvement plan an expandable section — collapsed by default
+```
+
+All customisations stay self-contained. The skill's design constraint
+is no external dependencies — no CDN links, no npm packages, no build
+step. Basic interactivity (sort, collapse, toggle) is achievable with
+a small amount of inline JavaScript.
+
+---
+
+## Step 7: Share the Dashboard
+
+You have four options depending on your audience.
+
+**Open locally.** The file opens in any browser with no setup:
+
+```bash
+open assessments/portfolio-dashboard.html
+```
+
+**Commit to the repo.** The dashboard lives alongside the assessment
+data, versioned in git. Anyone with access to the repo can open it:
+
+```bash
+git add assessments/portfolio-dashboard.html assessments/2026-04-08-portfolio-assessment.md
+git commit -m "Add Q2 2026 portfolio assessment and dashboard"
+git push
+```
+
+**GitHub Pages.** If the portfolio repo has Pages enabled, the
+dashboard is automatically hosted at a URL and accessible to anyone
+you share the link with — no authentication required.
+
+**Email or Slack.** Attach `portfolio-dashboard.html` as a file. No
+dependencies means it renders correctly on any machine without setup.
+The self-contained constraint makes this option reliable.
+
+---
+
+## Step 8: Keep It Current
+
+The trend panel is what makes the quarterly cadence valuable. Each
+time you run `/portfolio-assess` and regenerate the dashboard, the
+historical data grows and the trend lines become meaningful.
+
+The workflow is:
+
+1. Run `/portfolio-assess` with the same flags (quarterly)
+2. Regenerate the dashboard with the same prompt (or save the prompt
+   as a custom command for convenience)
+3. Commit both the new assessment file and the updated dashboard
+4. Share the updated dashboard
+
+After a year of quarterly assessments you will have four data points.
+The trend panel will show whether shared gaps are closing, whether
+the median level is rising, and which repos are improving fastest.
+This is the evidence that turns AI literacy work from an assertion
+into a measurable outcome.
+
+{: .note }
+> **Stale assessments.** Repos whose most recent assessment is older
+> than 90 days are flagged in the portfolio view. Re-run `/assess` in
+> those repos before the next portfolio run to keep the data current.
+
+---
+
+## What You Have Now
+
+After completing this tutorial you have:
+
+- A dated portfolio assessment document at
+  `assessments/YYYY-MM-DD-portfolio-assessment.md` recording the
+  current state of AI literacy across your repositories
+- A self-contained HTML dashboard at
+  `assessments/portfolio-dashboard.html` ready to share
+- A list of shared gaps and an improvement plan grouped by
+  organisational impact
+- A quarterly regeneration workflow that adds trend data over time
+
+---
+
+## Next Steps
+
+- [The Improvement Cycle](the-improvement-cycle) — walk one repo from
+  L2 to L3 using the assessment's improvement plan
+- [How-to: Run a Portfolio Assessment](../how-to/run-portfolio-assessment)
+  — flags, options, and edge cases for the `/portfolio-assess` command
+- [How-to: Build a Portfolio Dashboard](../how-to/build-portfolio-dashboard)
+  — prompt variations and customisation recipes for the dashboard
+- [Reference: Commands](../reference/commands) — full specification for
+  `/portfolio-assess` and related commands

--- a/docs/tutorials/harness-from-scratch.md
+++ b/docs/tutorials/harness-from-scratch.md
@@ -7,13 +7,395 @@ nav_order: 3
 
 # Harness for an Existing Codebase
 
-Most projects already have conventions — they just aren't written down or
-enforced. This tutorial covers how to retrofit a harness into a codebase
-that has an established style, existing CI, and opinions that may not match
-the plugin's defaults: how to surface what already exists, encode it faithfully
-in HARNESS.md, avoid duplicating rules that are already handled by linters
-or workflows, and promote unverified constraints to deterministic enforcement
-incrementally rather than all at once.
+Most projects already have conventions — they just aren't written down
+or enforced consistently. This tutorial covers how to retrofit a harness
+into a codebase that has an established style, existing CI, and opinions
+that may not match the plugin's defaults: how to surface what already
+exists, encode it faithfully in HARNESS.md, avoid duplicating rules
+already handled by linters or workflows, and promote unverified
+constraints to deterministic enforcement incrementally rather than
+all at once.
 
-{: .label .label-yellow }
-Coming Soon
+It takes about thirty minutes the first time through. You will end with a
+HARNESS.md that describes your project accurately, constraints that build
+on what you already have, and a clear path to promote each one when you
+are ready.
+
+---
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- Claude Code installed with the ai-literacy-superpowers plugin (see
+  [Getting Started](getting-started) if you haven't done this yet)
+- An existing project with at least some CI in place
+- A few minutes to talk through your conventions — the extraction
+  conversation is the most valuable part
+
+You do not need to clean up your codebase first. The commands work on
+real, in-progress projects.
+
+---
+
+## Step 1: Surface Tacit Knowledge with `/extract-conventions`
+
+Before touching HARNESS.md, run the convention extraction session. This
+is what separates retrofitting from guessing — it ensures the harness
+reflects what your team actually does, not what a template assumes.
+
+```text
+/extract-conventions
+```
+
+The command checks that CLAUDE.md and HARNESS.md exist. If either is
+missing, it will tell you what to run first. If this is a net-new setup,
+run `/harness-init` first to create the skeleton, then come back here.
+
+Once the session starts, you will see:
+
+```text
+## Convention Extraction
+
+I'll ask five questions to surface your team's tacit conventions.
+For each answer, I'll categorise it as:
+
+- **Constraint** (must-follow) → goes in HARNESS.md
+- **Convention** (should-follow) → goes in CLAUDE.md
+- **Style preference** (nice-to-have) → goes in CLAUDE.md
+- **Not encodable yet** → needs decomposition before encoding
+
+Take your time — the conversation matters as much as the output.
+```
+
+The five questions are:
+
+1. **Architecture** — What decisions should never be left to individual
+   judgment? Dependency direction, module boundaries, API rules.
+2. **AI corrections** — Which conventions do you keep fixing in
+   AI-generated code? These are your highest-value items.
+3. **Security instincts** — What security checks do senior engineers
+   apply automatically?
+4. **Review rejections** — What triggers an immediate rejection in code
+   review?
+5. **Refactoring philosophy** — Where is the line between helpful
+   abstraction and unnecessary complexity?
+
+Answer concretely. After each answer the agent restates it, asks one
+follow-up to sharpen the wording, and proposes a category. You confirm
+before it writes anything.
+
+{: .note }
+> **"It depends" is a signal, not a failure.** If an answer keeps landing
+> on "it depends on context," that convention needs decomposition into
+> specific, observable cases before it can be encoded. The agent will
+> flag these as "not encodable yet" — that is useful information, not
+> a problem to solve today.
+
+At the end, the agent compiles everything and presents a summary before
+writing:
+
+```text
+## Proposed Additions
+
+### HARNESS.md Constraints (must-follow)
+
+1. No imports from api/ into domain/ — dependency direction rule
+2. All returned errors must be wrapped with context
+
+### CLAUDE.md Conventions (should-follow)
+
+1. Variables must be 3+ characters except i, j, k, err
+2. Functions must not exceed 40 lines
+
+### Not Encodable Yet (needs decomposition)
+
+1. "Write clean code" — needs decomposition into observable properties
+```
+
+Confirm, and the agent appends the conventions to CLAUDE.md and adds the
+constraints to HARNESS.md as `unverified` — declared but not yet
+automated. You will promote them in later steps.
+
+---
+
+## Step 2: Run `/harness-init` with Selective Features
+
+Now run the initialiser. Because you already have CI and linters, you
+will be selective about what to configure:
+
+```text
+/harness-init
+```
+
+The `harness-discoverer` agent scans the project first. You will see
+output like:
+
+```text
+Discovery complete. Here's what your project already has:
+
+Stack
+  Primary language: Go
+  Build system: make / go build
+  Test framework: go test
+  CI: GitHub Actions (.github/workflows/ci.yml)
+
+Existing enforcement
+  golangci-lint configured (.golangci.yml)
+  go vet in CI
+  No pre-commit hooks detected
+  No secret scanner detected
+
+Convention documentation
+  README.md (found)
+  CLAUDE.md (found — 47 lines)
+  HARNESS.md (found — constraints: 2 unverified)
+```
+
+The discovery report surfaces what is already enforced. This matters for
+the next step.
+
+After discovery, you will see the feature selection menu:
+
+```text
+Which harness features would you like to configure?
+
+  [x] Context engineering     — stack declaration + conventions
+  [x] Architectural constraints — enforcement rules + secret detection
+  [x] Garbage collection      — periodic entropy checks
+  [ ] CI configuration        — GitHub Actions workflow + auto-enforcer
+  [x] Observability           — README badge + status section
+```
+
+Notice that CI configuration is deselected here. If your project already
+has a working CI pipeline, you will wire harness constraints into it
+manually rather than generating a new workflow. Check the box only if you
+want the plugin to generate a separate harness workflow file alongside
+your existing one.
+
+Deselect any features you already have covered. You can always re-run
+`/harness-init` later to add what you skipped.
+
+---
+
+## Step 3: Review What Was Generated
+
+Open `HARNESS.md`. Pay attention to the Constraints section — this is
+where the work of avoiding duplication happens.
+
+You will see entries like:
+
+```markdown
+## Constraints
+
+### Consistent formatting
+
+- **Rule**: All source files must pass gofmt without changes
+- **Enforcement**: deterministic
+- **Tool**: gofmt -l .
+- **Scope**: commit
+
+### No secrets in source
+
+- **Rule**: No API keys, tokens, passwords, or private keys in source
+- **Enforcement**: unverified
+- **Tool**: none yet
+- **Scope**: commit
+
+### No imports from api/ into domain/
+
+- **Rule**: The domain layer must not import from the api layer
+- **Enforcement**: unverified
+- **Tool**: none yet
+- **Scope**: pr
+```
+
+Now compare this against what your CI already enforces. Look at
+`.github/workflows/ci.yml` (or whichever CI file you have). For each
+constraint in HARNESS.md, ask: is this already checked?
+
+---
+
+## Step 4: Avoid Duplication — Map Existing Enforcement
+
+The key discipline when retrofitting is not re-declaring what tools
+already enforce. Duplication creates two sources of truth for the same
+rule, which drift and contradict each other.
+
+For each HARNESS.md constraint, decide which bucket it falls into:
+
+**Already enforced deterministically**: your linter, formatter, or CI
+job catches this mechanically. For example, if `golangci-lint` already
+enforces function length, do not add a harness constraint for function
+length. Set the existing constraint to `deterministic` and record the
+tool that runs it — the harness is documenting reality, not creating
+new enforcement.
+
+**Enforced, but not by a deterministic tool**: architectural rules, doc
+comment quality, naming conventions. A linter might catch some of these,
+but the rule requires judgment. These are candidates for `agent`
+enforcement.
+
+**Declared but not enforced**: conventions your team follows but no tool
+checks. These start as `unverified` and get promoted over time.
+
+Update each constraint's enforcement field to reflect reality:
+
+```markdown
+### Consistent formatting
+
+- **Rule**: All source files must pass gofmt without changes
+- **Enforcement**: deterministic
+- **Tool**: gofmt -l .
+- **Scope**: commit
+```
+
+```markdown
+### No imports from api/ into domain/
+
+- **Rule**: The domain layer must not import from the api layer
+- **Enforcement**: agent
+- **Tool**: harness-enforcer agent
+- **Scope**: pr
+```
+
+```markdown
+### No secrets in source
+
+- **Rule**: No API keys, tokens, passwords, or private keys in source
+- **Enforcement**: unverified
+- **Tool**: none yet
+- **Scope**: commit
+```
+
+{: .note }
+> **The harness does not need to own every constraint.** If golangci-lint
+> already enforces naming conventions, you can omit that constraint from
+> HARNESS.md entirely, or note it in a comment. The harness tracks what
+> matters for orientation and gap-filling — not what is already handled.
+
+---
+
+## Step 5: Promote Incrementally
+
+With your constraints categorised, start promoting them. The promotion
+ladder has three rungs:
+
+1. **Unverified** — declared intent, no automation
+2. **Agent** — LLM review against the prose rule
+3. **Deterministic** — tool-backed, exits non-zero on failure
+
+Use `/harness-constrain` to promote a constraint when you are ready:
+
+```text
+/harness-constrain
+```
+
+The command walks through each unverified constraint and asks what you
+want to do with it. For a constraint like "no secrets in source":
+
+```text
+Constraint: No secrets in source
+Current enforcement: unverified
+
+Options:
+  1. Promote to deterministic — gitleaks is not installed.
+     Install: brew install gitleaks
+     Then re-run to set enforcement to deterministic.
+
+  2. Promote to agent — the harness-enforcer agent will review
+     changes for hardcoded credentials.
+
+  3. Leave as unverified for now.
+```
+
+Start with the constraints where tooling already exists. Add `gitleaks`
+for secret detection. Use `go-cleanarch` or similar for import boundary
+rules if your language ecosystem has one. Leave complex judgment calls as
+`agent` — the harness-enforcer handles them well.
+
+Do not try to promote everything at once. An unverified constraint is
+not a failure — it is a documented intention. The goal is steady
+improvement over time, not a complete harness on day one.
+
+---
+
+## Step 6: Verify with `/harness-status`
+
+Once you have reviewed and updated HARNESS.md, run:
+
+```text
+/harness-status
+```
+
+This reads the harness and prints a summary without dispatching any
+agents:
+
+```text
+## Harness Status
+
+Last audit: 2026-04-08 (0 days ago)
+
+### Constraints: 2/4 enforced
+- Deterministic: 1 (tool-backed)
+- Agent: 1 (LLM-reviewed)
+- Unverified: 2 (declared only)
+
+### Garbage Collection: 2/2 active
+- Auto-fix enabled: 0 rules
+- Report-only: 2 rules
+
+### Drift: none detected
+
+### Next Steps
+- Run /harness-constrain to promote unverified constraints
+- Run /harness-audit for a full verification
+```
+
+The enforcement ratio (2/4 in this example) is the key number to watch.
+A ratio below 1.0 means some constraints are declared but not yet
+automated. That is expected when retrofitting — use this number as a
+target to improve over time rather than a pass/fail score.
+
+{: .note }
+> **Re-run `/harness-init` to add features later.** If you skipped CI
+> configuration this time, you can run `/harness-init` again to add it.
+> The command detects which sections are already configured and only
+> touches the sections you select.
+
+---
+
+## What You Have Now
+
+After completing this tutorial you have:
+
+- A `HARNESS.md` that describes your project accurately — conventions
+  extracted from your team's tacit knowledge, constraints that build on
+  your existing enforcement rather than duplicating it
+- A clear categorisation of every constraint: what is already enforced
+  deterministically, what needs agent review, and what is declared but
+  not yet automated
+- A promotion path — unverified constraints with a clear record of what
+  they need to become deterministic
+- A `CLAUDE.md` with conventions that any AI agent (or new team member)
+  can read to understand how your project works
+
+The harness is now a living document. Run `/harness-audit` periodically
+to check for drift between what HARNESS.md declares and what is actually
+enforced. Run `/extract-conventions` again after significant team
+changes or after a production incident reveals tacit knowledge that was
+not encoded.
+
+---
+
+## Next Steps
+
+- [How-to: Set Up Secret Detection](../how-to/set-up-secret-detection) —
+  promote the "no secrets in source" constraint from unverified to
+  deterministic using gitleaks
+- [Creating Your First Skill](your-first-skill) — encode domain knowledge
+  that agents carry into every session
+- [Reference: HARNESS.md Format](../reference/harness-md-format) — full
+  specification of every field in HARNESS.md
+- [Reference: Commands](../reference/commands) — full specification for
+  `/harness-constrain`, `/harness-audit`, and `/harness-gc`

--- a/docs/tutorials/the-improvement-cycle.md
+++ b/docs/tutorials/the-improvement-cycle.md
@@ -1,0 +1,555 @@
+---
+title: The Improvement Cycle
+layout: default
+parent: Tutorials
+nav_order: 6
+---
+
+# The Improvement Cycle
+
+This tutorial walks you through one complete improvement cycle: a
+project assessed at Level 2 that you will take to Level 3 using the
+assessment's improvement plan, then verify with a re-assessment.
+
+Level 2 (Verification) means a project has automated tests, CI, and
+systematic verification of AI output — but hasn't yet invested in
+habitat engineering. Level 3 (Habitat Engineering) is the jump from
+checking output to shaping input: you give AI agents the context,
+constraints, and memory they need to work reliably without constant
+correction.
+
+Plan for thirty to forty-five minutes the first time through. The
+cycle gets faster once the commands are familiar.
+
+---
+
+## Starting Point
+
+Your project has:
+
+- A CI workflow that runs tests
+- A passing test suite
+- Possibly some vulnerability scanning
+- No `CLAUDE.md` (no context file for AI agents)
+- No `HARNESS.md` (no declared constraints or enforcement)
+- No `REFLECTION_LOG.md` (no captured learning)
+
+This is a typical L2 project: the verification infrastructure exists,
+but the habitat is empty. AI agents working in this repo have no
+project-specific context — they operate on generic knowledge and
+whatever they can infer from the code.
+
+---
+
+## Step 1: Run `/assess`
+
+Open Claude Code in your project directory and run:
+
+```text
+/assess
+```
+
+The assessment runs in phases and takes about ten minutes.
+
+### Phase 1: Observable evidence
+
+The command scans your repository for signals at each framework level.
+It checks for CI workflows, test coverage enforcement, vulnerability
+scanning, `CLAUDE.md`, `HARNESS.md`, custom skills and agents,
+specification files, and more. This takes a few seconds:
+
+```text
+Scanning repository for observable evidence...
+
+Level 2 signals found:
+  CI workflow:        .github/workflows/ci.yml ✓
+  Test framework:     Jest (package.json) ✓
+  Test enforcement:   npm test in CI ✓
+
+Level 3 signals — not found:
+  CLAUDE.md:          missing
+  HARNESS.md:         missing
+  Custom skills:      none
+  REFLECTION_LOG.md:  missing
+  Hooks config:       missing
+
+Level 4+ signals — not found
+```
+
+### Phase 2: Clarifying questions
+
+The command asks three to five questions to fill gaps that the scan
+cannot answer — things like whether you verify AI output systematically
+or whether the team has shared AI conventions. Answer these concretely.
+
+```text
+Question 1/4:
+Do you verify AI-generated code before committing, or do you commit
+if it looks right at a glance?
+
+→ We run the tests, but no more than that.
+
+Question 2/4:
+Does your team have any shared conventions for how to prompt or work
+with AI tools, or does each developer do it differently?
+
+→ No shared conventions. Everyone works differently.
+```
+
+### Phase 3: Level assessment
+
+After the questions, the command applies the scoring heuristic. The
+assessed level is the highest level where you have substantial evidence
+across all three disciplines: context engineering, architectural
+constraints, and guardrail design. The weakest discipline sets the
+ceiling.
+
+```text
+Assessment summary:
+
+  Primary level:     L2 — Verification
+  Context eng.:      L2 (tests in CI, no context file)
+  Constraints:       L1 (no declared constraints)
+  Guardrails:        L2 (CI gates, no agent constraints)
+
+  Rationale: Tests are running in CI and AI output is verified,
+  but there is no context file for AI agents and no declared
+  constraints. Constraints are the weakest discipline at L1.
+
+  Assessed level: L2
+```
+
+### Phase 4: Assessment document
+
+The command writes a timestamped document to
+`assessments/YYYY-MM-DD-assessment.md` with the full evidence list,
+discipline scores, strengths, gaps, and recommendations. This document
+drives the improvement plan.
+
+{: .note }
+> **Immediate adjustments.** After producing the assessment document,
+> the command identifies habitat hygiene fixes it can apply right now
+> without requiring discussion — updating a stale badge count, adding
+> a missing entry to AGENTS.md. Review and accept or reject each one.
+> These are small fixes, not the improvement plan.
+
+---
+
+## Step 2: Review the Gaps
+
+After the immediate adjustments, the command shows you the gaps it
+identified — what's missing for the next level:
+
+```text
+Gaps (what's needed for Level 3):
+
+  1. No CLAUDE.md — agents have no project context
+  2. No HARNESS.md — no declared constraints or enforcement
+  3. No REFLECTION_LOG.md — no captured learning from sessions
+  4. No harness constraints enforced in CI
+```
+
+Read through these. They are the raw input for the improvement plan.
+
+The gaps also appear in section 7 of the assessment document, where
+they are paired with specific recommendations — the commands and skills
+that address each gap.
+
+---
+
+## Step 3: Choose Target Level
+
+After the workflow operation recommendations (things you can do
+differently with what you already have), the assessment invokes the
+improvement plan. It first asks where you want to go:
+
+```text
+You're currently at Level 2 (Verification).
+
+How far would you like to improve?
+
+1. Level 3 — Habitat Engineering (recommended next step)
+2. Level 4 — Specification Architecture
+3. Level 5 — Sovereign Engineering
+```
+
+Choose Level 3. The plan generates improvements for the L2→L3
+transition only. If you had chosen L4, the plan would include L2→L3
+improvements first, then L3→L4 — higher targets include all
+intermediate steps.
+
+The plan then checks which L3 items are already closed. In our
+starting project, none are:
+
+```text
+Generating improvement plan for L2 → L3...
+
+Checking existing state:
+  CLAUDE.md:         missing — gap open
+  HARNESS.md:        missing — gap open
+  REFLECTION_LOG.md: missing — gap open
+  Hooks config:      missing — gap open
+  CI enforcement:    not configured — gap open
+
+Plan: 4 items (1 high, 2 medium, 1 low)
+```
+
+---
+
+## Step 4: Walk Through the Improvement Plan
+
+The plan presents one item at a time. You choose Accept, Skip, or
+Defer for each.
+
+**Accept** runs the command or skill immediately and waits for it to
+finish before moving on.
+
+**Skip** removes the item from this session and does not record it for
+later.
+
+**Defer** keeps the item in the plan but does not execute it now. It
+appears in the next assessment's improvement plan as a carried-forward
+item.
+
+### Item 1: Run `/harness-init` (High priority)
+
+```text
+Improvement 1/4 (Level 2 → Level 3):
+  Gap:      No CLAUDE.md or HARNESS.md — agents have no context or
+            constraints
+  Action:   Run /harness-init
+  Priority: High — foundational. HARNESS.md is the L3 prerequisite.
+            Nothing else at this level works without it.
+
+  Accept / Skip / Defer?
+```
+
+Accept this one. `/harness-init` runs immediately — it discovers your
+stack, walks you through a short convention interview, and generates
+`HARNESS.md` and `CLAUDE.md`.
+
+The discovery phase shows what the agent found:
+
+```text
+Scanning project structure...
+
+Stack
+  Primary language: TypeScript
+  Build system:     npm / tsc
+  Test framework:   Jest
+  CI:               GitHub Actions (.github/workflows/ci.yml)
+
+Existing enforcement
+  Prettier configured (.prettierrc)
+  ESLint configured (.eslintrc.json)
+  No pre-commit hooks detected
+  No secret scanner detected
+
+Convention documentation
+  README.md (found)
+  No CLAUDE.md detected
+```
+
+The convention interview covers naming conventions, file structure,
+error handling, and documentation standards — one topic at a time.
+Answer specifically. The more concrete your answers, the more useful
+`HARNESS.md` will be to agents.
+
+After the interview, `HARNESS.md` is generated with your conventions
+and initial constraints, `CLAUDE.md` is created with your stack
+context, and a CI workflow is updated. The command commits both files.
+
+Once `/harness-init` finishes, the improvement plan resumes with item 2.
+
+### Item 2: Run `/harness-constrain` to promote a constraint (Medium priority)
+
+```text
+Improvement 2/4 (Level 2 → Level 3):
+  Gap:      No secrets constraint — risk of accidental credential
+            exposure in commits
+  Action:   Run /harness-constrain to add a secret-scanning constraint
+  Priority: Medium — closes a real security gap independently
+
+  Accept / Skip / Defer?
+```
+
+Accept this one too. `/harness-constrain` asks what you want to
+enforce, checks whether a tool is available (it looks for `gitleaks`),
+and adds a constraint to `HARNESS.md`:
+
+```text
+Adding constraint: No secrets in source
+
+gitleaks found at /usr/local/bin/gitleaks.
+
+Constraint:
+  Rule:        No API keys, tokens, passwords, or private keys in
+               committed source files
+  Enforcement: deterministic
+  Tool:        gitleaks detect --source . --no-banner --exit-code 1
+  Scope:       commit
+
+Add this constraint? [Y/n]
+```
+
+Accept. The constraint is added to `HARNESS.md` and the enforcement
+ratio updates. If gitleaks isn't installed, the constraint is added as
+`unverified` — declared but not yet automated — with the install
+command shown.
+
+### Item 3: Run `/reflect` to capture the first reflection (Medium priority)
+
+```text
+Improvement 3/4 (Level 2 → Level 3):
+  Gap:      No REFLECTION_LOG.md — learning from AI sessions is lost
+  Action:   Run /reflect to capture the first reflection entry
+  Priority: Medium — starts the learning loop that compounds over time
+
+  Accept / Skip / Defer?
+```
+
+Accept. `/reflect` asks you three questions:
+
+```text
+What was just worked on?
+→ Set up the project harness and ran the first AI literacy assessment.
+
+What was surprising or unexpected?
+→ The test coverage threshold was configured in package.json but not
+  enforced in CI — we thought it was running.
+
+What should future agents know about this area of the codebase?
+→ Coverage enforcement is handled by the Jest config, not a separate
+  tool. The CI step is "npm test", which runs Jest with coverage.
+```
+
+After you answer, `/reflect` classifies the signal type — in this
+case, the coverage gap is a `failure` signal — and proposes a
+constraint:
+
+```text
+Signal: failure — the coverage threshold existed but wasn't running.
+This is a preventable check that should have caught the gap.
+
+Proposed constraint:
+  Rule:        Test coverage must meet the threshold defined in
+               package.json before merging
+  Enforcement: deterministic
+  Tool:        npm test (Jest --coverage with threshold)
+  Scope:       pr
+
+Add this constraint? [Y/n]
+```
+
+Accept. The reflection entry is appended to `REFLECTION_LOG.md` and
+the new constraint is added to `HARNESS.md`. The enforcement ratio
+increases again.
+
+### Item 4: Add hooks configuration (Low priority)
+
+```text
+Improvement 4/4 (Level 2 → Level 3):
+  Gap:      No hooks configuration — commit-time constraints run
+            in CI but not locally
+  Action:   Configure pre-commit hooks via harness-engineering skill
+  Priority: Low — useful but not blocking. CI enforcement exists.
+
+  Accept / Skip / Defer?
+```
+
+Defer this one. You've already closed the most important gaps. Hooks
+are a refinement that makes the developer experience faster (local
+feedback instead of CI feedback), but the constraints are enforced
+either way. You'll revisit this next quarter.
+
+The plan records the deferred item and moves on.
+
+---
+
+## Step 5: Verify the New Harness
+
+After the improvement plan completes, check what was built:
+
+```text
+/harness-status
+```
+
+Output:
+
+```text
+## Harness Status
+
+Last audit: 2026-04-08 (0 days ago)
+
+### Constraints: 3/3 enforced
+- Deterministic: 3 (tool-backed)
+  • Consistent formatting (Prettier, commit scope)
+  • No secrets in source (gitleaks, commit scope)
+  • Tests must pass with coverage threshold (Jest, pr scope)
+- Agent:       0
+- Unverified:  0
+
+### Garbage Collection: 1/1 active
+- Documentation freshness (weekly, agent)
+
+### Drift: none detected
+
+### Next Steps
+- Run /harness-constrain to add or promote constraints
+- Run /harness-audit for a full verification
+```
+
+All three constraints are enforced. The enforcement ratio is 3/3 —
+every declared constraint is backed by a tool. This is the L3 target
+state for constraints.
+
+Open `HARNESS.md` to see the full picture: the Context section
+records your conventions, the Constraints section shows the three
+enforcement rules with their tools and scopes, and the Garbage
+Collection section shows the weekly documentation freshness check.
+
+---
+
+## Step 6: Re-assess
+
+Now re-run the assessment to see whether the improvements moved the
+level:
+
+```text
+/assess
+```
+
+The scan finds the new files:
+
+```text
+Scanning repository for observable evidence...
+
+Level 2 signals found:
+  CI workflow:        .github/workflows/ci.yml ✓
+  Test framework:     Jest (package.json) ✓
+  Test enforcement:   npm test in CI ✓
+
+Level 3 signals found:
+  CLAUDE.md:          ✓
+  HARNESS.md:         ✓ (3 constraints, 3 enforced)
+  REFLECTION_LOG.md:  ✓ (1 entry)
+  Custom agents/skills: none
+```
+
+The clarifying questions this time focus on how the new constraints
+are actually used — are pre-commit hooks running, is the coverage
+threshold being checked, are agents reading CLAUDE.md at session
+start? Answer based on what you've observed so far.
+
+The assessment result:
+
+```text
+Assessment summary:
+
+  Primary level:     L3 — Habitat Engineering
+  Context eng.:      L3 (CLAUDE.md with conventions)
+  Constraints:       L3 (HARNESS.md, 3/3 enforced)
+  Guardrails:        L2 (CI gates, no agent-level constraints yet)
+
+  Rationale: CLAUDE.md provides project context, HARNESS.md declares
+  three enforced constraints. Guardrails are still at L2 — the
+  harness enforces formatting, secrets, and test coverage but does
+  not yet include agent-specific safety gates. Weakest discipline
+  is Guardrails at L2, but L3 requires substantial evidence across
+  all three disciplines — context and constraints meet the bar, and
+  L2 guardrails are sufficient for L3.
+
+  Assessed level: L3
+```
+
+The README badge updates automatically:
+
+```text
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_3-20B2AA?style=flat-square)](assessments/2026-04-08-assessment.md)
+```
+
+---
+
+## Step 7: The Compound Effect
+
+Take stock of what changed in this session:
+
+**Before:** A project with CI and tests but no context for AI agents.
+Every session started from scratch — agents read the code but had no
+conventions, no constraints, no captured learning.
+
+**After:**
+
+- `CLAUDE.md` gives agents your naming conventions, file structure
+  rules, and error handling patterns before they write a single line
+- `HARNESS.md` declares three enforced constraints — formatting,
+  secrets, and coverage — backed by tools that run at commit and PR
+  time
+- `REFLECTION_LOG.md` has the first entry, with a constraint derived
+  from a real gap the assessment surfaced
+
+The compound effect is that each improvement makes the next one
+faster. Agents reading `CLAUDE.md` need fewer corrections. Constraints
+catching issues automatically free up review time. Reflections
+accumulate domain knowledge that would otherwise be re-discovered in
+each session.
+
+The next cycle — typically in three months — will start from L3 and
+target L4 (Specification Architecture). The gaps for L4 are different:
+specification files before code, an agent pipeline with a safety gate,
+implementation plans. The same process applies: assess, choose target,
+walk the plan, verify.
+
+---
+
+## Step 8: Schedule the Next Assessment
+
+The final summary from `/assess` includes a suggested next assessment
+date — typically three months out:
+
+```text
+Next assessment: 2026-07-08
+```
+
+Add this to your calendar or team planning tool. When the date
+arrives, running `/assess` again takes the same fifteen minutes but
+starts from a stronger baseline. The assessment finds what regressed
+(stale conventions, constraints that drifted) and what progressed
+(new skills, new agents, higher coverage).
+
+The improvement cycle is not a one-time upgrade. It is a quarterly
+practice that compounds over time — each cycle starts from where the
+last one left off, and the level reflects actual habits rather than
+aspirations.
+
+---
+
+## What You Have Now
+
+After completing this tutorial you have:
+
+- A `CLAUDE.md` that gives AI agents project context for every future
+  session
+- A `HARNESS.md` with three enforced constraints — formatting,
+  secrets, and test coverage — that run automatically at commit and
+  PR time
+- A `REFLECTION_LOG.md` with the first entry and a constraint derived
+  from a real gap
+- An AI literacy assessment document at
+  `assessments/YYYY-MM-DD-assessment.md` recording the L2→L3 journey
+- A README badge showing Level 3
+- A scheduled re-assessment three months from now
+
+---
+
+## Next Steps
+
+- [From Assessment to Dashboard](from-assessment-to-dashboard) — run
+  a portfolio assessment across multiple repos and generate a shareable
+  dashboard
+- [Getting Started](getting-started) — back to basics if you haven't
+  set up the plugin yet
+- [How-to: Add a Constraint](../how-to/add-a-constraint) — add
+  individual constraints without running the full init flow
+- [Reference: Commands](../reference/commands) — full specification for
+  `/assess`, `/harness-init`, `/reflect`, and `/harness-constrain`

--- a/docs/tutorials/your-first-assessment.md
+++ b/docs/tutorials/your-first-assessment.md
@@ -1,0 +1,339 @@
+---
+title: Your First Assessment
+layout: default
+parent: Tutorials
+nav_order: 4
+---
+
+# Your First Assessment
+
+An AI literacy assessment tells you where your team stands in its AI
+collaboration practices — not by what you intend, but by observable
+evidence in the repository combined with a short conversation. The result
+is a timestamped document, a level rating, a gap analysis, and a
+prioritised improvement plan.
+
+This tutorial walks you through running `/assess` from start to finish:
+what it scans for, what it asks, how to read the output, and how to
+act on the improvement plan it generates.
+
+It takes about thirty minutes, most of which is answering clarifying
+questions.
+
+---
+
+## Prerequisites
+
+Before running an assessment, your project should have at least some AI
+tooling in place — a CI workflow, a CLAUDE.md, some test coverage, or
+the beginnings of a harness. An assessment on a completely bare repository
+is technically valid (it will return Level 0) but not very interesting.
+
+You also need:
+
+- Claude Code installed with the ai-literacy-superpowers plugin (see
+  [Getting Started](getting-started))
+- Access to the project repository from your terminal
+
+The assessor can see everything Claude Code can see — files, CI
+configuration, directory structure. It does not need credentials or
+external access.
+
+---
+
+## Step 1: Run `/assess`
+
+Open a Claude Code session in your project directory and run:
+
+```text
+/assess
+```
+
+The assessor dispatches a scan immediately. You will not be asked
+anything yet — it gathers evidence first, then asks questions.
+
+---
+
+## Step 2: Understand the Scan Results
+
+After a few seconds, the assessor presents a structured summary of what
+it found. The output groups findings by framework level:
+
+```text
+## Repository Scan
+
+### Level 2 signals (Verification)
+  CI workflows: .github/workflows/ci.yml ✓
+  Test coverage enforcement: no threshold configured ✗
+  Vulnerability scanning: not detected ✗
+  Markdownlint: not configured ✗
+
+### Level 3 signals (Habitat Engineering)
+  CLAUDE.md: found — 52 lines ✓
+  HARNESS.md: found — 2 constraints, 1 enforced ✓
+  AGENTS.md: not found ✗
+  MODEL_ROUTING.md: not found ✗
+  Custom skills: .claude/skills/ — 1 skill ✓
+  Custom agents: not found ✗
+  Hooks: not configured ✗
+  REFLECTION_LOG.md: not found ✗
+
+### Level 4 signals (Specification Architecture)
+  Specifications directory: not found ✗
+  Implementation plans: not found ✗
+  Orchestrator with safety gates: not found ✗
+
+### Level 5 signals (Sovereign Engineering)
+  Platform tooling: not detected ✗
+  OTel configuration: not detected ✗
+```
+
+Read this list from top to bottom. Your level is determined by the
+highest level where you have substantial evidence across all three
+disciplines — context engineering, architectural constraints, and
+guardrail design. **The weakest discipline is the ceiling.**
+
+In the example above: Level 2 signals are present (CI exists) but
+coverage enforcement is missing. Level 3 signals show a CLAUDE.md and
+HARNESS.md but no AGENTS.md, hooks, or reflection log. The assessment
+will land around Level 2-3 depending on what the clarifying questions reveal.
+
+---
+
+## Step 3: Answer the Clarifying Questions
+
+After presenting the scan, the assessor asks 3-5 clarifying questions to
+fill gaps that files alone cannot answer. It asks one at a time and waits
+for each response before continuing.
+
+Typical questions:
+
+```text
+Do you write specs before code, or after — or not at all?
+```
+
+```text
+When AI generates code for this project, do you verify it
+systematically (tests, review) or trust it if it looks right?
+```
+
+```text
+Does your team have shared AI conventions, or does each developer
+work with AI in their own way?
+```
+
+```text
+Do you know roughly what your AI tools cost per month?
+```
+
+Answer honestly. The questions disambiguate between adjacent levels —
+a team that writes tests but does not check AI output systematically is
+at a different level than one that does both. The assessor is not
+grading intent; it is calibrating the evidence.
+
+---
+
+## Step 4: Read the Assessment Document
+
+After the questions, the assessor creates
+`assessments/YYYY-MM-DD-assessment.md`. Open it.
+
+The document has several sections:
+
+### Level Assessment
+
+```markdown
+## Level Assessment
+
+### Primary Level: 2 — Verification
+
+The project has CI and tests in place, and CLAUDE.md shows awareness
+of context engineering, but enforcement is thin (1 of 2 harness
+constraints enforced) and verification habits are not systematic —
+AI output is reviewed visually rather than through automated checks.
+The absence of test coverage thresholds and vulnerability scanning
+puts the ceiling at L2 despite the presence of L3 context artifacts.
+```
+
+This is the primary finding. Read the rationale — it explains not just
+the level but what is holding the project there.
+
+### Discipline Maturity
+
+```markdown
+### Discipline Maturity
+
+| Discipline | Strength (1-5) | Evidence |
+| --- | --- | --- |
+| Context Engineering | 3 | CLAUDE.md present, 1 custom skill, no AGENTS.md |
+| Architectural Constraints | 2 | 1 enforced constraint, 1 unverified |
+| Guardrail Design | 1 | CI exists, no coverage threshold, no mutation testing |
+```
+
+The weakest discipline (here, Guardrail Design at 1) is the ceiling.
+This tells you where to invest first — not the area where you are
+strongest, but the area holding you back.
+
+### Gaps
+
+```markdown
+## Gaps
+
+- No test coverage threshold — AI-generated code could reduce coverage
+  without triggering a failure
+- No vulnerability scanning in CI — known vulnerabilities in dependencies
+  would not be caught automatically
+- Hooks not configured — convention enforcement is documentation-only,
+  not real-time
+- REFLECTION_LOG.md absent — learning from sessions is not captured,
+  patterns are lost
+```
+
+This is the list of specific, concrete things missing for the next level.
+Each gap has a path to closure — that path appears in the improvement
+plan.
+
+---
+
+## Step 5: Accept or Defer Immediate Habitat Adjustments
+
+Before the improvement plan, the assessor identifies fixes it can make
+right now without requiring team discussion or code changes. These are
+habitat hygiene items:
+
+```text
+Immediate adjustment 1/3:
+  HARNESS.md Status section shows "Constraints enforced: 1/1"
+  but the file now has 2 constraints.
+  I'll update this to "Constraints enforced: 1/2".
+
+  Apply this fix? (yes/no)
+```
+
+```text
+Immediate adjustment 2/3:
+  README.md harness badge shows "0/1 enforced" but the harness
+  now has 1 enforced and 1 unverified.
+  I'll update the badge count.
+
+  Apply this fix? (yes/no)
+```
+
+Accept these. They take seconds and keep the harness accurate. Each
+accepted fix is recorded in the assessment document.
+
+---
+
+## Step 6: Walk Through the Improvement Plan
+
+After the immediate adjustments, the assessor presents the improvement
+plan item by item. For each item, you choose to accept, skip, or defer.
+
+```text
+Improvement 1/5 (Level 2 → Level 3):
+  Gap: No hooks configured
+  Action: Run /harness-init and select CI configuration
+  Priority: High — hooks are the real-time enforcement layer. Without
+  them, conventions are documentation, not enforcement.
+
+  Accept / Skip / Defer?
+```
+
+```text
+Improvement 2/5 (Level 2 → Level 3):
+  Gap: No REFLECTION_LOG.md
+  Action: Run /reflect after your next significant session
+  Priority: Medium — capturing learnings prevents the same mistakes
+  from recurring across sessions.
+
+  Accept / Skip / Defer?
+```
+
+If you accept an improvement that involves running a command (like
+`/harness-init`), the assessor runs it immediately and resumes the plan
+when it completes. If you defer, the item stays in the plan for the next
+assessment to pick up.
+
+Use defer for items that need team discussion or that you cannot address
+right now. Do not skip an item unless you have a specific reason it does
+not apply to your project — skipped items are removed from future
+assessments.
+
+The plan is also recorded in the assessment document with an accept /
+skip / defer count.
+
+---
+
+## Step 7: Check the README Badge
+
+After the plan, the assessor adds or updates an AI Literacy badge in
+your README:
+
+```markdown
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_2-4682B4?style=flat-square)](assessments/2026-04-08-assessment.md)
+```
+
+The badge links to the full assessment document. Its colour reflects
+the level — blue for Level 2, teal for Level 3, green for Level 4. The
+link is always to the most recent assessment, so anyone who clicks it
+sees the current evidence.
+
+Check that the badge appears correctly in your README. If the project is
+on GitHub and the assessed level is L3 or above, the assessor also adds
+the `agent-harness-enabled` topic tag to the repository.
+
+---
+
+## What You Have Now
+
+After completing this tutorial you have:
+
+- A timestamped assessment document at `assessments/YYYY-MM-DD-assessment.md`
+  with a level rating, rationale, discipline scores, and specific gaps
+- Immediate habitat fixes applied — stale counts, missing badge entries,
+  outdated status sections, all corrected
+- Workflow operation recommendations: specific changes to how you use
+  existing artifacts, accepted or deferred
+- An improvement plan with accepted items already run and deferred items
+  recorded for the next assessment
+- A README badge that shows the current level and links to the evidence
+
+The assessment is a snapshot. It reflects the state of the project at
+the time it ran. Run it again in three months and compare — the
+discipline scores and gaps tell you whether you are moving in the right
+direction.
+
+---
+
+## Planning the Next Quarterly Assessment
+
+The last section of the assessment document includes a suggested
+re-assessment date (three months from today). Add that to your calendar
+now, before you close the document.
+
+Before the next assessment:
+
+- Work through any deferred improvements — they will show up again
+- Run `/harness-audit` to check for drift between declared and actual
+  enforcement
+- Add entries to `REFLECTION_LOG.md` after significant sessions — the
+  assessor checks whether it has recent entries
+- If your team composition changed, run `/extract-conventions` to
+  re-surface tacit knowledge that may have shifted
+
+When you run `/assess` again, the assessor will compare the new findings
+against the previous assessment document. You will see what has changed
+and what gaps you have closed.
+
+---
+
+## Next Steps
+
+- [Harness for an Existing Codebase](harness-from-scratch) — if the
+  assessment revealed gaps in your harness, start here
+- [Creating Your First Skill](your-first-skill) — encode domain knowledge
+  the assessor found was missing
+- [How-to: Set Up Secret Detection](../how-to/set-up-secret-detection) —
+  a common Level 2 → Level 3 gap
+- [Reference: Commands](../reference/commands) — full specification for
+  `/assess`, `/reflect`, and `/harness-audit`

--- a/docs/tutorials/your-first-skill.md
+++ b/docs/tutorials/your-first-skill.md
@@ -7,9 +7,338 @@ nav_order: 2
 
 # Creating Your First Skill
 
-This tutorial walks you through creating a custom skill for your project —
-from identifying what knowledge to encode to writing the SKILL.md file and
-testing it with agents.
+A skill is a Markdown file that agents read when working. It encodes
+knowledge your team has — domain rules, recurring corrections, project
+patterns — in a form that any Claude Code agent can act on. Skills are
+the difference between an agent that writes code that looks reasonable
+and one that writes code that fits your project.
 
-{: .label .label-yellow }
-Coming Soon
+This tutorial walks you through creating a custom project-local skill,
+from identifying what to encode to writing the file and verifying the
+skill is active. It takes about twenty minutes.
+
+---
+
+## Prerequisites
+
+You need:
+
+- Claude Code installed with the ai-literacy-superpowers plugin (see
+  [Getting Started](getting-started) if you haven't done this yet)
+- A project with at least a `.claude/` directory — run `/superpowers-init`
+  if you don't have one
+
+You do not need any special knowledge of the skill format. The tutorial
+covers it from scratch.
+
+---
+
+## Step 1: What Is a Skill?
+
+Skills are files that agents read when the user's request matches the
+skill's description. When you start a session and ask Claude Code to
+review some code, it checks the available skills for descriptions that
+match the task. If a skill says "use when reviewing code," the agent
+reads it before proceeding.
+
+The content of a skill is the knowledge you want available. That can be:
+
+- **Domain rules** — what a concept means in your business, how it
+  differs from a generic implementation
+- **Recurring corrections** — patterns that AI keeps getting wrong in
+  your project, stated as what to do instead
+- **Project conventions** — how your team names things, structures code,
+  handles errors
+- **Review lenses** — a checklist or framework to apply when assessing
+  code quality
+
+Skills do not run code. They are read and applied — the agent uses the
+knowledge, judgment, and patterns to inform whatever it is doing.
+
+Look at the plugin's built-in skills as examples. The `cupid-code-review`
+skill encodes the CUPID framework as a set of review questions and
+signals. The `harness-engineering` skill explains the harness framework so
+any agent can understand the conceptual foundation. Both are between 100
+and 200 lines — specific enough to be useful, short enough to be read
+completely.
+
+---
+
+## Step 2: Identify What to Encode
+
+The best skills encode something that:
+
+1. **Recurs** — you find yourself correcting or explaining it repeatedly
+2. **Is specific** — it applies to this project, not to projects in general
+3. **Matters** — getting it wrong causes problems (review comments,
+   rework, bugs)
+
+Good starting points:
+
+- The conventions you most often fix in AI-generated code (also the
+  answer to extraction question 2)
+- Domain terms that AI consistently conflates with their generic meaning
+  (`Order` means purchase order, not sort order)
+- A review framework you apply consistently
+- A security pattern that must be applied in a specific way
+
+For this tutorial, imagine you work on a billing system where the concept
+of a `Customer` is very specific — it is always a paying account, never
+a trial, and it always has a billing contact. AI keeps generating code
+that uses `Customer` loosely. That is a good candidate for a skill.
+
+---
+
+## Step 3: Create the Directory Structure
+
+Project-local skills live in `.claude/skills/` at your project root.
+Each skill gets its own directory named after it.
+
+```bash
+mkdir -p .claude/skills/billing-domain/references
+```
+
+The structure will be:
+
+```text
+.claude/
+  skills/
+    billing-domain/
+      SKILL.md
+      references/        ← optional, for supplementary material
+```
+
+The `references/` directory is optional. Use it for lookup tables,
+examples, or extended material that is too long to put in the main file
+but that agents might need to consult.
+
+---
+
+## Step 4: Write the Frontmatter
+
+Create `.claude/skills/billing-domain/SKILL.md` and start with the
+frontmatter block:
+
+```markdown
+---
+name: billing-domain
+description: Use when generating, reviewing, or refactoring code that
+  involves customers, invoices, billing contacts, or payment processing —
+  encodes the domain model and the boundaries that must be respected
+---
+```
+
+The frontmatter has two required fields:
+
+**`name`** — must match the directory name. This is how the skill is
+identified.
+
+**`description`** — this is the most important field. Agents read the
+description to decide whether this skill is relevant to their current
+task. Write it as a natural sentence that includes the trigger phrases
+a person would use. Ask yourself: what words would appear in a task
+where this skill matters?
+
+Include:
+
+- The action verbs that should trigger the skill: `Use when generating`,
+  `Use when reviewing`, `Use when refactoring`
+- The nouns that signal relevance: the entities, concepts, or topics
+  the skill covers
+- A brief statement of what the skill provides
+
+Do not include implementation instructions in the description — save
+those for the skill body.
+
+---
+
+## Step 5: Write the Skill Content
+
+Below the frontmatter, write the skill itself. A skill has three parts:
+when to use it, the knowledge, and examples.
+
+### When to Use
+
+Start with a short paragraph that situates the skill. What is the
+context? What problem does it solve?
+
+```markdown
+# Billing Domain
+
+This project's billing domain has specific meanings that differ from
+generic usage. Agents working in this codebase need to respect these
+boundaries — conflating billing concepts with their generic counterparts
+causes subtle bugs that do not surface until billing runs.
+```
+
+### The Knowledge
+
+This is the main content. Write it as structured, specific guidance —
+not aspirations, but observable facts and rules.
+
+```markdown
+## Core Entities
+
+### Customer
+
+A `Customer` is always a paying account. In this system:
+
+- A Customer always has exactly one BillingContact
+- A Customer is never in trial status — trial accounts use the
+  `Prospect` type
+- A Customer.ID is a UUID that matches the Stripe customer ID
+- Do not use `Customer` to mean "user" or "person" — use `User`
+  for generic user operations
+
+### Invoice
+
+An `Invoice` is always associated with a Customer, never a Prospect.
+Invoices have a status lifecycle: `draft → issued → paid | void`.
+Do not skip lifecycle steps in code — always use the `Invoice.Transition`
+method.
+
+### BillingContact
+
+A BillingContact is a person, not an account. There is always exactly
+one per Customer. BillingContact.Email is validated at creation and
+must not be changed without going through `BillingContact.UpdateEmail`,
+which triggers notification.
+
+## Boundaries
+
+- Never pass raw Stripe objects beyond the `billing/stripe/` package.
+  Translate to domain types at the boundary.
+- Do not store payment method details anywhere outside the
+  `billing/payment/` package.
+- `billing/domain/` must not import from `billing/api/` or
+  `billing/storage/` — dependency goes inward only.
+```
+
+### Examples
+
+Where the rule is non-obvious, show an example of the violation and
+the correction. This is especially helpful for naming rules.
+
+For the billing domain skill, the examples section might look like this.
+
+**Using Customer where User is correct:**
+
+```go
+// Wrong — this is a generic user operation
+func GetCustomerByEmail(email string) (*Customer, error)
+
+// Right — GetCustomerByEmail implies a billing context that may not exist
+func GetUserByEmail(email string) (*User, error)
+```
+
+**Skipping the lifecycle transition:**
+
+```go
+// Wrong — sets status directly, bypassing notifications and validation
+invoice.Status = "paid"
+
+// Right — use the transition method
+err := invoice.Transition("paid")
+```
+
+Keep the examples short. One or two for each important rule is enough —
+agents read the examples to understand the pattern, then apply judgment
+from there.
+
+---
+
+## Step 6: Add Reference Files (Optional)
+
+If your skill has lookup tables, longer examples, or supplementary
+material that is too long for the main file, add it to the `references/`
+directory.
+
+For the billing domain skill, you might add a file with the full status
+lifecycle for each entity:
+
+```bash
+touch .claude/skills/billing-domain/references/lifecycle-diagrams.md
+```
+
+Reference the file in SKILL.md:
+
+```markdown
+## Additional Resources
+
+For the complete status lifecycle of each entity, consult
+`references/lifecycle-diagrams.md`.
+```
+
+Agents will read the main SKILL.md first. They will only consult
+reference files if the SKILL.md directs them to, or if the task
+requires it. Keep SKILL.md complete enough to stand alone — references
+are for depth, not for essential knowledge.
+
+---
+
+## Step 7: Test the Skill
+
+Start a new Claude Code session in the project:
+
+```bash
+claude
+```
+
+Ask it to do something that should trigger the skill:
+
+```text
+Write a function that finds all invoices for a given customer email address.
+```
+
+The agent should pick up the billing-domain skill because the task
+involves invoices and customers. You can confirm by checking whether the
+agent:
+
+- Uses `User` (not `Customer`) when the context is generic
+- Uses `Invoice.Transition` instead of direct status assignment
+- Respects the package boundary rules
+
+If the agent misses the skill, check two things:
+
+1. **The description** — does it include words that appear in the task?
+   "invoice" and "customer" should be in the description if that is what
+   the task uses.
+2. **The directory** — is SKILL.md at `.claude/skills/billing-domain/SKILL.md`?
+   The path must be exact.
+
+You can also ask the agent directly:
+
+```text
+What skills do you have available?
+```
+
+A well-formed skill should appear in the list.
+
+---
+
+## What You Have Now
+
+After completing this tutorial you have:
+
+- A project-local skill at `.claude/skills/billing-domain/SKILL.md` that
+  agents will read when working with your domain's entities
+- A clear structure you can copy for any future skills — frontmatter with
+  trigger-phrase description, when-to-use intro, specific knowledge,
+  and examples
+- An understanding of how to test that skills are being applied
+
+The skill is a living document. Update it when you discover new recurring
+corrections — after a code review where AI got something wrong is a good
+trigger. Add it to your HARNESS.md garbage collection rules to check
+for freshness periodically.
+
+---
+
+## Next Steps
+
+- [Harness for an Existing Codebase](harness-from-scratch) — encode more
+  of your conventions in HARNESS.md and promote them to enforcement
+- [Reference: Commands](../reference/commands) — `/harness-gc` for
+  managing skill freshness over time
+- [How-to Guides](../how-to/) — specific tasks like adding a constraint
+  or running an audit


### PR DESCRIPTION
## Summary

6 tutorials covering the full journey from setup to organisational scaling:

1. **Getting Started** (existed) — install, harness-init, first steps
2. **Creating Your First Skill** (was stub) — identify domain knowledge, write SKILL.md, test
3. **Harness for an Existing Codebase** (was stub) — extract conventions, selective init, avoid duplication, promote incrementally
4. **Your First Assessment** (new) — run /assess, understand output, walk improvement plan
5. **From Assessment to Dashboard** (new) — portfolio-assess across repos, generate HTML dashboard, share
6. **The Improvement Cycle** (new) — start at L2, improve to L3, re-assess, see the compound effect

All pass markdownlint with 0 errors.

## Test plan

- [ ] Verify 6 tutorial files exist (excluding index)
- [ ] Verify no "Coming Soon" stubs remain
- [ ] Verify nav_order is sequential (1-6)
- [ ] Verify markdownlint passes