### PR TITLE
Bump plugin version to 0.15.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.15.1",
+  "plugin_version": "0.15.2",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.15.2 — 2026-04-14
+
+### Bug fix
+
+- Fix intermittent YAML block omission in harness-health snapshots —
+  split Step 6 into separate markdown generation and YAML block steps
+  with mandatory marker and self-verification checkpoint. The trailing
+  instruction was unreliable under cognitive load from trend computation.
+
 ## 0.15.1 — 2026-04-14
 
 ### Bug fix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.15.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.15.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"


### PR DESCRIPTION
## Summary

- Patch bump 0.15.1 → 0.15.2 for the YAML block reliability fix merged in #124
- Updated plugin.json, README badge, marketplace.json, and CHANGELOG

## Test plan

- [ ] Version consistency CI check passes (all four locations match)