### PR TITLE
Add governance dimension documentation

### DIFF
--- a/docs/explanation/governance-as-meaning-alignment.md
+++ b/docs/explanation/governance-as-meaning-alignment.md
@@ -1,0 +1,164 @@
+---
+title: Governance as meaning-alignment
+layout: default
+parent: Explanation
+nav_order: 16
+---
+
+# Governance as Meaning-Alignment
+
+Governance failures are not primarily technical failures. They are
+reference frame translation failures. When the meaning encoded in
+governance language diverges from operational reality, the result is
+compliance theatre — governance that looks correct but governs nothing.
+
+This page explains why governance language drifts, how to detect it,
+and what the plugin provides to prevent it.
+
+---
+
+## The Core Problem
+
+Governance language carries different meanings in different reference
+frames. Consider "ensure human oversight of AI-generated code":
+
+| Frame | Interpretation |
+| ----- | -------------- |
+| Regulatory | A qualified human evaluates whether the AI decision is appropriate before it takes effect |
+| Engineering | A human clicks "approve" on a pull request that contains AI-generated code |
+| AI system | A boolean gate prevents merge without at least one approval |
+
+All three frames can be satisfied simultaneously while governance
+fails semantically. The approval happens, but the oversight is absent.
+The PR was approved, the audit trail exists, the gate passed — and
+nobody checked whether the code was correct.
+
+This is not a hypothetical. It is the default state of most governance
+constraints. The language sounds precise. The implementations diverge.
+The audits confirm the divergence. The risk persists.
+
+---
+
+## Semantic Drift
+
+Governance language drifts through five predictable stages:
+
+| Stage | What happens | Example |
+| ----- | ------------ | ------- |
+| 1. Coinage | A term is introduced with specific meaning | "Meaningful human oversight" means active evaluation by a qualified human |
+| 2. Adoption without frame | The term enters governance documents without its original context | Policy says "require meaningful human oversight" without defining "meaningful" |
+| 3. Implementation from a different frame | Engineers implement from their own reference frame | Team adds a PR approval gate — technically "human oversight" |
+| 4. Audit from yet another frame | Compliance verifies from the institutional frame | Audit confirms approval records exist — "oversight requirement met" |
+| 5. Crisis | The gap becomes visible through real-world harm | AI-generated code introduces a vulnerability despite "oversight" passing at every stage |
+
+Most governance constraints in the wild are at Stage 2 or 3. The
+language has been adopted, the implementation has diverged, and nobody
+has noticed because the audits check the wrong frame.
+
+The plugin's `/governance-audit` command detects which stage each
+constraint is in. Constraints at Stage 3 or higher need immediate
+attention.
+
+---
+
+## Governance Debt
+
+Governance debt is the accumulation of governance mechanisms whose
+language no longer corresponds to the risks they address. It is the
+fourth form of debt, alongside technical, cognitive, and intent debt.
+
+The four debts reinforce each other in a vicious cycle:
+
+1. **Governance debt** → intent debt: governance language obscures the
+   purpose of controls
+2. **Intent debt** → cognitive debt: teams cannot form accurate mental
+   models of what the governance actually requires
+3. **Cognitive debt** → technical debt: developers implement controls
+   they do not understand
+4. **Technical debt** → governance debt: the gap between governance
+   language and operational reality widens further
+
+Unlike technical debt, which becomes visible in hours or days,
+governance debt manifests over months or years — but when it does, it
+manifests as institutional crisis, not a failed build.
+
+---
+
+## The Three-Frame Translation Problem
+
+Every governance constraint operates at the intersection of three
+reference frames:
+
+| Interface | Failure mode | Detection |
+| --------- | ------------ | --------- |
+| Human ↔ AI | "It did what I said, not what I meant" | Tests, verification, falsification |
+| Human ↔ Institution | "The regulation does not match how we actually work" | Governance specification exercises |
+| AI ↔ Institution | "The system is compliant but not safe" | Adversarial compliance testing |
+
+The most dangerous failures occur when all three frames are misaligned
+simultaneously: the human understands the risk, the governance language
+does not capture it, and the AI system can demonstrate compliance while
+the risk persists.
+
+The plugin's `/governance-constrain` command includes a three-frame
+alignment check that surfaces these divergences before a constraint is
+written to `HARNESS.md`.
+
+---
+
+## Falsifiable Governance
+
+A governance constraint must answer three questions to be falsifiable:
+
+1. **What do you verify?** — the specific observable condition
+2. **What counts as evidence?** — what artefacts demonstrate compliance
+3. **What happens on failure?** — the response when verification fails
+
+If a constraint cannot answer all three, it is governance language
+pretending to be a constraint. It belongs in a policy document, not in
+`HARNESS.md`.
+
+**Before (governance language):**
+
+> Human oversight is required for all AI-generated code.
+
+**After (falsifiable governance constraint):**
+
+> Every PR containing AI-generated code must have at least one review
+> that includes a substantive comment on design intent and confirmation
+> that tests cover the changed behaviour. Verified by agent review of
+> PR comments. Evidence: PR review record. Failure action: PR cannot
+> merge until substantive review is added.
+
+The difference is not length. The difference is that the second version
+can be checked, can fail, and specifies what happens when it does.
+
+---
+
+## How the Plugin Helps
+
+The plugin provides three governance commands that address different
+stages of the governance lifecycle:
+
+| Command | Purpose | When to use |
+| ------- | ------- | ----------- |
+| `/governance-constrain` | Translate governance language into a falsifiable constraint with three-frame alignment | When encoding a new governance requirement |
+| `/governance-audit` | Detect semantic drift, inventory governance debt, check frame alignment | Quarterly, or when governance feels stale |
+| `/governance-health` | Quick pulse check on governance metrics and trends | Between quarterly audits |
+
+The governance-auditor agent owns the deep investigation work.
+Existing agents (harness-enforcer, harness-gc, assessor) gain
+lightweight governance awareness through the governance skills.
+
+A Stop hook nudges `/governance-audit` when governance-related files
+change during a session and the last audit is stale.
+
+For a hands-on walkthrough, start with the
+[Governance for Your Harness](../tutorials/governance-for-your-harness)
+tutorial. For specific tasks, see the how-to guides:
+
+- [Write a governance constraint](../how-to/write-a-governance-constraint)
+- [Run a governance audit](../how-to/run-a-governance-audit)
+- [Check governance health](../how-to/check-governance-health)
+- [Detect semantic drift](../how-to/detect-semantic-drift)
+- [Build a governance dashboard](../how-to/build-a-governance-dashboard)

