### PR TITLE
Add output validation checkpoints to 7 commands (0.19.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.19.3",
+  "plugin_version": "0.19.4",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.19.4 — 2026-04-15
+
+### Output validation checkpoints
+
+- Add validate-and-fix-in-place checkpoint to /harness-health —
+  verifies all 12 snapshot sections present, no deprecated YAML block
+- Add validation checkpoint to /assess — verifies assessment document
+  has required sections and parseable level number for portfolio
+  aggregation
+- Add validation checkpoint to /reflect — verifies all 8 mandatory
+  fields plus 4 session metadata subfields and Signal enum value
+- Add validation checkpoint to /cost-capture — verifies cost snapshot
+  has fields that /harness-health needs for Cost Indicators section
+- Add validation checkpoint to /harness-constrain — verifies
+  constraint block has required fields with valid enum values
+- Add validation checkpoint to /harness-init — verifies generated
+  HARNESS.md has all top-level sections, subsections, and template
+  version marker
+- Add validation checkpoint to /superpowers-init — verifies all 4
+  habitat files (CLAUDE.md, AGENTS.md, MODEL_ROUTING.md,
+  REFLECTION_LOG.md) have required sections
+
 ## 0.19.3 — 2026-04-15
 
 ### Governance Summary validation checkpoint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.3-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.4-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-19-2E8B57?style=flat-square)](#commands-19)

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -180,3 +180,19 @@
   - Model tiers used: most-capable (main conversation), standard (Explore subagent)
   - Pipeline stages completed: manual investigation, fix, reflect
   - Agent delegation: manual
+
+---
+
+- **Date**: 2026-04-15
+- **Agent**: claude-opus-4-6 (main conversation + governance-auditor subagent + Explore subagent)
+- **Task**: Observatory signal verification (72 signals across 5 sources), Governance Summary validation checkpoint, harness health snapshot regeneration
+- **Surprise**: The governance-auditor agent consistently ignored its own `## Governance Summary` format spec despite having detailed instructions (lines 92-144 of the agent file). The instructions were correct but the agent produced a loose `## Summary` section with missing fields every time — including when dispatched with explicit context about the required format. A subagent also hallucinated "23 GC rules" when there were 13 — a clean factual error on a countable quantity. Separately, the /harness-health command still generated the deprecated YAML `observatory_metrics` block (removed in v0.16.0) because the command spec did not explicitly forbid it.
+- **Proposal**: GOTCHA: Agent format specs for machine-readable output (regex-parsed headings, structured field lists) need three layers of defence: (1) clear instructions in the agent file, (2) a self-check instruction telling the agent to verify its own output before returning, (3) a validation checkpoint in the dispatching command that fixes the output in place. Instructions alone are not sufficient — agents drift from structured output formats under cognitive load, especially when the report body requires substantial analysis.
+- **Improvement**: The Observatory signal verification checklist should be a reusable skill or command (`/observatory-verify`) rather than a one-off prompt. It produced high-value findings (6 PARTIAL, 7 MISSING across 72 signals) and the structured table format made gaps immediately actionable.
+- **Signal**: failure
+- **Constraint**: none (fix already in place as command checkpoint in step 5 of /governance-audit)
+- **Session metadata**:
+  - Duration: ~45 min
+  - Model tiers used: most-capable (main conversation, ~70%), standard (Explore subagent, ~10%), capable (governance-auditor subagent, ~20%)
+  - Pipeline stages completed: harness-health, governance-audit, signal verification, fix, 3 PRs (#142-#144), reflect
+  - Agent delegation: partial (subagents for governance audit and exploration, manual for verification and fixes)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/assess.md
+++ b/ai-literacy-superpowers/commands/assess.md
@@ -44,7 +44,32 @@ The weakest discipline is the ceiling.
 Create `assessments/YYYY-MM-DD-assessment.md` using the template from
 the skill's references. Fill every section with specific evidence.
 
-### 5. Immediate Habitat Adjustments
+### 5. Validate Assessment Document
+
+**This step is mandatory.** After writing the assessment document,
+read `assessments/YYYY-MM-DD-assessment.md` and verify its structure
+against `ai-literacy-assessment/references/assessment-template.md`.
+
+**Structural checks:**
+
+1. Required sections present: Observable Evidence, Level Assessment,
+   Discipline Maturity, Strengths, Gaps, Recommendations
+2. Level Assessment contains a level number (1-5) and a level name
+   (e.g. "Level 3 — Adaptive Collaboration")
+3. Discipline Maturity contains a markdown table with rows for each
+   scored discipline
+4. Gaps section contains at least one item (every project has gaps)
+
+If any check fails, fix the document in place:
+
+- Add missing sections using the structure from the assessment
+  template reference
+- Ensure the level number is a single digit 1-5 that downstream
+  portfolio aggregation can parse
+
+Do not re-dispatch the assessor agent. Fix the output directly.
+
+### 6. Immediate Habitat Adjustments
 
 Identify and apply fixes that require no team discussion — habitat
 hygiene that should always be current:
@@ -65,7 +90,7 @@ hygiene that should always be current:
 Present each adjustment. Apply immediately. Record what was changed
 in the assessment document.
 
-### 6. Workflow Operation Recommendations
+### 7. Workflow Operation Recommendations
 
 Based on gaps identified, recommend changes to how existing artifacts
 are *operated* (not built — they exist, they just need different usage
@@ -87,7 +112,7 @@ If accepted, apply immediately:
 Record accepted and rejected recommendations in the assessment
 document.
 
-### 6b. Improvement Plan
+### 7b. Improvement Plan
 
 Invoke the `literacy-improvements` skill with the assessed level from
 step 3 and the gaps from section 7 of the assessment document. The
@@ -95,10 +120,10 @@ skill asks the user to choose a target level, generates a prioritised
 plan, and walks through each improvement interactively
 (accept/skip/defer).
 
-Phase 6 recommendations (operate better) and 6b improvements (build
+Phase 7 recommendations (operate better) and 7b improvements (build
 toward next level) are complementary — run both.
 
-### 7. Assessment Reflection
+### 8. Assessment Reflection
 
 Append a structured reflection to REFLECTION_LOG.md:
 
@@ -109,12 +134,12 @@ Append a structured reflection to REFLECTION_LOG.md:
 - **Proposal**: any patterns to add to AGENTS.md
 - **Improvement**: what would make the next assessment better
 
-### 8. Check README for broader updates
+### 9. Check README for broader updates
 
-Beyond the specific adjustments in step 5, do a final check:
+Beyond the specific adjustments in step 6, do a final check:
 has anything else in the README become stale? Update if needed.
 
-### 9. Badge
+### 10. Badge
 
 Add or update an AI Literacy badge in the README:
 
@@ -124,7 +149,7 @@ Add or update an AI Literacy badge in the README:
 
 Colours: L0=808080, L1=87CEEB, L2=4682B4, L3=20B2AA, L4=2E8B57, L5=DAA520
 
-### 9b. Tag Repository
+### 10b. Tag Repository
 
 If the assessed level is L3 or above and the project is hosted on
 GitHub, add the `agent-harness-enabled` topic tag:
@@ -142,7 +167,7 @@ Also add the harness-enabled badge to the README if not already present:
 If `gh` is not available, the repo is not on GitHub, or the level is
 below L3, skip silently.
 
-### 10. Commit
+### 11. Commit
 
 ```bash
 mkdir -p assessments
@@ -152,7 +177,7 @@ git commit -m "AI Literacy Assessment: Level N — LEVEL_NAME (YYYY-MM-DD)
 Assessment with immediate adjustments and accepted workflow changes."
 ```
 
-### 11. Report
+### 12. Report
 
 Present a summary to the user:
 

--- a/ai-literacy-superpowers/commands/cost-capture.md
+++ b/ai-literacy-superpowers/commands/cost-capture.md
@@ -98,7 +98,30 @@ MODEL_ROUTING.md. Present each change and ask for approval.
 Create `observability/costs/YYYY-MM-DD-costs.md` using the format
 from the cost-tracking skill.
 
-### 10. Commit
+### 10. Validate Cost Snapshot
+
+**This step is mandatory.** After writing the cost snapshot, read
+`observability/costs/YYYY-MM-DD-costs.md` and verify it contains the
+fields that `/harness-health` needs to parse for the Cost Indicators
+section.
+
+**Structural checks:**
+
+1. File exists at the expected path
+2. Period field present (date range for the snapshot)
+3. Total spend field present (even if estimated)
+4. Model routing reference present (whether MODEL_ROUTING.md was
+   updated)
+
+Reference the `cost-tracking` skill for the full field definitions.
+
+If any check fails, fix the snapshot in place:
+
+- Add missing fields with "not tracked" as the value
+
+Do not re-run the capture conversation. Fix the output directly.
+
+### 11. Commit
 
 ```bash
 mkdir -p observability/costs
@@ -106,7 +129,7 @@ git add observability/costs/ MODEL_ROUTING.md
 git commit -m "Cost snapshot: YYYY-MM-DD"
 ```
 
-### 11. Summary
+### 12. Summary
 
 ```text
 Cost snapshot captured: observability/costs/YYYY-MM-DD-costs.md

--- a/ai-literacy-superpowers/commands/harness-constrain.md
+++ b/ai-literacy-superpowers/commands/harness-constrain.md
@@ -71,11 +71,36 @@ Constraints section. Follow the standard format:
 - **Scope**: [commit | pr | weekly | manual]
 ```
 
-### 9. Update CI (if deterministic + PR scope)
+### 9. Validate Constraint Block
+
+**This step is mandatory.** After adding or updating the constraint
+in HARNESS.md, read the constraint block you just wrote and verify
+its structure against the constraint template in
+`templates/HARNESS.md`.
+
+**Structural checks:**
+
+1. All required fields present: Rule, Enforcement, Tool, Scope
+2. Enforcement value is one of: `deterministic`, `agent`,
+   `unverified`
+3. Scope value is one of: `commit`, `pr`, `weekly`, `manual`
+4. If a `Governance requirement` field is present, all governance
+   fields must also be present: Operational meaning, Verification
+   method, Evidence, Failure action, Frame check
+
+If any check fails, fix the constraint block in place:
+
+- Add missing fields with placeholder values
+- Normalise Enforcement and Scope to valid enum values if they are
+  close matches (e.g. "det" to "deterministic")
+
+Do not restart the constraint conversation. Fix the output directly.
+
+### 10. Update CI (if deterministic + PR scope)
 
 If the constraint is deterministic and PR-scoped, add the tool step
 to the CI workflow file.
 
-### 10. Commit
+### 11. Commit
 
 Commit the updated HARNESS.md (and CI file if changed).

--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -96,14 +96,43 @@ Collection, Mutation Testing, Compound Learning, Session Quality,
 Operational Cadence, Cost Indicators, Regression Indicators, Meta,
 Changes Since Last Snapshot, and Trends (if previous snapshot exists).
 
-### 7. Update README
+### 7. Validate Snapshot Structure
+
+**This step is mandatory.** After writing the snapshot file, read
+`observability/snapshots/YYYY-MM-DD-snapshot.md` and verify its
+structure against `references/snapshot-format.md`.
+
+**Structural checks:**
+
+1. All 12 section headings present in order: Enforcement,
+   Enforcement Loop History, Garbage Collection, Mutation Testing,
+   Compound Learning, Session Quality, Operational Cadence,
+   Cost Indicators, Regression Indicators, Meta,
+   Changes Since Last Snapshot, Trends
+2. Trends section is conditional — required only when a previous
+   snapshot exists (step 3 found one)
+3. No YAML `observatory_metrics` block anywhere in the file
+   (deprecated in v0.16.0)
+4. Each section contains the fields defined in
+   `references/snapshot-format.md` for that section
+
+If any check fails, fix the snapshot in place:
+
+- Add missing sections using the field templates from
+  `references/snapshot-format.md` with placeholder values
+- Reorder sections if present but misordered
+- Remove any YAML `observatory_metrics` block if found
+
+Do not regenerate the snapshot. Fix the output directly.
+
+### 8. Update README
 
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)
 
-### 8. Print Summary
+### 9. Print Summary
 
 Print the full snapshot to the session so the developer sees it
 immediately.
@@ -120,7 +149,7 @@ Since last snapshot (YYYY-MM-DD):
   Health: Healthy / Attention / Degraded
 ```
 
-### 9. Nudge Overdue Actions
+### 10. Nudge Overdue Actions
 
 If any cadence is overdue, print a nudge:
 

--- a/ai-literacy-superpowers/commands/harness-init.md
+++ b/ai-literacy-superpowers/commands/harness-init.md
@@ -172,7 +172,35 @@ already exists, update it to the current version. If it does not
 exist, insert it after the line containing
 `https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->`.
 
-### 8. Generate CI Configuration
+### 8. Validate Generated HARNESS.md
+
+**This step is mandatory.** After writing HARNESS.md, read it and
+verify its structure against `templates/HARNESS.md`.
+
+**Structural checks:**
+
+1. All 4 top-level sections present: `## Context`,
+   `## Constraints`, `## Garbage Collection`, `## Observability`
+2. Context section has `### Stack` and `### Conventions`
+   subsections (either with content or the placeholder marker)
+3. Observability section has `### Operating cadence`,
+   `### Health thresholds`, and `### Regression detection`
+   subsections
+4. `## Status` section present with all 4 fields: Last audit,
+   Constraints enforced, Garbage collection active, Drift detected
+5. Template version marker comment present:
+   `<!-- template-version: X.Y.Z -->` where X.Y.Z matches the
+   current plugin version
+
+If any check fails, fix HARNESS.md in place:
+
+- Add missing sections from the template with placeholder markers
+- Insert the template version marker if absent
+- Add missing Status fields with default values
+
+Do not re-run the init conversation. Fix the output directly.
+
+### 9. Generate CI Configuration
 
 **Gate**: only run this step if "CI configuration" was selected in
 step 3.
@@ -213,7 +241,7 @@ produced contains any agent-scoped PR constraints. If it does:
 
 If no agent PR constraints exist, skip this offer silently.
 
-### 9. Add README Badge
+### 10. Add README Badge
 
 **Gate**: only run this step if "Observability" was selected in step 3.
 
@@ -233,7 +261,7 @@ manually:
 [![Harness](https://img.shields.io/badge/Harness-0%2FN_enforced-808080?style=flat-square)](HARNESS.md)
 ```
 
-### 10. Commit
+### 11. Commit
 
 Stage and commit all generated files:
 
@@ -243,7 +271,7 @@ Stage and commit all generated files:
 
 Commit message: "Initialize project harness with HARNESS.md"
 
-### 11. Tag Repository
+### 12. Tag Repository
 
 If the project is hosted on GitHub, add the `agent-harness-enabled`
 topic tag to the repository:
@@ -262,7 +290,7 @@ Also add the badge to the README if not already present:
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)
 ```
 
-### 12. Summary
+### 13. Summary
 
 Tell the user:
 

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -93,6 +93,29 @@ Capture a post-task reflection and append it to REFLECTION_LOG.md.
 1. Append the entry to `REFLECTION_LOG.md` (after the last existing
    entry, preserving the `---` separator)
 
+1. **Validate the reflection entry.** Read the last entry in
+   `REFLECTION_LOG.md` and verify its structure against the entry
+   template in step 2 above.
+
+   **Structural checks:**
+
+   1. Entry starts with `---` separator
+   2. All 8 mandatory fields present: Date, Agent, Task, Surprise,
+      Proposal, Improvement, Signal, Constraint
+   3. Session metadata block present with all 4 subfields: Duration,
+      Model tiers used, Pipeline stages completed, Agent delegation
+   4. Signal field value is one of: `context`, `instruction`,
+      `workflow`, `failure`, `none`
+
+   If any check fails, fix the entry in place:
+
+   - Add missing fields with `"unknown"` values
+   - Add missing session metadata subfields with `"unknown"`
+   - If Signal value is not in the enum, set it to `none`
+
+   Do not ask the user to re-enter the reflection. Fix the output
+   directly.
+
 1. Do NOT modify `AGENTS.md` — only humans edit that file. If the
    reflection contains a proposal, note it and let the human decide.
 

--- a/ai-literacy-superpowers/commands/superpowers-init.md
+++ b/ai-literacy-superpowers/commands/superpowers-init.md
@@ -11,7 +11,7 @@ files are not overwritten unless you confirm.
 
 ## What this command does
 
-It walks through eight steps in sequence:
+It walks through nine steps in sequence:
 
 ### 1. Discover
 
@@ -93,7 +93,36 @@ Copy CI templates from `${CLAUDE_PLUGIN_ROOT}/templates/`:
 Use the harness-engineering skill to verify the scaffold is coherent before
 presenting it to the user.
 
-### 8. Commit and summary
+### 8. Validate Habitat Files
+
+**This step is mandatory.** After all habitat files are generated,
+read each one and verify its structure against the corresponding
+template in `${CLAUDE_PLUGIN_ROOT}/templates/`.
+
+**Structural checks per file:**
+
+1. **CLAUDE.md**: has required sections `## Workflow`,
+   `## Build and Test`, `## Learnings`
+   (reference: `templates/CLAUDE.md`)
+2. **AGENTS.md**: has required sections `## STYLE`, `## GOTCHAS`,
+   `## ARCH_DECISIONS`, `## TEST_STRATEGY`, `## DESIGN_DECISIONS`
+   (reference: `templates/AGENTS.md`)
+3. **MODEL_ROUTING.md**: has required sections
+   `## Agent Routing Table` (with markdown table),
+   `## Token Budget Guidance` (with markdown table)
+   (reference: `templates/MODEL_ROUTING.md`)
+4. **REFLECTION_LOG.md**: exists and has the header comment
+   containing the entry format template
+
+If any check fails, fix the file in place:
+
+- Add missing sections from the corresponding template
+- Do not overwrite existing content in sections that are already
+  populated
+
+Do not re-run the init conversation. Fix each file directly.
+
+### 9. Commit and summary
 
 Stage all new files and commit with a message in the form:
 

--- a/docs/superpowers/plans/2026-04-15-output-validation-checkpoints.md
+++ b/docs/superpowers/plans/2026-04-15-output-validation-checkpoints.md
@@ -1,0 +1,616 @@
+# Output Validation Checkpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add validate-and-fix-in-place checkpoint steps to 7 commands that produce structured output parsed by downstream consumers.
+
+**Architecture:** Each command gets a new numbered step inserted between output generation and the next action (commit, badge update, etc.). The step reads the output file, checks structural requirements against the referenced format spec, and fixes deviations in place. No agent re-dispatch. No new files created.
+
+**Tech Stack:** Markdown command specs (no application code). Markdownlint for validation.
+
+---
+
+## File Map
+
+All changes are to existing command files in `ai-literacy-superpowers/commands/`:
+
+| File | Change | Reference spec |
+| --- | --- | --- |
+| `harness-health.md` | Insert step 7, renumber 7-9 to 8-10 | `references/snapshot-format.md` |
+| `assess.md` | Insert step 5, renumber 5-11 to 6-12 | `ai-literacy-assessment/references/assessment-template.md` |
+| `reflect.md` | Insert step 6, renumber 6-7 to 7-8 | Entry template in `commands/reflect.md` itself |
+| `cost-capture.md` | Insert step 10, renumber 10-11 to 11-12 | `cost-tracking/SKILL.md` |
+| `harness-constrain.md` | Insert step 9, renumber 9-10 to 10-11 | Constraint template in `templates/HARNESS.md` |
+| `harness-init.md` | Insert step 8, renumber 8-12 to 9-13 | `templates/HARNESS.md` |
+| `superpowers-init.md` | Insert step 8, renumber 8 to 9 | `templates/CLAUDE.md`, `templates/AGENTS.md`, `templates/MODEL_ROUTING.md` |
+
+Also modified:
+
+| File | Change |
+| --- | --- |
+| `ai-literacy-superpowers/.claude-plugin/plugin.json` | Version 0.19.3 to 0.19.4 |
+| `.claude-plugin/marketplace.json` | plugin_version 0.19.3 to 0.19.4 |
+| `README.md` | Badge version 0.19.3 to 0.19.4 |
+| `CHANGELOG.md` | New 0.19.4 entry |
+
+---
+
+### Task 1: `/harness-health` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/harness-health.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/harness-health.md` to confirm
+current step numbering. Steps 1-6 are before the insertion point,
+step 7 (Update README) is the first step to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 7. Validate Snapshot Structure` after step 6
+(Generate Markdown Sections) and before the current step 7 (Update
+README). Content:
+
+```markdown
+### 7. Validate Snapshot Structure
+
+**This step is mandatory.** After writing the snapshot file, read
+`observability/snapshots/YYYY-MM-DD-snapshot.md` and verify its
+structure against `references/snapshot-format.md`.
+
+**Structural checks:**
+
+1. All 12 section headings present in order: Enforcement,
+   Enforcement Loop History, Garbage Collection, Mutation Testing,
+   Compound Learning, Session Quality, Operational Cadence,
+   Cost Indicators, Regression Indicators, Meta,
+   Changes Since Last Snapshot, Trends
+2. Trends section is conditional — required only when a previous
+   snapshot exists (step 3 found one)
+3. No YAML `observatory_metrics` block anywhere in the file
+   (deprecated in v0.16.0)
+4. Each section contains the fields defined in
+   `references/snapshot-format.md` for that section
+
+If any check fails, fix the snapshot in place:
+
+- Add missing sections using the field templates from
+  `references/snapshot-format.md` with placeholder values
+- Reorder sections if present but misordered
+- Remove any YAML `observatory_metrics` block if found
+
+Do not regenerate the snapshot. Fix the output directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing steps:
+
+- `### 7. Update README` becomes `### 8. Update README`
+- `### 8. Print Summary` becomes `### 9. Print Summary`
+- `### 9. Nudge Overdue Actions` becomes `### 10. Nudge Overdue Actions`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/harness-health.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/harness-health.md
+git commit -m "Add snapshot validation checkpoint to /harness-health"
+```
+
+---
+
+### Task 2: `/assess` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/assess.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/assess.md` to confirm current
+step numbering. Steps 1-4 are before the insertion point, step 5
+(Immediate Habitat Adjustments) is the first step to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 5. Validate Assessment Document` after step 4
+(Document) and before the current step 5 (Immediate Habitat
+Adjustments). Content:
+
+```markdown
+### 5. Validate Assessment Document
+
+**This step is mandatory.** After writing the assessment document,
+read `assessments/YYYY-MM-DD-assessment.md` and verify its structure
+against `ai-literacy-assessment/references/assessment-template.md`.
+
+**Structural checks:**
+
+1. Required sections present: Observable Evidence, Level Assessment,
+   Discipline Maturity, Strengths, Gaps, Recommendations
+2. Level Assessment contains a level number (1-5) and a level name
+   (e.g. "Level 3 — Adaptive Collaboration")
+3. Discipline Maturity contains a markdown table with rows for each
+   scored discipline
+4. Gaps section contains at least one item (every project has gaps)
+
+If any check fails, fix the document in place:
+
+- Add missing sections using the structure from the assessment
+  template reference
+- Ensure the level number is a single digit 1-5 that downstream
+  portfolio aggregation can parse
+
+Do not re-dispatch the assessor agent. Fix the output directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing steps:
+
+- `### 5. Immediate Habitat Adjustments` becomes `### 6. Immediate Habitat Adjustments`
+- `### 6. Workflow Operation Recommendations` becomes `### 7. Workflow Operation Recommendations`
+- `### 6b. Improvement Plan` becomes `### 7b. Improvement Plan`
+- `### 7. Assessment Reflection` becomes `### 8. Assessment Reflection`
+- `### 8. Check README for broader updates` becomes `### 9. Check README for broader updates`
+- `### 9. Badge` becomes `### 10. Badge`
+- `### 9b. Tag Repository` becomes `### 10b. Tag Repository`
+- `### 10. Commit` becomes `### 11. Commit`
+- `### 11. Report` becomes `### 12. Report`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/assess.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/assess.md
+git commit -m "Add assessment document validation checkpoint to /assess"
+```
+
+---
+
+### Task 3: `/reflect` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/reflect.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/reflect.md`. The file uses
+numbered list items (1. 1. 1. ...) not headings for steps. The
+insertion point is after step 5 (append entry) and before step 6
+(do not modify AGENTS.md).
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new numbered step after the "Append the entry to
+`REFLECTION_LOG.md`" step and before the "Do NOT modify `AGENTS.md`"
+step. Content:
+
+```markdown
+1. **Validate the reflection entry.** Read the last entry in
+   `REFLECTION_LOG.md` and verify its structure against the entry
+   template above.
+
+   **Structural checks:**
+
+   1. Entry starts with `---` separator
+   2. All 8 mandatory fields present: Date, Agent, Task, Surprise,
+      Proposal, Improvement, Signal, Constraint
+   3. Session metadata block present with all 4 subfields: Duration,
+      Model tiers used, Pipeline stages completed, Agent delegation
+   4. Signal field value is one of: `context`, `instruction`,
+      `workflow`, `failure`, `none`
+
+   If any check fails, fix the entry in place:
+
+   - Add missing fields with `"unknown"` values
+   - Add missing session metadata subfields with `"unknown"`
+   - If Signal value is not in the enum, set it to `none`
+
+   Do not ask the user to re-enter the reflection. Fix the output
+   directly.
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/reflect.md"`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/reflect.md
+git commit -m "Add reflection entry validation checkpoint to /reflect"
+```
+
+---
+
+### Task 4: `/cost-capture` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/cost-capture.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/cost-capture.md`. Steps 1-9
+are before the insertion point, step 10 (Commit) is the first step
+to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 10. Validate Cost Snapshot` after step 9 (Write
+the Snapshot) and before the current step 10 (Commit). Content:
+
+```markdown
+### 10. Validate Cost Snapshot
+
+**This step is mandatory.** After writing the cost snapshot, read
+`observability/costs/YYYY-MM-DD-costs.md` and verify it contains the
+fields that `/harness-health` needs to parse for the Cost Indicators
+section.
+
+**Structural checks:**
+
+1. File exists at the expected path
+2. Period field present (date range for the snapshot)
+3. Total spend field present (even if estimated)
+4. Model routing reference present (whether MODEL_ROUTING.md was
+   updated)
+
+Reference the `cost-tracking` skill for the full field definitions.
+
+If any check fails, fix the snapshot in place:
+
+- Add missing fields with `"not tracked"` as the value
+
+Do not re-run the capture conversation. Fix the output directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing steps:
+
+- `### 10. Commit` becomes `### 11. Commit`
+- `### 11. Summary` becomes `### 12. Summary`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/cost-capture.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/cost-capture.md
+git commit -m "Add cost snapshot validation checkpoint to /cost-capture"
+```
+
+---
+
+### Task 5: `/harness-constrain` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/harness-constrain.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/harness-constrain.md`. Steps
+1-8 are before the insertion point, step 9 (Update CI) is the first
+step to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 9. Validate Constraint Block` after step 8 (Update
+HARNESS.md) and before the current step 9 (Update CI). Content:
+
+```markdown
+### 9. Validate Constraint Block
+
+**This step is mandatory.** After adding or updating the constraint
+in HARNESS.md, read the constraint block you just wrote and verify
+its structure against the constraint template in
+`templates/HARNESS.md`.
+
+**Structural checks:**
+
+1. All required fields present: Rule, Enforcement, Tool, Scope
+2. Enforcement value is one of: `deterministic`, `agent`,
+   `unverified`
+3. Scope value is one of: `commit`, `pr`, `weekly`, `manual`
+4. If a `Governance requirement` field is present, all governance
+   fields must also be present: Operational meaning, Verification
+   method, Evidence, Failure action, Frame check
+
+If any check fails, fix the constraint block in place:
+
+- Add missing fields with placeholder values
+- Normalise Enforcement and Scope to valid enum values if they are
+  close matches (e.g. "det" to "deterministic")
+
+Do not restart the constraint conversation. Fix the output directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing steps:
+
+- `### 9. Update CI (if deterministic + PR scope)` becomes `### 10. Update CI (if deterministic + PR scope)`
+- `### 10. Commit` becomes `### 11. Commit`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/harness-constrain.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/harness-constrain.md
+git commit -m "Add constraint block validation checkpoint to /harness-constrain"
+```
+
+---
+
+### Task 6: `/harness-init` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/harness-init.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/harness-init.md`. Steps 1-7
+are before the insertion point, step 8 (Generate CI Configuration)
+is the first step to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 8. Validate Generated HARNESS.md` after step 7
+(Generate HARNESS.md) and before the current step 8 (Generate CI
+Configuration). Content:
+
+```markdown
+### 8. Validate Generated HARNESS.md
+
+**This step is mandatory.** After writing HARNESS.md, read it and
+verify its structure against `templates/HARNESS.md`.
+
+**Structural checks:**
+
+1. All 4 top-level sections present: `## Context`,
+   `## Constraints`, `## Garbage Collection`, `## Observability`
+2. Context section has `### Stack` and `### Conventions`
+   subsections (either with content or the placeholder marker)
+3. Observability section has `### Operating cadence`,
+   `### Health thresholds`, and `### Regression detection`
+   subsections
+4. `## Status` section present with all 4 fields: Last audit,
+   Constraints enforced, Garbage collection active, Drift detected
+5. Template version marker comment present:
+   `<!-- template-version: X.Y.Z -->` where X.Y.Z matches the
+   current plugin version
+
+If any check fails, fix HARNESS.md in place:
+
+- Add missing sections from the template with placeholder markers
+- Insert the template version marker if absent
+- Add missing Status fields with default values
+
+Do not re-run the init conversation. Fix the output directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing steps:
+
+- `### 8. Generate CI Configuration` becomes `### 9. Generate CI Configuration`
+- `### 9. Add README Badge` becomes `### 10. Add README Badge`
+- `### 10. Commit` becomes `### 11. Commit`
+- `### 11. Tag Repository` becomes `### 12. Tag Repository`
+- `### 12. Summary` becomes `### 13. Summary`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/harness-init.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/harness-init.md
+git commit -m "Add HARNESS.md validation checkpoint to /harness-init"
+```
+
+---
+
+### Task 7: `/superpowers-init` checkpoint
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/commands/superpowers-init.md`
+
+- [ ] **Step 1: Read the current file**
+
+Read `ai-literacy-superpowers/commands/superpowers-init.md`. Steps
+1-7 are before the insertion point, step 8 (Commit and summary) is
+the step to renumber.
+
+- [ ] **Step 2: Insert the checkpoint step**
+
+Insert a new `### 8. Validate Habitat Files` after step 7 (Scaffold)
+and before the current step 8 (Commit and summary). Content:
+
+```markdown
+### 8. Validate Habitat Files
+
+**This step is mandatory.** After all habitat files are generated,
+read each one and verify its structure against the corresponding
+template in `${CLAUDE_PLUGIN_ROOT}/templates/`.
+
+**Structural checks per file:**
+
+1. **CLAUDE.md**: has required sections `## Workflow`,
+   `## Build and Test`, `## Learnings`
+   (reference: `templates/CLAUDE.md`)
+2. **AGENTS.md**: has required sections `## STYLE`, `## GOTCHAS`,
+   `## ARCH_DECISIONS`, `## TEST_STRATEGY`, `## DESIGN_DECISIONS`
+   (reference: `templates/AGENTS.md`)
+3. **MODEL_ROUTING.md**: has required sections
+   `## Agent Routing Table` (with markdown table),
+   `## Token Budget Guidance` (with markdown table)
+   (reference: `templates/MODEL_ROUTING.md`)
+4. **REFLECTION_LOG.md**: exists and has the header comment
+   containing the entry format template
+
+If any check fails, fix the file in place:
+
+- Add missing sections from the corresponding template
+- Do not overwrite existing content in sections that are already
+  populated
+
+Do not re-run the init conversation. Fix each file directly.
+```
+
+- [ ] **Step 3: Renumber subsequent steps**
+
+Renumber the existing step:
+
+- `### 8. Commit and summary` becomes `### 9. Commit and summary`
+
+- [ ] **Step 4: Lint**
+
+Run: `npx markdownlint-cli2 "ai-literacy-superpowers/commands/superpowers-init.md"`
+Expected: 0 errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/superpowers-init.md
+git commit -m "Add habitat file validation checkpoint to /superpowers-init"
+```
+
+---
+
+### Task 8: Version bump and changelog
+
+**Files:**
+
+- Modify: `ai-literacy-superpowers/.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump plugin.json version**
+
+In `ai-literacy-superpowers/.claude-plugin/plugin.json`, change:
+`"version": "0.19.3"` to `"version": "0.19.4"`
+
+- [ ] **Step 2: Bump marketplace.json plugin_version**
+
+In `.claude-plugin/marketplace.json`, change:
+`"plugin_version": "0.19.3"` to `"plugin_version": "0.19.4"`
+
+- [ ] **Step 3: Update README badge**
+
+In `README.md`, change: `Plugin-v0.19.3` to `Plugin-v0.19.4`
+
+- [ ] **Step 4: Add CHANGELOG entry**
+
+Add a new section at the top of `CHANGELOG.md`:
+
+```markdown
+## 0.19.4 — 2026-04-15
+
+### Output validation checkpoints
+
+- Add validate-and-fix-in-place checkpoint to /harness-health —
+  verifies all 12 snapshot sections present, no deprecated YAML block
+- Add validation checkpoint to /assess — verifies assessment document
+  has required sections and parseable level number for portfolio
+  aggregation
+- Add validation checkpoint to /reflect — verifies all 8 mandatory
+  fields plus 4 session metadata subfields and Signal enum value
+- Add validation checkpoint to /cost-capture — verifies cost snapshot
+  has fields that /harness-health needs for Cost Indicators section
+- Add validation checkpoint to /harness-constrain — verifies
+  constraint block has required fields with valid enum values
+- Add validation checkpoint to /harness-init — verifies generated
+  HARNESS.md has all top-level sections, subsections, and template
+  version marker
+- Add validation checkpoint to /superpowers-init — verifies all 4
+  habitat files (CLAUDE.md, AGENTS.md, MODEL_ROUTING.md,
+  REFLECTION_LOG.md) have required sections
+```
+
+- [ ] **Step 5: Lint all changed files**
+
+Run: `npx markdownlint-cli2 "CHANGELOG.md" "README.md"`
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ai-literacy-superpowers/.claude-plugin/plugin.json \
+       .claude-plugin/marketplace.json \
+       README.md CHANGELOG.md
+git commit -m "Bump to 0.19.4 — output validation checkpoints"
+```
+
+---
+
+### Task 9: Push and PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/governance-summary-checkpoint
+```
+
+Note: use the existing branch if still on it, or create a new branch
+`add-output-validation-checkpoints` if starting fresh from main.
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "Add output validation checkpoints to 7 commands (0.19.4)" \
+  --body "## Summary
+- Add validate-and-fix-in-place checkpoints to 7 commands that produce structured output
+- Each checkpoint reads the output, verifies structure against the format spec, fixes deviations in place
+- Follows the pattern established in /governance-audit step 5
+
+## Commands updated
+1. /harness-health — 12 snapshot sections
+2. /assess — assessment template sections
+3. /reflect — 8 fields + session metadata + Signal enum
+4. /cost-capture — cost snapshot fields
+5. /harness-constrain — constraint block fields + enums
+6. /harness-init — HARNESS.md sections + template marker
+7. /superpowers-init — 4 habitat files
+
+## Test plan
+- [ ] CI passes (markdownlint, version-check)
+- [ ] Each command file has a validation step
+- [ ] No step numbers are duplicated or skipped"
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks <number> --watch
+```
+
+Expected: all checks pass.

--- a/docs/superpowers/specs/2026-04-15-output-validation-checkpoints-design.md
+++ b/docs/superpowers/specs/2026-04-15-output-validation-checkpoints-design.md
@@ -1,0 +1,225 @@
+# Output Validation Checkpoints
+
+## Problem
+
+Agents producing structured output drift from their format specs under
+cognitive load. The governance-auditor proved this: detailed instructions
+(lines 92-144 of the agent file) were consistently ignored, producing a
+loose `## Summary` section instead of the machine-readable
+`## Governance Summary` contract. The fix — a validation checkpoint in
+the dispatching command — works because it verifies the output after the
+agent finishes, then fixes deviations in place.
+
+Six other HIGH+ risk commands produce structured output that downstream
+agents, commands, or external consumers parse. None of them have
+validation checkpoints.
+
+## Approach
+
+Add a validate-and-fix-in-place checkpoint step to each of the 7
+commands that produce structured, parseable output. Each checkpoint:
+
+1. Reads the output file after it is written
+2. Checks structural requirements against the referenced format spec
+3. Fixes deviations in place (does not re-dispatch the agent)
+
+Checkpoints reference existing format specs rather than inlining field
+definitions, to avoid duplication.
+
+This is a patch-level change (output compliance fix, not new features).
+
+## Checkpoint Specifications
+
+### 1. `/harness-health` — snapshot validation
+
+**Insert after**: Step 6 (Generate Markdown Sections)
+**Insert before**: Step 7 (Update README)
+
+**Output file**: `observability/snapshots/YYYY-MM-DD-snapshot.md`
+**Format reference**: `references/snapshot-format.md`
+
+**Structural checks**:
+
+- File exists at the expected path
+- All 12 section headings present in order:
+  1. `## Enforcement`
+  2. `## Enforcement Loop History`
+  3. `## Garbage Collection`
+  4. `## Mutation Testing`
+  5. `## Compound Learning`
+  6. `## Session Quality`
+  7. `## Operational Cadence`
+  8. `## Cost Indicators`
+  9. `## Regression Indicators`
+  10. `## Meta`
+  11. `## Changes Since Last Snapshot`
+  12. `## Trends` (conditional — only required when previous snapshot
+      exists)
+- No YAML `observatory_metrics` block (deprecated in v0.16.0)
+- Each section contains the fields defined in `references/snapshot-format.md`
+
+**Fix strategy**: Add missing sections with placeholder values sourced
+from the format spec. Reorder if present but misordered. Remove
+deprecated YAML block if found.
+
+### 2. `/assess` — assessment document validation
+
+**Insert after**: assessor agent writes the document
+**Insert before**: README badge update
+
+**Output file**: `assessments/YYYY-MM-DD-assessment.md`
+**Format reference**: `ai-literacy-assessment/references/assessment-template.md`
+
+**Structural checks**:
+
+- File exists at the expected path
+- Required sections present: Observable Evidence, Level Assessment,
+  Discipline Maturity, Strengths, Gaps, Recommendations
+- Level Assessment contains a level number (1-5) and level name
+- Discipline Maturity contains a markdown table with scored disciplines
+
+**Fix strategy**: Add missing sections from template. Ensure level
+number is parseable by downstream portfolio aggregation.
+
+### 3. `/reflect` — reflection entry validation
+
+**Insert after**: entry is appended to REFLECTION_LOG.md
+**Insert before**: commit
+
+**Output file**: `REFLECTION_LOG.md` (last entry only)
+**Format reference**: the entry template in `commands/reflect.md`
+
+**Structural checks**:
+
+- Last entry starts with `---` separator
+- All 8 mandatory fields present: Date, Agent, Task, Surprise,
+  Proposal, Improvement, Signal, Constraint
+- Session metadata block present with all 4 subfields: Duration,
+  Model tiers used, Pipeline stages completed, Agent delegation
+- Signal field value is one of: `context`, `instruction`, `workflow`,
+  `failure`, `none`
+
+**Fix strategy**: Add missing fields with `"unknown"` values. Fix
+Signal value to `none` if not in the enum. Add missing session metadata
+subfields with `"unknown"`.
+
+### 4. `/cost-capture` — cost snapshot validation
+
+**Insert after**: snapshot is written
+**Insert before**: commit
+
+**Output file**: `observability/costs/YYYY-MM-DD-costs.md`
+**Format reference**: `cost-tracking/SKILL.md`
+
+**Structural checks**:
+
+- File exists at the expected path
+- Required fields present for `/harness-health` to parse: period,
+  total spend, model routing reference
+
+**Fix strategy**: Add missing fields with `"not tracked"` placeholders.
+
+### 5. `/harness-constrain` — constraint block validation
+
+**Insert after**: constraint is added to HARNESS.md
+**Insert before**: test run dispatch
+
+**Output file**: `HARNESS.md` (newly added constraint block only)
+**Format reference**: constraint template block in `templates/HARNESS.md`
+
+**Structural checks**:
+
+- Newly added constraint block has all required fields: Rule,
+  Enforcement, Tool, Scope
+- Enforcement value is one of: `deterministic`, `agent`, `unverified`
+- Scope value is one of: `commit`, `pr`, `weekly`, `manual`
+- If a `Governance requirement` field is present, all governance fields
+  must also be present: Operational meaning, Verification method,
+  Evidence, Failure action, Frame check
+
+**Fix strategy**: Add missing fields with placeholder values. Normalise
+Enforcement and Scope to valid enum values if they are close matches.
+
+### 6. `/harness-init` — generated HARNESS.md validation
+
+**Insert after**: HARNESS.md is generated
+**Insert before**: CI workflow generation
+
+**Output file**: `HARNESS.md`
+**Format reference**: `templates/HARNESS.md`
+
+**Structural checks**:
+
+- All 4 top-level sections present: `## Context`, `## Constraints`,
+  `## Garbage Collection`, `## Observability`
+- Context section has `### Stack` and `### Conventions` subsections
+- Observability section has `### Operating cadence`,
+  `### Health thresholds`, and `### Regression detection` subsections
+- `## Status` section present with all 4 fields: Last audit,
+  Constraints enforced, Garbage collection active, Drift detected
+- Template version marker comment present:
+  `<!-- template-version: X.Y.Z -->`
+
+**Fix strategy**: Add missing sections from template. Insert template
+version marker if absent.
+
+### 7. `/superpowers-init` — habitat file validation
+
+**Insert after**: all habitat files are generated
+**Insert before**: commit
+
+**Output files**: `CLAUDE.md`, `AGENTS.md`, `MODEL_ROUTING.md`,
+`REFLECTION_LOG.md`
+**Format references**: corresponding files in `templates/`
+
+**Structural checks per file**:
+
+- **CLAUDE.md**: has required sections: Workflow, Build and Test,
+  Learnings
+- **AGENTS.md**: has required sections: STYLE, GOTCHAS,
+  ARCH_DECISIONS, TEST_STRATEGY, DESIGN_DECISIONS
+- **MODEL_ROUTING.md**: has required sections: Agent Routing (with
+  table), Token Budget Guidance (with table)
+- **REFLECTION_LOG.md**: has the header comment with entry format
+  template
+
+**Fix strategy**: Add missing sections from templates. Do not overwrite
+existing content in sections that are already populated.
+
+## Checkpoint Pattern
+
+Every checkpoint follows the same structure in the command spec:
+
+```text
+### N. Validate [output name]
+
+**This step is mandatory.** After [producer] writes [output file],
+read it and verify the structure matches the [format reference].
+
+**Structural checks:**
+
+1. [check 1]
+2. [check 2]
+...
+
+If any check fails, fix the output in place using data from the
+[producer]'s output. Do not re-dispatch the [agent/command].
+```
+
+## Scope
+
+- 7 command files modified (new step added to each)
+- 0 agent files modified (agents keep existing instructions;
+  checkpoints are in the dispatching commands)
+- 0 format spec files modified (checkpoints reference, not duplicate)
+- Version bump: 0.19.3 to 0.19.4 (patch — compliance fix)
+
+## Out of Scope
+
+- MEDIUM risk producers (convention-sync, harness-gc, code-reviewer)
+  are not included in this change. They can be added later if format
+  drift is observed.
+- Agent-level self-check instructions are not added. The
+  governance-auditor already has one; the others can get them later.
+  The command-level checkpoint is the reliable layer.
+- No new format specs are created. Existing references are sufficient.


### PR DESCRIPTION
## Summary

- Add validate-and-fix-in-place checkpoints to 7 commands that produce structured output parsed by downstream consumers
- Each checkpoint reads the output after it's written, verifies structure against the format spec, and fixes deviations in place
- Follows the pattern established in `/governance-audit` step 5 (PR #144)

## Commands updated

1. `/harness-health` — verifies 12 snapshot sections, no deprecated YAML block
2. `/assess` — verifies assessment template sections, parseable level number
3. `/reflect` — verifies 8 fields + 4 session metadata subfields + Signal enum
4. `/cost-capture` — verifies cost snapshot fields for harness-health parsing
5. `/harness-constrain` — verifies constraint block fields + enum values
6. `/harness-init` — verifies HARNESS.md sections + template version marker
7. `/superpowers-init` — verifies 4 habitat files have required sections

## Context

Observatory signal verification (this session) found 6 PARTIAL and 7 MISSING signals across 72 checked. Source 4 (governance audit reports) had the worst gap — the agent consistently ignored its own format spec. The checkpoint pattern from PR #144 proved effective, so we're applying it to all HIGH+ risk producers.

Spec: `docs/superpowers/specs/2026-04-15-output-validation-checkpoints-design.md`

## Test plan

- [ ] CI passes (markdownlint, version-check, spec-first)
- [ ] Each of the 7 command files has a validation step
- [ ] No step numbers are duplicated or skipped
- [ ] CHANGELOG has 0.19.4 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)