### PR TITLE
Sync YAML block reliability fix to packaged plugin

### DIFF
--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -86,7 +86,7 @@ Run the five meta-checks from
 
 Determine aggregate health status: Healthy / Attention / Degraded.
 
-### 6. Generate Snapshot
+### 6. Generate Markdown Sections
 
 Write the snapshot to `observability/snapshots/YYYY-MM-DD-snapshot.md`
 using the format defined in `references/snapshot-format.md`.
@@ -95,14 +95,34 @@ Include all sections: Enforcement, Garbage Collection, Mutation Testing,
 Compound Learning, Session Quality, Operational Cadence, Cost Indicators,
 Meta, and Trends (if previous snapshot exists).
 
-### 7. Update README
+Do NOT close the file yet — Step 7 adds a required block.
+
+### 7. Append Observatory YAML Metrics Block
+
+**This step is mandatory for every snapshot, regardless of whether a
+previous snapshot exists.** Do not skip it.
+
+After the last markdown section, append the Observatory YAML metrics
+block fenced by `---` delimiters. This block contains all quantitative
+metrics in structured, typed YAML for machine consumption. See
+`references/snapshot-format.md` § Observatory Metrics Block for the
+exact schema and generation rules.
+
+Use the data already gathered in steps 2–5 — no new collection is
+needed. The YAML block uses the same values as the markdown sections.
+
+**Verify:** before moving to Step 8, confirm the written file ends with
+the closing `---` fence of the YAML block. If it does not, append the
+block now.
+
+### 8. Update README
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)
 
-### 8. Print Summary
+### 9. Print Summary
 
 Print the full snapshot to the session so the developer sees it
 immediately.
@@ -119,7 +139,7 @@ Since last snapshot (YYYY-MM-DD):
   Health: Healthy / Attention / Degraded
 ```
 
-### 9. Nudge Overdue Actions
+### 10. Nudge Overdue Actions
 
 If any cadence is overdue, print a nudge:
 


### PR DESCRIPTION
## Summary

- The YAML block step fix from #124 was only applied to the root `commands/harness-health.md`, not the packaged copy at `ai-literacy-superpowers/commands/harness-health.md`
- Syncs the same split-step pattern (Step 6 → markdown, Step 7 → mandatory YAML block with verification) to the packaged plugin

## Test plan

- [ ] Verify packaged `harness-health.md` has Step 7 (Append Observatory YAML Metrics Block)
- [ ] Verify step numbering is sequential (6–10) with no gaps