### PR TITLE
Fix gc-rotate.sh crash on missing Observability section

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.15.0",
+  "plugin_version": "0.15.1",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.15.0"
+      "version": "0.15.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.15.1 — 2026-04-14
+
+### Bug fix
+
+- Fix `gc-rotate.sh` crash when HARNESS.md has no `## Observability`
+  section — `set -euo pipefail` caused the grep pipeline to exit
+  non-zero before reaching the default cadence fallback. Added
+  `|| true` to let empty results fall through. Fixes #122.
+
 ## Marketplace 0.2.1 — 2026-04-14
 
 ### GC findings fix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.15.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.15.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
+++ b/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
@@ -23,7 +23,7 @@ STALENESS_THRESHOLD=30
 cadence=$(grep -A5 '## Observability' "$HARNESS_FILE" 2>/dev/null \
   | grep 'Snapshot cadence:' \
   | sed 's/.*Snapshot cadence:[[:space:]]*//' \
-  | tr -d '[:space:]')
+  | tr -d '[:space:]') || true
 case "$cadence" in
   weekly)      STALENESS_THRESHOLD=10 ;;
   fortnightly) STALENESS_THRESHOLD=21 ;;


### PR DESCRIPTION
## Summary

- Fix `gc-rotate.sh` exiting with code 1 when HARNESS.md has no `## Observability` section
- Add `|| true` to the cadence-reading pipeline so empty grep results fall through to the default 30-day threshold
- Bump plugin version 0.15.0 → 0.15.1

Fixes #122.

## Root cause

`set -euo pipefail` + a grep pipeline that returns non-zero when the section is absent = script dies before reaching the `case` fallback.

## Test plan

- [x] Reproduced: `CLAUDE_PROJECT_DIR="." bash gc-rotate.sh` → exit 1 (before fix)
- [x] Verified: same command → exit 0 (after fix)
- [x] ShellCheck passes
- [ ] CI checks pass