### PR TITLE
Close Observatory signal gaps in snapshot format and governance auditor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.19.1",
+  "plugin_version": "0.19.2",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.19.2 — 2026-04-15
+
+### Observatory signal completeness
+
+- Add GC cadence compliance field to snapshot format — reports whether
+  GC runs are within declared schedule, not just the last run date
+- Add per-activity overdue annotations to Operational Cadence section —
+  each activity now shows on-schedule/overdue status with target cadence
+- Add `inactive` as third Learning flow state for projects with zero
+  reflections, alongside existing `active` and `stalled`
+- Add `Cadence compliance` and `Health` fields to Meta section template
+  with full computation instructions — previously produced by agents
+  but undocumented in the format spec
+- Enforce `## Governance Summary` heading in governance-auditor output
+  (was `## Summary`) — fixes regex parsing for Observatory consumers
+- Require all nine Governance Summary fields to be present even when
+  values are zero, with explicit computation instructions for each
+- Enforce numeric `N/5` format for Semantic drift stage (was
+  qualitative) and add `Frame alignment score` percentage computation
+
 ## 0.19.1 — 2026-04-15
 
 ### Markdownlint compliance

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.1-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-19-2E8B57?style=flat-square)](#commands-19)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/governance-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/governance-auditor.agent.md
@@ -89,9 +89,14 @@ most recent harness health snapshot (if one exists in
 
 ## Governance Summary Section
 
-Include this markdown section at the top of the audit report, after
-the header. This provides the key metrics in a format that agents
-(including the snapshot generator) can parse directly.
+Include a `## Governance Summary` section at the top of the audit
+report, immediately after the `# Governance Audit — YYYY-MM-DD`
+header. The heading **must** be `## Governance Summary` (not
+`## Summary`) — this exact heading is used by the Observatory and
+snapshot agents for regex-based parsing.
+
+Every field below **must** appear, even when the value is zero. Agents
+consuming this section expect all nine fields in this order.
 
 ```text
 ## Governance Summary
@@ -109,18 +114,34 @@ the header. This provides the key metrics in a format that agents
 
 **Field computation:**
 
+- `Total constraints`: Count governance constraints in HARNESS.md
+  (constraints with a `Governance requirement` field).
 - `Falsifiable`: Count constraints scored "Falsifiable" in the
-  constraint assessment.
+  constraint assessment. Include the annotation
+  `(with verification criteria)`.
 - `Vague`: Count constraints scored "Vague" in the constraint
-  assessment.
-- `Falsifiability ratio`: `(falsifiable_count / constraint_count) * 100`,
-  rounded to nearest integer.
-- `Semantic drift stage`: The numeric 1–5 drift severity already
-  computed for the audit report's drift analysis section.
-- `Aggregate debt score`: Sum of `severity × blast_radius` across all
-  items in the governance debt inventory table.
+  assessment. Include the annotation
+  `(lacking operational meaning)`. Report `0` if none are vague.
+- `Falsifiability ratio`:
+  `(falsifiable_count / constraint_count) * 100`, rounded to nearest
+  integer. Express as `N%`.
+- `Semantic drift stage`: An integer from 1 to 5 representing drift
+  severity, followed by `/5`. Use the drift stage already computed
+  for the audit report's drift analysis section. If no drift is
+  detected, use `1/5` (Stage 1 = no drift).
 - `Drift velocity`: Compare the current drift stage with the previous
-  audit report. If no previous audit exists, use `stable`.
+  audit report's drift stage. `stable` if unchanged, `increasing` if
+  the stage rose, `decreasing` if it fell. If no previous audit
+  exists, use `stable`.
+- `Governance debt items`: Count of items in the governance debt
+  inventory. Report `0` if the inventory is empty.
+- `Aggregate debt score`: Sum of `severity × blast_radius` across all
+  items in the governance debt inventory table. Report `0` when no
+  debt items exist.
+- `Frame alignment score`: Percentage of constraints where all three
+  frames (engineering, compliance, AI system) are confirmed aligned.
+  `(aligned_count / constraint_count) * 100`, rounded to nearest
+  integer. Express as `N%`.
 
 ## What You Do NOT Do
 

--- a/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
+++ b/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
@@ -64,6 +64,7 @@ the previous snapshot and only re-check if a loop's status changes.
 ## Garbage Collection
 - Rules active: N/M
 - Last run: YYYY-MM-DD
+- Cadence compliance: on schedule / overdue (N days since last run, threshold T)
 - Findings since last snapshot: N
 ```
 
@@ -74,6 +75,7 @@ the previous snapshot and only re-check if a loop's status changes.
 | N (active) | Count GC rules with enforcement != none |
 | M (total) | Count all GC rules |
 | Last run | Date of most recent /harness-gc or /harness-audit |
+| Cadence compliance | Compare days since last run against the declared GC cadence. "on schedule" if within threshold, "overdue" if exceeded. Include days since last run and the threshold value for parsability |
 | Findings | Count of GC findings since previous snapshot date (from audit reports or commit messages) |
 
 ### Mutation Testing
@@ -136,9 +138,9 @@ guessing.
 
 ```text
 ## Operational Cadence
-- Last /harness-audit: YYYY-MM-DD
-- Last /assess: YYYY-MM-DD
-- Last /reflect: YYYY-MM-DD
+- Last /harness-audit: YYYY-MM-DD (N days ago — on schedule / overdue, target T days)
+- Last /assess: YYYY-MM-DD (N days ago — on schedule / overdue, target T days)
+- Last /reflect: YYYY-MM-DD (N days ago — on schedule / overdue, target T days)
 - Outer loop overdue: yes/no
 ```
 
@@ -146,10 +148,10 @@ guessing.
 
 | Field | How to compute |
 | ------- | --------------- |
-| Last /harness-audit | HARNESS.md Status section "Last audit" date |
-| Last /assess | Most recent file in assessments/ directory |
-| Last /reflect | Most recent date in REFLECTION_LOG.md |
-| Outer loop overdue | yes if any of the above is older than its declared cadence (audit: 90 days, assess: 90 days, reflect: 30 days) |
+| Last /harness-audit | HARNESS.md Status section "Last audit" date. Annotate with days ago, `on schedule` or `overdue`, and the cadence target from HARNESS.md Observability section (default 90 days) |
+| Last /assess | Most recent file in assessments/ directory. Same annotation format |
+| Last /reflect | Most recent date in REFLECTION_LOG.md. Same annotation format (default 30 days) |
+| Outer loop overdue | yes if any of the above is overdue relative to its declared cadence |
 
 ### Cost Indicators
 
@@ -180,15 +182,26 @@ recent file in `observability/costs/` matching `*-costs.md`.
 ```text
 ## Meta
 - Snapshot cadence: on schedule / overdue
-- Learning flow: active / stalled
+- Cadence compliance: N/4 on schedule (audit, assess, reflect, GC)
+- Learning flow: active / stalled / inactive
 - GC effectiveness: productive / silent
 - Trend alerts: none / [list declining metrics]
+- Health: Healthy / Attention / Degraded
 ```
 
 **Source:** Computed from other sections and previous snapshot.
 
-See `references/meta-observability-checks.md` for check definitions
-and thresholds.
+| Field | How to compute |
+| ------- | --------------- |
+| Snapshot cadence | Compare days since previous snapshot to cadence threshold from HARNESS.md Observability section. "on schedule" if within threshold, "overdue" if exceeded |
+| Cadence compliance | Count how many of the four tracked activities (audit, assess, reflect, GC) are on schedule. Report as `N/4 on schedule` |
+| Learning flow | `active` if new reflections exist since last snapshot. `stalled` if REFLECTION_LOG has entries but none are recent (> unpromoted reflection age threshold from HARNESS.md). `inactive` if REFLECTION_LOG has zero entries or does not exist |
+| GC effectiveness | `productive` if any GC rule produced a finding since the last snapshot. `silent` if all rules reported zero findings |
+| Trend alerts | List any metrics that have declined for the configured consecutive-declining-trend threshold (from HARNESS.md Health thresholds). "none" if no alerts |
+| Health | `Healthy` if all layers operating and no overdue cadences. `Attention` if one layer degraded or outer loop overdue. `Degraded` if multiple layers degraded or no snapshot in 30+ days. See SKILL.md README Health Indicator for colour mapping |
+
+See `references/meta-observability-checks.md` for additional check
+definitions and thresholds.
 
 ### Regression Indicators
 


### PR DESCRIPTION
## Summary

- Add 4 missing/incomplete fields to the snapshot format spec so the Observatory can read all expected signals without computing them itself
- Tighten governance-auditor agent instructions to enforce exact heading name, all 9 fields present, and numeric formats — closing the spec-to-output gap

### Snapshot format changes (snapshot-format.md)
- **GC section**: add `Cadence compliance: on schedule / overdue` field with computation instructions
- **Operational Cadence section**: add per-activity `on schedule / overdue` annotations with target cadence values
- **Meta section**: add `Cadence compliance: N/4 on schedule` field, `inactive` as third Learning flow state, `Health: Healthy / Attention / Degraded` field, and full computation table for all Meta fields
- **Meta section**: previously had no computation table — now fully documented

### Governance auditor changes (governance-auditor.agent.md)
- Enforce `## Governance Summary` heading (was producing `## Summary`)
- Require all 9 fields present even when values are zero
- Add explicit computation for `Total constraints`, `Frame alignment score` (as N%), and `Aggregate debt score` (report 0 when empty)
- Enforce `Semantic drift stage: N/5` integer format (was qualitative "low")
- Add `Drift velocity` computation instructions (compare with previous audit)

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` passes with 0 errors
- [ ] CI checks pass (version bumped to 0.19.2)