### PR TITLE
Add Observatory-ready YAML metrics block to health snapshots

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.0",
-  "plugin_version": "0.12.0",
+  "plugin_version": "0.13.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.0 — 2026-04-14
+
+### Observatory-Ready Metrics
+
+- Add YAML metrics block to harness health snapshots — structured,
+  typed `observatory_metrics` block appended after all markdown
+  sections, enabling machine consumption without brittle regex parsing
+- Add per-context-layer freshness tracking in `context_depth.layers` —
+  each of the five context layers reports `present` and `last_modified`
+- Add per-constraint enforcement detail in `constraint_maturity.constraints` —
+  each constraint listed with name, tier, and enforced status
+- Add observatory metrics schema documentation with versioning policy
+  (patch/minor/major) and changelog at
+  `references/observatory-metrics-schema.md`
+
 ## 0.12.0 — 2026-04-13
 
 ### Governance Dimension Support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.12.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.13.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/commands/harness-health.md
+++ b/commands/harness-health.md
@@ -94,6 +94,12 @@ Include all sections: Enforcement, Garbage Collection, Mutation Testing,
 Compound Learning, Operational Cadence, Cost Indicators, Meta, and
 Trends (if previous snapshot exists).
 
+After all markdown sections, append the Observatory YAML metrics block
+at the end of the file, fenced by `---` delimiters. This block contains
+all quantitative metrics in structured, typed YAML for machine
+consumption. See `references/snapshot-format.md` § Observatory Metrics
+Block for the exact schema and generation rules.
+
 ### 7. Update README
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:

--- a/skills/harness-observability/SKILL.md
+++ b/skills/harness-observability/SKILL.md
@@ -109,6 +109,28 @@ The harness-auditor agent runs five meta-checks:
 For thresholds and detailed check definitions, consult
 `references/meta-observability-checks.md`.
 
+## Observatory Metrics Block
+
+Every snapshot must include a YAML metrics block appended after all
+markdown sections (including Trends, if present). This block provides
+all quantitative metrics in a structured, typed format for machine
+consumption by the Observatory.
+
+**Generation step:** After writing all markdown sections to the snapshot
+file, append the YAML metrics block as described in
+`references/snapshot-format.md` § Observatory Metrics Block. The block
+is fenced by `---` delimiters and contains the `observatory_metrics`
+root key.
+
+All values in the YAML block come from the same data sources already
+read for the markdown sections — no additional data collection is
+required. Follow the generation rules and null-handling policy in the
+format spec.
+
+The schema version is tracked in
+`references/observatory-metrics-schema.md`. The `schema_version` field
+in the YAML block must match the current documented version.
+
 ## When to Use This Skill
 
 | Situation | Action |

--- a/skills/harness-observability/references/observatory-metrics-schema.md
+++ b/skills/harness-observability/references/observatory-metrics-schema.md
@@ -1,0 +1,91 @@
+# Observatory Metrics Schema
+
+This document defines the versioning policy for the YAML metrics block
+appended to every harness health snapshot. The Observatory and any other
+machine consumer of snapshot files relies on this schema being stable
+and versioned.
+
+## Current Version: 1.0.0
+
+The `observatory_metrics` block contains structured, typed metrics
+across five top-level sections:
+
+| Section | Purpose |
+|---------|---------|
+| `habitat_configuration` | Context depth, constraint maturity, entropy management, compound learning, feedback loops, agent delegation, observability |
+| `outcomes` | Mutation kill rates and cost indicators |
+| `operational_cadence` | Days since key operations and overdue flags |
+| `schema_version` | The version of this schema (string) |
+| `plugin_version` | The plugin version that generated the snapshot |
+| `timestamp` | ISO 8601 UTC timestamp of snapshot generation |
+
+For the full field definitions and generation rules, see
+`snapshot-format.md` section Observatory Metrics Block.
+
+## Versioning Policy
+
+The `schema_version` field in the YAML block identifies which version
+of this schema was used to generate the snapshot. Consumers check this
+field before parsing.
+
+### Patch (1.0.x)
+
+Documentation clarification only. No structural change to the YAML
+block. Observatory parsers are unaffected and do not need updating.
+
+**Examples:** fixing a typo in this document, clarifying a generation
+rule, adding an explanatory note.
+
+### Minor (1.x.0)
+
+A new field is added. Existing fields are unchanged in name, type, and
+semantics. The change is backwards-compatible — Observatory parsers
+should add extraction for the new field but will not break on older
+snapshots that lack it.
+
+**Examples:** adding a new metric under `habitat_configuration`,
+adding a new section alongside `outcomes`.
+
+**Parser guidance:** Use safe access (e.g. `.get()` or optional
+chaining) for fields introduced after 1.0.0. Check `schema_version`
+to know which fields are guaranteed to be present.
+
+### Major (x.0.0)
+
+A field is renamed, removed, or its semantics change. This is a
+breaking change. Observatory parsers must be updated before consuming
+snapshots with the new major version. Major bumps should be extremely
+rare.
+
+**Examples:** renaming `enforcement_ratio` to `enforcement_score`,
+removing the `signal_distribution` object, changing `velocity` from
+promotions-per-week to promotions-per-month.
+
+**Parser guidance:** On encountering an unrecognised major version,
+parsers should log a warning and skip the block rather than crash.
+
+## Release Process
+
+When the schema changes:
+
+1. Update the schema definition in `snapshot-format.md`
+2. Bump the version in this document's "Current Version" heading
+3. Add an entry to the Changelog section below
+4. Update the `schema_version` value in the snapshot format spec
+5. Flag the schema version bump in the plugin's release notes and
+   CHANGELOG.md so Observatory maintainers are aware
+
+## Changelog
+
+### 1.0.0
+
+Initial release. Includes:
+
+- `habitat_configuration`: context depth with per-layer freshness,
+  constraint maturity with per-constraint detail, entropy management,
+  compound learning with signal distribution and velocity, feedback
+  loops, agent delegation, and observability with meta-checks
+- `outcomes`: mutation kill rates (aggregate and per-language) and
+  cost indicators
+- `operational_cadence`: days since audit/assess/reflect with overdue
+  flags

