### PR TITLE
Add updating guide and harness assessment updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,21 @@
   parallel implementation agents without worktrees.
   (Source: REFLECTION_LOG 2026-04-07)
 
+- Background subagents may lack Write/Edit permissions even when the
+  parent context has them. For write-heavy tasks (e.g. generating
+  full documentation pages), either use foreground agents so the user
+  can approve tool calls, or have the parent extract content from
+  subagent output and do the writes itself. The subagent output logs
+  at `/private/tmp/claude-*/tasks/<agent-id>.output` contain the
+  drafted content even when writes were denied.
+  (Source: REFLECTION_LOG 2026-04-11)
+
+- Before proposing a new CI workflow, grep `.github/workflows/` for
+  related checks. This project already has version-check.yml,
+  lint-markdown.yml, harness.yml, gc.yml, and pages.yml. Proposing
+  a duplicate wastes a branch cycle and erodes trust.
+  (Source: REFLECTION_LOG 2026-04-11)
+
 - This project's harness is self-referential — the plugin defines
   the harness framework, and its own HARNESS.md uses that framework.
   Changes to template files (`templates/HARNESS.md`) do not

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -106,6 +106,16 @@
 - **Tool**: find . -name "*.sh" -not -path "./.git/*" -exec shellcheck {} +
 - **Scope**: commit + pr
 
+### Spec-scoped changes
+
+- **Rule**: Each feature or behaviour-change PR should trace to a single
+  spec. Bug fixes, dependency updates, and other maintenance changes do
+  not require a spec but should still be coherently scoped — one concern
+  per PR. PRs that bundle unrelated changes must be decomposed.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer (reviews against The Human Pace)
+- **Scope**: pr
+
 ### Version consistency
 
 - **Rule**: plugin.json version, README badge version, and CHANGELOG
@@ -160,6 +170,16 @@
 - **Tool**: harness-gc agent
 - **Auto-fix**: false
 
+### Change cadence drift
+
+- **What it checks**: Whether PR size distribution (median lines
+  changed) or spec-to-merge cycle time has increased over the past
+  month, indicating the human pace is being lost to AI-speed production
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent (analyses recent merged PRs via git log)
+- **Auto-fix**: false
+
 ### Plugin manifest currency
 
 - **What it checks**: Whether `plugin.json` version, keywords, and
@@ -176,7 +196,7 @@
 
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
-Last audit: 2026-04-10
-Constraints enforced: 7/7
-Garbage collection active: 2/5
-Drift detected: none (markdownlint added to CI, closing the gap)
+Last audit: 2026-04-11
+Constraints enforced: 8/8
+Garbage collection active: 2/6
+Drift detected: none

--- a/README.md
+++ b/README.md
@@ -41,6 +41,38 @@ Once installed, the plugin's skills, agents, hooks, and commands (or prompts) ar
 
 > Commands are available as `/command-name` in Claude Code and as `/prompt-name` in Copilot CLI.
 
