### PR TITLE
Add release traceability governance constraint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.16.0",
+  "plugin_version": "0.17.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,50 @@
+# Auto-tag on version bump.
+#
+# When plugin.json version changes on push to main, creates a git
+# tag vX.Y.Z pointing at the merge commit. Part of the release
+# governance constraint — ensures every published version has an
+# immutable tag.
+
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ai-literacy-superpowers/.claude-plugin/plugin.json'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check if tag needed
+        id: check
+        run: |
+          VERSION=$(grep '"version"' ai-literacy-superpowers/.claude-plugin/plugin.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          TAG="v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          if git tag -l "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists — skipping"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG does not exist — will create"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git tag "${{ steps.check.outputs.tag }}"
+          git push origin "${{ steps.check.outputs.tag }}"
+          echo "Created and pushed tag ${{ steps.check.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.17.0 — 2026-04-15
+
+### Release governance
+
+- Add first governance constraint: release traceability — every
+  plugin version must have a matching changelog heading and git tag
+- Add auto-tag workflow (`.github/workflows/auto-tag.yml`) that
+  creates `vX.Y.Z` tags on merge when the version changes
+- Add "Release tag completeness" GC rule with auto-fix for missing
+  tags
+- HARNESS.md Status: 12/12 constraints enforced, 3/8 GC rules active
+
 ## 0.16.0 — 2026-04-15
 
 ### Observatory rebase: YAML to markdown

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -154,6 +154,30 @@
 - **Tool**: .github/workflows/version-check.yml
 - **Scope**: pr
 
+### Release traceability
+
+- **Rule**: Every version in `plugin.json` must have a matching
+  `## X.Y.Z — YYYY-MM-DD` heading in `CHANGELOG.md` and a `vX.Y.Z`
+  git tag. The changelog heading must match at PR time. The git tag
+  is created automatically on merge by the auto-tag workflow.
+- **Enforcement**: deterministic
+- **Tool**: .github/workflows/version-check.yml (changelog match),
+  .github/workflows/auto-tag.yml (tag creation)
+- **Scope**: pr + post-merge
+- **Governance requirement**: All published plugin versions must have
+  a corresponding changelog entry and a tag on GitHub
+- **Operational meaning**: PR is blocked if `CHANGELOG.md` top heading
+  does not match `plugin.json` version. On merge to main, CI creates a
+  `vX.Y.Z` git tag if one does not already exist. A GC rule verifies
+  completeness and auto-creates any missing tags.
+- **Verification method**: deterministic — version-check CI (PR gate),
+  auto-tag CI (post-merge), release-tag-completeness GC (periodic)
+- **Evidence**: CI check output, git tag list, GC run logs
+- **Failure action**: block merge (changelog mismatch); auto-create
+  tag (GC finding)
+- **Frame check**: engineering / compliance / AI system interpretations
+  confirmed aligned (see spec 2026-04-15-release-governance-constraint-design.md)
+
 ---
 
 ## Garbage Collection
@@ -229,13 +253,23 @@
 - **Tool**: harness-gc agent
 - **Auto-fix**: false
 
+### Release tag completeness
+
+- **What it checks**: Whether every version heading in `CHANGELOG.md`
+  has a corresponding `vX.Y.Z` git tag
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: for v in $(grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md); do git tag -l "v$v" | grep -q "v$v" || echo "MISSING: v$v"; done
+- **Auto-fix**: true (creates missing tags pointing at the merge
+  commit that introduced the version heading)
+
 ---
 
 ## Status
 
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
-Last audit: 2026-04-11
-Constraints enforced: 11/11
-Garbage collection active: 2/7
+Last audit: 2026-04-15
+Constraints enforced: 12/12
+Garbage collection active: 3/8
 Drift detected: none

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.16.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.17.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-18-2E8B57?style=flat-square)](#commands-18)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/docs/superpowers/specs/2026-04-15-release-governance-constraint-design.md
+++ b/docs/superpowers/specs/2026-04-15-release-governance-constraint-design.md
@@ -1,0 +1,58 @@
+# Release Governance Constraint
+
+## Problem
+
+Published plugin versions have no governance enforcement ensuring
+traceability. A version can be bumped in `plugin.json` without a
+corresponding changelog entry (partially addressed by the existing
+version-check CI workflow) or a git tag. Without tags, there is no
+immutable pointer to the code that shipped for a given version.
+
+## Approach
+
+Add a governance constraint to HARNESS.md encoding the requirement:
+
+> Every published plugin version must have a corresponding changelog
+> entry and a git tag.
+
+### What already exists
+
+The `version-check.yml` CI workflow already verifies that the
+`plugin.json` version matches the top `CHANGELOG.md` heading at PR
+time. This covers the changelog side of the constraint.
+
+### What needs adding
+
+1. **Auto-tagger workflow** — a new GitHub Actions workflow that
+   creates a `vX.Y.Z` git tag on push to main when the `plugin.json`
+   version differs from the latest existing tag.
+
+2. **GC rule with auto-fix** — a new garbage collection rule in
+   HARNESS.md that periodically verifies every version in the
+   changelog has a corresponding git tag, and auto-creates missing
+   tags.
+
+3. **Governance constraint in HARNESS.md** — the formal constraint
+   with governance template fields (operational meaning, evidence,
+   failure action, three-frame alignment).
+
+### Three-frame alignment
+
+- **Engineering**: PR blocked if changelog heading doesn't match
+  version; CI auto-tags on merge; GC catches missed tags.
+- **Compliance**: Git tag history and changelog provide audit trail.
+  Missing tags are auto-remediated and logged.
+- **AI system**: Deterministic checks at PR time (existing) and
+  post-merge (new auto-tagger). GC rule is deterministic with
+  auto-fix.
+
+All three frames aligned — confirmed during `/governance-constrain`
+guided workflow.
+
+## Expected Outcome
+
+- HARNESS.md gains its first governance constraint
+- New `.github/workflows/auto-tag.yml` workflow
+- New GC rule "Release tag completeness" in HARNESS.md
+- HARNESS.md Status updated (12/12 constraints, 3/8 GC active)
+- Minor version bump (governance constraint is behavioural)


### PR DESCRIPTION
## Summary

- First governance constraint in HARNESS.md: every plugin version must have a matching changelog heading and `vX.Y.Z` git tag
- Add auto-tag workflow (`.github/workflows/auto-tag.yml`) that creates tags on merge when `plugin.json` version changes
- Add "Release tag completeness" GC rule with auto-fix for missing tags
- Bump to v0.17.0 (new governance constraint is behavioural)
- HARNESS.md Status: 12/12 constraints enforced, 3/8 GC active

Spec: `docs/superpowers/specs/2026-04-15-release-governance-constraint-design.md`

Designed via `/governance-constrain` guided workflow with three-frame alignment confirmed.

## Test plan

- [ ] CI checks pass (markdownlint, version consistency, spec-first)
- [ ] HARNESS.md constraint is parseable by harness-enforcer
- [ ] Auto-tag workflow triggers on next version bump merge to main
- [ ] GC rule detects missing tags when run via `/harness-gc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)