--- a/docs/how-to/build-a-governance-dashboard.md
+++ b/docs/how-to/build-a-governance-dashboard.md
@@ -1,0 +1,80 @@
+---
+title: Build a Governance Dashboard
+layout: default
+parent: How-to Guides
+nav_order: 33
+---
+
+# Build a Governance Dashboard
+
+Generate an HTML dashboard visualising governance health, constraint
+quality, debt trends, and frame alignment.
+
+---
+
+## Prerequisites
+
+- At least one `/governance-audit` run (the dashboard reads audit
+  report data)
+
+---
+
+## 1. Generate the dashboard
+
+```text
+/governance-health --dashboard
+```
+
+This creates a self-contained HTML file at
+`observability/governance/governance-dashboard.html`.
+
+---
+
+## 2. Open and review
+
+Open the HTML file in a browser. The dashboard has six sections:
+
+| Section | What it shows |
+| ------- | ------------- |
+| Health summary | Overall score, constraint quality distribution, last audit date |
+| Constraint quality table | Each constraint with falsifiability, drift risk, frame alignment, promotion level |
+| Governance debt inventory | Debt items sorted by severity × blast radius score |
+| Drift timeline | Line chart showing drift score over quarterly audit data points |
+| Three-frame alignment heatmap | Per-constraint grid showing engineering, compliance, and AI system alignment |
+| Trend comparison | Sparkline charts for falsifiability ratio, debt size, drift velocity |
+
+---
+
+## 3. Read the signals
+
+Key things to watch:
+
+- **Constraint quality distribution** — if the vague (red) bar is
+  growing, governance constraints are being added without
+  operationalisation
+- **Drift timeline** — an upward trend means governance language is
+  diverging from reality faster than you are fixing it
+- **Three-frame heatmap** — red cells indicate specific constraints
+  where the three frames disagree
+
+---
+
+## 4. Regenerate after each audit
+
+Run `/governance-health --dashboard` after each quarterly
+`/governance-audit` to update the trend data. The dashboard reads all
+audit reports in `observability/governance/` for historical comparison.
+
+---
+
+## What you have now
+
+A self-contained HTML governance dashboard with no external
+dependencies, showing health metrics, debt trends, and frame alignment.
+
+## Next steps
+
+- Share the dashboard with your team for governance visibility
+- The governance data also feeds into the
+  [portfolio dashboard](build-portfolio-dashboard) when using
+  `/portfolio-assess`

--- a/docs/how-to/check-governance-health.md
+++ b/docs/how-to/check-governance-health.md
@@ -1,0 +1,76 @@
+---
+title: Check Governance Health
+layout: default
+parent: How-to Guides
+nav_order: 31
+---
+
+# Check Governance Health
+
+Quick governance pulse check between quarterly audits.
+
+---
+
+## Prerequisites
+
+- At least one previous `/governance-audit` run (for meaningful data)
+
+---
+
+## 1. Run the health check
+
+```text
+/governance-health
+```
+
+The command reads your most recent audit report and current
+`HARNESS.md` to produce a summary table.
+
+---
+
+## 2. Read the metrics
+
+| Metric | What it means |
+| ------ | ------------- |
+| Constraints | Total governance constraints in HARNESS.md |
+| Falsifiability | Proportion scored as falsifiable (target: > 0.75) |
+| Drift score | Overall semantic drift risk (low / medium / high) |
+| Debt items | Number of governance debt items |
+| Frame alignment | Proportion with confirmed three-frame alignment |
+| Last audit | Date of most recent governance audit |
+| Drift velocity | Whether drift is stable, increasing, or decreasing |
+
+---
+
+## 3. Interpret the colours
+
+| Colour | Condition |
+| ------ | --------- |
+| Green | Falsifiability > 0.75, drift low, debt < 3, audit < 90 days |
+| Amber | Falsifiability 0.50–0.75, drift medium, debt 3–5, audit 90–180 days |
+| Red | Falsifiability < 0.50, drift high, debt > 5, audit > 180 days |
+
+---
+
+## 4. Act on recommendations
+
+If the health check flags issues:
+
+- **Audit stale** → run `/governance-audit`
+- **Falsifiability low** → rewrite vague constraints with
+  `/governance-constrain`
+- **Drift high** → run a full audit to identify which constraints
+  have drifted
+
+---
+
+## What you have now
+
+A current view of governance health without running a full audit.
+
+## Next steps
+
+- [Run a governance audit](run-a-governance-audit) if any metric is
+  red
+- [Build a governance dashboard](build-a-governance-dashboard) for a
+  visual overview

--- a/docs/how-to/detect-semantic-drift.md
+++ b/docs/how-to/detect-semantic-drift.md
@@ -1,0 +1,86 @@
+---
+title: Detect Semantic Drift
+layout: default
+parent: How-to Guides
+nav_order: 32
+---
+
+# Detect Semantic Drift in Your Constraints
+
+Find governance constraints whose meaning has diverged from the
+reality they govern, and fix them before they reach crisis.
+
+---
+
+## Prerequisites
+
+- Governance constraints in `HARNESS.md`
+- The ai-literacy-superpowers plugin is installed
+
+---
+
+## 1. Recognise drift signals
+
+Semantic drift is likely when:
+
+- **Implementation changed** — the code files a governance constraint
+  references have changed substantially, but the constraint language
+  has not
+- **Process changed** — your team adopted a new CI pipeline, review
+  process, or toolchain, but governance constraints still reference
+  the old process
+- **Regulatory environment changed** — the regulation or standard
+  cited by a constraint has been updated
+- **Term meaning shifted** — your team now uses a governance term
+  differently than when the constraint was written
+
+---
+
+## 2. Confirm with a governance audit
+
+```text
+/governance-audit
+```
+
+The audit scores each constraint's drift risk and identifies which
+of the five drift stages it is in. Focus on constraints at Stage 3
+or higher — these are constraints where the implementation checks
+form (action exists) rather than substance (action is meaningful).
+
+---
+
+## 3. Rewrite drifted constraints
+
+For each drifted constraint, run:
+
+```text
+/governance-constrain
+```
+
+The guided workflow helps you re-translate the governance requirement
+into current operational meaning. Pay particular attention to the
+three-frame check — drift often occurs because the frames have moved
+apart since the constraint was written.
+
+---
+
+## 4. Verify the fix
+
+After rewriting, run `/governance-health` to confirm the drift score
+has improved. Over multiple audits, the drift velocity metric will
+show whether your governance constraints are converging with reality
+or diverging from it.
+
+---
+
+## What you have now
+
+A method for detecting governance drift before it reaches crisis, and
+a workflow for fixing drifted constraints.
+
+## Next steps
+
+- [Run a governance audit](run-a-governance-audit) quarterly to catch
+  drift early
+- [Check governance health](check-governance-health) between audits
+  for a quick pulse

