### PR TITLE
Add Observability section to template and adopt 0.18.1 content

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.18.1",
+  "plugin_version": "0.19.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.19.0 — 2026-04-15
+
+### Harness template — Observability section
+
+- Add `## Observability` section to HARNESS.md template with snapshot
+  cadence, operating cadence, health thresholds, and regression
+  detection configuration — new harnesses now include self-monitoring
+  defaults out of the box
+
+### Harness upgrade — adopt 0.18.1 template content
+
+- Accept all new template items: 2 constraints (Tests must pass,
+  Spec conformance), 4 active GC rules (Dependency currency,
+  Observability archive, Convention file sync, Reflection-driven
+  regression detection), and 7 commented-out GC rules (governance
+  and fitness function templates)
+- Update template-version marker to 0.19.0
+
 ## 0.18.1 — 2026-04-15
 
 ### Repo cleanup

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.18.0 -->
+<!-- template-version: 0.19.0 -->
 
 ## Context
 
@@ -179,6 +179,25 @@
 - **Frame check**: engineering / compliance / AI system interpretations
   confirmed aligned (see spec 2026-04-15-release-governance-constraint-design.md)
 
+### Tests must pass
+
+- **Rule**: The project's test suite must pass with zero failures before
+  any code is merged
+- **Enforcement**: unverified
+- **Tool**: none yet
+- **Scope**: pr
+
+<!-- Uncomment if using spec-first development:
+
+### Spec conformance
+
+- **Rule**: All code changes covered by a spec must pass the spec's
+  associated test suite before merge
+- **Enforcement**: deterministic
+- **Tool**: <project test runner command>
+- **Scope**: pr
+-->
+
 ---
 
 ## Garbage Collection
@@ -274,6 +293,118 @@
 - **Tool**: compare template-version comment in HARNESS.md against
   plugin.json version
 - **Auto-fix**: false
+
+### Dependency currency
+
+- **What it checks**: Whether project dependencies have known
+  vulnerabilities or are more than one major version behind latest
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Observability archive
+
+- **What it checks**: Whether snapshots older than 6 months exist in
+  `observability/snapshots/` and should be moved to
+  `observability/archive/`
+- **Frequency**: monthly
+- **Enforcement**: deterministic
+- **Tool**: file date check
+- **Auto-fix**: true (move to archive directory)
+
+### Convention file sync
+
+- **What it checks**: Whether .cursor/rules/, .github/copilot-instructions.md,
+  and .windsurf/rules/ exist and reflect the current HARNESS.md conventions
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Reflection-driven regression detection
+
+- **What it checks**: Whether REFLECTION_LOG.md contains recurring
+  failure patterns (same type of surprise across 2+ entries) that
+  are not yet covered by a HARNESS.md constraint
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+<!-- Uncomment if governance constraints are declared above:
+
+### Governance constraint freshness
+
+- **What it checks**: Whether governance constraints have been
+  reviewed since the technology or process they govern changed
+- **Frequency**: monthly
+- **Enforcement**: agent
+- **Tool**: governance-auditor agent
+- **Auto-fix**: false
+
+### Semantic drift early warning
+
+- **What it checks**: Whether implementation files referenced by
+  governance constraints have changed substantially since the
+  constraint was last audited
+- **Frequency**: monthly
+- **Enforcement**: agent
+- **Tool**: governance-auditor agent
+- **Auto-fix**: false
+
+### Governance debt cycle check
+
+- **What it checks**: Whether governance constraints reference other
+  constraints that have unresolved governance debt, indicating the
+  four-debt vicious cycle may be active
+- **Frequency**: quarterly
+- **Enforcement**: agent
+- **Tool**: governance-auditor agent
+- **Auto-fix**: false
+
+Run /governance-audit quarterly to keep governance constraints fresh.
+-->
+
+<!-- Uncomment fitness function rules relevant to your stack:
+
+### Layer boundary compliance
+
+- **What it checks**: Whether modules respect declared architectural
+  boundaries (no imports from forbidden layers)
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: npx dependency-cruiser --validate .dependency-cruiser.js src/
+- **Auto-fix**: false
+
+### Complexity hotspots
+
+- **What it checks**: Whether any files show increasing cognitive
+  complexity correlated with high git churn
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Coupling trend
+
+- **What it checks**: Whether inter-module coupling metrics have
+  increased since the last snapshot
+- **Frequency**: weekly
+- **Enforcement**: agent
+- **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Dependency age budget
+
+- **What it checks**: Whether the total dependency age (libyear score)
+  exceeds the project's declared threshold or has increased since the
+  last snapshot
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: npx libyear (or ecosystem equivalent)
+- **Auto-fix**: false
+-->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.18.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-19-2E8B57?style=flat-square)](#commands-19)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.18.0 -->
+<!-- template-version: 0.19.0 -->
 
 ## Context
 
@@ -265,6 +265,44 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 - **Tool**: npx libyear (or ecosystem equivalent)
 - **Auto-fix**: false
 -->
+---
+
+## Observability
+
+<!-- Snapshot cadence controls how often /harness-health should run.
+     Options: weekly (staleness threshold: 10 days), fortnightly (21 days),
+     monthly (30 days). Observatory corpus projects should use weekly. -->
+
+- Snapshot cadence: monthly
+
+### Operating cadence
+
+<!-- Target frequency for each observability activity. Meta-observability
+     checks compare actual run dates against these targets. -->
+
+- Harness audit (/harness-audit): quarterly (90 days)
+- AI literacy assessment (/assess): quarterly (90 days)
+- Reflection review and promotion: monthly (30 days)
+- Cost capture (/cost-capture): quarterly (90 days)
+
+### Health thresholds
+
+<!-- Thresholds for the aggregate health status in each snapshot's Meta
+     section. Adjust to match the project's maturity. -->
+
+- Minimum enforcement ratio for Healthy: 70%
+- Consecutive zero-finding GC snapshots before alert: 3
+- Unpromoted reflection age before learning flow is stalled: 60 days
+- Consecutive declining trend snapshots before alert: 3
+
+### Regression detection
+
+<!-- Conditions that trigger the regression flag in each snapshot's
+     Regression Indicators section. -->
+
+- Cadence non-compliance threshold: 2 or more activities overdue
+- Reflection drought threshold: 4 consecutive weeks with zero reflections
+
 ---
 
 ## Status


### PR DESCRIPTION
## Summary

- Adds `## Observability` section to HARNESS.md template with snapshot cadence, operating cadence, health thresholds, and regression detection defaults
- Adopts all new 0.18.1 template items into project harness: 2 constraints (Tests must pass, Spec conformance), 4 active GC rules, 7 commented-out GC rule templates
- Bumps plugin version 0.18.1 → 0.19.0

## Test plan

- [ ] Verify HARNESS.md template has the new Observability section between GC and Status
- [ ] Verify project HARNESS.md has all 13 new items
- [ ] Verify version is 0.19.0 in plugin.json, README badge, CHANGELOG, and marketplace.json
- [ ] CI checks pass (markdownlint, version consistency, spec-first)