### PR TITLE
Add Tier 3 Observatory: violation tracking, portfolio metrics, event log

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.0",
-  "plugin_version": "0.14.0",
+  "plugin_version": "0.15.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   gc:
@@ -44,6 +44,12 @@ jobs:
           ./gitleaks --version
           ./gitleaks detect --source . --no-banner --exit-code 1
           echo "Secret scanner is operational and scan is clean"
+
+      - name: Log finding (secret-scanner)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"investigative","constraint":"secret-scanner-operational","gc_rule":"secret-scanner","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
 
       - name: "GC: Snapshot staleness"
         run: |
@@ -76,6 +82,12 @@ jobs:
 
           echo "Snapshot is within 30-day freshness window"
 
+      - name: Log finding (snapshot-staleness)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"investigative","constraint":"snapshot-staleness","gc_rule":"snapshot-staleness","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
       - name: "GC: Shell scripts pass syntax check"
         run: |
           failed=0
@@ -87,6 +99,12 @@ jobs:
           done < <(find . -name "*.sh" -not -path "./.git/*")
           exit $failed
 
+      - name: Log finding (shell-syntax)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"investigative","constraint":"shell-scripts-syntax-check","gc_rule":"shell-syntax","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
       - name: "GC: Shell scripts use strict mode"
         run: |
           failed=0
@@ -97,6 +115,23 @@ jobs:
             fi
           done < <(find . -name "*.sh" -not -path "./.git/*")
           exit $failed
+
+      - name: Log finding (strict-mode)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"investigative","constraint":"shell-scripts-strict-mode","gc_rule":"strict-mode","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
+      - name: Commit violation log
+        if: always()
+        run: |
+          if [ -f observability/violations.jsonl ] && ! git diff --quiet observability/violations.jsonl 2>/dev/null; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add observability/violations.jsonl
+            git commit -m "chore: update violation log [skip ci]" --allow-empty || true
+            git push || true
+          fi
 
       - name: Summary
         if: always()

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   enforce:
@@ -32,10 +32,22 @@ jobs:
       - name: "Constraint: Consistent markdown formatting"
         uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9  # v23.0.0
 
+      - name: Log violation (markdown-lint)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"strict","constraint":"consistent-markdown-formatting","pr":"${{ github.event.pull_request.number }}","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
       - name: "Constraint: No secrets in source"
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar xz
           ./gitleaks detect --source . --no-banner --exit-code 1
+
+      - name: Log violation (no-secrets)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"strict","constraint":"no-secrets-in-source","pr":"${{ github.event.pull_request.number }}","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
 
       - name: "Constraint: Shell scripts pass syntax check"
         run: |
@@ -48,6 +60,12 @@ jobs:
           done < <(find . -name "*.sh" -not -path "./.git/*")
           exit $failed
 
+      - name: Log violation (shell-syntax)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"strict","constraint":"shell-scripts-syntax-check","pr":"${{ github.event.pull_request.number }}","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
       - name: "Constraint: Shell scripts use strict mode"
         run: |
           failed=0
@@ -59,10 +77,33 @@ jobs:
           done < <(find . -name "*.sh" -not -path "./.git/*")
           exit $failed
 
+      - name: Log violation (strict-mode)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"strict","constraint":"shell-scripts-strict-mode","pr":"${{ github.event.pull_request.number }}","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
       - name: "Constraint: ShellCheck compliance"
         run: |
           sudo apt-get -qq install -y shellcheck
           find . -name "*.sh" -not -path "./.git/*" -exec shellcheck {} +
+
+      - name: Log violation (shellcheck)
+        if: failure()
+        run: |
+          mkdir -p observability
+          echo '{"timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'","loop":"strict","constraint":"shellcheck-compliance","pr":"${{ github.event.pull_request.number }}","ci_run":"${{ github.run_id }}"}' >> observability/violations.jsonl
+
+      - name: Commit violation log
+        if: always()
+        run: |
+          if [ -f observability/violations.jsonl ] && ! git diff --quiet observability/violations.jsonl 2>/dev/null; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add observability/violations.jsonl
+            git commit -m "chore: update violation log [skip ci]" --allow-empty || true
+            git push || true
+          fi
 
       - name: Summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.15.0 — 2026-04-14
