### PR TITLE
Add Tier 2 Observatory metrics and configurable cadence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.0",
-  "plugin_version": "0.13.0",
+  "plugin_version": "0.14.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.14.0 — 2026-04-14
+
+### Observatory Tier 2: Regression Detection, Loop Tracking, Session Metadata
+
+- Add `regression_indicators` section to Observatory YAML block —
+  `snapshot_stale`, `cadence_non_compliant_count`,
+  `consecutive_zero_reflection_weeks`, and composite `regression_flag`
+- Expand `feedback_loops` with per-loop `active` and `first_activated`
+  date fields, determined via git history lookups with caching
+- Add session metadata to reflection entries — duration, model tiers
+  used, pipeline stages completed, and agent delegation mode
+  (best-effort, "unknown" always valid)
+- Standardise governance audit YAML block with `schema_version`,
+  `falsifiable_count`, `vague_count`, `drift_stage`, and
+  `debt_total_score` fields
+- Support configurable snapshot cadence via HARNESS.md Observability
+  section — weekly (10d), fortnightly (21d), monthly (30d, default).
+  Staleness check scripts and meta-observability checks now respect
+  the configured threshold
+- Bump Observatory metrics schema to 1.1.0 (backwards-compatible)
+
 ## 0.13.0 — 2026-04-14
 
 ### Observatory-Ready Metrics

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.13.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.14.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -20,6 +20,15 @@
      - **Improvement**: [what would make the pipeline smoother next time]
      - **Signal**: [context | instruction | workflow | failure | none]
      - **Constraint**: [proposed constraint, or "none"]
+     - **Session metadata**:
+       - Duration: [estimated session duration, e.g. "45 min" or "unknown"]
+       - Model tiers used: [e.g. "capable (30%), standard (70%)" or "unknown"]
+       - Pipeline stages completed: [e.g. "5/5" or list of agents, or "unknown"]
+       - Agent delegation: [full pipeline | partial | manual | unknown]
+
+     Session metadata fields are best-effort. Use "unknown" for any
+     value that cannot be determined. Entries written before 2026-04-14
+     predate session metadata — treat missing fields as "unknown".
 
      Signal types classify where the learning should route:
        context     → HARNESS.md Context section (priming gaps)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/governance-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/governance-auditor.agent.md
@@ -93,18 +93,35 @@ Include this YAML block in the report for snapshot integration:
 
 ```yaml
 governance:
-  constraint_count: [count]
-  falsifiability_ratio: [0-1]
-  drift_score: [low|medium|high]
-  debt_inventory_size: [count]
-  frame_alignment_score: [0-1]
-  last_audit: [YYYY-MM-DD]
-  drift_velocity: [stable|increasing|decreasing]
+  schema_version: "1.0.0"
+  constraint_count: <int, total governance constraints in HARNESS.md>
+  falsifiability_ratio: <float 0-1, falsifiable_count / constraint_count>
+  falsifiable_count: <int, constraints rated "Falsifiable">
+  vague_count: <int, constraints rated "Vague">
+  drift_stage: <int 1-5, semantic drift severity from the five-stage model>
+  drift_score: "<low | medium | high>"
+  drift_velocity: "<stable | increasing | decreasing>"
+  debt_inventory_size: <int, number of governance debt items>
+  debt_total_score: <int, sum of (severity × blast_radius) across all debt items>
+  frame_alignment_score: <float 0-1, three-frame alignment score>
+  last_audit: "<YYYY-MM-DD>"
 ```
 
-Compute `drift_velocity` by comparing the current `drift_score` with
-the previous audit report (if one exists). If no previous audit
-exists, use `stable`.
+**Field computation:**
+
+- `schema_version`: Always `"1.0.0"`. Bump per the same policy as the
+  snapshot metrics schema (patch for docs, minor for new fields, major
+  for breaking changes).
+- `falsifiable_count`: Count constraints scored "Falsifiable" in the
+  constraint assessment.
+- `vague_count`: Count constraints scored "Vague" in the constraint
+  assessment. `constraint_count - falsifiable_count - partially_operationalised_count`.
+- `drift_stage`: The numeric 1–5 drift severity already computed for
+  the audit report's drift analysis section.
+- `debt_total_score`: Sum of `severity × blast_radius` across all
+  items in the governance debt inventory table.
+- `drift_velocity`: Compare the current `drift_score` with the
+  previous audit report. If no previous audit exists, use `stable`.
 
 ## What You Do NOT Do
 

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -27,7 +27,31 @@ Capture a post-task reflection and append it to REFLECTION_LOG.md.
    - **Improvement**: [what would make the process better]
    - **Signal**: [context | instruction | workflow | failure | none]
    - **Constraint**: [proposed constraint, or "none"]
