### PR TITLE
Fix intermittent YAML block omission in harness-health snapshots

### DIFF
--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -164,3 +164,19 @@
   - Model tiers used: capable (harness-gc subagent), most-capable (main conversation)
   - Pipeline stages completed: harness-health, harness-gc, fix, PR, merge, reflect
   - Agent delegation: partial (subagent for GC, manual for fixes and PR)
+
+---
+
+- **Date**: 2026-04-14
+- **Agent**: claude-opus-4-6 (main conversation)
+- **Task**: Diagnosed and fixed intermittent YAML block omission in harness-health snapshots by restructuring command spec instructions
+- **Surprise**: The bug was not in code but in prompt architecture. The YAML block instruction was a single trailing sentence inside the content-heaviest step of the command spec. When previous snapshots existed (adding cognitive load from trend computation and template bias from reading old snapshots that predate the YAML spec), the model would treat its job as done after writing the last markdown section. The same instruction design principles that prevent bugs in code — single responsibility, explicit contracts, verification steps — apply directly to prompt-based command specs.
+- **Proposal**: GOTCHA: Command specs that instruct the model to generate multi-part output (e.g. markdown sections + YAML block) must give each part its own numbered step. Trailing instructions inside content-heavy steps are unreliable — the model loses them under cognitive load. Mandatory outputs should be marked **bold mandatory**, contrasted with conditional outputs, and include a self-verification checkpoint ("confirm the file ends with X before proceeding"). This applies to all command specs in the plugin, not just harness-health.
+- **Improvement**: Audit other command specs for "trailing instruction" patterns where a required output is appended as an afterthought inside a step that already produces substantial content. The snapshot-format reference should also lead with the mandatory/conditional distinction for each section.
+- **Signal**: instruction
+- **Constraint**: none
+- **Session metadata**:
+  - Duration: ~15 min
+  - Model tiers used: most-capable (main conversation), standard (Explore subagent)
+  - Pipeline stages completed: manual investigation, fix, reflect
+  - Agent delegation: manual

--- a/commands/harness-health.md
+++ b/commands/harness-health.md
@@ -85,7 +85,7 @@ Run the five meta-checks from
 
 Determine aggregate health status: Healthy / Attention / Degraded.
 
-### 6. Generate Snapshot
+### 6. Generate Markdown Sections
 
 Write the snapshot to `observability/snapshots/YYYY-MM-DD-snapshot.md`
 using the format defined in `references/snapshot-format.md`.
@@ -94,27 +94,41 @@ Include all sections: Enforcement, Garbage Collection, Mutation Testing,
 Compound Learning, Operational Cadence, Cost Indicators, Meta, and
 Trends (if previous snapshot exists).
 
-After all markdown sections, append the Observatory YAML metrics block
-at the end of the file, fenced by `---` delimiters. This block contains
-all quantitative metrics in structured, typed YAML for machine
-consumption. See `references/snapshot-format.md` § Observatory Metrics
-Block for the exact schema and generation rules.
+Do NOT close the file yet — Step 7 adds a required block.
 
-### 7. Emit Observatory Events
+### 7. Append Observatory YAML Metrics Block
+
+**This step is mandatory for every snapshot, regardless of whether a
+previous snapshot exists.** Do not skip it.
+
+After the last markdown section, append the Observatory YAML metrics
+block fenced by `---` delimiters. This block contains all quantitative
+metrics in structured, typed YAML for machine consumption. See
+`references/snapshot-format.md` § Observatory Metrics Block for the
+exact schema and generation rules.
+
+Use the data already gathered in steps 2–5 — no new collection is
+needed. The YAML block uses the same values as the markdown sections.
+
+**Verify:** before moving to Step 8, confirm the written file ends with
+the closing `---` fence of the YAML block. If it does not, append the
+block now.
+
+### 8. Emit Observatory Events
 
 After writing the snapshot, emit events to `observability/events.jsonl`
 as specified in `references/observatory-events.md`: a `snapshot.created`
 event always, plus constraint lifecycle events and regression transition
 events when detected by comparing with the previous snapshot.
 
-### 8. Update README
+### 9. Update README
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)
 
-### 9. Print Summary
+### 10. Print Summary
 
 Print the full snapshot to the session so the developer sees it
 immediately.
@@ -130,7 +144,7 @@ Since last snapshot (YYYY-MM-DD):
   Health: Healthy / Attention / Degraded
 ```
 
-### 10. Nudge Overdue Actions
+### 11. Nudge Overdue Actions
 
 If any cadence is overdue, print a nudge:
 

--- a/observability/events.jsonl
+++ b/observability/events.jsonl
@@ -1,1 +1,2 @@
 {"type": "reflection.captured", "timestamp": "2026-04-14T12:45:00Z", "signal": "workflow", "has_proposal": true, "has_constraint": false}
+{"type": "reflection.captured", "timestamp": "2026-04-14T18:00:00Z", "signal": "instruction", "has_proposal": true, "has_constraint": false}

--- a/skills/harness-observability/references/snapshot-format.md
+++ b/skills/harness-observability/references/snapshot-format.md
@@ -171,11 +171,14 @@ works reliably.
 
 ## Observatory Metrics Block
 
+**This block is mandatory in every snapshot.** Unlike the Trends section
+(which is omitted when no previous snapshot exists), the YAML metrics
+block is always present — even in the very first snapshot.
+
 After all markdown sections (including the optional Trends section),
-every snapshot includes a YAML metrics block fenced by `---` delimiters
-at the end of the file. This block contains all quantitative metrics in
-a structured, typed format intended for machine consumption by the
-Observatory.
+every snapshot ends with a YAML metrics block fenced by `---` delimiters.
+This block contains all quantitative metrics in a structured, typed
+format intended for machine consumption by the Observatory.
 
 The existing markdown sections remain the primary human-readable output.
 The YAML block is complementary — it does not replace or duplicate the


### PR DESCRIPTION
## Summary

- Split Step 6 (Generate Snapshot) into Step 6 (Generate Markdown Sections) + Step 7 (Append Observatory YAML Metrics Block), making the YAML block a dedicated mandatory step with a self-verification checkpoint
- Added bold mandatory callout to snapshot-format.md contrasting the unconditional YAML block with the conditional Trends section
- Captured reflection on prompt architecture reliability patterns

## Root cause

The YAML block instruction was a trailing sentence inside the content-heaviest step of the command spec. Three factors caused intermittent omission: buried instruction position, conditional contamination from the adjacent Trends qualifier, and template bias from reading previous snapshots that predate the YAML spec.

## Test plan

- [ ] Run `/harness-health` on a project with pre-existing snapshots and verify the YAML block is generated
- [ ] Run `/harness-health` on a project with no prior snapshots and verify the YAML block is generated
- [ ] Verify step numbering is sequential (6–11) with no gaps or duplicates