--- a/docs/how-to/run-a-governance-audit.md
+++ b/docs/how-to/run-a-governance-audit.md
@@ -1,0 +1,106 @@
+---
+title: Run a Governance Audit
+layout: default
+parent: How-to Guides
+nav_order: 30
+---
+
+# Run a Governance Audit
+
+Investigate governance health — falsifiability, semantic drift,
+governance debt, and three-frame alignment across all governance
+constraints.
+
+---
+
+## Prerequisites
+
+- `HARNESS.md` with at least one governance constraint (a constraint
+  that uses governance language or has a `Governance requirement`
+  field)
+- The ai-literacy-superpowers plugin is installed
+
+---
+
+## 1. Run the audit
+
+```text
+/governance-audit
+```
+
+The command dispatches the governance-auditor agent, which scans
+`HARNESS.md` and runs the full audit process.
+
+---
+
+## 2. Read the falsifiability scores
+
+Each governance constraint is scored on a three-point scale:
+
+| Score | Meaning |
+| ----- | ------- |
+| Falsifiable | Has verification criteria, evidence, and failure action |
+| Partially operationalised | Has some operational detail but gaps |
+| Vague | Governance language without operational meaning |
+
+Vague constraints are governance debt. Rewrite them with
+`/governance-constrain`.
+
+---
+
+## 3. Check the drift stages
+
+Each constraint gets a drift stage from 1 to 5:
+
+| Stage | Signal |
+| ----- | ------ |
+| 1 | Healthy — meaning matches reality |
+| 2 | Adopted without frame — language present, context missing |
+| 3 | Implemented from wrong frame — verification checks form, not substance |
+| 4 | Audited from wrong frame — compliance passes, risk persists |
+| 5 | Crisis — governance failure has caused real harm |
+
+Constraints at Stage 3 or higher need immediate attention.
+
+---
+
+## 4. Review the debt inventory
+
+Governance debt items are scored by severity (1–3) multiplied by blast
+radius (1–3). A score of 9 means critical — the constraint language is
+fundamentally misaligned and other constraints depend on it.
+
+| Score | Priority |
+| ----- | -------- |
+| 1–2 | Address next quarter |
+| 3–4 | Address this quarter |
+| 6 | Address within two weeks |
+| 9 | Address immediately |
+
+---
+
+## 5. Act on recommendations
+
+The audit report ends with prioritised recommendations. Common actions:
+
+- **Vague constraint** → run `/governance-constrain` to rewrite
+- **Drifted constraint** → update the operational meaning and re-run
+  the three-frame check
+- **Debt cycle detected** → review the connected constraints together
+
+The report is saved to `observability/governance/audit-YYYY-MM-DD.md`.
+
+---
+
+## What you have now
+
+A governance audit report with falsifiability scores, drift stages,
+debt inventory, and prioritised recommendations.
+
+## Next steps
+
+- [Check governance health](check-governance-health) for a quick
+  pulse between audits
+- [Build a governance dashboard](build-a-governance-dashboard) to
+  visualise trends
+- Add `/governance-audit` to your quarterly operating cadence

--- a/docs/how-to/write-a-governance-constraint.md
+++ b/docs/how-to/write-a-governance-constraint.md
@@ -1,0 +1,104 @@
+---
+title: Write a Governance Constraint
+layout: default
+parent: How-to Guides
+nav_order: 29
+---
+
+# Write a Governance Constraint
+
+Translate a governance requirement into a falsifiable HARNESS.md
+constraint with three-frame alignment.
+
+---
+
+## Prerequisites
+
+- `HARNESS.md` exists in your project root
+- The ai-literacy-superpowers plugin is installed
+
+---
+
+## 1. Start the guided workflow
+
+```text
+/governance-constrain
+```
+
+The command walks through six prompts. Answer each one before
+proceeding.
+
+---
+
+## 2. Identify the governance requirement
+
+The first prompt asks: **What governance requirement are you
+encoding?**
+
+State the institutional language — the regulation, policy, or internal
+standard. For example:
+
+> Internal AI governance policy Section 4.2 — meaningful human review
+> of AI-assisted work
+
+---
+
+## 3. Translate to operational meaning
+
+The second prompt asks: **What does this mean operationally?**
+
+Describe what must actually happen in engineering terms. Be specific.
+"Ensure quality" is not operational. "Every PR must have a review
+comment addressing design intent" is operational.
+
+---
+
+## 4. Define verification, evidence, and failure
+
+The next prompts ask:
+
+- **How do you verify compliance?** — choose deterministic (tool),
+  agent (LLM review), or manual
+- **What counts as evidence?** — test reports, audit logs, review
+  records
+- **What happens on failure?** — block merge, file incident, alert
+  team
+
+---
+
+## 5. Complete the three-frame check
+
+The command presents the constraint from three perspectives:
+
+- **Engineering frame**: what the team must technically do
+- **Compliance frame**: what the audit trail must show
+- **AI system frame**: what the automated gate checks
+
+Confirm the three frames align. If they diverge, resolve the
+divergence before proceeding — the command helps you work through it.
+
+---
+
+## 6. Review the written constraint
+
+The command writes the constraint to `HARNESS.md` using the
+governance template with all fields: Rule, Enforcement, Tool, Scope,
+Governance requirement, Operational meaning, Verification method,
+Evidence, Failure action, and Frame check.
+
+Review the result in `HARNESS.md` to confirm it reads correctly.
+
+---
+
+## What you have now
+
+A governance constraint in `HARNESS.md` that encodes operational
+meaning, has defined verification criteria, and has been checked for
+three-frame alignment.
+
+## Next steps
+
+- [Run a governance audit](run-a-governance-audit) to assess all your
+  governance constraints
+- [Detect semantic drift](detect-semantic-drift) to catch constraints
+  that have diverged from reality

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Agents
 
-The plugin ships 10 agents organised into three groups: the
+The plugin ships 11 agents organised into four groups: the
 **spec-first pipeline** that coordinates feature work end to end,
 the **harness agents** that verify and maintain infrastructure
 conventions, and the **assessor** that measures AI literacy.
@@ -176,6 +176,30 @@ with a literacy level badge.
 
 ---
 
+## Governance
+
+### governance-auditor
+
+- **Tools**: Read, Write, Edit, Glob, Grep, Bash
+- **Dispatched by**: `/governance-audit`, `/governance-health`,
+  orchestrator (for governance-related tasks)
+- **Trust boundary**: Read + limited Write (audit reports and snapshot
+  updates only)
+
+Governance specialist for deep investigation. Detects semantic drift
+using the five-stage model, inventories governance debt with severity
+and blast radius scoring, checks three-frame alignment between
+engineering, compliance, and AI system interpretations, and produces
+structured audit reports to `observability/governance/`. Reads the
+`governance-audit-practice`, `governance-constraint-design`, and
+`governance-observability` skills before acting.
+
+Does not modify `HARNESS.md` constraints directly — reports findings
+for humans to decide on. Uses the best available model because
+governance analysis requires nuanced judgement about meaning.
+
+---
+
 ## Tool Summary
 
 | Agent | Read | Write | Edit | Glob | Grep | Bash | Agent | WebFetch | Trust |
@@ -190,6 +214,7 @@ with a literacy level badge.
 | harness-enforcer | x | | | x | x | x | | | read-only |
 | harness-gc | x | x | x | x | x | x | | | read-write |
 | assessor | x | x | x | x | x | x | | | read-write |
+| governance-auditor | x | x | x | x | x | x | | | read-write (limited) |
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Commands
 
