### PR TITLE
Add reflection: first full GC run findings

### DIFF
--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -148,3 +148,19 @@
   - Model tiers used: unknown
   - Pipeline stages completed: manual implementation (no orchestrator pipeline)
   - Agent delegation: manual
+
+---
+
+- **Date**: 2026-04-14
+- **Agent**: claude-opus-4-6 (main conversation + harness-gc subagent)
+- **Task**: Ran /harness-health and /harness-gc (first full run of all 7 GC rules), fixed marketplace.json drift, created issues for remaining findings (PR #120)
+- **Surprise**: Three things: (1) The health badge script matches substrings — "Trend alerts: none" triggered the "alert" detector, producing a false "Degraded" status. Worked around by rephrasing to "Trend concerns: none". (2) First full GC run found 4/7 rules with findings (11 command-prompt sync issues, marketplace version stuck at 0.1.0 since creation), confirming the "silent" GC effectiveness flag was masking real entropy. (3) Re-running a failed GitHub Actions workflow reuses the original event payload — adding a label after the first run and re-triggering does not pick up the new label. A fresh push is needed to trigger a new workflow run with current label state.
+- **Proposal**: Future agents should know: (1) the badge script in `scripts/update-health-badge.sh` uses substring matching on the Meta section — avoid words like "alert", "stalled", "silent", "overdue" in field names when the value is negative (e.g. use "Trend concerns: none" not "Trend alerts: none"); (2) running /harness-gc is essential to move health from "Attention" to "Healthy" — the 5 agent-scoped GC rules only execute on explicit invocation, not via CI; (3) when adding labels to exempt a PR from CI checks, push a new commit (even empty) rather than re-running the failed workflow, because GitHub Actions re-runs reuse the original event payload
+- **Improvement**: The badge script should read the YAML metrics block (`observatory_metrics.observability.health`) instead of parsing the markdown Meta section with substring matching — this would eliminate the false-positive class entirely. Filed as a mental note for next plugin development session.
+- **Signal**: workflow
+- **Constraint**: none
+- **Session metadata**:
+  - Duration: ~30 min
+  - Model tiers used: capable (harness-gc subagent), most-capable (main conversation)
+  - Pipeline stages completed: harness-health, harness-gc, fix, PR, merge, reflect
+  - Agent delegation: partial (subagent for GC, manual for fixes and PR)

--- a/observability/events.jsonl
+++ b/observability/events.jsonl
@@ -1,0 +1,1 @@
+{"type": "reflection.captured", "timestamp": "2026-04-14T12:45:00Z", "signal": "workflow", "has_proposal": true, "has_constraint": false}


### PR DESCRIPTION
## Summary

- Append reflection entry for the /harness-health + /harness-gc session
- Three workflow learnings: badge script substring matching, GC silent status masking real entropy, GitHub Actions re-run payload behaviour
- Emit `reflection.captured` Observatory event

## Test plan

- [ ] REFLECTION_LOG.md has valid entry format
- [ ] events.jsonl has valid JSON line
- [ ] CI checks pass