### PR TITLE
Update harness health snapshot with audit findings

### DIFF
--- a/observability/snapshots/2026-04-15-snapshot.md
+++ b/observability/snapshots/2026-04-15-snapshot.md
@@ -2,9 +2,42 @@
 
 ## Enforcement
 
-- Constraints: 11/11 enforced (100%)
-- Deterministic: 8 | Agent: 3 | Unverified: 0
-- Drift detected: none
+- Constraints: 12/12 enforced (100%)
+- Deterministic: 9 | Agent: 3 | Unverified: 0
+- Passing: 10/12 (1 failing, 2 PR-scoped unchecked)
+- Drift detected: yes (3 items — see below)
+
+### Constraint results
+
+| Constraint | Enforcement | Result |
+| --- | --- | --- |
+| Consistent markdown formatting | deterministic | FAIL (44 errors) |
+| No secrets in source | deterministic | PASS |
+| Shell scripts pass syntax check | deterministic | PASS |
+| All frontmatter has name and description | agent | PASS |
+| Shell scripts use strict mode | deterministic | PASS |
+| ShellCheck compliance | deterministic | PASS |
+| Spec-scoped changes | agent (PR) | unchecked |
+| Spec-first commit ordering | deterministic (CI) | PASS |
+| Spec captures intent | agent (PR) | unchecked |
+| Version consistency | deterministic (CI) | PASS |
+| Marketplace plugin version sync | deterministic (CI) | PASS |
+| Release traceability | deterministic (CI) | PASS |
+
+### Drift items
+
+1. **Missing hook script** (critical): `hooks/scripts/drift-check.sh`
+   is referenced in `hooks/hooks.json` (Stop hook) but does not exist
+   on disk. The hook silently fails at every session end.
+2. **Markdown lint constraint failing**: 44 markdownlint errors across
+   the codebase — MD040 (code blocks without language, 12), MD036
+   (emphasis as heading, 12), MD033 (inline HTML, 8), MD001 (heading
+   level skip, 4), MD003 (setext headings, 2), MD046 (code block
+   style, 1). Errors concentrate in articles/, docs/explanation/, and
+   docs/superpowers/plans/.
+3. **README badges stale**: Harness badge says 11/11 (should be 12/12),
+   Skills badge says 27 (should be 29), Commands badge says 18 (should
+   be 19).
 
 ## Enforcement Loop History
 
@@ -14,12 +47,9 @@
 
 ## Garbage Collection
 
-- Rules active: 2/7
+- Rules active: 3/8
 - Last run: 2026-04-14
-- Findings since last snapshot: yes (4 of 7 rules flagged issues
-  during first full GC run on 2026-04-14 — 11 command-prompt sync
-  divergences, marketplace version drift, documentation references
-  to removed content)
+- Findings since last snapshot: none (0 days since last snapshot)
 
 ### Rule status
 
@@ -32,6 +62,7 @@
 | Change cadence drift | agent | no (requires LLM) |
 | Plugin manifest currency | agent | no (requires LLM) |
 | Marketplace listing drift | agent | no (requires LLM) |
+| Release tag completeness | deterministic | yes (weekly CI) |
 
 ## Mutation Testing
 
@@ -39,27 +70,30 @@
 
 ## Compound Learning
 
-- REFLECTION_LOG entries: 12 (2 new since last snapshot)
+- REFLECTION_LOG entries: 13 (1 new since last snapshot)
 - AGENTS.md entries: 10 (5 gotchas, 2 arch decisions)
 - Promotions since last snapshot: 0
 
 ### Learning flow
 
 - Status: active
-- 2 new reflections since 2026-04-14, 0 curated into AGENTS.md
-- Signal distribution: context 3, instruction 2, workflow 6, failure 1
+- 1 new reflection since 2026-04-15 (this audit), 0 curated into
+  AGENTS.md
+- Signal distribution: context 2, instruction 1, workflow 5, failure 0
+  (5 entries predate Signal field — treated as "none")
 
 ## Session Quality
 
-- Entries with Signal field: 8/12 (67%)
-- Entries with Session metadata: 3/12 (25%)
-- Pre-Signal entries (before 2026-04-08): 4
+- Entries with Signal field: 8/13 (62%)
+- Entries with Session metadata: 3/13 (23%)
+- Pre-Signal entries (before 2026-04-08): 5
 
 ## Operational Cadence
 
-- Last /harness-audit: 2026-04-11 (4 days ago)
+- Last /harness-audit: 2026-04-15 (today)
 - Last /assess: 2026-04-11 (4 days ago)
 - Last /reflect: 2026-04-14 (1 day ago)
