### PR TITLE
Add cost-tracking skill and /cost-capture command (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.9.0 — 2026-04-10
+
+### Cost Tracking
+
+- Add cost-tracking skill — guides quarterly AI cost data capture from
+  provider dashboards, records structured cost snapshots, compares
+  trends, and updates MODEL_ROUTING.md with observed patterns
+- Add /cost-capture command — interactive cost capture with provider
+  dashboard guidance, comparison to previous snapshot, budget check
+- Expand snapshot format Cost Indicators section with actual fields:
+  last capture date, monthly average, budget status, cost trend
+- Update /harness-health to read from observability/costs/ directory
+- Add "Track AI Costs" how-to guide
+- Closes the cost visibility gap identified in the L5 assessment
+
 ## 0.8.3 — 2026-04-10
 
 ### Reflection-Driven Improvements

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.8.3-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
-[![Skills](https://img.shields.io/badge/Skills-23-2E8B57?style=flat-square)](#skills-23)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.9.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Skills](https://img.shields.io/badge/Skills-24-2E8B57?style=flat-square)](#skills-24)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
-[![Commands](https://img.shields.io/badge/Commands-14-2E8B57?style=flat-square)](#commands-14)
+[![Commands](https://img.shields.io/badge/Commands-15-2E8B57?style=flat-square)](#commands-15)
 [![Harness](https://img.shields.io/badge/Harness-7%2F7_enforced-2E8B57?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-04-08-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -82,7 +82,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 ## What You Get
 
-### Skills (23)
+### Skills (24)
 
 Code quality and harness engineering knowledge that agents read when working in your codebase.
 
@@ -111,6 +111,7 @@ Code quality and harness engineering knowledge that agents read when working in 
 | portfolio-assessment | Multi-repo assessment aggregation — level distribution, shared gaps, and portfolio improvement plans |
 | portfolio-dashboard | Generate a self-contained HTML dashboard from portfolio assessment data with trend visualisation |
 | team-api | Create or update a Team Topologies Team API document with AI literacy portfolio data |
+| cost-tracking | Quarterly AI cost capture — record spend, compare trends, inform model routing |
 
 ### Agents (10)
 
@@ -129,7 +130,7 @@ A coordinated team that handles the full development lifecycle.
 | harness-auditor | Meta-agent — checks whether the harness matches reality | Write to Status only |
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 
-### Commands (14)
+### Commands (15)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -147,6 +148,7 @@ A coordinated team that handles the full development lifecycle.
 | `/extract-conventions` | Guided session — surfaces tacit team conventions and maps them to CLAUDE.md and HARNESS.md |
 | `/convention-sync` | Sync HARNESS.md conventions to Cursor, Copilot, and Windsurf convention files |
 | `/portfolio-assess` | Multi-repo AI literacy assessment — aggregate across local repos, GitHub orgs, or topic tags |
+| `/cost-capture` | Capture AI tool cost data — record spend, compare to previous snapshot, update model routing |
 
 ### Templates (9)
 
@@ -291,7 +293,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (23)                     Domain knowledge for agents
+│   └── Skills (24)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/cost-capture.md
+++ b/ai-literacy-superpowers/commands/cost-capture.md
@@ -1,0 +1,120 @@
+---
+name: cost-capture
+description: Capture AI tool cost data — guide through provider dashboards, record spend and token usage, compare to previous snapshot, update MODEL_ROUTING.md
+---
+
+# /cost-capture
+
+Capture a cost snapshot for this project's AI tool usage.
+
+Read the `cost-tracking` skill before proceeding — it contains the
+snapshot format, provider dashboard URLs, and the comparison logic.
+
+## Process
+
+### 1. Find Previous Snapshot
+
+Check for existing cost snapshots:
+
+```bash
+ls observability/costs/*-costs.md 2>/dev/null | sort | tail -1
+```
+
+If a previous snapshot exists, read it for comparison. If none exist,
+this is the first capture.
+
+### 2. Ask About Providers
+
+```text
+Which AI providers are you using?
+
+1. Anthropic only
+2. OpenAI only
+3. Both Anthropic and OpenAI
+4. Other (specify)
+```
+
+### 3. Guide to Dashboard
+
+For each provider, give the dashboard URL and tell the user what to
+look for:
+
+- Monthly spend for the reporting period
+- Token usage (input and output) if available
+- Model-level breakdown if available
+
+Ask the user to read off the numbers. One provider at a time.
+
+### 4. Record Model Breakdown
+
+If the user can see per-model data:
+
+```text
+Can you see a breakdown by model? If so, list each model with
+its token usage or cost.
+```
+
+If not available, skip this section.
+
+### 5. Estimate Project Share
+
+If the user has multiple projects on the same account:
+
+```text
+Roughly what percentage of the total spend is this project?
+An estimate is fine — we're looking for order of magnitude,
+not precision.
+```
+
+### 6. Compare to Previous
+
+If a previous snapshot exists, compute and present:
+
+- Spend change ($ and %)
+- Token volume change
+- Model mix changes
+- Any concerning trends
+
+### 7. Budget Check
+
+```text
+Do you have a monthly budget for AI tools?
+
+1. Yes — what is it?
+2. No — would you like to set one based on current spend?
+3. Not applicable
+```
+
+If spend exceeds budget, flag it.
+
+### 8. Update MODEL_ROUTING.md
+
+If the cost data suggests routing changes (e.g. heavy frontier use
+for tasks that could use standard models), propose updates to
+MODEL_ROUTING.md. Present each change and ask for approval.
+
+### 9. Write the Snapshot
+
+Create `observability/costs/YYYY-MM-DD-costs.md` using the format
+from the cost-tracking skill.
+
+### 10. Commit
+
+```bash
+mkdir -p observability/costs
+git add observability/costs/ MODEL_ROUTING.md
+git commit -m "Cost snapshot: YYYY-MM-DD"
+```
+
+### 11. Summary
+
+```text
+Cost snapshot captured: observability/costs/YYYY-MM-DD-costs.md
+
+  Period: YYYY-MM to YYYY-MM
+  Total spend: $X,XXX
+  Monthly average: $X,XXX
+  Trend: [increasing/stable/decreasing vs previous]
+  Budget status: [within/over/not set]
+  MODEL_ROUTING.md: [updated/unchanged]
+```

--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -20,6 +20,7 @@ No agents dispatched. Reads existing data sources directly:
 - AGENTS.md → gotcha and arch decision counts
 - `assessments/` directory → latest assessment date
 - MODEL_ROUTING.md → existence and content
+- `observability/costs/` → latest cost snapshot for Cost Indicators
 - `observability/snapshots/` → previous snapshot for trend comparison
 
 ### Deep Mode (`/harness-health --deep`)

--- a/ai-literacy-superpowers/skills/cost-tracking/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-tracking/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: cost-tracking
+description: Use when the user wants to capture AI tool costs, review spending trends, set cost budgets, or integrate cost data into health snapshots — guides quarterly cost capture, records data in a structured format, and updates MODEL_ROUTING.md with observed cost patterns
+---
+
+# Cost Tracking
+
+Capture, record, and track AI tool costs over time. Cost data feeds
+into health snapshots and informs model routing decisions.
+
+This skill does not access billing APIs directly — it guides the user
+through checking their provider dashboards and recording the data in
+a structured format that the plugin can read.
+
+## Why Track Costs
+
+Without cost data:
+
+- MODEL_ROUTING.md routing rules are theoretical
+- The break-even calculation for self-hosting is impossible
+- Cost per PR/feature is unknown — no way to optimise
+- Budget conversations happen without evidence
+
+With cost data:
+
+- Routing rules are validated against actual spend
+- Self-hosting decisions are grounded in real numbers
+- Cost trends reveal whether AI adoption is efficient
+- Budget conversations have receipts
+
+## The Cost Snapshot
+
+Cost data is captured in `observability/costs/YYYY-MM-DD-costs.md`.
+Each file records one capture session (typically quarterly).
+
+### Format
+
+```markdown
+# Cost Snapshot — YYYY-MM-DD
+
+## Provider Spend
+
+| Provider | Period | Spend | Tokens (input) | Tokens (output) |
+| --- | --- | --- | --- | --- |
+| Anthropic | YYYY-MM to YYYY-MM | $X,XXX | XXM | XXM |
+| OpenAI | YYYY-MM to YYYY-MM | $X,XXX | XXM | XXM |
+
+## Model Breakdown (if available)
+
+| Model | Tokens (input) | Tokens (output) | Estimated cost |
+| --- | --- | --- | --- |
+| claude-sonnet-4 | XXM | XXM | $XXX |
+| claude-opus-4 | XXM | XXM | $XXX |
+| claude-haiku-4 | XXM | XXM | $XXX |
+
+## Per-Project Estimate
+
+| Project/Repo | Estimated share | Rationale |
+| --- | --- | --- |
+| ai-literacy-superpowers | XX% | Primary development repo |
+| ai-literacy-exemplar | XX% | Secondary, used for testing |
+
+## Observations
+
+- [Any patterns noticed — cost spikes, model tier shifts, etc.]
+
+## Budget Status
+
+- Monthly budget: $X,XXX (or "not set")
+- Current monthly average: $X,XXX
+- Trend: increasing / stable / decreasing
+- Action needed: yes / no
+```
+
+## Process
+
+### Step 1: Check Provider Dashboards
+
+Guide the user to their billing pages:
+
+**Anthropic:**
+
+```text
+Check your usage at: https://console.anthropic.com/settings/billing
+Look for: monthly spend, token usage by model, usage over time
+```
+
+**OpenAI:**
+
+```text
+Check your usage at: https://platform.openai.com/usage
+Look for: monthly spend, model breakdown, daily usage chart
+```
+
+**Other providers:** Ask the user where to find their billing data.
+
+### Step 2: Record the Data
+
+Create `observability/costs/YYYY-MM-DD-costs.md` using the format
+above. Ask the user for each field:
+
+1. Which providers are in use?
+2. What was the spend for the period?
+3. Can they break it down by model? (Not always available)
+4. Which projects consumed the most? (Estimate if not precise)
+
+### Step 3: Compare to Previous Snapshot
+
+If a previous cost snapshot exists in `observability/costs/`, read it
+and compute:
+
+- Spend delta ($ and %)
+- Token volume delta
+- Model mix changes
+- Cost per token trend
+
+### Step 4: Update MODEL_ROUTING.md
+
+If the cost data reveals patterns that should change routing:
+
+- High spend on frontier models for tasks that could use standard →
+  suggest updating the Agent Routing table
+- Consistent use below the self-hosting break-even → note that
+  cloud is still optimal
+- Spend above budget → flag which model tier is the driver
+
+Update the Sovereignty Considerations section with observed data.
+
+### Step 5: Update Health Snapshot
+
+The next `/harness-health` run will read the latest cost snapshot
+and populate the Cost Indicators section. The skill does not update
+the snapshot directly — it produces the cost data file that the
+snapshot reads.
+
+### Step 6: Commit
+
+```bash
+mkdir -p observability/costs
+git add observability/costs/YYYY-MM-DD-costs.md MODEL_ROUTING.md
+git commit -m "Cost snapshot: YYYY-MM-DD ($X,XXX monthly average)"
+```
+
+## Cadence
+
+Quarterly, aligned with the assessment cadence. The recommended
+workflow:
+
+1. Run `/assess` (quarterly)
+2. Run `/cost-capture` (same session or same week)
+3. Run `/harness-health` (reads both)
+4. Review the portfolio dashboard (shows cost trends if available)
+
+## What This Skill Does NOT Do
+
+- Access billing APIs directly (the user reads their dashboard)
+- Make routing changes without user approval
+- Require exact per-project attribution (estimates are fine)
+- Replace financial tooling (this is engineering visibility, not
+  accounting)

--- a/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
+++ b/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
@@ -136,9 +136,23 @@ guessing.
 ## Cost Indicators
 - Model routing configured: yes/no
 - Tier distribution: (from MODEL_ROUTING.md)
+- Last cost capture: YYYY-MM-DD (or "never")
+- Monthly average: $X,XXX (or "not tracked")
+- Budget status: within/over/not set
+- Cost trend: increasing/stable/decreasing (vs previous capture)
 ```
 
-**Source:** MODEL_ROUTING.md existence and content.
+**Source:** MODEL_ROUTING.md existence and content, plus the most
+recent file in `observability/costs/` matching `*-costs.md`.
+
+| Field | How to compute |
+|-------|---------------|
+| Model routing configured | Check MODEL_ROUTING.md exists and has routing table |
+| Tier distribution | Read Agent Routing table from MODEL_ROUTING.md |
+| Last cost capture | Most recent filename date in observability/costs/ |
+| Monthly average | Read from the most recent cost snapshot |
+| Budget status | Read from the most recent cost snapshot |
+| Cost trend | Compare current and previous cost snapshots |
 
 ### Meta
 

--- a/docs/how-to/track-ai-costs.md
+++ b/docs/how-to/track-ai-costs.md
@@ -1,0 +1,105 @@
+---
+title: Track AI Costs
+layout: default
+parent: How-to Guides
+nav_order: 25
+---
+
+# Track AI Costs
+
+Capture AI tool spending data and integrate it into your health
+snapshots and model routing decisions.
+
+---
+
+## Prerequisites
+
+- A MODEL_ROUTING.md file (run `/harness-init` or copy from
+  `templates/MODEL_ROUTING.md` if you don't have one)
+- Access to your AI provider's billing dashboard
+
+---
+
+## 1. Run the cost capture command
+
+```text
+/cost-capture
+```
+
+The command guides you through checking your provider dashboards and
+recording the data. It asks for:
+
+- Which providers you use (Anthropic, OpenAI, others)
+- Monthly spend for the reporting period
+- Token usage by model (if available)
+- Project share estimate (if multiple projects on one account)
+
+---
+
+## 2. Check your provider dashboard
+
+The command gives you the URL for each provider:
+
+- **Anthropic**: `https://console.anthropic.com/settings/billing`
+- **OpenAI**: `https://platform.openai.com/usage`
+
+Look for monthly spend, token usage breakdown, and any model-level
+detail. Read the numbers to the command when prompted.
+
+---
+
+## 3. Review the comparison
+
+If you have a previous cost snapshot, the command computes:
+
+- Spend change (dollar amount and percentage)
+- Token volume change
+- Model mix shifts
+- Whether you're within budget
+
+If this is your first capture, there's nothing to compare yet — the
+next quarterly capture will show the trend.
+
+---
+
+## 4. Set a budget (optional)
+
+The command asks whether you have a monthly AI budget. If not, it
+offers to suggest one based on current spend. A budget turns cost
+tracking from observation into a guardrail — the health snapshot will
+flag when spend exceeds it.
+
+---
+
+## 5. Review MODEL_ROUTING.md updates
+
+If the cost data suggests routing changes — for example, heavy
+frontier model use on tasks that could use standard models — the
+command proposes updates to MODEL_ROUTING.md. Each change is
+presented for your approval before being applied.
+
+---
+
+## 6. Find the output
+
+The cost snapshot is saved to:
+
+```text
+observability/costs/YYYY-MM-DD-costs.md
+```
+
+The next `/harness-health` run reads this file and populates the
+Cost Indicators section of the health snapshot.
+
+---
+
+## 7. Keep it current
+
+Run `/cost-capture` quarterly, aligned with `/assess`:
+
+1. Run `/assess` (quarterly)
+2. Run `/cost-capture` (same session)
+3. Run `/harness-health` (reads both)
+
+Over time, the cost snapshots build a spending trend that informs
+model routing decisions and budget conversations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,11 +46,11 @@ stays trustworthy at scale.
 
 It gives you:
 
-- **23 skills** — domain knowledge for security auditing, constraint
+- **24 skills** — domain knowledge for security auditing, constraint
   design, context engineering, fitness functions, model sovereignty, and more
 - **10 agents** — autonomous workers for orchestration, enforcement,
   garbage collection, code review, and TDD
-- **14 commands** — slash commands for harness lifecycle, assessment,
+- **15 commands** — slash commands for harness lifecycle, assessment,
   portfolio assessment, reflection, and convention management
 - **3 enforcement loops** — advisory at edit time, strict at merge
   time, investigative on schedule

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,6 +7,6 @@ nav_order: 3
 
 # Commands
 
-All 14 slash commands with usage and arguments.
+All 15 slash commands with usage and arguments.
 
 {: .label .label-yellow } Coming Soon

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Skills
 
-The plugin ships 23 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 24 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -116,6 +116,10 @@ Self-contained HTML dashboard from portfolio assessment data.
 ### team-api
 
 Team Topologies Team API document generation and update. Covers creating a new Team API from a template or updating an existing one with AI literacy portfolio data — repo levels, discipline scores, shared gaps, and improvement priorities. Bridges portfolio assessment into organisational communication artifacts. Covers generating a shareable dashboard with level distribution, repo table, shared gaps, improvement plan, and trend visualisation from multiple quarterly assessments. Output is a single HTML file with no external dependencies. Covers discovering repos from local paths, GitHub orgs, or topic tags, reading or estimating individual assessment levels, aggregating into a portfolio view with level distribution, shared gaps, and outliers, and generating improvement plans grouped by organisational impact.
+
+### cost-tracking
+
+Quarterly AI cost capture and tracking. Covers guiding users through provider billing dashboards, recording spend and token usage in a structured format, comparing to previous snapshots for trend analysis, and updating MODEL_ROUTING.md with observed cost patterns.
 
 ### auto-enforcer-action
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -39,9 +39,9 @@ should see output similar to:
 ```text
 Installing ai-literacy-superpowers from marketplace Habitat-Thinking...
 Plugin installed: ai-literacy-superpowers
-  23 skills
+  24 skills
   10 agents
-  14 commands
+  15 commands
 ```
 
 The plugin is now available in every Claude Code session. You don't need to


### PR DESCRIPTION
## Summary

Closes the cost visibility gap identified in the L5 assessment.

- Add `cost-tracking` skill — guides quarterly AI cost capture from provider dashboards, records structured snapshots, compares trends, updates MODEL_ROUTING.md
- Add `/cost-capture` command — interactive cost capture with dashboard guidance, previous snapshot comparison, budget check, routing update proposals
- Expand snapshot format Cost Indicators with real fields (last capture, monthly average, budget status, cost trend)
- Update `/harness-health` to read from `observability/costs/`
- Add "Track AI Costs" how-to guide
- Update counts: skills 23→24, commands 14→15, version 0.8.3→0.9.0

## Test plan

- [ ] Verify cost-tracking SKILL.md has complete process with snapshot format
- [ ] Verify /cost-capture has 11-step interactive process
- [ ] Verify snapshot format Cost Indicators has 6 fields with computation table
- [ ] Verify /harness-health reads observability/costs/
- [ ] Verify how-to guide at docs/how-to/track-ai-costs.md
- [ ] Verify all counts show 24 skills / 15 commands / v0.9.0