### PR TITLE
Add Governance Summary validation checkpoint (0.19.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.19.2",
+  "plugin_version": "0.19.3",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.19.3 — 2026-04-15
+
+### Governance Summary validation checkpoint
+
+- Add step 5 to /governance-audit command: validate the Governance
+  Summary section after the governance-auditor agent writes the report,
+  fixing heading, field count, and value formats in place rather than
+  re-dispatching the agent
+- Strengthen governance-auditor agent instructions: mark the Governance
+  Summary section as a critical format contract, add self-check
+  instruction, explicitly forbid 0-based drift stage scale
+- Fix existing governance audit report to use the correct
+  `## Governance Summary` heading with all nine structured fields
+
 ## 0.19.2 — 2026-04-15
 
 ### Observatory signal completeness

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.2-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.3-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-19-2E8B57?style=flat-square)](#commands-19)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/governance-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/governance-auditor.agent.md
@@ -87,16 +87,28 @@ After writing the report, update the governance metrics block in the
 most recent harness health snapshot (if one exists in
 `observability/snapshots/`).
 
-## Governance Summary Section
+## Governance Summary Section — CRITICAL FORMAT CONTRACT
+
+**This section is a machine-readable contract.** The Habitat
+Observatory plugin parses it by exact regex. Every deviation —
+wrong heading, missing field, wrong format — breaks the pipeline.
 
 Include a `## Governance Summary` section at the top of the audit
 report, immediately after the `# Governance Audit — YYYY-MM-DD`
-header. The heading **must** be `## Governance Summary` (not
-`## Summary`) — this exact heading is used by the Observatory and
-snapshot agents for regex-based parsing.
+header.
 
-Every field below **must** appear, even when the value is zero. Agents
-consuming this section expect all nine fields in this order.
+**Non-negotiable rules:**
+
+1. The heading **must** be `## Governance Summary` — not
+   `## Summary`, not `## Overview`, not any variant
+2. All nine fields below **must** appear, in this exact order,
+   even when the value is zero
+3. Each field starts with a dash and space on its own line
+4. Field names and annotations must match exactly — they are
+   parsed by regex
+
+**Write this section by copying the template below and filling in
+the values. Do not rephrase, reorder, or omit any field:**
 
 ```text
 ## Governance Summary
@@ -111,6 +123,11 @@ consuming this section expect all nine fields in this order.
 - Aggregate debt score: N (sum of severity x blast radius)
 - Frame alignment score: N%
 ```
+
+**Self-check before finishing:** After writing the report, verify
+your `## Governance Summary` section has exactly 9 bullet lines
+and the heading is `## Governance Summary`. If it does not, fix
+it before returning the report.
 
 **Field computation:**
 
@@ -128,7 +145,8 @@ consuming this section expect all nine fields in this order.
 - `Semantic drift stage`: An integer from 1 to 5 representing drift
   severity, followed by `/5`. Use the drift stage already computed
   for the audit report's drift analysis section. If no drift is
-  detected, use `1/5` (Stage 1 = no drift).
+  detected, use `1/5` (Stage 1 = no drift). **Never use 0 — the
+  scale starts at 1.**
 - `Drift velocity`: Compare the current drift stage with the previous
   audit report's drift stage. `stable` if unchanged, `increasing` if
   the stage rose, `decreasing` if it fell. If no previous audit

--- a/ai-literacy-superpowers/commands/governance-audit.md
+++ b/ai-literacy-superpowers/commands/governance-audit.md
@@ -54,7 +54,51 @@ The governance-auditor will:
    `observability/governance/audit-YYYY-MM-DD.md`
 8. Output the governance metrics block
 
-### 5. Update Harness Health Snapshot
+### 5. Validate the Governance Summary
+
+**This step is mandatory.** After the governance-auditor writes the
+report, read `observability/governance/audit-YYYY-MM-DD.md` and
+verify the `## Governance Summary` section meets the Observatory
+contract. Check each requirement:
+
+1. **Heading**: Must be `## Governance Summary` (not `## Summary`
+   or any variant). The Observatory parses this heading by exact
+   regex match.
+
+2. **Nine fields present**: The section must contain exactly these
+   fields in this order, each on its own line as a bullet point:
+
+   ```text
+   - Total constraints: N
+   - Falsifiable: N (with verification criteria)
+   - Vague: N (lacking operational meaning)
+   - Falsifiability ratio: N%
+   - Semantic drift stage: N/5
+   - Drift velocity: stable/increasing/decreasing
+   - Governance debt items: N
+   - Aggregate debt score: N (sum of severity x blast radius)
+   - Frame alignment score: N%
+   ```
+
+3. **Value rules**:
+   - Semantic drift stage must use 1-5 scale (1 = no drift), not 0
+   - Falsifiability ratio and Frame alignment score must be
+     percentages (`N%`), not fractions
+   - Drift velocity must be one of: `stable`, `increasing`,
+     `decreasing`
+   - Aggregate debt score is 0 when no debt items exist
+   - Frame alignment score = `(aligned / total) * 100`, rounded
+
+If any check fails, fix the report in place:
+
+- Rename `## Summary` to `## Governance Summary` if needed
+- Add or reformat missing fields using data from the report body
+  (constraint assessment, debt inventory, drift analysis sections)
+- Rewrite values to match the required format
+
+Do not re-dispatch the agent. Fix the output directly.
+
+### 6. Update Harness Health Snapshot
 
 If a harness health snapshot exists in `observability/snapshots/`,
 update it with the governance metrics block from the audit report.
@@ -63,7 +107,7 @@ If no snapshot exists, create the governance metrics block in the
 audit report and note that it should be included in the next
 `/harness-health` run.
 
-### 6. Present Results
+### 7. Present Results
 
 Show the user:
 
@@ -74,7 +118,7 @@ Show the user:
 - Three-frame alignment summary
 - Any debt cycle reinforcement patterns
 
-### 7. Recommend Actions
+### 8. Recommend Actions
 
 Based on audit findings, suggest next steps:
 
@@ -84,7 +128,7 @@ Based on audit findings, suggest next steps:
 - Governance debt items prioritised by score
 - Frame misalignment that needs resolution
 
-### 8. Offer Dashboard Generation
+### 9. Offer Dashboard Generation
 
 Ask the user if they want to generate or update the governance
 health dashboard:
@@ -92,7 +136,7 @@ health dashboard:
 > Run `/governance-health --dashboard` to generate an HTML dashboard
 > with these results.
 
-### 9. Commit
+### 10. Commit
 
 ```bash
 git add observability/governance/

--- a/observability/governance/audit-2026-04-15.md
+++ b/observability/governance/audit-2026-04-15.md
@@ -1,21 +1,22 @@
 # Governance Audit — 2026-04-15 (revised)
 
-## Summary
+## Governance Summary
 
-- Governance constraints assessed: 1 (Release traceability)
-- Total harness constraints: 13
-- Total GC rules: 13
-- Falsifiability ratio: 1/1 (100%) for governance constraints
-- Overall drift score: low
+- Total constraints: 1
+- Falsifiable: 1 (with verification criteria)
+- Vague: 0 (lacking operational meaning)
+- Falsifiability ratio: 100%
+- Semantic drift stage: 1/5
+- Drift velocity: stable
 - Governance debt items: 0
-- Three-frame alignment: confirmed aligned
-- Debt cycle reinforcement: none detected
-- **Governance health: Healthy**
+- Aggregate debt score: 0 (sum of severity x blast radius)
+- Frame alignment score: 100%
 
 This is a re-audit on the same date as the initial governance audit.
 The plugin has grown from 0.17.1 to 0.19.2 since the first audit
 earlier today, adding 8 more versions. All enforcement mechanisms
 remain operational and have been exercised under increased load.
+Governance health: Healthy.
 
 ## Constraint Assessment
 
@@ -118,31 +119,6 @@ unresolved debt. The constraint's operational meaning is self-contained.
 
 The constraint's frame check field references the design spec, which
 is present in the repository. No circular dependencies exist.
-
-## Governance Metrics
-
-```text
-governance:
-  audit_date: 2026-04-15
-  audit_revision: 2
-  constraints_assessed: 1
-  falsifiable: 1
-  partially_operationalised: 0
-  vague: 0
-  falsifiability_ratio: 1.0
-  drift_score: 0.0
-  max_drift_stage: 0
-  debt_items: 0
-  debt_cycles: 0
-  frame_alignment: all_aligned
-  health: Healthy
-  harness_constraints_total: 13
-  harness_gc_rules_total: 13
-  plugin_version: 0.19.2
-  changelog_versions: 33
-  missing_tags: 0
-  last_audit: 2026-04-15
-```
 
 ## Prioritised Recommendations
 


### PR DESCRIPTION
## Summary

- Add validation checkpoint (step 5) to `/governance-audit` command that verifies the agent's output matches the Observatory contract before proceeding
- Strengthen `governance-auditor` agent instructions: mark Governance Summary as critical format contract, add self-check instruction, forbid 0-based drift scale
- Fix existing governance audit report to use `## Governance Summary` heading with all nine structured fields in the required format

Closes the Source 4 gaps identified in the Observatory signal verification: the agent spec already defined the correct format but the agent wasn't following it. The checkpoint catches and fixes format deviations without re-dispatching the agent.

## Test plan

- [ ] CI passes (markdownlint, version-check, spec-first)
- [ ] `grep -c '^## Governance Summary$' observability/governance/audit-2026-04-15.md` returns 1
- [ ] Governance Summary section has exactly 9 bullet fields
- [ ] No `## Governance Metrics` YAML block remains in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)