+- Last /governance-audit: 2026-04-15 (today)
 - Outer loop overdue: no
 
 ## Cost Indicators
@@ -70,59 +104,72 @@
 
 ## Regression Indicators
 
-- Snapshot stale: no (1 day since last, threshold 30)
-- Snapshot age: 1 day
+- Snapshot stale: no (0 days since last, threshold 30)
+- Snapshot age: 0 days
 - Cadence non-compliance: 0 of 4 activities overdue
 - Consecutive weeks without reflections: 0
 - Regression flag: no
 
 ## Changes Since Last Snapshot
 
-- Constraints added: none
+- Constraints added: 1 (Release traceability — now 12 total)
 - Constraints promoted: none
 - Constraints removed: none
 - Assessments completed: none
-- Governance audits completed: none
+- Governance audits completed: 1 (2026-04-15)
+- Drift items found: 3 (missing hook script, markdown lint failing,
+  stale README badges)
 
 ## Meta
 
-- Snapshot cadence: on schedule (1 day since last, threshold 30)
-- Learning flow: active (2 reflections added since last snapshot)
+- Snapshot cadence: on schedule (0 days since last, threshold 30)
+- Learning flow: active (1 reflection added since last snapshot)
 - GC effectiveness: productive (4/7 rules found issues on 2026-04-14)
-- Trend concerns: none
-- Health: **Healthy**
+- Trend concerns: drift items require attention
+- Health: **Attention**
 
-## Trends (vs 2026-04-14)
+## Trends (vs 2026-04-15 previous)
 
 | Metric | Previous | Current | Change |
 | --- | --- | --- | --- |
-| Constraints enforced | 11/11 (100%) | 11/11 (100%) | stable |
-| GC rules active | 2/7 | 2/7 | stable |
-| REFLECTION_LOG entries | 10 | 12 | +2 |
+| Constraints enforced | 11/11 (100%) | 12/12 (100%) | +1 constraint |
+| Constraints passing | 11/11 | 10/12 | -1 (lint failing) |
+| GC rules active | 2/7 | 3/8 | +1 rule, +1 total |
+| REFLECTION_LOG entries | 12 | 13 | +1 |
 | AGENTS.md entries | 10 | 10 | stable |
-| Promotions | 3 | 0 | period reset |
+| Promotions | 0 | 0 | stable |
 | Cadence status | on schedule | on schedule | unchanged |
+| Drift items | 0 | 3 | +3 (new findings) |
 
-Direction: stable with one notable upgrade — GC effectiveness moved
-from "silent" to "productive" after the first full GC run on
-2026-04-14 found issues in 4 of 7 rules. This is a genuine health
-improvement: the entropy-fighting loop is now demonstrably working.
+Direction: the enforcement ratio remains 100% (all constraints have
+mechanisms) but compliance dropped — the markdown lint constraint is
+actively failing with 44 errors, a missing hook script means the
+drift-check Stop hook never executes, and README badges are stale.
+The health status moves from "Healthy" to "Attention" until drift
+items are resolved.
 
 ## Notes
 
-Short interval since last snapshot (1 day). Key change is the GC
-effectiveness upgrade — the 2026-04-14 /harness-gc run (first full
-execution of all 7 rules) found actionable issues: marketplace.json
-version drift was fixed in PR #120, command-prompt sync divergences
-were filed as issues. The "silent" flag that persisted across the
-previous 3 snapshots was masking real entropy that the agent-scoped
-GC rules could not detect without explicit invocation.
+This snapshot was generated by a full /harness-audit that dispatched
+three subagents (discoverer, enforcer, auditor) in parallel. The
+previous same-day snapshot reported 11/11 constraints because it
+predated the Release traceability constraint. This snapshot corrects
+the count and surfaces three drift items that were previously invisible:
+the missing drift-check.sh hook script (which has been silently failing
+since it was referenced), 44 markdownlint violations across articles
+and docs, and stale README badges that undercount skills and commands.
+
+The most critical finding is the missing `hooks/scripts/drift-check.sh`
+— this is infrastructure drift where a declared mechanism cannot
+execute. The markdown lint violations are lower priority (style issues,
+not structural) but signal that the constraint is enforced without
+compliance, which undermines trust in the enforcement loop.
 
 ---
 observatory_metrics:
   schema_version: "1.2.0"
-  plugin_version: "0.16.0"
-  timestamp: "2026-04-15T12:00:00Z"
+  plugin_version: "0.17.1"
+  timestamp: "2026-04-15T18:00:00Z"
 
   habitat_configuration:
     context_depth:
@@ -137,68 +184,87 @@ observatory_metrics:
 
     constraint_maturity:
       enforcement_ratio: 1.0