-All 15 slash commands registered in `commands/`. Each command is
+All 18 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -239,3 +239,47 @@ Manage git worktrees for parallel agent isolation. Three modes:
   the current branch.
 - **`/worktree clean [name]`** — Remove the named worktree and its
   branch.
+
+---
+
+## Governance
+
+Commands for writing, auditing, and monitoring governance constraints.
+
+### /governance-constrain
+
+- **Skills read**: governance-constraint-design
+- **Agents dispatched**: none
+
+Guided authoring of governance constraints. Walks through six
+prompts: governance requirement, operational meaning, verification
+method, evidence and failure action, and three-frame alignment check.
+Writes the result to `HARNESS.md` using the governance constraint
+template with all extended fields. Suggests a promotion path after
+writing.
+
+### /governance-audit
+
+- **Skills read**: governance-audit-practice, governance-observability
+- **Agents dispatched**: governance-auditor
+
+Deep governance investigation. Dispatches the governance-auditor
+agent to scan `HARNESS.md`, score falsifiability, detect semantic
+drift, build a governance debt inventory, check three-frame
+alignment, and produce a structured report to
+`observability/governance/audit-YYYY-MM-DD.md`. Updates governance
+metrics in the harness health snapshot. Intended cadence: quarterly,
+alongside `/assess` and `/harness-audit`.
+
+### /governance-health
+
+- **Skills read**: governance-observability
+- **Agents dispatched**: none (dispatches governance-auditor only
+  for snapshot governance section)
+
+Quick governance pulse check. Reads the most recent audit report and
+current `HARNESS.md` to display a summary table with constraint
+count, falsifiability ratio, drift score, debt inventory size, frame
+alignment score, last audit date, and drift velocity. Pass
+`--dashboard` to generate a self-contained HTML governance dashboard
+at `observability/governance/governance-dashboard.html`.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -143,6 +143,22 @@ you to review and curate learnings. This closes the gap in the
 compound learning lifecycle where reflections are captured but never
 promoted to team memory.
 
+### Governance drift check (command)
+
+- **Event**: Stop
+- **Matcher**: `*`
+- **Type**: command
+- **Script**: `hooks/scripts/governance-drift-check.sh`
+- **Timeout**: 10s
+
+Checks whether governance-related files were modified during the
+session and whether the last governance audit is stale (> 90 days).
+Detects three signals: HARNESS.md changes involving governance
+language, compliance or policy document modifications, and audit
+staleness. Also flags when governance constraints exist in
+HARNESS.md but no audit has ever been run. Nudges
+`/governance-audit` or `/governance-health`.
+
 ---
 
 ## Configuration

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Skills
 
-The plugin ships 24 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 27 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -124,3 +124,19 @@ Quarterly AI cost capture and tracking. Covers guiding users through provider bi
 ### auto-enforcer-action
 
 Automatic PR constraint checking via GitHub Actions. Covers installing and configuring the GitHub Action that runs harness constraint checks on every pull request without manual intervention.
+
+---
+
+## Governance
+
+### governance-constraint-design
+
+Falsifiable governance constraint authoring. Covers the falsifiability test (what to verify, what counts as evidence, what happens on failure), the three-frame translation step (engineering, compliance, AI system perspectives), an anti-patterns gallery with falsifiable rewrites, and the governance constraint template for HARNESS.md. Referenced by `/governance-constrain` and the harness-enforcer agent.
+
+### governance-audit-practice
+
+Governance audit methodology. Covers the seven-step audit process, the five-stage semantic drift model with detection heuristics, governance debt scoring (severity × blast radius matrix), three-frame alignment assessment, four-debt cycle reinforcement detection, and audit report format. Referenced by the governance-auditor agent.
+
+### governance-observability
+
+Governance metrics and dashboard specification. Covers the seven governance metrics (constraint count, falsifiability ratio, drift score, debt inventory size, frame alignment score, last audit date, drift velocity), the snapshot format extension, staleness thresholds, audit report format, HTML dashboard section specifications, and portfolio integration. Referenced by the governance-auditor agent and `/governance-health`.