+   - **Session metadata**:
+     - Duration: [estimated session duration, e.g. "45 min" or "unknown"]
+     - Model tiers used: [e.g. "capable (30%), standard (70%)" or "unknown"]
+     - Pipeline stages completed: [e.g. "5/5" or "spec-writer, tdd-agent, code-reviewer" or "unknown"]
+     - Agent delegation: [full pipeline | partial | manual | unknown]
    ```
+
+   **Session metadata rules:**
+
+   - All session metadata fields are best-effort. Fill in what you
+     know from the session you just completed. If a value is not
+     determinable, use `"unknown"` — never omit the field.
+   - **Duration**: Estimate from the session's start and end. If you
+     do not track time, use `"unknown"`.
+   - **Model tiers used**: If MODEL_ROUTING.md is configured and the
+     session used multiple tiers, report the approximate distribution.
+     Otherwise `"unknown"`.
+   - **Pipeline stages completed**: If the orchestrator ran, list
+     which agents were invoked. If the session was a single-agent
+     interaction, note that.
+   - **Agent delegation**: `"full pipeline"` if the orchestrator ran
+     the full spec→TDD→implement→review→integrate pipeline;
+     `"partial"` if some stages were skipped; `"manual"` if the
+     developer worked without the pipeline; `"unknown"` if you cannot
+     determine.
 
 1. **Signal classification** — review the Surprise and Improvement
    fields and classify the signal type:

--- a/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
+++ b/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
@@ -18,6 +18,18 @@ if [ ! -f "$HARNESS_FILE" ]; then
   exit 0
 fi
 
+# Read configured cadence from HARNESS.md Observability section
+STALENESS_THRESHOLD=30
+cadence=$(grep -A5 '## Observability' "$HARNESS_FILE" 2>/dev/null \
+  | grep 'Snapshot cadence:' \
+  | sed 's/.*Snapshot cadence:[[:space:]]*//' \
+  | tr -d '[:space:]')
+case "$cadence" in
+  weekly)      STALENESS_THRESHOLD=10 ;;
+  fortnightly) STALENESS_THRESHOLD=21 ;;
+  monthly)     STALENESS_THRESHOLD=30 ;;
+esac
+
 # Rotate through rules by day-of-year
 day_of_year=$(date +%j | sed 's/^0*//')
 rule_index=$((day_of_year % 4))
@@ -53,8 +65,8 @@ case $rule_index in
     fi
     current_epoch=$(date +%s)
     age_days=$(( (current_epoch - snapshot_epoch) / 86400 ))
-    if [ "$age_days" -gt 30 ]; then
-      printf '{"systemMessage": "GC check (snapshot staleness): latest snapshot is %d days old. Run /harness-health to update."}' "$age_days"
+    if [ "$age_days" -gt "$STALENESS_THRESHOLD" ]; then
+      printf '{"systemMessage": "GC check (snapshot staleness): latest snapshot is %d days old (cadence threshold: %d days). Run /harness-health to update."}' "$age_days" "$STALENESS_THRESHOLD"
     fi
     ;;
   2)

--- a/ai-literacy-superpowers/skills/governance-observability/SKILL.md
+++ b/ai-literacy-superpowers/skills/governance-observability/SKILL.md
@@ -17,13 +17,18 @@ for governance health. This skill is referenced by:
 
 | Metric | Type | Description |
 | --- | --- | --- |
+| `schema_version` | string | Version of the governance metrics schema |
 | `constraint_count` | integer | Total governance constraints in HARNESS.md |
 | `falsifiability_ratio` | float (0-1) | Proportion of governance constraints scored as "falsifiable" |
+| `falsifiable_count` | integer | Number of constraints rated "Falsifiable" |
+| `vague_count` | integer | Number of constraints rated "Vague" |
+| `drift_stage` | integer (1-5) | Numeric semantic drift severity from the five-stage model |
 | `drift_score` | enum (low/medium/high) | Overall semantic drift risk across all governance constraints |
+| `drift_velocity` | enum (stable/increasing/decreasing) | Direction of drift trend between audits |
 | `debt_inventory_size` | integer | Number of governance debt items identified |
+| `debt_total_score` | integer | Sum of (severity x blast_radius) across all debt items |
 | `frame_alignment_score` | float (0-1) | Proportion of governance constraints with confirmed three-frame alignment |
 | `last_audit` | date (YYYY-MM-DD) | Date of most recent governance audit |
-| `drift_velocity` | enum (stable/increasing/decreasing) | Direction of drift trend between audits |
 
 ## Snapshot Format Extension
 
@@ -33,13 +38,18 @@ harness metrics:
 
 ```yaml
 governance:
