### PR TITLE
Add Stop hook to sync plugin to global cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.19.0 — 2026-04-15
 
+### Dev workflow — global plugin sync
+
+- Add sync-to-global-cache.sh script and Stop hook in
+  settings.local.json — syncs local plugin to the global Claude Code
+  cache at session end so the installed version always reflects the
+  working copy
+
 ### Harness template — Observability section
 
 - Add `## Observability` section to HARNESS.md template with snapshot

--- a/ai-literacy-superpowers/scripts/sync-to-global-cache.sh
+++ b/ai-literacy-superpowers/scripts/sync-to-global-cache.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Sync local plugin to the global Claude Code plugin cache.
+#
+# Reads the version from plugin.json and rsyncs the local
+# ai-literacy-superpowers/ directory to the matching version slot
+# in ~/.claude/plugins/cache/. Skips silently if nothing changed
+# or if the cache directory structure doesn't exist.
+#
+# Intended as a Stop hook in settings.local.json so the global
+# install stays current during development.
+#
+# Usage: bash sync-to-global-cache.sh [project-dir]
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${1:-.}}"
+PLUGIN_DIR="${PROJECT_DIR}/ai-literacy-superpowers"
+PLUGIN_JSON="${PLUGIN_DIR}/.claude-plugin/plugin.json"
+CACHE_BASE="${HOME}/.claude/plugins/cache/ai-literacy-superpowers/ai-literacy-superpowers"
+
+# Guard: plugin.json must exist
+if [ ! -f "$PLUGIN_JSON" ]; then
+  exit 0
+fi
+
+# Guard: cache base must exist (plugin is installed globally)
+if [ ! -d "$CACHE_BASE" ]; then
+  exit 0
+fi
+
+# Read version
+version=$(sed -n 's/.*"version": "\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p' "$PLUGIN_JSON" | head -1)
+if [ -z "$version" ]; then
+  exit 0
+fi
+
+TARGET="${CACHE_BASE}/${version}"
+
+# Create version directory if this is a new version
+mkdir -p "$TARGET"
+
+# Sync — delete ensures removed files don't linger in cache
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude '.github' \
+  "${PLUGIN_DIR}/" "${TARGET}/"
+
+# Report what happened
+printf '{"systemMessage": "Plugin v%s synced to global cache."}' "$version"
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `sync-to-global-cache.sh` script that rsyncs the local plugin directory to `~/.claude/plugins/cache/` at the version matching `plugin.json`
- Wired as a Stop hook in `settings.local.json` so the globally installed plugin stays current during development
- No version bump — this is a dev workflow addition (script + local settings), not a behavioural plugin change

## Test plan

- [x] Script runs successfully: outputs `{"systemMessage": "Plugin v0.19.0 synced to global cache."}`
- [x] Verified `0.19.0` appeared in `~/.claude/plugins/cache/ai-literacy-superpowers/ai-literacy-superpowers/`
- [ ] CI checks pass