-      total_constraints: 11
-      enforced: 11
-      deterministic: 8
+      total_constraints: 12
+      enforced: 12
+      deterministic: 9
       agent_backed: 3
       unverified: 0
-      drift_detected: false
+      passing: 10
+      failing: 1
+      unchecked: 2
+      drift_detected: true
+      drift_items: 3
       constraints:
         - name: "Consistent markdown formatting"
           tier: "deterministic"
           enforced: true
+          passing: false
         - name: "No secrets in source"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "Shell scripts pass syntax check"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "All frontmatter has name and description"
           tier: "agent_backed"
           enforced: true
+          passing: true
         - name: "Shell scripts use strict mode"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "ShellCheck compliance"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "Spec-scoped changes"
           tier: "agent_backed"
           enforced: true
+          passing: null
         - name: "Spec-first commit ordering"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "Spec captures intent"
           tier: "agent_backed"
           enforced: true
+          passing: null
         - name: "Version consistency"
           tier: "deterministic"
           enforced: true
+          passing: true
         - name: "Marketplace plugin version sync"
           tier: "deterministic"
           enforced: true
+          passing: true
+        - name: "Release traceability"
+          tier: "deterministic"
+          enforced: true
+          passing: true
 
     entropy_management:
-      gc_rules_active: 2
-      gc_rules_total: 7
-      gc_active_ratio: 0.29
-      findings_since_last_snapshot: 4
+      gc_rules_active: 3
+      gc_rules_total: 8
+      gc_active_ratio: 0.375
+      findings_since_last_snapshot: 0
       cadence_compliant: true
       last_run: "2026-04-14"
 
     compound_learning:
-      reflection_log_entries: 12
-      reflections_this_period: 2
+      reflection_log_entries: 13
+      reflections_this_period: 1
       agents_md_entries: 10
       gotchas: 5
       arch_decisions: 2
       promotions_this_period: 0
-      velocity: 2.0
+      velocity: 1.0
       signal_distribution:
-        context: 3
-        instruction: 2
-        workflow: 6
-        failure: 1
+        context: 2
+        instruction: 1
+        workflow: 5
+        failure: 0
 
     feedback_loops:
       advisory:
@@ -214,7 +280,7 @@ observatory_metrics:
       latency:
         advisory_violations_this_period: 0
         strict_violations_this_period: 0
-        investigative_findings_this_period: 4
+        investigative_findings_this_period: 0
       violations_total: 0
 
     agent_delegation:
@@ -223,14 +289,14 @@ observatory_metrics:
     observability:
       configured_cadence: "monthly"
       cadence_threshold_days: 30
-      health: "Healthy"
-      snapshot_age_days: 1
+      health: "Attention"
+      snapshot_age_days: 0
       meta_checks:
         snapshot_currency: "on_schedule"
         cadence_compliance: "all_on_schedule"
         learning_flow: "active"
         gc_effectiveness: "productive"
-        trend_direction: "stable"
+        trend_direction: "attention"
 
   outcomes:
     mutation_kill_rate:
@@ -242,17 +308,30 @@ observatory_metrics:
       trend: "unknown"
 
   operational_cadence:
-    days_since_audit: 4
+    days_since_audit: 0
     days_since_assess: 4
     days_since_reflect: 1
+    days_since_governance_audit: 0
     audit_overdue: false
     assess_overdue: false
     reflect_overdue: false
 
-regression_indicators:
+  regression_indicators:
     snapshot_stale: false
-    snapshot_age_days: 1
+    snapshot_age_days: 0
     cadence_non_compliant_count: 0
     consecutive_zero_reflection_weeks: 0
     regression_flag: false
+
+  drift:
+    items:
+      - id: "missing-drift-check-sh"
+        severity: "critical"
+        description: "hooks/scripts/drift-check.sh referenced in hooks.json but missing from disk"
+      - id: "markdown-lint-failing"
+        severity: "medium"
+        description: "44 markdownlint errors — constraint enforced but not passing"
+      - id: "readme-badges-stale"
+        severity: "low"
+        description: "Harness 11→12, Skills 27→29, Commands 18→19"
 ---


### PR DESCRIPTION
## Summary

- Updates the 2026-04-15 harness health snapshot with results from a full three-agent audit (discoverer, enforcer, auditor)
- Corrects constraint count from 11 to 12 (Release traceability was missing)
- Surfaces 3 drift items: missing `hooks/scripts/drift-check.sh`, 44 markdownlint violations, stale README badges
- Health status moves from Healthy to Attention

## Test plan

- [ ] Snapshot passes markdownlint
- [ ] YAML metrics block is well-formed
- [ ] No version bump needed (observability artifact only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)