### PR TITLE
Add cross-repo exemption to spec-first check

### DIFF
--- a/.github/workflows/spec-first-check.yml
+++ b/.github/workflows/spec-first-check.yml
@@ -1,8 +1,8 @@
 # Spec-first commit ordering check for pull requests.
 #
 # Verifies that the first commit on a feature branch contains only
-# a spec file in docs/superpowers/specs/. Bug-fix and maintenance
-# PRs are exempt.
+# a spec file in docs/superpowers/specs/. Bug-fix, maintenance, and
+# cross-repo PRs (where the spec lives in another repo) are exempt.
 
 name: Spec-First Check
 
@@ -30,7 +30,7 @@ jobs:
           echo "Branch: $BRANCH"
 
           # Exempt by branch prefix
-          if [[ "$BRANCH" == fix/* ]] || [[ "$BRANCH" == chore/* ]]; then
+          if [[ "$BRANCH" == fix/* ]] || [[ "$BRANCH" == chore/* ]] || [[ "$BRANCH" == cross-repo/* ]]; then
             echo "exempt=true" >> "$GITHUB_OUTPUT"
             echo "Exempt by branch prefix: $BRANCH"
             exit 0
@@ -45,7 +45,7 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request?.labels || [];
-            const exemptLabels = ['bug', 'fix', 'chore', 'maintenance'];
+            const exemptLabels = ['bug', 'fix', 'chore', 'maintenance', 'cross-repo'];
             const isExempt = labels.some(l => exemptLabels.includes(l.name));
             core.setOutput('exempt', isExempt.toString());
             if (isExempt) {
@@ -110,6 +110,9 @@ jobs:
             echo "If this is a bug fix or maintenance PR, add one of these labels:"
             echo "  bug, fix, chore, maintenance"
             echo "Or use a branch prefix: fix/, chore/"
+            echo ""
+            echo "If the spec lives in another repo (cross-repo work), add the"
+            echo "'cross-repo' label or use the cross-repo/ branch prefix."
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,24 @@ Bump when the listing contract itself changes:
 The listing version follows the same semver rules as the plugin while
 pre-1.0. A listing-only change does not require a plugin version bump.
 
+## Cross-Repo Spec-First Discipline
+
+When work in this plugin is driven by a spec in another repo (typically
+`ai-literacy-for-software-engineers`), the spec-first CI check cannot
+see the spec. Two options:
+
+1. **Copy the spec** into `docs/superpowers/specs/` as the first commit
+   on the branch. This satisfies the spec-first gate and keeps a local
+   record of what drove the change. Preferred for large feature work.
+
+2. **Use the cross-repo exemption** — name the branch `cross-repo/...`
+   or add the `cross-repo` label to the PR. The spec-first check will
+   skip. Use this for sync-driven changes where the spec already exists
+   upstream and copying it would be redundant.
+
+In the PR description, always link to the upstream spec regardless of
+which option you choose.
+
 ## Sync from Source
 
 This plugin's reusable components originate from the


### PR DESCRIPTION
## Summary

- Add `cross-repo/` branch prefix and `cross-repo` label as exemptions to the spec-first commit ordering CI check
- Document the cross-repo spec-first convention in CLAUDE.md with two options: copy the spec locally (preferred for large features) or use the exemption (for sync-driven changes)
- Update error message to mention the cross-repo option

Addresses the spec-first check failure on PR #109 — the governance dimension spec lived in the `ai-literacy-for-software-engineers` repo, so the plugin's CI couldn't see it.

## Test plan

- [ ] Verify the `fix/` branch prefix exempts this PR from the spec-first check
- [ ] Verify a branch named `cross-repo/foo` would be exempt
- [ ] Verify a PR with the `cross-repo` label would be exempt
- [ ] Verify normal feature branches still require spec-first commit ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)