+
+### Observatory Tier 3: Violation Tracking, Portfolio Metrics, Event Log
+
+- Add violation tracking via `observability/violations.jsonl` — advisory
+  hook, CI constraint checks, and GC workflow now log detected violations
+  as JSON Lines entries with timestamp, loop, constraint, and context
+- Add violation latency metrics to snapshot YAML block —
+  `feedback_loops.latency` with per-loop counts and `violations_total`
+- Add `observatory_portfolio` YAML block to portfolio assessment reports
+  with summary, level distribution, habitat aggregates (mean enforcement
+  ratio, learning velocity, GC active ratio, context depth), gaps,
+  outliers, and per-project detail
+- Add Observatory event log at `observability/events.jsonl` — 10 event
+  types tracking state transitions (snapshot creation, assessments,
+  governance audits, constraint lifecycle, regression transitions,
+  reflections, cadence configuration)
+- Add event emission to `/harness-health`, `/reflect`,
+  `/harness-constrain`, `/assess`, and `governance-auditor`
+- Add `observatory-events.md` reference documenting event log format,
+  event types, and emission matrix
+- Bump Observatory metrics schema to 1.2.0 (backwards-compatible)
+
 ## 0.14.0 — 2026-04-14
 
 ### Observatory Tier 2: Regression Detection, Loop Tracking, Session Metadata

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.14.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.15.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/governance-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/governance-auditor.agent.md
@@ -123,6 +123,18 @@ governance:
 - `drift_velocity`: Compare the current `drift_score` with the
   previous audit report. If no previous audit exists, use `stable`.
 
+## Observatory Event Emission
+
+After writing the audit report, append a `governance.audited` event
+to `observability/events.jsonl` (create the file if it does not exist):
+
+```json
+{"type": "governance.audited", "timestamp": "<ISO 8601 UTC>", "path": "observability/governance/audit-YYYY-MM-DD.md", "drift_stage": <int>, "debt_total_score": <int>}
+```
+
+Event logging is best-effort — if writing fails, complete the audit
+normally.
+
 ## What You Do NOT Do
 
 - Do not modify HARNESS.md constraints directly — you report

--- a/ai-literacy-superpowers/commands/harness-constrain.md
+++ b/ai-literacy-superpowers/commands/harness-constrain.md
@@ -76,6 +76,17 @@ Constraints section. Follow the standard format:
 If the constraint is deterministic and PR-scoped, add the tool step
 to the CI workflow file.
 
-### 10. Commit
+### 10. Emit Observatory Event
+
+Append the appropriate event to `observability/events.jsonl` (create
+the file if it does not exist):
+
+- New constraint: `constraint.added` with name and tier
+- Promoted constraint: `constraint.promoted` with name, old tier, new tier
+- Removed constraint: `constraint.removed` with name and reason
+
+Event logging is best-effort — if writing fails, continue normally.
+
+### 11. Commit
 
 Commit the updated HARNESS.md (and CI file if changed).

--- a/ai-literacy-superpowers/commands/portfolio-assess.md
+++ b/ai-literacy-superpowers/commands/portfolio-assess.md
@@ -91,7 +91,18 @@ Write the portfolio assessment to
 `assessments/YYYY-MM-DD-portfolio-assessment.md` using the template
 from the skill's references.
 
-### 7. Summary
+### 7. Append Observatory YAML Block
+
+After generating the markdown portfolio report, append an
+`observatory_portfolio` YAML block (fenced by `---`) at the end of the
+file. Populate all fields from the data already gathered during
+assessment. For habitat aggregates (`mean_enforcement_ratio`,
+`mean_learning_velocity`, `mean_gc_active_ratio`, `mean_context_depth`),
+read the most recent `observatory_metrics` YAML block from each
+project's `observability/snapshots/` directory if locally accessible.
+See `references/portfolio-template.md` for the YAML block template.
+
+### 8. Summary
 
 Print a summary:
 

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -93,6 +93,16 @@ Capture a post-task reflection and append it to REFLECTION_LOG.md.
 1. Append the entry to `REFLECTION_LOG.md` (after the last existing
    entry, preserving the `---` separator)
 
