### PR TITLE
Scope version bump requirement to plugin directory

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -101,7 +101,7 @@ jobs:
 
           echo "Marketplace plugin_version in sync: $MARKETPLACE"
 
-      - name: Check version bumped for skill/agent/command changes
+      - name: Check version bumped for plugin changes
         run: |
           PLUGIN="${{ steps.versions.outputs.plugin }}"
           TAG="${{ steps.versions.outputs.tag }}"
@@ -112,15 +112,20 @@ jobs:
             exit 0
           fi
 
-          # Check if skills, agents, or commands changed vs base branch
+          # Skip if PR has the no-bump label (formatting-only fixes)
+          LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          if echo "$LABELS" | grep -q 'no-bump'; then
+            echo "no-bump label present — skipping version bump check"
+            exit 0
+          fi
+
+          # Check if any plugin files changed vs base branch
           CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- \
-            'ai-literacy-superpowers/skills/*/SKILL.md' \
-            'ai-literacy-superpowers/agents/*.agent.md' \
-            'ai-literacy-superpowers/commands/*.md' \
+            'ai-literacy-superpowers/' \
             2>/dev/null || true)
 
           if [ -n "$CHANGED" ] && [ "$PLUGIN" = "$TAG" ]; then
-            echo "::error::Skills, agents, or commands changed but version was not bumped (still $PLUGIN)"
+            echo "::error::Plugin files changed but version was not bumped (still $PLUGIN)"
             echo ""
             echo "Changed files:"
             echo "$CHANGED"
@@ -129,11 +134,13 @@ jobs:
             echo "  - ai-literacy-superpowers/.claude-plugin/plugin.json"
             echo "  - README.md (Plugin badge)"
             echo "  - CHANGELOG.md (add new heading)"
+            echo ""
+            echo "If this is a formatting-only fix, add the 'no-bump' label to skip."
             exit 1
           fi
 
           if [ -n "$CHANGED" ]; then
-            echo "Component changes detected and version bumped: $TAG -> $PLUGIN"
+            echo "Plugin changes detected and version bumped: $TAG -> $PLUGIN"
           else
-            echo "No component changes — version bump not required"
+            echo "No plugin changes — version bump not required"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
 - Upgrade HARNESS.md to template 0.19.0 with Observability section and
   governance constraint template; correct audit status counts and badge
 
+### Version bump scoping
+
+- Scope version bump requirement to `ai-literacy-superpowers/` plugin
+  directory only — changes outside the plugin (articles, docs, CI,
+  root config) no longer trigger the CI version bump check
+- Add `no-bump` PR label exemption for formatting-only fixes to plugin
+  files that don't warrant a version bump
+- Update CLAUDE.md convention, HARNESS.md constraint, and
+  version-check.yml workflow to reflect the scoped rules
+
 ## 0.19.0 — 2026-04-15
 
 ### Dev workflow — global plugin sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,21 @@ The plugin follows [semver](https://semver.org/) while pre-1.0:
 - **0.MINOR.0** — new skills, agents, commands, or behavioural changes
 - **0.x.PATCH** — bug fixes, doc-only changes, count corrections
 
-Before every PR, check whether the change warrants a version bump:
+Version bumps are only required when files inside `ai-literacy-superpowers/`
+change. Changes outside the plugin directory (articles, docs, observability,
+root config) do not require a version bump.
+
+When a PR touches `ai-literacy-superpowers/` files, check whether the
+change warrants a bump:
 
 1. Read the current version from `ai-literacy-superpowers/.claude-plugin/plugin.json`
 2. If the change adds or removes a skill, agent, or command, or changes
    plugin behaviour, bump the minor version (e.g. 0.4.0 → 0.5.0)
-3. If the change is a fix or doc update only, bump the patch version
-   (e.g. 0.4.0 → 0.4.1)
-4. If the change is trivial (typo, whitespace, internal spec/plan), no bump needed
+3. If the change is a fix or doc update to plugin files only, bump the
+   patch version (e.g. 0.4.0 → 0.4.1)
+4. If the change is trivial (typo, whitespace, formatting-only fixes
+   like adding code fence languages), no bump needed — add the
+   `no-bump` label to the PR to skip the CI check
 5. When bumping, update all three locations:
    - `ai-literacy-superpowers/.claude-plugin/plugin.json` (`"version"` field)
    - `README.md` (Plugin version badge)

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -140,8 +140,11 @@
 ### Version consistency
 
 - **Rule**: plugin.json version, README badge version, and CHANGELOG
-  heading must all match. Skills/agents/commands changes require a
-  version bump.
+  heading must all match. Changes to files inside
+  `ai-literacy-superpowers/` (skills, agents, commands, hooks, config)
+  require a version bump. Changes outside the plugin directory do not.
+  Trivial formatting-only fixes to plugin files can skip the bump with
+  the `no-bump` PR label.
 - **Enforcement**: deterministic
 - **Tool**: .github/workflows/version-check.yml
 - **Scope**: pr


### PR DESCRIPTION
## Summary

- Scope the version bump CI check to only trigger when files inside `ai-literacy-superpowers/` change — changes to articles, docs, CI workflows, and root config no longer require a version bump
- Add `no-bump` PR label exemption for trivial formatting fixes to plugin files
- Update CLAUDE.md convention, HARNESS.md constraint text, and `version-check.yml` workflow to reflect the scoped rules

**Motivation:** PR #139 required a forced patch bump (0.19.0 → 0.19.1) because markdownlint fixes added code fence language specifiers to three command files. The version check couldn't distinguish cosmetic from behavioural changes. This fix prevents that class of false positive.

## Test plan

- [x] Markdownlint passes on all changed files
- [ ] CI version check passes (no plugin files changed, so bump not required)
- [ ] CI spec-first check passes (`fix/` branch prefix is exempt)