### PR TITLE
Add 2026-04-15 harness health snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)
 [![Harness](https://img.shields.io/badge/Harness-11%2F11_enforced-2E8B57?style=flat-square)](HARNESS.md)
-[![Harness Health](https://img.shields.io/badge/Harness_Health-Attention-DAA520?style=flat-square)](observability/snapshots/2026-04-14-snapshot.md)
+[![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-04-15-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)

--- a/observability/snapshots/2026-04-15-snapshot.md
+++ b/observability/snapshots/2026-04-15-snapshot.md
@@ -1,0 +1,258 @@
+# Harness Health Snapshot — 2026-04-15
+
+## Enforcement
+
+- Constraints: 11/11 enforced (100%)
+- Deterministic: 8 | Agent: 3 | Unverified: 0
+- Drift detected: none
+
+## Enforcement Loop History
+
+- Advisory (edit-time): active since 2026-03-30
+- Strict (merge-time): active since 2026-04-06
+- Investigative (scheduled): active since 2026-04-06
+
+## Garbage Collection
+
+- Rules active: 2/7
+- Last run: 2026-04-14
+- Findings since last snapshot: yes (4 of 7 rules flagged issues
+  during first full GC run on 2026-04-14 — 11 command-prompt sync
+  divergences, marketplace version drift, documentation references
+  to removed content)
+
+### Rule status
+
+| Rule | Enforcement | Automated |
+| --- | --- | --- |
+| Documentation freshness | agent | no (requires LLM) |
+| Secret scanner operational | deterministic | yes (weekly CI) |
+| Snapshot staleness | deterministic | yes (weekly CI) |
+| Command-prompt sync | agent | no (requires LLM) |
+| Change cadence drift | agent | no (requires LLM) |
+| Plugin manifest currency | agent | no (requires LLM) |
+| Marketplace listing drift | agent | no (requires LLM) |
+
+## Mutation Testing
+
+- Not applicable — this project has no application code or test suite
+
+## Compound Learning
+
+- REFLECTION_LOG entries: 12 (2 new since last snapshot)
+- AGENTS.md entries: 10 (5 gotchas, 2 arch decisions)
+- Promotions since last snapshot: 0
+
+### Learning flow
+
+- Status: active
+- 2 new reflections since 2026-04-14, 0 curated into AGENTS.md
+- Signal distribution: context 3, instruction 2, workflow 6, failure 1
+
+## Session Quality
+
+- Entries with Signal field: 8/12 (67%)
+- Entries with Session metadata: 3/12 (25%)
+- Pre-Signal entries (before 2026-04-08): 4
+
+## Operational Cadence
+
+- Last /harness-audit: 2026-04-11 (4 days ago)
+- Last /assess: 2026-04-11 (4 days ago)
+- Last /reflect: 2026-04-14 (1 day ago)
+- Outer loop overdue: no
+
+## Cost Indicators
+
+- Model routing configured: yes (MODEL_ROUTING.md present)
+- Tier distribution: documented (most-capable, standard, capable tiers)
+- Actual cost data captured: no
+
+## Regression Indicators
+
+- Snapshot stale: no (1 day since last, threshold 30)
+- Snapshot age: 1 day
+- Cadence non-compliance: 0 of 4 activities overdue
+- Consecutive weeks without reflections: 0
+- Regression flag: no
+
+## Changes Since Last Snapshot
+
+- Constraints added: none
+- Constraints promoted: none
+- Constraints removed: none
+- Assessments completed: none
+- Governance audits completed: none
+
+## Meta
+
+- Snapshot cadence: on schedule (1 day since last, threshold 30)
+- Learning flow: active (2 reflections added since last snapshot)
+- GC effectiveness: productive (4/7 rules found issues on 2026-04-14)
+- Trend concerns: none
+- Health: **Healthy**
+
+## Trends (vs 2026-04-14)
+
+| Metric | Previous | Current | Change |
+| --- | --- | --- | --- |
+| Constraints enforced | 11/11 (100%) | 11/11 (100%) | stable |
+| GC rules active | 2/7 | 2/7 | stable |
+| REFLECTION_LOG entries | 10 | 12 | +2 |
+| AGENTS.md entries | 10 | 10 | stable |
+| Promotions | 3 | 0 | period reset |
+| Cadence status | on schedule | on schedule | unchanged |
+
+Direction: stable with one notable upgrade — GC effectiveness moved
+from "silent" to "productive" after the first full GC run on
+2026-04-14 found issues in 4 of 7 rules. This is a genuine health
+improvement: the entropy-fighting loop is now demonstrably working.
+
+## Notes
+
+Short interval since last snapshot (1 day). Key change is the GC
+effectiveness upgrade — the 2026-04-14 /harness-gc run (first full
+execution of all 7 rules) found actionable issues: marketplace.json
+version drift was fixed in PR #120, command-prompt sync divergences
+were filed as issues. The "silent" flag that persisted across the
+previous 3 snapshots was masking real entropy that the agent-scoped
+GC rules could not detect without explicit invocation.
+
+---
+observatory_metrics:
+  schema_version: "1.2.0"
+  plugin_version: "0.16.0"
+  timestamp: "2026-04-15T12:00:00Z"
+
+  habitat_configuration:
+    context_depth:
+      score: 0.8
+      layers_present: 4
+      layers:
+        stack: { present: true, last_modified: "2026-04-13" }
+        conventions: { present: true, last_modified: "2026-04-13" }
+        arch_decisions: { present: true, last_modified: "2026-04-12" }
+        rationale: { present: true, last_modified: "2026-04-13" }
+        threat_model: { present: false, last_modified: null }
+
+    constraint_maturity:
+      enforcement_ratio: 1.0
+      total_constraints: 11
+      enforced: 11
+      deterministic: 8
+      agent_backed: 3
+      unverified: 0
+      drift_detected: false
+      constraints:
+        - name: "Consistent markdown formatting"
+          tier: "deterministic"
+          enforced: true
+        - name: "No secrets in source"
+          tier: "deterministic"
+          enforced: true
+        - name: "Shell scripts pass syntax check"
+          tier: "deterministic"
+          enforced: true
+        - name: "All frontmatter has name and description"
+          tier: "agent_backed"
+          enforced: true
+        - name: "Shell scripts use strict mode"
+          tier: "deterministic"
+          enforced: true
+        - name: "ShellCheck compliance"
+          tier: "deterministic"
+          enforced: true
+        - name: "Spec-scoped changes"
+          tier: "agent_backed"
+          enforced: true
+        - name: "Spec-first commit ordering"
+          tier: "deterministic"
+          enforced: true
+        - name: "Spec captures intent"
+          tier: "agent_backed"
+          enforced: true
+        - name: "Version consistency"
+          tier: "deterministic"
+          enforced: true
+        - name: "Marketplace plugin version sync"
+          tier: "deterministic"
+          enforced: true
+
+    entropy_management:
+      gc_rules_active: 2
+      gc_rules_total: 7
+      gc_active_ratio: 0.29
+      findings_since_last_snapshot: 4
+      cadence_compliant: true
+      last_run: "2026-04-14"
+
+    compound_learning:
+      reflection_log_entries: 12
+      reflections_this_period: 2
+      agents_md_entries: 10
+      gotchas: 5
+      arch_decisions: 2
+      promotions_this_period: 0
+      velocity: 2.0
+      signal_distribution:
+        context: 3
+        instruction: 2
+        workflow: 6
+        failure: 1
+
+    feedback_loops:
+      advisory:
+        active: true
+        first_activated: "2026-03-30"
+      strict:
+        active: true
+        first_activated: "2026-04-06"
+      investigative:
+        active: true
+        first_activated: "2026-04-06"
+      coverage: 3
+      latency:
+        advisory_violations_this_period: 0
+        strict_violations_this_period: 0
+        investigative_findings_this_period: 4
+      violations_total: 0
+
+    agent_delegation:
+      agents_configured: 11
+
+    observability:
+      configured_cadence: "monthly"
+      cadence_threshold_days: 30
+      health: "Healthy"
+      snapshot_age_days: 1
+      meta_checks:
+        snapshot_currency: "on_schedule"
+        cadence_compliance: "all_on_schedule"
+        learning_flow: "active"
+        gc_effectiveness: "productive"
+        trend_direction: "stable"
+
+  outcomes:
+    mutation_kill_rate:
+      aggregate: null
+      by_language: {}
+    cost:
+      model_routing_configured: true
+      tier_distribution: {}
+      trend: "unknown"
+
+  operational_cadence:
+    days_since_audit: 4
+    days_since_assess: 4
+    days_since_reflect: 1
+    audit_overdue: false
+    assess_overdue: false
+    reflect_overdue: false
+
+  regression_indicators:
+    snapshot_stale: false
+    snapshot_age_days: 1
+    cadence_non_compliant_count: 0
+    consecutive_zero_reflection_weeks: 0
+    regression_flag: false
+---


### PR DESCRIPTION
## Summary

- Adds daily harness health snapshot for 2026-04-15
- GC effectiveness upgraded from "silent" to "productive" after first full GC run (2026-04-14) found issues in 4/7 rules
- README health badge updated: Attention → Healthy, linked to new snapshot
- REFLECTION_LOG grew from 10 to 12 entries; all cadences on schedule

## Test plan

- [ ] CI checks pass (markdownlint, version consistency)
- [ ] Snapshot file renders correctly in GitHub
- [ ] README badge shows "Healthy" in green

🤖 Generated with [Claude Code](https://claude.com/claude-code)