### PR TITLE
Add Human Pace template entries and assessment signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.9.3 — 2026-04-11
+
+### Human Pace Template and Assessment Signals
+
+- Add spec-scoped changes constraint to template HARNESS.md — new
+  projects get one-concern-per-PR enforcement by default
+- Add change cadence drift GC rule to template HARNESS.md — weekly
+  monitoring of PR size distribution and cycle time
+- Add Human Pace observable evidence signals to assessment skill at
+  L2 (TDD-paced diffs), L3 (spec-scoped constraint, cadence drift GC),
+  L4 (spec-to-PR mapping), and L5 (cadence metrics as health signal)
+
 ## 0.9.2 — 2026-04-10
 
 ### Bug Fix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.9.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.9.3-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-24-2E8B57?style=flat-square)](#skills-24)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-15-2E8B57?style=flat-square)](#commands-15)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -28,6 +28,7 @@ team is operating at. Each signal maps to a specific level:
 - Vulnerability scanning (govulncheck, OWASP, Docker Scout)
 - Markdownlint or other linting in CI
 - Mutation testing configuration
+- Small, TDD-paced diffs visible in commit history (Human Pace signal)
 
 **Level 3 indicators (habitat engineering)**:
 
@@ -41,6 +42,8 @@ team is operating at. Each signal maps to a specific level:
 - Hooks configuration (`hooks.json`)
 - `REFLECTION_LOG.md` with entries
 - `.markdownlint.json` or equivalent config
+- Spec-scoped changes constraint in HARNESS.md (Human Pace signal)
+- Change cadence drift GC rule active (Human Pace signal)
 
 **Level 4 indicators (specification architecture)**:
 
@@ -49,6 +52,7 @@ team is operating at. Each signal maps to a specific level:
 - Agent pipeline with orchestrator
 - Plan approval gate in orchestrator
 - Loop guardrails (MAX_REVIEW_CYCLES)
+- Spec-to-PR mapping — each spec produces one PR (Human Pace signal)
 
 **Level 5 indicators (sovereign engineering)**:
 
@@ -57,6 +61,7 @@ team is operating at. Each signal maps to a specific level:
 - OpenTelemetry configuration
 - Organisational governance documentation
 - Multiple agent teams or cloud async agents
+- Change cadence metrics reviewed as team health signal (Human Pace signal)
 
 ### Phase 2: Clarifying Questions
 

--- a/templates/HARNESS.md
+++ b/templates/HARNESS.md
@@ -67,6 +67,16 @@
 - **Tool**: none yet
 - **Scope**: pr
 
+### Spec-scoped changes
+
+- **Rule**: Each feature or behaviour-change PR should trace to a single
+  spec. Bug fixes, dependency updates, and other maintenance changes do
+  not require a spec but should still be coherently scoped — one concern
+  per PR. PRs that bundle unrelated changes must be decomposed.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer (reviews against Theme 18: The Human Pace)
+- **Scope**: pr
+
 ---
 
 ## Garbage Collection
@@ -111,6 +121,16 @@
 - **Enforcement**: deterministic
 - **Tool**: file date check
 - **Auto-fix**: true (move to archive directory)
+
+### Change cadence drift
+
+- **What it checks**: Whether PR size distribution (median lines
+  changed) or spec-to-merge cycle time has increased over the past
+  month, indicating the human pace is being lost to AI-speed production
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent (analyses recent merged PRs via git log)
+- **Auto-fix**: false
 
 ---
 


### PR DESCRIPTION
## Summary

- Add spec-scoped changes constraint to template HARNESS.md
- Add change cadence drift GC rule to template HARNESS.md
- Add Human Pace observable evidence signals to assessment skill at L2-L5

Reflects Theme 18 from the framework into the plugin so new projects get
Human Pace enforcement by default and assessments scan for pace signals.