--- a/skills/harness-observability/references/snapshot-format.md
+++ b/skills/harness-observability/references/snapshot-format.md
@@ -168,3 +168,146 @@ Agents reading snapshots should:
 
 The format is deliberately simple and consistent so regex-based parsing
 works reliably.
+
+## Observatory Metrics Block
+
+After all markdown sections (including the optional Trends section),
+every snapshot includes a YAML metrics block fenced by `---` delimiters
+at the end of the file. This block contains all quantitative metrics in
+a structured, typed format intended for machine consumption by the
+Observatory.
+
+The existing markdown sections remain the primary human-readable output.
+The YAML block is complementary — it does not replace or duplicate the
+markdown, but provides the same data in a format that avoids brittle
+regex parsing.
+
+For the schema versioning policy and changelog, see
+`observatory-metrics-schema.md`.
+
+### Schema
+
+```yaml
+---
+observatory_metrics:
+  schema_version: "1.0.0"
+  plugin_version: "<read from plugin.json>"
+  timestamp: "<ISO 8601 UTC timestamp of snapshot generation>"
+
+  habitat_configuration:
+    context_depth:
+      score: <float 0-1>
+      layers_present: <int 0-5>
+      layers:
+        stack: { present: <bool>, last_modified: "<YYYY-MM-DD or null>" }
+        conventions: { present: <bool>, last_modified: "<YYYY-MM-DD or null>" }
+        arch_decisions: { present: <bool>, last_modified: "<YYYY-MM-DD or null>" }
+        rationale: { present: <bool>, last_modified: "<YYYY-MM-DD or null>" }
+        threat_model: { present: <bool>, last_modified: "<YYYY-MM-DD or null>" }
+
+    constraint_maturity:
+      enforcement_ratio: <float 0-1>
+      total_constraints: <int>
+      enforced: <int>
+      deterministic: <int>
+      agent_backed: <int>
+      unverified: <int>
+      drift_detected: <bool>
+      constraints:
+        - name: "<constraint name>"
+          tier: "<deterministic | agent_backed | unverified>"
+          enforced: <bool>
+
+    entropy_management:
+      gc_rules_active: <int>
+      gc_rules_total: <int>
+      gc_active_ratio: <float 0-1>
+      findings_since_last_snapshot: <int>
+      cadence_compliant: <bool>
+      last_run: "<YYYY-MM-DD or null>"
+
+    compound_learning:
+      reflection_log_entries: <int>
+      reflections_this_period: <int>
+      agents_md_entries: <int>
+      gotchas: <int>
+      arch_decisions: <int>
+      promotions_this_period: <int>
+      velocity: <float or null>
+      signal_distribution:
+        context: <int>
+        instruction: <int>
+        workflow: <int>
+        failure: <int>
+
+    feedback_loops:
+      advisory_active: <bool>
+      strict_active: <bool>
+      investigative_active: <bool>
+      coverage: <int 0-3>
+
+    agent_delegation:
+      agents_configured: <int>
+
+    observability:
+      health: "<Healthy | Attention | Degraded>"
+      snapshot_age_days: <int>
+      meta_checks:
+        snapshot_currency: "<on_schedule | overdue | stale>"
+        cadence_compliance: "<all_on_schedule | [list of overdue items]>"
+        learning_flow: "<active | stalled | inactive>"
+        gc_effectiveness: "<productive | silent>"
+        trend_direction: "<stable | [list of declining metrics]>"
+
+  outcomes:
+    mutation_kill_rate:
+      aggregate: <float 0-1 or null>
+      by_language: {}
+    cost:
+      model_routing_configured: <bool>
+      tier_distribution: {}
+      trend: "<rising | stable | declining | unknown>"
+
+  operational_cadence:
+    days_since_audit: <int or null>
+    days_since_assess: <int or null>
+    days_since_reflect: <int or null>
+    audit_overdue: <bool>
+    assess_overdue: <bool>
+    reflect_overdue: <bool>
+---
+```
+
+### Generation Rules
+
+All values come from the same data sources already read for the
+markdown sections — no new data collection is required.
+
+| Field | How to compute |
+|-------|---------------|
+| `schema_version` | Always `"1.0.0"` (bump per `observatory-metrics-schema.md` policy) |
+| `plugin_version` | Read `version` from `plugin.json` |
+| `timestamp` | ISO 8601 UTC timestamp at the moment the snapshot is generated |
+| `context_depth.score` | Count layers where `present == true` AND `last_modified` is within the last 30 days, divided by 5 |
+| `context_depth.layers_present` | Count layers where `present == true` |
+| `context_depth.layers.stack` | Check CLAUDE.md existence and git modification date |
+| `context_depth.layers.conventions` | Check CLAUDE.md existence and git modification date |
+| `context_depth.layers.arch_decisions` | Check HARNESS.md existence and git modification date |
+| `context_depth.layers.rationale` | Check `specs/` directory existence and most recent file modification date |
+| `context_depth.layers.threat_model` | Check for threat model documentation; if absent, `present: false`, `last_modified: null` |
+| `constraint_maturity.*` | Same counts as the Enforcement markdown section |
+| `constraint_maturity.constraints[]` | Each constraint from HARNESS.md Constraints section with name, tier, and enforced status |
+| `entropy_management.*` | Same data as the Garbage Collection markdown section |
+| `compound_learning.velocity` | `promotions_this_period` divided by weeks between this snapshot and the previous one; `null` if no previous snapshot |
+| `compound_learning.signal_distribution` | Count REFLECTION_LOG.md entries by `signal:` field value |
+| `feedback_loops.*` | Check for advisory, strict, and investigative enforcement loops in project configuration |
+| `agent_delegation.agents_configured` | Count `.agent.md` files in `agents/` directory |
+| `observability.*` | Same data as the Meta markdown section |
+| `outcomes.mutation_kill_rate.*` | Same data as the Mutation Testing markdown section |
+| `outcomes.cost.*` | Same data as the Cost Indicators markdown section |
+| `operational_cadence.*` | Same data as the Operational Cadence markdown section |
+
+**Null handling:** Use `null` (not empty string, not `0`) for values
+that cannot be determined. For example, if no previous snapshot exists,
+`velocity` is `null`. If mutation testing is not configured,
+`aggregate` is `null`.


### PR DESCRIPTION
## Summary

- Append a structured `observatory_metrics` YAML block (schema v1.0.0) to every harness health snapshot — machine-readable metrics for the Observatory without changing existing human-readable markdown sections
- Add per-context-layer freshness tracking (`context_depth.layers`) and per-constraint enforcement detail (`constraint_maturity.constraints`) within the YAML block
- Add schema versioning documentation with patch/minor/major policy at `references/observatory-metrics-schema.md`
- Update snapshot format spec, SKILL.md generation instructions, and `/harness-health` command to include YAML block generation

## Test plan

- [ ] Run `/harness-health` on the repo and verify the snapshot contains all existing markdown sections unchanged
- [ ] Verify the YAML metrics block appears at the end of the snapshot file, fenced by `---`
- [ ] Verify `schema_version` is `"1.0.0"`
- [ ] Verify `context_depth.layers` has entries for all five layers with `present` and `last_modified`
- [ ] Verify `constraint_maturity.constraints` lists each constraint with `name`, `tier`, and `enforced`
- [ ] Verify values are populated from real data (not placeholders)
- [ ] Verify `observatory-metrics-schema.md` exists at `skills/harness-observability/references/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)