+1. **Emit Observatory event.** Append a `reflection.captured` event
+   to `observability/events.jsonl` (create the file if it does not
+   exist):
+
+   ```json
+   {"type": "reflection.captured", "timestamp": "<ISO 8601 UTC>", "signal": "<signal value>", "has_proposal": <bool>, "has_constraint": <bool>}
+   ```
+
+   Event logging is best-effort — if writing fails, continue normally.
+
 1. Do NOT modify `AGENTS.md` — only humans edit that file. If the
    reflection contains a proposal, note it and let the human decide.
 

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -180,7 +180,21 @@ Capture a reflection on the assessment itself:
 
 Append this to REFLECTION_LOG.md as a structured entry.
 
-### Phase 7: README Badge
+### Phase 7: Emit Observatory Event
+
+After writing the assessment document, append an `assessment.completed`
+event to `observability/events.jsonl` (create the file if it does not
+exist):
+
+```json
+{"type": "assessment.completed", "timestamp": "<ISO 8601 UTC>", "path": "assessments/YYYY-MM-DD-assessment.md", "level": <int>, "previous_level": <int or null>}
+```
+
+Read the previous assessment to determine `previous_level`. If no
+previous assessment exists, use `null`. Event logging is best-effort —
+if writing fails, continue normally.
+
+### Phase 8: README Badge
 
 Add or update a badge in the project's README showing the assessed
 level:

--- a/ai-literacy-superpowers/skills/portfolio-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/portfolio-assessment/SKILL.md
@@ -151,13 +151,34 @@ Typical actions: roll out a specific tool, share a constraint pattern.
 Present the plan with estimated impact (how many repos each action
 lifts and toward which level).
 
-### Step 6: Present and Record
+### Step 6: Gather Habitat Metrics from Snapshots
+
+For each assessed project that is locally accessible, check for a
+harness-health snapshot in `observability/snapshots/`. If one exists,
+read the most recent snapshot's `observatory_metrics` YAML block and
+extract:
+
+- `habitat_configuration.constraint_maturity.enforcement_ratio`
+- `habitat_configuration.compound_learning.velocity`
+- `habitat_configuration.entropy_management.gc_active_ratio`
+- `habitat_configuration.context_depth.score`
+
+If a project has an assessment but no snapshot, its habitat metrics
+are `null`.
+
+Compute means across projects that have values for each metric.
+
+### Step 7: Present and Record
 
 Display the full portfolio view to the user.
 
 Write the document to `assessments/YYYY-MM-DD-portfolio-assessment.md`
 in the current working directory (typically the portfolio or platform
 repo). Use the template from `references/portfolio-template.md`.
+
+After the markdown content, append the `observatory_portfolio` YAML
+block (fenced by `---`) with all fields populated from the gathered
+data. See the template for the complete schema.
 
 ## What This Skill Does NOT Do
 