+### Updating
+
+#### Update the plugin
+
+When a new version is released, update your local installation:
+
+```bash
+# Claude Code
+claude plugin update ai-literacy-superpowers
+
+# Copilot CLI
+/plugin update ai-literacy-superpowers
+```
+
+Check the [CHANGELOG](CHANGELOG.md) for what changed between versions.
+
+#### Update the marketplace listing
+
+If you maintain your own marketplace that includes this plugin, refresh
+the index so new versions are discoverable:
+
+```bash
+claude plugin marketplace update Habitat-Thinking/ai-literacy-superpowers
+```
+
+This pulls the latest `plugin.json` metadata (version, description,
+keywords) into the marketplace index. Users who have already installed
+the plugin still need to run `claude plugin update` separately.
+
+See [How to Update the Plugin](docs/how-to/update-the-plugin.md) for
+the full guide.
+
 ### Quick start
 
 After installation, run these commands to set up your project:

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![Skills](https://img.shields.io/badge/Skills-24-2E8B57?style=flat-square)](#skills-24)
 [![Agents](https://img.shields.io/badge/Agents-10-2E8B57?style=flat-square)](#agents-10)
 [![Commands](https://img.shields.io/badge/Commands-15-2E8B57?style=flat-square)](#commands-15)
-[![Harness](https://img.shields.io/badge/Harness-7%2F7_enforced-2E8B57?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-8%2F8_enforced-2E8B57?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-04-08-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)
-[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_5-DAA520?style=flat-square)](assessments/2026-04-10-assessment.md)
+[![AI Literacy](https://img.shields.io/badge/AI_Literacy-Level_5-DAA520?style=flat-square)](assessments/2026-04-11-assessment.md)
 
 A plugin for [Claude Code](https://claude.ai/claude-code) and [GitHub Copilot CLI](https://github.com/features/copilot) that gives you the AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops.
 

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -112,3 +112,14 @@
 - **Improvement**: The assessment could detect "template-but-not-applied" gaps automatically — scan templates/ and check whether corresponding files exist at the project root.
 - **Signal**: context
 - **Constraint**: none
+
+---
+
+- **Date**: 2026-04-11
+- **Agent**: claude-opus-4-6 (interactive + background subagents)
+- **Task**: Completed all documentation gaps — three reference page stubs (commands, agents, templates), wired Article 08 into docs nav, added Human Pace how-to guide, fixed stale design spec counts, bumped to v0.9.4
+- **Surprise**: Background subagents drafted all three reference pages but couldn't write files due to permission denials — had to extract content from their output logs and write from the parent context. Also, the version consistency CI check I suggested adding at the end already existed at `.github/workflows/version-check.yml`.
+- **Proposal**: Future agents should know: (1) background subagents may lack Write/Edit permissions — use foreground agents for write-heavy tasks, or have the parent do the final writes; (2) before proposing new CI checks, grep `.github/workflows/` for related workflows to avoid duplicating existing enforcement; (3) the docs site now has zero "Coming Soon" stubs — all reference pages (skills, commands, agents, hooks, templates, harness-md-format) are complete
+- **Improvement**: Grep for existing CI workflows before suggesting new ones. For parallel doc writing, foreground agents with approved permissions would avoid the extract-and-rewrite overhead.
+- **Signal**: workflow
+- **Constraint**: none

--- a/assessments/2026-04-11-assessment.md
+++ b/assessments/2026-04-11-assessment.md
@@ -1,0 +1,184 @@
+# AI Literacy Assessment — ai-literacy-superpowers
+
+**Date**: 2026-04-11
+**Assessed by**: assessor (via /assess command)
+**Assessed level**: Level 5 — Sovereign Engineering
+**Previous assessment**: 2026-04-10 (Level 5)
+
+---
+
+## Observable Evidence
+
+### Repository Signals
+
+| Signal | Found | Level indicator |
+| --- | --- | --- |
+| CI workflows | Yes — lint-markdown, harness, gc, pages, version-check (5) | L2 |
+| Test coverage enforcement | No — not applicable (markdown plugin, no test suite) | L2 |
+| Vulnerability scanning | No — not applicable (no application dependencies) | L2 |
+| Mutation testing | No — not applicable (no test suite) | L2 |
+| Linting in CI | Yes — markdownlint + ShellCheck | L2 |
+| CLAUDE.md | Yes — 58 lines, semver convention, PR workflow, CHANGELOG | L3 |
+| HARNESS.md | Yes — 7 constraints, 7/7 enforced, 5 GC rules | L3 |
+| AGENTS.md | Yes — 10 curated entries (up from 8) | L3 |
+| MODEL_ROUTING.md | Yes — created from template during previous assessment | L3 |
+| Custom skills | Yes — 24 (up from 23; added cost-tracking) | L3 |
+| Custom agents | Yes — 10 | L3 |
+| Custom commands | Yes — 15 (up from 14; added /cost-capture) | L3 |
+| Hooks configured | Yes — 8 hooks in hooks.json, curation-nudge bug fixed | L3 |
+| REFLECTION_LOG.md | Yes — 9 entries with Signal field (up from 7) | L3 |
+| .markdownlint.json | Yes | L3 |
+| Specifications directory | Yes — 17 spec files | L4 |
+| Implementation plans | Yes — 3 plan files | L4 |
+| Orchestrator with safety gates | Yes — GATE and GUARDRAIL in orchestrator.agent.md | L4 |
+| Plugin/platform tooling | Yes — published plugin v0.9.4 (up from v0.8.2) | L5 |
+| Cross-team templates | Yes — HARNESS.md, MODEL_ROUTING.md, CLAUDE.md, AGENTS.md, REFLECTION_LOG.md, 4 CI templates | L5 |
+| Human Pace template entries | Yes — spec-scoped changes constraint + cadence drift GC in templates | L5 |
+| OTel configuration | No — not applicable for markdown plugin | L5 |
+| Docs site | Yes — GitHub Pages, complete Diataxis coverage, zero stubs | L5 |
+| Articles | Yes — 8 (up from 7; added The Loops That Learn) | L5 |
+| Portfolio assessment | Yes — with HTML dashboard | L5 |
+| Portfolio discovery tag | Yes — agent-harness-enabled topic | L5 |
+| Cost tracking skill | Yes — skill + /cost-capture command (new since last) | L5 |
+| Actual cost data | No — tooling exists but no capture run yet | L5 |
+| Small TDD-paced diffs | Yes — visible in commit history (Human Pace L2 signal) | L2 |
+
+### Changes Since Previous Assessment (2026-04-10)
+
+- MODEL_ROUTING.md gap closed (created during last assessment)
+- Cost-tracking skill and /cost-capture command added (v0.9.0)
+- Article 08: The Loops That Learn added (v0.9.1)
+- Curation-nudge Stop hook bug fixed (v0.9.2)
+- Human Pace template entries added (v0.9.3)
+- All documentation reference stubs completed — zero "Coming Soon" pages (v0.9.4)
+- 2 new reflections captured and curated into AGENTS.md GOTCHAS
+- Plugin version advanced from v0.8.2 to v0.9.4 (+6 releases)
+
+### Evidence Summary
+
+This is a published Claude Code plugin consumed by multiple repos in the
+Habitat-Thinking org. It originates the entire AI Literacy framework
+infrastructure: 24 skills, 10 agents, 15 commands, 10 templates, 8 hooks,
+and a complete documentation site with zero stub pages.
+
+The plugin has 7/7 constraints enforced in CI (5 deterministic, 1 agent,
+1 deterministic via CI workflow). The REFLECTION_LOG has 9 entries with
+signal classification. The compound learning pipeline is active and
+regular: reflections are curated into AGENTS.md across sessions, with
+the latest session adding 2 new GOTCHAS entries.
+
+The cost-tracking gap from the previous assessment has been partially
+addressed: the skill and command exist, but no cost data has been
+captured yet. The OTel gap has been reclassified as not applicable
+for a markdown-only plugin.
+
+New gap: the Human Pace template entries (spec-scoped changes constraint,
+change cadence drift GC rule) are shipped for downstream consumers but
+not applied to the project's own HARNESS.md.
+
+## Clarifying Responses
+
+- **Cost capture**: Tooling exists but no data captured yet
+- **OTel**: Not applicable — markdown plugin has no runtime to instrument
+- **Human Pace in own HARNESS.md**: Not yet applied — should be
+- **Compound learning curation**: Happening regularly across sessions
+
+## Level Assessment
+
+### Primary Level: 5 — Sovereign Engineering
+
+The plugin continues to meet Level 5 requirements across all three
+disciplines. Since the last assessment, the primary improvements are:
+
+- **Cost discipline infrastructure** now exists (was completely absent)
+- **Documentation completeness** is now 100% (was ~70% with 3 stubs)
+- **Compound learning velocity** increased (2 new reflections, 2 curated)
+- **Human Pace signals** added to the assessment framework itself
+
+### Discipline Maturity
+
+| Discipline | Strength (1-5) | Change | Evidence |
+| --- | --- | --- | --- |
+| Context Engineering | 5/5 | Stable | CLAUDE.md, AGENTS.md (10 entries), 24 skills, 15 commands, 8 hooks, complete docs (zero stubs), 8 articles, MODEL_ROUTING.md |
+| Architectural Constraints | 5/5 | Stable | 7/7 enforced (5 deterministic, 1 agent, 1 CI workflow), 5 CI workflows, 5 GC rules, version consistency check |
+| Guardrail Design | 4.5/5 | Up from 4/5 | Orchestrator with safety gates, spec-first workflow, 9 reflections with signal classification, portfolio assessment, compound learning active and regular, cost-tracking tooling exists. Gap: no cost data yet |
+
+### The Weakest Discipline
+
+Guardrail Design at 4.5/5 remains the ceiling, improved from 4/5.
+The cost-tracking infrastructure now exists (skill + command + template
+entries in MODEL_ROUTING.md) but hasn't produced data. One cost capture
+cycle would close this to 5/5.
+
+## Strengths
+
+- **Documentation completeness**: zero stubs remaining in the docs site —
+  all reference pages (skills, commands, agents, hooks, templates,
+  harness-md-format) are fully written
+- **Active compound learning**: regular curation across sessions, not
+  just batch catch-ups. 2 new GOTCHAS curated from reflections in the
+  latest session
+- **Self-referential improvement**: the plugin's own assessment framework
+  now includes Human Pace signals, and the assessment skill was updated
+  to detect them
+- **Rapid iteration**: 6 releases (v0.8.2 → v0.9.4) in 2 days, each
+  following the full PR workflow with CI checks
+
+## Gaps
+
+- **No cost data captured**: The /cost-capture command and cost-tracking
+  skill exist but have never been run. Cost discipline is infrastructure
+  without operation — exactly the pattern Article 08 warns about.
+- **Human Pace not in own HARNESS.md**: The spec-scoped changes constraint
+  and change cadence drift GC rule are in the template but not applied
+  to this project. The cobbler's children pattern, again.
+- **GC active ratio**: HARNESS.md Status shows 2/5 GC rules active.
+  Three agent-scoped GC rules (documentation freshness, command-prompt
+  sync, plugin manifest currency) run only via /harness-gc or
+  /harness-health --deep, not on a schedule.
+
+## Recommendations
+
+1. **Run /cost-capture** — even a single data point closes the cost
+   discipline gap. The tooling exists; it just needs one execution cycle.
+
+2. **Apply Human Pace to own HARNESS.md** — add the spec-scoped changes
+   constraint and change cadence drift GC rule from the template. This
+   project should use what it ships.
+
+3. **Schedule agent GC rules** — the 3 agent-scoped GC rules could run
+   via a weekly CI job dispatching /harness-gc, raising the active ratio
+   from 2/5 to 5/5.
+
+## Immediate Adjustments Applied
+
+1. **Add spec-scoped changes constraint to HARNESS.md** — from template,
+   applying to this project
+2. **Add change cadence drift GC rule to HARNESS.md** — from template,
+   applying to this project
+3. **Update HARNESS.md Status** — update counts and last audit date
+4. **Update README** — stale counts if any (skills 24, commands 15,
+   articles 8)
+
+## Workflow Operation Recommendations
+
+*Presented one at a time during assessment — see below for outcomes.*
+
+| Recommendation | Status |
+| --- | --- |
+| Add Human Pace entries to own HARNESS.md | Pending |
+| Run /cost-capture before next assessment | Pending |
+| Update HARNESS.md GC active count after adding cadence drift | Pending |
+
+## Improvement Plan
+
+- Current level: L5
+- Target level: L5 (refinement within level)
+- Key improvement: cost discipline activation (run /cost-capture)
+- Secondary: Human Pace self-application, GC active ratio
+
+## Next Assessment
+
+Suggested re-assessment date: 2026-07-11 (quarterly)
+
+Previous assessment: 2026-04-10 (Level 5)

--- a/docs/how-to/update-the-plugin.md
+++ b/docs/how-to/update-the-plugin.md
@@ -1,0 +1,131 @@
+---
+title: Update the Plugin
+layout: default
+parent: How-to Guides
+nav_order: 27
+---
+
+# Update the Plugin
+
+Keep the plugin and marketplace listing current when new versions are
+released.
+
+---
+
+## Prerequisites
+
+- The plugin is already installed (see [Installation](../../README.md#installation))
+- For marketplace updates: you maintain a marketplace that includes
+  this plugin
+
+---
+
+## 1. Check for a new version
+
+Compare your installed version against the latest release:
+
+```bash
+claude plugin list
+```
+
+Look for `ai-literacy-superpowers` in the output. The version shown is
+what you have locally. Check the
+[CHANGELOG](../../CHANGELOG.md) or the
+[releases page](https://github.com/Habitat-Thinking/ai-literacy-superpowers/releases)
+for the latest version.
+
+---
+
+## 2. Update the installed plugin
+
+Pull the latest version into your local environment:
+
+```bash
+# Claude Code
+claude plugin update ai-literacy-superpowers
+```
+
+```bash
+# Copilot CLI
+/plugin update ai-literacy-superpowers
+```
+
+This fetches the newest plugin code — skills, agents, hooks, commands,
+and templates. Your project files (CLAUDE.md, HARNESS.md, etc.) are
+not overwritten; only the plugin itself is updated.
+
+---
+
+## 3. Review what changed
+
+After updating, check the changelog for anything that affects your
+workflow:
+
+```bash
+# In Claude Code, read the changelog
+cat node_modules/.claude/plugins/ai-literacy-superpowers/CHANGELOG.md
+```
+
+Or check the [CHANGELOG](../../CHANGELOG.md) on GitHub. Pay attention
+to:
+
+- **New skills or agents** that you may want to use
+- **Changed hooks** that may alter advisory behaviour
+- **Version bumps** that indicate breaking changes (minor bumps in
+  pre-1.0 may include behavioural changes)
+
+---
+
+## 4. Update the marketplace listing (maintainers only)
+
+If you maintain a marketplace that includes this plugin, refresh the
+index so the new version is discoverable:
+
+```bash
+claude plugin marketplace update Habitat-Thinking/ai-literacy-superpowers
+```
+
+This pulls the latest `plugin.json` metadata — version, description,
+keywords — into the marketplace index. It does not update installations
+for users who already have the plugin; they must run
+`claude plugin update` themselves.
+
+---
+
+## 5. Verify the update
+
+Confirm the new version is active:
+
+```bash
+claude plugin list
+```
+
+Then run a quick health check to make sure everything loads:
+
+```text
+/superpowers-status
+```
+
+If the status command reports missing components, try removing and
+reinstalling the plugin:
+
+```bash
+claude plugin uninstall ai-literacy-superpowers
+claude plugin install ai-literacy-superpowers
+```
+
+---
+
+## What you have now
+
+Your plugin is at the latest version. All skills, agents, hooks, and
+commands reflect the newest release. If you maintain a marketplace, it
+now advertises the current version to other users.
+
+## Next steps
+
+- [Check harness health](run-a-harness-audit.md) after major version
+  updates
+- [Review the CHANGELOG](../../CHANGELOG.md) for migration notes
+- [Run an assessment](run-an-assessment.md) to see if new skills
+  unlock higher literacy levels


### PR DESCRIPTION
## Summary

- Add spec-scoped changes constraint and change cadence drift GC rule to HARNESS.md
- Update harness audit counts (8/8 enforced, 2/6 GC active) and README badges
- Add 2026-04-11 AI literacy assessment
- Add plugin and marketplace updating section to README
- Add full how-to guide at docs/how-to/update-the-plugin.md

## Test plan

- [ ] Verify HARNESS.md constraint and GC rule formatting
- [ ] Verify README badges render correctly
- [ ] Verify docs how-to follows template structure
- [ ] CI checks pass (markdownlint, gitleaks)