--- a/docs/superpowers/plans/2026-04-13-governance-documentation.md
+++ b/docs/superpowers/plans/2026-04-13-governance-documentation.md
@@ -1,0 +1,100 @@
+# Governance Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add governance documentation to the plugin's Jekyll docs site — 1 explanation, 1 tutorial, 5 how-to guides, and updates to 4 reference pages.
+
+**Architecture:** Follow the existing Diataxis structure. Each new page gets Jekyll frontmatter with title, layout, parent, and nav_order. All pages are pure markdown — no code, no build steps. Reference pages are extended inline. Markdownlint validates every file.
+
+**Tech Stack:** Jekyll (Just the Docs theme), Markdown, markdownlint-cli2
+
+**Spec:** `docs/superpowers/specs/2026-04-13-governance-documentation-design.md`
+
+**All paths relative to:** `/Users/russellmiles/code/russmiles/ai-literacy-superpowers/`
+
+---
+
+### Task 1: Write the Explanation Page
+
+**Files:**
+- Create: `docs/explanation/governance-as-meaning-alignment.md`
+
+- [ ] **Step 1: Write the explanation page** — Create the file with the full content covering: the core problem (governance language carries different meanings in different frames), semantic drift (five stages), governance debt (fourth debt, vicious cycle), the three-frame translation problem, falsifiable governance (the three questions), and how the plugin helps (commands overview with links to tutorial and how-to guides). Use Jekyll frontmatter: title "Governance as meaning-alignment", parent "Explanation", nav_order 16.
+
+- [ ] **Step 2: Run markdownlint** — `npx markdownlint-cli2 "docs/explanation/governance-as-meaning-alignment.md"` — Expected: 0 errors.
+
+- [ ] **Step 3: Commit** — `git add docs/explanation/governance-as-meaning-alignment.md && git commit -m "Add governance-as-meaning-alignment explanation page"`
+
+---
+
+### Task 2: Write the Tutorial
+
+**Files:**
+- Create: `docs/tutorials/governance-for-your-harness.md`
+
+- [ ] **Step 1: Write the tutorial** — Create the file walking through: spot governance language in existing constraints, run `/governance-audit` and read the report, write a governance constraint with `/governance-constrain` (show before/after), check health with `/governance-health` (explain the metrics table and colour thresholds), generate the dashboard with `--dashboard` flag. Use Jekyll frontmatter: title "Governance for Your Harness", parent "Tutorials", nav_order 8. End with "What you have now" and "Next steps" sections.
+
+- [ ] **Step 2: Run markdownlint** — `npx markdownlint-cli2 "docs/tutorials/governance-for-your-harness.md"` — Expected: 0 errors.
+
+- [ ] **Step 3: Commit** — `git add docs/tutorials/governance-for-your-harness.md && git commit -m "Add governance tutorial — audit, constrain, monitor workflow"`
+
+---
+
+### Task 3: Write the Five How-To Guides
+
+**Files:**
+- Create: `docs/how-to/write-a-governance-constraint.md`
+- Create: `docs/how-to/run-a-governance-audit.md`
+- Create: `docs/how-to/check-governance-health.md`
+- Create: `docs/how-to/detect-semantic-drift.md`
+- Create: `docs/how-to/build-a-governance-dashboard.md`
+
+All guides follow the template in `docs/how-to/_template.md`: one-line description, prerequisites, numbered H2 steps, "What you have now", "Next steps". 60-120 lines each. Jekyll frontmatter with parent "How-to Guides".
+
+- [ ] **Step 1: Write `write-a-governance-constraint.md`** — nav_order 29. Steps: start `/governance-constrain`, identify the governance requirement, translate to operational meaning, define verification/evidence/failure, complete three-frame check, review the written constraint. Show one complete example.
+
+- [ ] **Step 2: Write `run-a-governance-audit.md`** — nav_order 30. Steps: run `/governance-audit`, read falsifiability scores (table: falsifiable/partial/vague), check drift stages (table: stages 1-5 with signals), review debt inventory (scoring matrix), act on recommendations. Note report save location.
+
+- [ ] **Step 3: Write `check-governance-health.md`** — nav_order 31. Steps: run `/governance-health`, read the metrics table (explain each metric), interpret colours (green/amber/red thresholds table), act on recommendations. Shorter guide.
+
+- [ ] **Step 4: Write `detect-semantic-drift.md`** — nav_order 32. Steps: recognise drift signals (implementation changed, process changed, regulatory changed, term meaning shifted), confirm with `/governance-audit` (focus on Stage 3+), rewrite drifted constraints with `/governance-constrain`, verify fix with `/governance-health`.
+
+- [ ] **Step 5: Write `build-a-governance-dashboard.md`** — nav_order 33. Steps: run `/governance-health --dashboard`, open HTML file, review six dashboard sections (table describing each), read the signals (what to watch for), regenerate after each quarterly audit. Mention portfolio integration.
+
+- [ ] **Step 6: Run markdownlint on all five** — `npx markdownlint-cli2 "docs/how-to/write-a-governance-constraint.md" "docs/how-to/run-a-governance-audit.md" "docs/how-to/check-governance-health.md" "docs/how-to/detect-semantic-drift.md" "docs/how-to/build-a-governance-dashboard.md"` — Expected: 0 errors.
+
+- [ ] **Step 7: Commit** — `git add docs/how-to/write-a-governance-constraint.md docs/how-to/run-a-governance-audit.md docs/how-to/check-governance-health.md docs/how-to/detect-semantic-drift.md docs/how-to/build-a-governance-dashboard.md && git commit -m "Add five governance how-to guides"`
+
+---
+
+### Task 4: Update Reference Pages
+
+**Files:**
+- Modify: `docs/reference/agents.md`
+- Modify: `docs/reference/commands.md`
+- Modify: `docs/reference/skills.md`
+- Modify: `docs/reference/hooks.md`
+
+- [ ] **Step 1: Update `agents.md`** — Change "ships 10 agents" to "ships 11 agents". Add "## Governance Agents" section with `governance-auditor` entry (Tools, Dispatched by, Trust boundary, description). Add row to Tool Summary table. Follow the existing entry format (see harness-auditor or assessor entries for pattern).
+
+- [ ] **Step 2: Update `commands.md`** — Change "All 15 slash commands" to "All 18 slash commands". Add "## Governance" section with three entries: `/governance-constrain` (skills read, agents dispatched, description), `/governance-audit`, `/governance-health`. Follow existing entry format (see `/harness-audit` for pattern).
+
+- [ ] **Step 3: Update `skills.md`** — Change "ships 24 skills" to "ships 27 skills". Add "## Governance" section with three entries: `governance-constraint-design`, `governance-audit-practice`, `governance-observability`. One paragraph each describing coverage. Follow existing entry format.
+
+- [ ] **Step 4: Update `hooks.md`** — Add "### Governance drift check (command)" entry after the last Stop hook. Include Event, Matcher, Type, Script, Timeout, and description of what it detects and nudges. Follow existing entry format (see drift-check or curation-nudge).
+
+- [ ] **Step 5: Run markdownlint** — `npx markdownlint-cli2 "docs/reference/agents.md" "docs/reference/commands.md" "docs/reference/skills.md" "docs/reference/hooks.md"` — Expected: 0 errors.
+
+- [ ] **Step 6: Commit** — `git add docs/reference/agents.md docs/reference/commands.md docs/reference/skills.md docs/reference/hooks.md && git commit -m "Add governance entries to reference pages (agents, commands, skills, hooks)"`
+
+---
+
+### Task 5: Final Verification
+
+- [ ] **Step 1: Run markdownlint on all 11 files** — `npx markdownlint-cli2 "docs/explanation/governance-as-meaning-alignment.md" "docs/tutorials/governance-for-your-harness.md" "docs/how-to/write-a-governance-constraint.md" "docs/how-to/run-a-governance-audit.md" "docs/how-to/check-governance-health.md" "docs/how-to/detect-semantic-drift.md" "docs/how-to/build-a-governance-dashboard.md" "docs/reference/agents.md" "docs/reference/commands.md" "docs/reference/skills.md" "docs/reference/hooks.md"` — Expected: 0 errors across all files.
+
+- [ ] **Step 2: Verify cross-references** — Check that all internal links between governance doc pages point to existing files.
+
+- [ ] **Step 3: Verify nav_order uniqueness** — `grep -r "nav_order" docs/explanation/ docs/tutorials/ docs/how-to/ docs/reference/` — Confirm no duplicate values within the same parent.
+
+- [ ] **Step 4: Verify file count** — 7 new files (1 explanation + 1 tutorial + 5 how-to), 4 modified reference files.