--- a/ai-literacy-superpowers/skills/portfolio-assessment/references/portfolio-template.md
+++ b/ai-literacy-superpowers/skills/portfolio-assessment/references/portfolio-template.md
@@ -99,6 +99,66 @@ Repos with assessments older than 90 days:
 Suggested re-assessment date: {{YYYY-MM-DD}} (quarterly)
 ```
 
+## Observatory Portfolio YAML Block
+
+Append this YAML block at the end of the portfolio assessment file,
+after all markdown content, fenced by `---` delimiters:
+
+```yaml
+---
+observatory_portfolio:
+  schema_version: "1.0.0"
+  timestamp: "<ISO 8601 UTC>"
+
+  summary:
+    project_count: <int, total projects discovered>
+    assessed_count: <int, projects with assessments>
+    estimated_count: <int, projects with estimated levels>
+    unassessed_count: <int, projects with no assessment data>
+    assessment_coverage: <float 0-1, assessed / total>
+
+  level_distribution:
+    L0: <int>
+    L1: <int>
+    L2: <int>
+    L3: <int>
+    L4: <int>
+    L5: <int>
+    median_level: <int>
+
+  habitat_aggregates:
+    mean_enforcement_ratio: <float 0-1 or null>
+    mean_learning_velocity: <float or null>
+    mean_gc_active_ratio: <float 0-1 or null>
+    mean_context_depth: <float 0-1 or null>
+
+  gaps:
+    shared: <list of strings, gaps appearing in 3+ repos>
+    shared_count: <int>
+
+  outliers:
+    high: <list of project names scoring above median + 1 level>
+    low: <list of project names scoring below median - 1 level>
+
+  stale_assessments:
+    count: <int, assessments older than 90 days>
+    projects: <list of project names>
+
+  projects:
+    - id: "<project identifier>"
+      level: <int 0-5>
+      assessed: <bool>
+      enforcement_ratio: <float 0-1 or null>
+      learning_velocity: <float or null>
+      last_assessment: "<YYYY-MM-DD or null>"
+---
+```
+
+Habitat aggregate values are computed from the most recent
+`observatory_metrics` YAML block in each project's
+`observability/snapshots/` directory. Projects without snapshots
+contribute `null` and are excluded from the mean calculations.
+
 ## Parsing Notes
 
 When reading individual assessment documents to build the portfolio:

--- a/commands/harness-health.md
+++ b/commands/harness-health.md
@@ -100,14 +100,21 @@ all quantitative metrics in structured, typed YAML for machine
 consumption. See `references/snapshot-format.md` § Observatory Metrics
 Block for the exact schema and generation rules.
 
-### 7. Update README
+### 7. Emit Observatory Events
+
+After writing the snapshot, emit events to `observability/events.jsonl`
+as specified in `references/observatory-events.md`: a `snapshot.created`
+event always, plus constraint lifecycle events and regression transition
+events when detected by comparing with the previous snapshot.
+
+### 8. Update README
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)
 
-### 8. Print Summary
+### 9. Print Summary
 
 Print the full snapshot to the session so the developer sees it
 immediately.
@@ -123,7 +130,7 @@ Since last snapshot (YYYY-MM-DD):
   Health: Healthy / Attention / Degraded
 ```
 
-### 9. Nudge Overdue Actions
+### 10. Nudge Overdue Actions
 
 If any cadence is overdue, print a nudge:
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if HARNESS.md exists in the project root. If it does, read the Constraints section and identify any constraints with scope 'commit'. For each commit-scoped constraint, evaluate whether the file being written or edited would violate it. If violations are found, return a warning describing each violation with the constraint name. Do not block — only warn. If no HARNESS.md exists or no commit-scoped constraints apply, return nothing.",
+            "prompt": "Check if HARNESS.md exists in the project root. If it does, read the Constraints section and identify any constraints with scope 'commit'. For each commit-scoped constraint, evaluate whether the file being written or edited would violate it. If violations are found, return a warning describing each violation with the constraint name. Do not block — only warn. Additionally, for each violation detected, append a JSON line to observability/violations.jsonl (create the file if it does not exist) with the fields: timestamp (current ISO 8601 UTC), loop (\"advisory\"), constraint (the constraint name from HARNESS.md), file (the file being written or edited), and description (one-line summary of the violation). If no HARNESS.md exists or no commit-scoped constraints apply, return nothing.",
             "timeout": 30
           }
         ]

--- a/skills/harness-observability/SKILL.md
+++ b/skills/harness-observability/SKILL.md
@@ -145,14 +145,40 @@ consumption by the Observatory.
      without REFLECTION_LOG entries, working backwards from today
    - `regression_flag`: logical OR of the three trigger conditions
 