+  schema_version: "1.0.0"
   constraint_count: 4
   falsifiability_ratio: 0.75
+  falsifiable_count: 3
+  vague_count: 0
+  drift_stage: 1
   drift_score: low
+  drift_velocity: stable
   debt_inventory_size: 2
+  debt_total_score: 8
   frame_alignment_score: 0.50
   last_audit: 2026-04-13
-  drift_velocity: stable
 ```
 
 ## Staleness Thresholds

--- a/hooks/scripts/snapshot-staleness-check.sh
+++ b/hooks/scripts/snapshot-staleness-check.sh
@@ -11,6 +11,21 @@ set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 SNAPSHOT_DIR="${PROJECT_DIR}/observability/snapshots"
+HARNESS_FILE="${PROJECT_DIR}/HARNESS.md"
+
+# Read configured cadence from HARNESS.md Observability section
+STALENESS_THRESHOLD=30
+if [ -f "$HARNESS_FILE" ]; then
+  cadence=$(grep -A5 '## Observability' "$HARNESS_FILE" 2>/dev/null \
+    | grep 'Snapshot cadence:' \
+    | sed 's/.*Snapshot cadence:[[:space:]]*//' \
+    | tr -d '[:space:]')
+  case "$cadence" in
+    weekly)      STALENESS_THRESHOLD=10 ;;
+    fortnightly) STALENESS_THRESHOLD=21 ;;
+    monthly)     STALENESS_THRESHOLD=30 ;;
+  esac
+fi
 
 # If no snapshot directory exists, nothing to check
 if [ ! -d "$SNAPSHOT_DIR" ]; then
@@ -42,8 +57,8 @@ fi
 current_epoch=$(date +%s)
 age_days=$(( (current_epoch - snapshot_epoch) / 86400 ))
 
-if [ "$age_days" -gt 30 ]; then
-  printf '{"systemMessage": "Harness health snapshot is %d days old (last: %s). Run /harness-health to update."}' "$age_days" "$snapshot_date"
+if [ "$age_days" -gt "$STALENESS_THRESHOLD" ]; then
+  printf '{"systemMessage": "Harness health snapshot is %d days old (last: %s, cadence threshold: %d days). Run /harness-health to update."}' "$age_days" "$snapshot_date" "$STALENESS_THRESHOLD"
 fi
 
 exit 0

--- a/skills/harness-observability/SKILL.md
+++ b/skills/harness-observability/SKILL.md
@@ -116,20 +116,43 @@ markdown sections (including Trends, if present). This block provides
 all quantitative metrics in a structured, typed format for machine
 consumption by the Observatory.
 
-**Generation step:** After writing all markdown sections to the snapshot
-file, append the YAML metrics block as described in
-`references/snapshot-format.md` § Observatory Metrics Block. The block
-is fenced by `---` delimiters and contains the `observatory_metrics`
-root key.
+**Generation steps:**
+
+1. After writing all markdown sections to the snapshot file, append
+   the YAML metrics block as described in
+   `references/snapshot-format.md` § Observatory Metrics Block. The
+   block is fenced by `---` delimiters and contains the
+   `observatory_metrics` root key.
+
+2. **Read the configured cadence.** Check the HARNESS.md Observability
+   section for `Snapshot cadence`. Map to a threshold: weekly=10 days,
+   fortnightly=21 days, monthly=30 days. Default to monthly if not
+   configured. Include `configured_cadence` and
+   `cadence_threshold_days` in the `observability` section.
+
+3. **Compute feedback loop activation.** For each loop (advisory,
+   strict, investigative), determine whether it is active and when it
+   was first activated using git history. Cache `first_activated` dates
+   from the previous snapshot — only re-check git history when a
+   loop's status transitions from inactive to active.
+
+4. **Compute regression indicators.** After computing the meta-
+   observability checks, populate the `regression_indicators` section:
+   - `snapshot_stale`: previous snapshot age exceeds cadence threshold
+   - `cadence_non_compliant_count`: count of overdue activities
+     (already computed for Meta section)
+   - `consecutive_zero_reflection_weeks`: count consecutive weeks
+     without REFLECTION_LOG entries, working backwards from today
+   - `regression_flag`: logical OR of the three trigger conditions
 
 All values in the YAML block come from the same data sources already
 read for the markdown sections — no additional data collection is
-required. Follow the generation rules and null-handling policy in the
-format spec.
+required beyond the git history lookups for loop activation dates.
+Follow the generation rules and null-handling policy in the format spec.
 
 The schema version is tracked in
 `references/observatory-metrics-schema.md`. The `schema_version` field
-in the YAML block must match the current documented version.
+in the YAML block must match the current documented version (1.1.0).
 
 ## When to Use This Skill
 

--- a/skills/harness-observability/references/meta-observability-checks.md
+++ b/skills/harness-observability/references/meta-observability-checks.md
@@ -13,20 +13,27 @@ works."
 ### 1. Snapshot Currency
 
 **What it verifies:** The most recent snapshot in
-`observability/snapshots/` is less than 30 days old.
+`observability/snapshots/` is within the project's configured cadence
+threshold.
 
 **How to check:**
-1. List files in `observability/snapshots/`
-2. Parse the most recent filename date (YYYY-MM-DD)
-3. Compare with today's date
+1. Read HARNESS.md Observability section for `Snapshot cadence` value
+2. Map cadence to threshold: weekly=10 days, fortnightly=21 days,
+   monthly=30 days. Default to monthly if not configured.
+3. List files in `observability/snapshots/`
+4. Parse the most recent filename date (YYYY-MM-DD)
+5. Compare with today's date using the configured threshold
 
 **Thresholds:**
 
 | Age | Status | Signal |
 |-----|--------|--------|
-| < 30 days | On schedule | Outer loop is running |
-| 30-60 days | Overdue | Outer loop slipping |
-| > 60 days | Stale | Outer loop not running |
+| < threshold | On schedule | Outer loop is running |
+| threshold to 2× threshold | Overdue | Outer loop slipping |
+| > 2× threshold | Stale | Outer loop not running |
+
+Where threshold is the configured cadence threshold (weekly=10,
+fortnightly=21, monthly=30).
 
 **What it means:** If snapshots aren't being taken, the harness has no
 visibility into its own health. All other observability layers depend on

--- a/skills/harness-observability/references/observatory-metrics-schema.md
+++ b/skills/harness-observability/references/observatory-metrics-schema.md
@@ -5,7 +5,7 @@ appended to every harness health snapshot. The Observatory and any other
 machine consumer of snapshot files relies on this schema being stable
 and versioned.
 
-## Current Version: 1.0.0
+## Current Version: 1.1.0
 
 The `observatory_metrics` block contains structured, typed metrics
 across five top-level sections:
@@ -76,6 +76,25 @@ When the schema changes:
    CHANGELOG.md so Observatory maintainers are aware
 
 ## Changelog
+
+### 1.1.0
+
+Backwards-compatible additions:
+
+- Added `regression_indicators` section with `snapshot_stale`,
+  `snapshot_age_days`, `cadence_non_compliant_count`,
+  `consecutive_zero_reflection_weeks`, and `regression_flag` fields
+- Expanded `feedback_loops` with per-loop `active` and
+  `first_activated` fields (replaces flat `advisory_active` etc.
+  booleans). The `coverage` summary field is retained for backwards
+  compatibility
+- Added `configured_cadence` and `cadence_threshold_days` to the
+  `observability` section
+- Expanded governance YAML block (separate `schema_version`) with
+  `falsifiable_count`, `vague_count`, `drift_stage`, and
+  `debt_total_score` fields
+- Added session metadata to reflection entry format (not in YAML
+  block — in REFLECTION_LOG.md entries)
 
 ### 1.0.0
 

--- a/skills/harness-observability/references/snapshot-format.md
+++ b/skills/harness-observability/references/snapshot-format.md
@@ -190,7 +190,7 @@ For the schema versioning policy and changelog, see
 ```yaml
 ---
 observatory_metrics:
-  schema_version: "1.0.0"
+  schema_version: "1.1.0"
   plugin_version: "<read from plugin.json>"
   timestamp: "<ISO 8601 UTC timestamp of snapshot generation>"
 
@@ -241,15 +241,23 @@ observatory_metrics:
         failure: <int>
 
     feedback_loops:
-      advisory_active: <bool>
-      strict_active: <bool>
-      investigative_active: <bool>
-      coverage: <int 0-3>
+      advisory:
+        active: <bool>
+        first_activated: "<YYYY-MM-DD or null>"
+      strict:
+        active: <bool>
+        first_activated: "<YYYY-MM-DD or null>"
+      investigative:
+        active: <bool>
+        first_activated: "<YYYY-MM-DD or null>"
+      coverage: <int 0-3, count of active loops>
 
     agent_delegation:
       agents_configured: <int>
 
     observability:
+      configured_cadence: "<weekly | fortnightly | monthly>"
+      cadence_threshold_days: <int, 10 | 21 | 30>
       health: "<Healthy | Attention | Degraded>"
       snapshot_age_days: <int>
       meta_checks:
@@ -275,6 +283,13 @@ observatory_metrics:
     audit_overdue: <bool>
     assess_overdue: <bool>
     reflect_overdue: <bool>
+
+  regression_indicators:
+    snapshot_stale: <bool, true if snapshot_age_days > configured cadence threshold>
+    snapshot_age_days: <int, days since previous snapshot, 0 if first>
+    cadence_non_compliant_count: <int, number of scheduled activities overdue>
+    consecutive_zero_reflection_weeks: <int, consecutive weeks with no REFLECTION_LOG entries>
+    regression_flag: <bool, true if ANY of: snapshot_stale, cadence_non_compliant_count >= 2, consecutive_zero_reflection_weeks >= 4>
 ---
 ```
 
@@ -285,7 +300,7 @@ markdown sections — no new data collection is required.
 
 | Field | How to compute |
 |-------|---------------|
-| `schema_version` | Always `"1.0.0"` (bump per `observatory-metrics-schema.md` policy) |
+| `schema_version` | Always `"1.1.0"` (bump per `observatory-metrics-schema.md` policy) |
 | `plugin_version` | Read `version` from `plugin.json` |
 | `timestamp` | ISO 8601 UTC timestamp at the moment the snapshot is generated |
 | `context_depth.score` | Count layers where `present == true` AND `last_modified` is within the last 30 days, divided by 5 |
@@ -300,12 +315,31 @@ markdown sections — no new data collection is required.
 | `entropy_management.*` | Same data as the Garbage Collection markdown section |
 | `compound_learning.velocity` | `promotions_this_period` divided by weeks between this snapshot and the previous one; `null` if no previous snapshot |
 | `compound_learning.signal_distribution` | Count REFLECTION_LOG.md entries by `signal:` field value |
-| `feedback_loops.*` | Check for advisory, strict, and investigative enforcement loops in project configuration |
+| `feedback_loops.advisory.active` | `true` if `hooks/` directory exists and hooks configuration defines PreToolUse or Stop hooks |
+| `feedback_loops.advisory.first_activated` | Git history: first commit that added hooks configuration (e.g. `git log --diff-filter=A --format=%ai -- .claude/hooks.json`). `null` if hooks don't exist |
+| `feedback_loops.strict.active` | `true` if a CI workflow enforcing harness constraints exists (`.github/workflows/harness.yml` or similar referencing HARNESS.md) |
+| `feedback_loops.strict.first_activated` | Git history: first commit that added the CI enforcement workflow. `null` if no CI enforcement exists |
+| `feedback_loops.investigative.active` | `true` if HARNESS.md Garbage Collection section has at least one rule with enforcement = "agent" or "deterministic" |
+| `feedback_loops.investigative.first_activated` | Git history: first commit that added a GC rule to HARNESS.md. `null` if no GC rules exist |
+| `feedback_loops.coverage` | Count of active loops (0-3) |
 | `agent_delegation.agents_configured` | Count `.agent.md` files in `agents/` directory |
 | `observability.*` | Same data as the Meta markdown section |
 | `outcomes.mutation_kill_rate.*` | Same data as the Mutation Testing markdown section |
 | `outcomes.cost.*` | Same data as the Cost Indicators markdown section |
 | `operational_cadence.*` | Same data as the Operational Cadence markdown section |
+| `observability.configured_cadence` | Read HARNESS.md Observability section `Snapshot cadence` value. Default `monthly` if not configured |
+| `observability.cadence_threshold_days` | Map cadence to threshold: weekly=10, fortnightly=21, monthly=30 |
+| `regression_indicators.snapshot_stale` | `true` if `snapshot_age_days` exceeds the configured cadence threshold. `false` if this is the first snapshot |
+| `regression_indicators.snapshot_age_days` | Days between previous snapshot date and today. `0` if no previous snapshot |
+| `regression_indicators.cadence_non_compliant_count` | Count of the four scheduled activities (audit/90d, assess/90d, reflect/30d, GC/declared cadence) that are overdue. Reuse data from Meta section |
+| `regression_indicators.consecutive_zero_reflection_weeks` | Count consecutive calendar weeks (working backwards from today) with zero REFLECTION_LOG.md entries. `0` if the most recent entry is this week |
+| `regression_indicators.regression_flag` | Logical OR of: `snapshot_stale == true`, `cadence_non_compliant_count >= 2`, `consecutive_zero_reflection_weeks >= 4` |
+
+**Activation date caching:** The git history lookups for
+`first_activated` dates only need to run once. After the first
+snapshot records the dates, subsequent snapshots can read them from
+the previous snapshot and only re-check if a loop's `active` status
+has changed from `false` to `true`.
 
 **Null handling:** Use `null` (not empty string, not `0`) for values
 that cannot be determined. For example, if no previous snapshot exists,

--- a/templates/HARNESS.md
+++ b/templates/HARNESS.md
@@ -106,7 +106,8 @@
 ### Snapshot staleness
 
 - **What it checks**: Whether the most recent harness health snapshot
-  in `observability/snapshots/` is less than 30 days old
+  in `observability/snapshots/` is within the configured cadence
+  threshold (see Observability section)
 - **Frequency**: weekly
 - **Enforcement**: deterministic
 - **Tool**: file date check
@@ -131,6 +132,16 @@
 - **Enforcement**: agent
 - **Tool**: harness-gc agent (analyses recent merged PRs via git log)
 - **Auto-fix**: false
+
+---
+
+## Observability
+
+<!-- Snapshot cadence controls how often /harness-health should be run.
+     Observatory corpus projects should use "weekly" for maximum data quality.
+     Default is "monthly" which aligns with the standard 30-day staleness threshold. -->
+
+- Snapshot cadence: monthly
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `regression_indicators` section to Observatory YAML block with automated regression flag (schema 1.1.0)
- Expand `feedback_loops` with per-loop `active` and `first_activated` date fields using git history lookups
- Add session metadata to reflection entries (duration, model tiers, pipeline stages, agent delegation)
- Standardise governance audit YAML block with `falsifiable_count`, `vague_count`, `drift_stage`, `debt_total_score`
- Support configurable snapshot cadence via HARNESS.md Observability section (weekly/fortnightly/monthly)
- Update staleness check scripts and meta-observability checks to respect configured cadence threshold

## Test plan

- [ ] Run `/harness-health` — verify YAML block contains `regression_indicators` with all five fields populated
- [ ] Verify `feedback_loops` has per-loop `active` and `first_activated` fields
- [ ] Run `/reflect` — verify new entry includes Session metadata section (values may be "unknown")
- [ ] Run `/governance-audit` — verify YAML block contains `falsifiable_count`, `vague_count`, `drift_stage`, `debt_total_score`, `schema_version`
- [ ] Add `- Snapshot cadence: weekly` to HARNESS.md Observability section — verify staleness check uses 10-day threshold
- [ ] Confirm `schema_version` in snapshot YAML block reads `"1.1.0"`
- [ ] Confirm changelog in `observatory-metrics-schema.md` documents all additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)