--- a/docs/superpowers/specs/2026-04-13-governance-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-governance-documentation-design.md
@@ -1,0 +1,294 @@
+# Design: Governance Dimension Documentation
+
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Summary
+
+Add governance documentation to the plugin's Jekyll docs site following the existing Diataxis structure: 1 explanation page, 1 tutorial, 5 how-to guides, and updates to 4 existing reference pages. Covers the conceptual foundation (governance as meaning-alignment), a complete walkthrough (audit-then-fix-then-monitor), practical task guides (one per governance workflow), and reference entries for all new components.
+
+## Motivation
+
+The plugin now has governance support (v0.12.0) — a governance-auditor agent, three skills, three commands, a stop hook, and extensions to three existing agents. None of this is documented on the docs site. Users discovering the governance features have no explanation of why governance language drifts, no tutorial for getting started, no task-oriented guides for specific workflows, and no reference entries for the new components.
+
+## Scope
+
+### In scope
+
+1. **One explanation page** — `explanation/governance-as-meaning-alignment.md`
+2. **One tutorial** — `tutorials/governance-for-your-harness.md`
+3. **Five how-to guides** — write constraint, run audit, check health, detect drift, build dashboard
+4. **Four reference page updates** — agents.md, commands.md, skills.md, hooks.md
+5. **Navigation updates** — nav_order values for new pages
+
+### Out of scope
+
+- Changes to the governance plugin components themselves
+- New reference pages (governance entries go in existing pages)
+- Docs site infrastructure changes (Jekyll config, theme, etc.)
+- Cross-repo sync (follows separately)
+
+## Design
+
+### 1. Explanation: Governance as Meaning-Alignment
+
+**File:** `docs/explanation/governance-as-meaning-alignment.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Governance as meaning-alignment
+layout: default
+parent: Explanation
+nav_order: 16
+---
+```
+
+**Content structure:**
+
+1. **Opening** — governance failures are not technical failures, they are reference frame translation failures. One paragraph framing the problem.
+
+2. **The core problem** — governance language ("ensure fairness", "maintain transparency", "require human oversight") carries different meanings in different reference frames. The regulator, the engineer, and the AI system each interpret the same words differently. When all three frames are satisfied syntactically while governance fails semantically — the approval happens, but the oversight is absent.
+
+3. **Semantic drift** — the five-stage process: coinage → adoption without frame → implementation from different frame → audit from yet another frame → crisis. Brief description of each stage with the "meaningful human oversight" running example.
+
+4. **Governance debt** — the fourth form of debt alongside technical, cognitive, and intent debt. The vicious cycle: governance debt → intent debt → cognitive debt → technical debt → governance debt. Unlike technical debt (visible in hours), governance debt manifests over years.
+
+5. **The three-frame translation problem** — table showing the three interfaces (Human ↔ AI, Human ↔ Institution, AI ↔ Institution), failure modes, and detection methods. The most dangerous failures occur when all three frames are misaligned simultaneously.
+
+6. **Falsifiable governance** — a governance constraint must answer three questions: what do you verify, what counts as evidence, what happens on failure. If it cannot answer all three, it is governance language pretending to be a constraint. Brief comparison of a vague constraint and its falsifiable rewrite.
+
+7. **How the plugin helps** — brief overview connecting concepts to tools: `/governance-constrain` for authoring, `/governance-audit` for detection, `/governance-health` for monitoring. Links to tutorial and how-to guides.
+
+**Tone:** Conceptual, building from first principles. Matches existing explanation pages like `harness-engineering.md`. No code blocks except the constraint comparison example.
+
+### 2. Tutorial: Governance for Your Harness
+
+**File:** `docs/tutorials/governance-for-your-harness.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Governance for your harness
+layout: default
+parent: Tutorials
+nav_order: 8
+---
+```
+
+**Content structure:**
+
+1. **Opening** — one sentence: take your harness from "governance language without operational meaning" to "falsifiable governance constraints with drift detection."
+
+2. **Prerequisites** — a project with the plugin installed and a HARNESS.md. Link to `harness-from-scratch` tutorial if needed.
+
+3. **Step 1: Spot governance language in your constraints** — guide the reader to look at their existing HARNESS.md constraints for governance terms (fairness, oversight, transparency, compliance, accountability). Show an example of a constraint that uses governance language without operationalising it.
+
+4. **Step 2: Run your first governance audit** — run `/governance-audit`. Walk through what the governance-auditor agent produces: the falsifiability scores (falsifiable / partially operationalised / vague), the drift stages, the debt inventory. Show example output.
+
+5. **Step 3: Write your first governance constraint** — run `/governance-constrain` and walk through the guided workflow step by step. Show the three-frame alignment check in action. Show the before (vague) and after (falsifiable) constraint side by side in HARNESS.md.
+
+6. **Step 4: Check governance health** — run `/governance-health`. Explain each metric in the summary table: constraint count, falsifiability ratio, drift score, debt items, frame alignment, drift velocity. Explain the colour coding.
+
+7. **Step 5: Generate the dashboard** — run `/governance-health --dashboard`. Describe what opens in the browser — the six dashboard sections and what they show.
+
+8. **What you have now** — summary: governance constraints that encode operational meaning, an audit baseline, a health snapshot, and a dashboard for tracking trends.
+
+9. **Next steps** — add `/governance-audit` to your quarterly cadence (alongside `/assess` and `/harness-audit`). Write governance constraints for your other governance requirements. Explore the how-to guides for specific tasks.
+
+**Tone:** Step-by-step, welcoming, practical. Matches `your-first-assessment.md`.
+
+### 3. How-To Guides (5 pages)
+
+All how-to guides follow the template in `how-to/_template.md`: title, one-line description, prerequisites, numbered steps (H2 headings), "What you have now", "Next steps".
+
+#### 3.1 Write a Governance Constraint
+
+**File:** `docs/how-to/write-a-governance-constraint.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Write a governance constraint
+layout: default
+parent: How-To Guides
+nav_order: 29
+---
+```
+
+**Content:**
+
+1. One-liner: translate a governance requirement into a falsifiable HARNESS.md constraint with three-frame alignment.
+2. Prerequisites: HARNESS.md exists, plugin installed.
+3. Steps: run `/governance-constrain`, walk through each prompt (governance requirement → operational meaning → verification → evidence/failure → three-frame check → write to HARNESS.md → promotion path).
+4. Show one complete example: "human review of AI-generated code" → the full governance constraint template with all fields filled.
+5. What you have now: a governance constraint in HARNESS.md that encodes operational meaning, with three-frame alignment confirmed.
+6. Next steps: run `/governance-audit` to assess it, link to detect-semantic-drift guide.
+
+#### 3.2 Run a Governance Audit
+
+**File:** `docs/how-to/run-a-governance-audit.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Run a governance audit
+layout: default
+parent: How-To Guides
+nav_order: 30
+---
+```
+
+**Content:**
+
+1. One-liner: investigate governance health — falsifiability, semantic drift, governance debt, and three-frame alignment.
+2. Prerequisites: HARNESS.md with at least one governance constraint.
+3. Steps: run `/governance-audit`, describe what the governance-auditor agent does (7-step process), how to read the report (constraint assessment table, debt inventory, debt cycle analysis, prioritised recommendations), where the report is saved.
+4. Show example report sections with annotations explaining each part.
+5. What you have now: a governance audit report in `observability/governance/` and updated health snapshot.
+6. Next steps: fix vague constraints with `/governance-constrain`, check trends with `/governance-health`, add to quarterly cadence.
+
+#### 3.3 Check Governance Health
+
+**File:** `docs/how-to/check-governance-health.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Check governance health
+layout: default
+parent: How-To Guides
+nav_order: 31
+---
+```
+
+**Content:**
+
+1. One-liner: quick governance pulse check between quarterly audits.
+2. Prerequisites: at least one previous `/governance-audit` run (for meaningful data).
+3. Steps: run `/governance-health`, read the summary table (each metric explained), understand the colour coding (green/amber/red thresholds), interpret the recommendations.
+4. Show example summary output with annotations.
+5. What you have now: a current view of governance health without running a full audit.
+6. Next steps: if stale or unhealthy, run `/governance-audit`. Link to dashboard guide.
+
+#### 3.4 Detect Semantic Drift in Your Constraints
+
+**File:** `docs/how-to/detect-semantic-drift.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Detect semantic drift in your constraints
+layout: default
+parent: How-To Guides
+nav_order: 32
+---
+```
+
+**Content:**
+
+1. One-liner: find governance constraints whose meaning has diverged from the reality they govern.
+2. Prerequisites: governance constraints in HARNESS.md.
+3. Steps:
+   - Recognise drift signals: implementation files changed substantially, team workflow changed, regulatory environment updated, team uses governance terms differently
+   - Run `/governance-audit` to confirm — read the drift stage (1-5) and drift risk (low/medium/high) for each constraint
+   - For constraints at Stage 3+, run `/governance-constrain` to rewrite with updated operational meaning
+   - After fixing, run `/governance-health` to check drift velocity trend
+4. Table: the five drift stages with detection heuristics (brief version).
+5. What you have now: a method for detecting and fixing governance drift before it reaches crisis.
+6. Next steps: set up quarterly cadence, link to governance audit guide.
+
+#### 3.5 Build a Governance Dashboard
+
+**File:** `docs/how-to/build-a-governance-dashboard.md`
+
+**Frontmatter:**
+
+```yaml
+---
+title: Build a governance dashboard
+layout: default
+parent: How-To Guides
+nav_order: 33
+---
+```
+
+**Content:**
+
+1. One-liner: generate an HTML dashboard visualising governance health, constraint quality, debt trends, and frame alignment.
+2. Prerequisites: at least one `/governance-audit` run.
+3. Steps: run `/governance-health --dashboard`, describe the generated HTML file location, walk through each dashboard section (health summary cards, constraint quality table, debt inventory, drift timeline, three-frame heatmap, trend comparison).
+4. Explain how to read each visualisation — what the colours mean, what trends to watch for, when to act.
+5. Portfolio integration: mention that governance data feeds into the portfolio dashboard when using `/portfolio-assess`.
+6. What you have now: a self-contained HTML governance dashboard.
+7. Next steps: share with your team, regenerate after each quarterly audit, link to portfolio dashboard guide.
+
+### 4. Reference Page Updates
+
+#### 4.1 `reference/agents.md`
+
+Add governance-auditor entry matching existing format:
+
+- **Name:** governance-auditor
+- **Role:** Governance specialist — semantic drift analysis, governance debt inventory, constraint falsifiability scoring, three-frame alignment checks
+- **Trust boundary:** Read + limited Write (audit reports and snapshot updates only)
+- **Tools:** Read, Write, Edit, Glob, Grep, Bash
+- **Dispatched by:** `/governance-audit`, `/governance-health`, orchestrator (for governance-related tasks)
+- **Model tier:** Best available (governance analysis requires nuanced judgement)
+
+#### 4.2 `reference/commands.md`
+
+Add three entries matching existing format:
+
+- **/governance-constrain** — guided governance constraint authoring with three-frame alignment check. Reads `governance-constraint-design` skill. Writes to HARNESS.md.
+- **/governance-audit** — deep governance investigation. Dispatches governance-auditor agent. Writes report to `observability/governance/`. Quarterly cadence.
+- **/governance-health** — governance health pulse check. Reads most recent audit report. Pass `--dashboard` to generate HTML dashboard.
+
+#### 4.3 `reference/skills.md`
+
+Add three entries matching existing format:
+
+- **governance-constraint-design** — falsifiable governance constraint authoring. Three-frame translation, anti-patterns gallery, governance constraint template. Referenced by `/governance-constrain` and harness-enforcer.
+- **governance-audit-practice** — governance audit methodology. Five-stage semantic drift model, debt scoring matrix, frame alignment review. Referenced by governance-auditor agent.
+- **governance-observability** — governance metrics, snapshot format extension, dashboard specification. Referenced by governance-auditor and `/governance-health`.
+
+#### 4.4 `reference/hooks.md`
+
+Add governance drift check entry matching existing format:
+
+- **Name:** governance-drift-check
+- **Event:** Stop
+- **Type:** command (shell script)
+- **What it detects:** governance-related file changes during session, governance audit staleness (>90 days), governance constraints without any audit
+- **What it nudges:** `/governance-audit` or `/governance-health`
+- **Advisory:** yes (never blocks)
+
+### 5. Navigation
+
+New pages use `nav_order` values that place them logically within their sections:
+
+- Explanation: nav_order 16 (after existing explanation pages)
+- Tutorial: nav_order 8 (after existing tutorials)
+- How-to guides: nav_order 29-33 (after existing how-to guides)
+
+## Component Summary
+
+| Type | File | Status |
+|------|------|--------|
+| Explanation | `explanation/governance-as-meaning-alignment.md` | New |
+| Tutorial | `tutorials/governance-for-your-harness.md` | New |
+| How-To | `how-to/write-a-governance-constraint.md` | New |
+| How-To | `how-to/run-a-governance-audit.md` | New |
+| How-To | `how-to/check-governance-health.md` | New |
+| How-To | `how-to/detect-semantic-drift.md` | New |
+| How-To | `how-to/build-a-governance-dashboard.md` | New |
+| Reference | `reference/agents.md` | Updated |
+| Reference | `reference/commands.md` | Updated |
+| Reference | `reference/skills.md` | Updated |
+| Reference | `reference/hooks.md` | Updated |