+5. **Read the violation log.** If `observability/violations.jsonl`
+   exists, read it and count violations since the previous snapshot
+   date, grouped by loop (advisory, strict, investigative). Include
+   the counts in `feedback_loops.latency` and the total line count
+   in `feedback_loops.violations_total`. If the file does not exist,
+   all counts are `0`.
+
+6. **Emit Observatory events.** After writing the snapshot file,
+   append events to `observability/events.jsonl` (create the file if
+   it does not exist). See `references/observatory-events.md` for
+   the full event specification.
+
+   - Always emit a `snapshot.created` event.
+   - **Constraint diff:** Compare the current HARNESS.md constraints
+     with the previous snapshot's `constraint_maturity.constraints`
+     array. Emit `constraint.added` for new constraints,
+     `constraint.promoted` for tier changes, and `constraint.removed`
+     for absent constraints.
+   - **Regression transitions:** Compare the current
+     `regression_flag` with the previous snapshot. Emit
+     `regression.detected` if it transitions false → true, or
+     `regression.cleared` if it transitions true → false.
+
+   Event logging is best-effort — if writing fails, complete the
+   snapshot normally.
+
 All values in the YAML block come from the same data sources already
-read for the markdown sections — no additional data collection is
-required beyond the git history lookups for loop activation dates.
-Follow the generation rules and null-handling policy in the format spec.
+read for the markdown sections — the only additional reads are the
+violation log and event log. Follow the generation rules and
+null-handling policy in the format spec.
 
 The schema version is tracked in
 `references/observatory-metrics-schema.md`. The `schema_version` field
-in the YAML block must match the current documented version (1.1.0).
+in the YAML block must match the current documented version (1.2.0).
 
 ## When to Use This Skill
 

