### PR TITLE
Fix curation-nudge Stop hook arithmetic bug (v0.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.2 — 2026-04-10
+
+### Bug Fix
+
+- Fix curation-nudge Stop hook arithmetic error — `grep -c` outputs 0
+  to stdout before exiting non-zero under `set -e`, causing the
+  `|| echo "0"` fallback to produce `"0\n0"` which breaks arithmetic.
+  Fixed both `reflection_count` (line 27) and `promoted_count` (line 42)
+  to use `|| var=0` pattern instead.
+
 ## 0.9.1 — 2026-04-10
 
 ### Article 08: The Loops That Learn

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.9.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.9.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-24-2E8B57?style=flat-square)](#skills-24)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-15-2E8B57?style=flat-square)](#commands-15)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/curation-nudge.sh
+++ b/ai-literacy-superpowers/hooks/scripts/curation-nudge.sh
@@ -24,7 +24,7 @@ if [ ! -f "$REFLECTION_LOG" ]; then
 fi
 
 # Count reflection entries (lines starting with "- **Date**:")
-reflection_count=$(grep -c '^\- \*\*Date\*\*:' "$REFLECTION_LOG" 2>/dev/null || echo "0")
+reflection_count=$(grep -c '^\- \*\*Date\*\*:' "$REFLECTION_LOG" 2>/dev/null) || reflection_count=0
 
 # If no reflections, nothing to curate
 if [ "$reflection_count" -eq 0 ]; then
@@ -39,7 +39,7 @@ fi
 
 # Count promoted entries (non-comment bullet points in content sections)
 # Filter out HTML comments and count actual content bullets
-promoted_count=$(sed '/^<!--/,/-->$/d' "$AGENTS_FILE" | grep -c '^- ' 2>/dev/null || echo "0")
+promoted_count=$(sed '/^<!--/,/-->$/d' "$AGENTS_FILE" | grep -c '^- ' 2>/dev/null) || promoted_count=0
 
 # If reflections significantly outnumber promoted entries, nudge
 unpromoted=$((reflection_count - promoted_count))


### PR DESCRIPTION
## Summary

Fixes a bug reported by users in other repos where the curation-nudge Stop hook crashes with an arithmetic error.

**Root cause:** `grep -c` outputs `0` to stdout before exiting non-zero (no matches) under `set -euo pipefail`. The `|| echo "0"` fallback then appends a second `0`, producing `"0\n0"` which breaks the arithmetic expression on line 45.

**Fix:** Change `$(grep -c ... || echo "0")` to `$(grep -c ...) || var=0` on both lines 27 and 42. This assigns the fallback value directly to the variable instead of concatenating it with grep's stdout.

**Scope:** Only `curation-nudge.sh` had this pattern. All other hook scripts checked — no other instances found.

## Test plan

- [ ] Verify ShellCheck passes on curation-nudge.sh
- [ ] Verify the fix works on a repo with no AGENTS.md entries (the failing case)
- [ ] Verify the fix works on a repo with AGENTS.md entries (the passing case)