--- a/docs/tutorials/governance-for-your-harness.md
+++ b/docs/tutorials/governance-for-your-harness.md
@@ -1,0 +1,236 @@
+---
+title: Governance for Your Harness
+layout: default
+parent: Tutorials
+nav_order: 8
+---
+
+# Governance for Your Harness
+
+Take your harness from "governance language without operational meaning"
+to "falsifiable governance constraints with drift detection and a health
+dashboard." This tutorial walks through auditing what you have, writing
+a proper governance constraint, and monitoring governance health.
+
+It takes about twenty minutes.
+
+---
+
+## Prerequisites
+
+You need:
+
+- Claude Code installed with the ai-literacy-superpowers plugin
+  (see [Getting Started](getting-started))
+- A project with a `HARNESS.md` — if you do not have one yet, run
+  through [Harness from Scratch](harness-from-scratch) first
+
+The tutorial works best if your `HARNESS.md` already has a few
+constraints. Most teams have at least one constraint that uses
+governance language without operationalising it — that is what we will
+find and fix.
+
+---
+
+## Step 1: Spot Governance Language in Your Constraints
+
+Open your `HARNESS.md` and look at the Constraints section. Scan for
+terms like:
+
+- "human review required"
+- "ensure compliance"
+- "maintain transparency"
+- "follow best practices"
+- "responsible use"
+
+These are governance language — they sound precise but carry different
+meanings depending on who reads them. A constraint that says "human
+review required" does not specify what the human must verify, what
+counts as evidence of review, or what happens when review is
+inadequate.
+
+If you find one, note it. We will come back to it in Step 3.
+
+If your constraints do not contain governance language, you can still
+continue — Step 2 will confirm whether the plugin's governance-auditor
+agrees with your assessment.
+
+---
+
+## Step 2: Run Your First Governance Audit
+
+Run the governance audit command:
+
+```text
+/governance-audit
+```
+
+The governance-auditor agent scans your `HARNESS.md` and produces a
+report covering:
+
+- **Falsifiability scores** — each governance constraint scored as
+  falsifiable, partially operationalised, or vague
+- **Drift stages** — which of the five semantic drift stages each
+  constraint is in (1 = healthy, 5 = crisis)
+- **Governance debt inventory** — constraints whose language no longer
+  matches the reality they govern, scored by severity and blast radius
+- **Three-frame alignment** — whether the engineering, compliance, and
+  AI system interpretations of each constraint agree
+
+The report is saved to `observability/governance/audit-YYYY-MM-DD.md`.
+
+Read through the constraint assessment table. If any constraint shows
+"vague" for falsifiability or Stage 3+ for drift, that is where to
+focus first.
+
+---
+
+## Step 3: Write Your First Governance Constraint
+
+Pick the vaguest governance constraint from the audit (or the one you
+spotted in Step 1) and rewrite it as a falsifiable governance
+constraint:
+
+```text
+/governance-constrain
+```
+
+The command walks you through a guided workflow:
+
+1. **Governance requirement** — what institutional language are you
+   encoding? For example: "Internal AI policy Section 4 — human review
+   of AI-generated code"
+
+2. **Operational meaning** — what does this actually mean in
+   engineering terms? For example: "Every PR with AI-generated code
+   must have a review comment addressing design intent and test
+   coverage"
+
+3. **Verification** — how do you check compliance? Choose
+   deterministic (tool), agent (LLM review), or manual
+
+4. **Evidence and failure** — what proves compliance? What happens
+   when it fails?
+
+5. **Three-frame alignment check** — the command presents the
+   constraint from engineering, compliance, and AI system perspectives
+   and asks you to confirm they align
+
+After completing the workflow, the constraint is written to
+`HARNESS.md` with the full governance template:
+
+```markdown
+### AI-generated code review quality
+
+- **Rule**: Every PR containing AI-generated code must have at least
+  one review with a substantive comment on design intent and
+  confirmation that tests cover changed behaviour
+- **Enforcement**: agent
+- **Tool**: harness-enforcer
+- **Scope**: pr
+- **Governance requirement**: Internal AI policy Section 4.2
+- **Operational meaning**: reviewers must demonstrate cognitive
+  engagement, not just approval-click
+- **Verification method**: agent reviews PR comments for evidence of
+  design reasoning and test coverage confirmation
+- **Evidence**: PR review record with design and test comments
+- **Failure action**: PR flagged for additional review
+- **Frame check**: confirmed aligned
+```
+
+Compare this with the original vague version. The difference is that
+this constraint can be checked, can fail, and specifies what happens
+when it does.
+
+---
+
+## Step 4: Check Governance Health
+
+Run the health check to see your governance metrics:
+
+```text
+/governance-health
+```
+
+You will see a summary table:
+
+```text
+Governance Health
+─────────────────────────────────────────
+Constraints:          4
+Falsifiability:       0.75 (3/4 falsifiable)
+Drift score:          low
+Debt items:           1
+Frame alignment:      0.75 (3/4 aligned)
+Last audit:           2026-04-13 (0 days ago)
+Drift velocity:       stable
+─────────────────────────────────────────
+```
+
+Each metric has a colour threshold:
+
+| Metric | Green | Amber | Red |
+| ------ | ----- | ----- | --- |
+| Falsifiability | > 0.75 | 0.50–0.75 | < 0.50 |
+| Drift score | low | medium | high |
+| Debt items | 0–2 | 3–5 | > 5 |
+| Last audit | < 90 days | 90–180 days | > 180 days |
+
+If anything is amber or red, the health check recommends specific
+actions — usually running `/governance-constrain` to rewrite vague
+constraints or `/governance-audit` for a deeper investigation.
+
+---
+
+## Step 5: Generate the Dashboard
+
+For a visual overview, generate the governance dashboard:
+
+```text
+/governance-health --dashboard
+```
+
+This creates a self-contained HTML file at
+`observability/governance/governance-dashboard.html`. Open it in a
+browser to see:
+
+1. **Health summary cards** — overall score, constraint quality
+   distribution, last audit date
+2. **Constraint quality table** — each constraint with falsifiability,
+   drift risk, frame alignment, and promotion level
+3. **Governance debt inventory** — debt items sorted by score
+4. **Drift timeline** — how drift has changed across quarterly audits
+5. **Three-frame alignment heatmap** — visual showing where
+   engineering, compliance, and AI system frames agree or diverge
+6. **Trend comparison** — sparkline charts for key metrics over time
+
+The dashboard works offline — it is a single HTML file with no
+external dependencies.
+
+---
+
+## What You Have Now
+
+After completing this tutorial:
+
+- A governance audit baseline in `observability/governance/`
+- At least one falsifiable governance constraint in `HARNESS.md` with
+  three-frame alignment confirmed
+- A governance health snapshot showing your current metrics
+- A visual dashboard for tracking governance trends
+
+---
+
+## Next Steps
+
+- **Add governance to your quarterly cadence** — run `/governance-audit`
+  alongside `/assess` and `/harness-audit` each quarter
+- **Write more governance constraints** — use `/governance-constrain`
+  for each governance requirement your team operates under
+- **Watch for the drift nudge** — the governance drift check Stop hook
+  will alert you when governance-related files change and the audit
+  is stale
+- **Explore the how-to guides** for specific tasks:
+  [write a constraint](../how-to/write-a-governance-constraint),
+  [detect drift](../how-to/detect-semantic-drift),
+  [build a dashboard](../how-to/build-a-governance-dashboard)


### PR DESCRIPTION
## Summary

- Add governance-as-meaning-alignment explanation page — semantic drift, governance debt, three-frame problem, falsifiable governance
- Add governance tutorial — audit existing constraints, write a falsifiable constraint, check health, generate dashboard
- Add five governance how-to guides: write a constraint, run an audit, check health, detect semantic drift, build a dashboard
- Update four reference pages with governance entries: agents (governance-auditor), commands (3 governance commands), skills (3 governance skills), hooks (governance drift check)

7 new pages, 4 updated pages, 0 markdownlint errors. Follows the existing Diataxis structure with Jekyll frontmatter and nav_order values.

Complements the governance plugin support landed in PR #109.

## Test plan

- [ ] Verify all 11 files pass markdownlint
- [ ] Verify nav_order values don't conflict within parent groups
- [ ] Verify internal cross-references between governance pages resolve
- [ ] Verify reference page counts are updated (27 skills, 11 agents, 18 commands)
- [ ] Build the Jekyll site locally and verify governance pages appear in sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)