--- a/skills/harness-observability/references/observatory-events.md
+++ b/skills/harness-observability/references/observatory-events.md
@@ -1,0 +1,151 @@
+# Observatory Event Log
+
+The event log records Observatory-relevant state transitions in a
+persistent, append-only file. It enables the Observatory to track
+precise timing of key events without parsing multiple files across
+multiple dates.
+
+## File
+
+**Path:** `observability/events.jsonl`
+
+**Format:** JSON Lines — one JSON object per line, append-only,
+committed to git.
+
+**Rules:**
+
+- Create the file if it does not exist (first event creates it)
+- Append a single line per event (no pretty-printing)
+- Never modify or delete existing lines
+- If writing fails, the originating command should complete normally —
+  event logging is best-effort, never blocking
+
+## Event Types
+
+### snapshot.created
+
+Emitted by `/harness-health` after a snapshot file is written.
+
+```json
+{"type": "snapshot.created", "timestamp": "<ISO 8601 UTC>", "path": "observability/snapshots/YYYY-MM-DD-snapshot.md", "schema_version": "1.2.0", "health": "<Healthy | Attention | Degraded>"}
+```
+
+### assessment.completed
+
+Emitted by `/assess` after an assessment file is written.
+
+```json
+{"type": "assessment.completed", "timestamp": "<ISO 8601 UTC>", "path": "assessments/YYYY-MM-DD-assessment.md", "level": 3, "previous_level": 2}
+```
+
+If no previous assessment exists, `previous_level` is `null`.
+
+### governance.audited
+
+Emitted by the `governance-auditor` agent after an audit file is
+written.
+
+```json
+{"type": "governance.audited", "timestamp": "<ISO 8601 UTC>", "path": "observability/governance/audit-YYYY-MM-DD.md", "drift_stage": 2, "debt_total_score": 12}
+```
+
+### constraint.added
+
+Emitted by `/harness-constrain` when a new constraint is added to
+HARNESS.md, or by `/harness-health` when a constraint appears in
+the current HARNESS.md but was absent from the previous snapshot's
+`constraint_maturity.constraints` array.
+
+```json
+{"type": "constraint.added", "timestamp": "<ISO 8601 UTC>", "constraint": "<name>", "tier": "<deterministic | agent_backed | unverified>"}
+```
+
+### constraint.promoted
+
+Emitted by `/harness-constrain` when a constraint's tier changes
+upward, or by `/harness-health` when a constraint's tier has changed
+since the previous snapshot.
+
+```json
+{"type": "constraint.promoted", "timestamp": "<ISO 8601 UTC>", "constraint": "<name>", "old_tier": "<previous tier>", "new_tier": "<new tier>"}
+```
+
+### constraint.removed
+
+Emitted by `/harness-constrain` when a constraint is removed, or by
+`/harness-health` when a constraint was in the previous snapshot but
+is absent from the current HARNESS.md.
+
+```json
+{"type": "constraint.removed", "timestamp": "<ISO 8601 UTC>", "constraint": "<name>", "reason": "<reason or null>"}
+```
+
+### regression.detected
+
+Emitted by `/harness-health` when `regression_flag` transitions from
+`false` to `true` (comparing the current computation with the previous
+snapshot's `regression_indicators.regression_flag`).
+
+```json
+{"type": "regression.detected", "timestamp": "<ISO 8601 UTC>", "trigger": "<snapshot_stale | cadence_non_compliant | zero_reflections>", "snapshot_age_days": 35}
+```
+
+The `trigger` field names the specific condition(s) that caused the
+flag. If multiple triggers fired, emit one event with the primary
+trigger.
+
+### regression.cleared
+
+Emitted by `/harness-health` when `regression_flag` transitions from
+`true` to `false`.
+
+```json
+{"type": "regression.cleared", "timestamp": "<ISO 8601 UTC>", "duration_days": 17}
+```
+
+`duration_days` is the number of days between the `regression.detected`
+event and this clearing event.
+
+### reflection.captured
+
+Emitted by `/reflect` after a reflection entry is appended to
+REFLECTION_LOG.md.
+
+```json
+{"type": "reflection.captured", "timestamp": "<ISO 8601 UTC>", "signal": "<context | instruction | workflow | failure | none>", "has_proposal": true, "has_constraint": false}
+```
+
+### cadence.configured
+
+Emitted when the Observability section of HARNESS.md is modified to
+change the snapshot cadence.
+
+```json
+{"type": "cadence.configured", "timestamp": "<ISO 8601 UTC>", "cadence": "weekly", "previous": "monthly"}
+```
+
+## Event Emission Matrix
+
+| Command / Agent | Event type(s) | When |
+| --- | --- | --- |
+| `/harness-health` | `snapshot.created` | After snapshot file is written |
+| `/harness-health` | `regression.detected` | When `regression_flag` transitions false → true |
+| `/harness-health` | `regression.cleared` | When `regression_flag` transitions true → false |
+| `/harness-health` | `constraint.added`, `constraint.promoted`, `constraint.removed` | When constraint diff detects changes vs previous snapshot |
+| `/assess` | `assessment.completed` | After assessment file is written |
+| `/governance-audit` | `governance.audited` | After audit file is written |
+| `/reflect` | `reflection.captured` | After reflection appended to REFLECTION_LOG.md |
+| `/harness-constrain` | `constraint.added`, `constraint.promoted`, `constraint.removed` | When a constraint is added, promoted, or removed |
+
+## Constraint Lifecycle Detection
+
+When `/harness-health` runs, it reads the current HARNESS.md
+constraints and compares with the previous snapshot's
+`constraint_maturity.constraints` array:
+
+- A constraint in current HARNESS.md but not in the previous
+  snapshot: emit `constraint.added`
+- A constraint whose tier has changed since the previous snapshot:
+  emit `constraint.promoted`
+- A constraint in the previous snapshot but absent from the current
+  HARNESS.md: emit `constraint.removed`

--- a/skills/harness-observability/references/observatory-metrics-schema.md
+++ b/skills/harness-observability/references/observatory-metrics-schema.md
@@ -5,7 +5,7 @@ appended to every harness health snapshot. The Observatory and any other
 machine consumer of snapshot files relies on this schema being stable
 and versioned.
 
-## Current Version: 1.1.0
+## Current Version: 1.2.0
 
 The `observatory_metrics` block contains structured, typed metrics
 across five top-level sections:
@@ -76,6 +76,24 @@ When the schema changes:
    CHANGELOG.md so Observatory maintainers are aware
 
 ## Changelog
+
+### 1.2.0
+
+Backwards-compatible additions:
+
+- Added violation tracking via `observability/violations.jsonl` —
+  JSONL append-only log recording constraint violations with loop,
+  constraint name, and timestamp
+- Added `feedback_loops.latency` with per-loop violation counts
+  (`advisory_violations_this_period`, `strict_violations_this_period`,
+  `investigative_findings_this_period`) and `violations_total`
+- Added `observatory_portfolio` YAML block schema for portfolio
+  assessments with summary, level distribution, habitat aggregates,
+  gaps, outliers, and per-project detail
+- Added Observatory event log at `observability/events.jsonl` with
+  10 event types for state transition tracking
+- Added `observatory-events.md` reference document specifying event
+  log format and emission matrix
 
 ### 1.1.0
 

--- a/skills/harness-observability/references/snapshot-format.md
+++ b/skills/harness-observability/references/snapshot-format.md
@@ -190,7 +190,7 @@ For the schema versioning policy and changelog, see
 ```yaml
 ---
 observatory_metrics:
-  schema_version: "1.1.0"
+  schema_version: "1.2.0"
   plugin_version: "<read from plugin.json>"
   timestamp: "<ISO 8601 UTC timestamp of snapshot generation>"
 
@@ -251,6 +251,11 @@ observatory_metrics:
         active: <bool>
         first_activated: "<YYYY-MM-DD or null>"
       coverage: <int 0-3, count of active loops>
+      latency:
+        advisory_violations_this_period: <int>
+        strict_violations_this_period: <int>
+        investigative_findings_this_period: <int>
+      violations_total: <int, total lines in violations.jsonl>
 
     agent_delegation:
       agents_configured: <int>
@@ -322,6 +327,10 @@ markdown sections — no new data collection is required.
 | `feedback_loops.investigative.active` | `true` if HARNESS.md Garbage Collection section has at least one rule with enforcement = "agent" or "deterministic" |
 | `feedback_loops.investigative.first_activated` | Git history: first commit that added a GC rule to HARNESS.md. `null` if no GC rules exist |
 | `feedback_loops.coverage` | Count of active loops (0-3) |
+| `feedback_loops.latency.advisory_violations_this_period` | Count entries in `observability/violations.jsonl` where `loop == "advisory"` and `timestamp` is after the previous snapshot date. `0` if no violations file or no entries |
+| `feedback_loops.latency.strict_violations_this_period` | Count entries where `loop == "strict"` since previous snapshot |
+| `feedback_loops.latency.investigative_findings_this_period` | Count entries where `loop == "investigative"` since previous snapshot |
+| `feedback_loops.violations_total` | Total line count of `observability/violations.jsonl`. `0` if file does not exist |
 | `agent_delegation.agents_configured` | Count `.agent.md` files in `agents/` directory |
 | `observability.*` | Same data as the Meta markdown section |
 | `outcomes.mutation_kill_rate.*` | Same data as the Mutation Testing markdown section |


### PR DESCRIPTION
## Summary

- Add violation tracking via `observability/violations.jsonl` — advisory hooks, CI constraint checks, and GC workflows log detected violations as timestamped JSON Lines entries
- Add `feedback_loops.latency` violation counts and `violations_total` to snapshot YAML block (schema 1.2.0)
- Add `observatory_portfolio` YAML block to portfolio assessment reports with habitat aggregates from project snapshots
- Add Observatory event log (`observability/events.jsonl`) with 10 event types for state transition tracking
- Add event emission to `/harness-health`, `/reflect`, `/harness-constrain`, `/assess`, and `governance-auditor`
- Add `observatory-events.md` reference specifying event log format and emission matrix

## Test plan

- [ ] Run `/harness-health` — verify YAML block contains `feedback_loops.latency` with violation count fields
- [ ] Verify `observability/events.jsonl` exists and has a `snapshot.created` entry after running `/harness-health`
- [ ] If constraints changed, verify `constraint.added`/`constraint.promoted` events appear
- [ ] Run `/reflect` — verify a `reflection.captured` event is appended to `events.jsonl`
- [ ] Run `/portfolio-assess --local .` — verify report contains `observatory_portfolio` YAML block
- [ ] Trigger a CI constraint check failure — verify a line is appended to `violations.jsonl`
- [ ] Confirm `schema_version` in snapshot YAML block reads `"1.2.0"`
- [ ] Confirm changelog in `observatory-metrics-schema.md` documents all additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)