### PR TITLE
Close docs site gaps: 5 new pages, 2 updated

### DIFF
--- a/docs/explanation/regression-detection.md
+++ b/docs/explanation/regression-detection.md
@@ -1,0 +1,73 @@
+---
+title: Regression Detection
+layout: default
+parent: Explanation
+nav_order: 17
+---
+
+# Regression Detection
+
+In harness engineering, regression means something different than it does in software testing. Code regression is a broken feature. Harness regression is a broken habit. When the practices that keep a harness alive stop happening -- when audits are skipped, when reflections dry up, when snapshots go stale -- the harness degrades silently. The constraints still fire. The rules still exist. But the human-in-the-loop activities that evolved and maintained the harness have stopped, and the harness slowly becomes cargo cult: a system that looks correct but is no longer serving the purpose it was designed for.
+
+Regression detection is the harness's immune system. It monitors four key signals about whether the team is still actively engaging with the harness and learning from it. When one signal weakens, the harness notifies the team. When multiple signals weaken together, the harness escalates its alert. This page explains what regression looks like, how it is measured, and how to configure thresholds that match your team's cadence.
+
+---
+
+## What Regression Means Here
+
+Regression in harness practice is distinct from code regression in two ways.
+
+First, it is about practices, not features. A regression does not mean a constraint broke or a rule stopped firing. It means the team has stopped running the practices that keep the harness evolving. An audit that should happen monthly but has not run in three months is a regression. A reflection log that was capturing insights weekly but has been empty for a month is a regression.
+
+Second, regression is slow and silent. Code regressions announce themselves loudly through test failures or user complaints. Harness regression is gradual drift. The harness continues to operate. Constraints still validate. The CI pipeline still runs. But the team's engagement with the harness has quietly atrophied.
+
+This distinction matters because it determines how regression is detected. You cannot catch harness regression with unit tests or CI checks. You have to observe the actual behaviour of the team -- whether they are running audits, updating constraints, capturing reflections, and cleaning up garbage. If those activities stop, the harness stops learning, and it begins to calcify.
+
+---
+
+## The Four Regression Indicators
+
+Every harness health snapshot tracks four indicators that collectively measure whether the team is actively using the harness or letting it decay.
+
+**Snapshot stale.** The most recent snapshot in `observability/snapshots/` is older than the configured cadence threshold, typically 30 days for a monthly audit cadence. If nobody has run `/harness-health` in 30 days, the harness has no telemetry. The team is operating without visibility into the harness's own state. This is the most direct signal that engagement has dropped.
+
+**Cadence non-compliance.** The `/harness-health` command tracks four key activities: audit (usually monthly), assess (usually quarterly), reflect (ongoing, tracked weekly), and GC (usually monthly). For each activity, the snapshot records when it was last completed and compares it to the declared cadence in `HARNESS.md`. If an activity is overdue relative to its declared cadence, it counts as non-compliant. One non-compliant activity is normal -- schedules slip, urgent work interrupts planned audits. Two or more non-compliant activities signals something systemic has changed. The team is not just behind; they have stopped prioritizing harness maintenance.
+
+**Consecutive weeks without reflections.** Reflections are the compound learning engine of the harness. They capture surprises, adaptations, and decisions. If the reflection log goes silent for four or more consecutive weeks, the team has stopped learning from sessions. This matters because reflections feed garbage collection rules, inform constraint adjustments, and encode institutional knowledge. A drought in reflections means the harness is not evolving in response to new problems.
+
+**Regression flag.** A boolean that fires when any of the following conditions are true: snapshot stale, non-compliance is 2 or higher, or consecutive weeks without reflections is 4 or more. This is the aggregate signal. It says: something about your engagement with the harness has changed, and you should pay attention.
+
+---
+
+## Configuring Thresholds
+
+Thresholds are not one-size-fits-all. A team that audits monthly has different tolerance for staleness than a team that audits quarterly. Thresholds are configured in `HARNESS.md` under the Observability section, specifically under `### Regression detection`.
+
+Two thresholds are commonly tuned:
+
+**Cadence non-compliance threshold.** Default is 2. This means the regression flag does not fire unless two or more tracked activities are overdue. Teams that run a tighter schedule (weekly audits, bi-weekly reflections) might lower this to 1, meaning any missed activity triggers attention. Teams that are less frequent (quarterly audits) might raise it to 3.
+
+**Reflection drought threshold.** Default is 4 weeks. This means the regression flag fires if no reflections have been captured in the past four consecutive weeks. Teams that capture reflections in almost every session might lower this to 2 weeks. Teams that reflect less frequently might raise it to 6 or 8 weeks.
+
+When you adjust these thresholds, document why in the `HARNESS.md` comment. The reason matters because the threshold is a claim about your team's rhythm and capacity. If you raise the reflection drought threshold to 8 weeks, you are saying: "Our team reflects less frequently, and that is intentional." If someone later comes back and questions why reflections have been sparse, the documented threshold explains that the threshold itself is already part of the harness.
+
+---
+
+## Connection to Health Status
+
+Regression indicators feed into the Meta section's aggregate health assessment. The harness health snapshot produces an overall status: Healthy, Attention, or Degraded.
+
+If the regression flag is false and other health layers (enforcement drift, silent garbage collection) are nominal, the harness is Healthy. If the regression flag is true, the harness moves toward Attention. If regression is combined with other degraded signals -- say, enforcement has drifted, garbage collection has found multiple stale items, and the team has stopped reflecting -- the harness moves to Degraded.
+
+Attention means the harness is notifying you that engagement has slipped. It is not an emergency. It is a signal to check in: Are we still running audits? Can we carve out time for reflections? Degraded means multiple layers of the harness have weakened together, and you should probably pause feature work to spend a session hardening and re-engaging with the harness.
+
+The regression signal is different from a constraint failure or a garbage collection finding. Those are about specific problems. Regression is about the health of your relationship with the harness itself. Treat it as you would treat a doctor's warning that your fitness is declining: not a diagnosis of disease, but a prompt to pay attention before the decline becomes costly to reverse.
+
+---
+
+## Further reading
+
+- [Harness Engineering]({% link explanation/harness-engineering.md %}) -- the three-component model (context, constraints, observation) that regression detection is part of
+- [Garbage Collection]({% link explanation/garbage-collection.md %}) -- how scheduled checks detect codebase entropy over time
+- [Compound Learning]({% link explanation/compound-learning.md %}) -- how reflections drive the learning loop and why their absence signals regression
+- [Three Enforcement Loops]({% link explanation/three-enforcement-loops.md %}) -- how regression detection fits into the outer (scheduled) enforcement loop

--- a/docs/how-to/configure-observability.md
+++ b/docs/how-to/configure-observability.md
@@ -1,0 +1,113 @@
+---
+title: Configure Observability
+layout: default
+parent: How-to Guides
+nav_order: 35
+---
+
+# Configure Observability
+
+Set snapshot cadence, operating targets, health thresholds, and regression detection in HARNESS.md.
+
+---
+
+## 1. Open the Observability section
+
+Locate `## Observability` in your HARNESS.md file. The section contains three subsections:
+
+- Operating cadence
+- Health thresholds
+- Regression detection
+
+---
+
+## 2. Set snapshot cadence
+
+Choose how often snapshots are collected. Edit this line under the Observability section:
+
+```yaml
+- Snapshot cadence: monthly
+```
+
+Options:
+
+- **Weekly**: 10-day staleness threshold. Recommended for Observatory corpus projects.
+- **Fortnightly**: 21-day staleness threshold.
+- **Monthly**: 30-day staleness threshold. Default.
+
+---
+
+## 3. Configure operating cadence targets
+
+Set target frequencies for each harness activity. Update these four lines:
+
+```yaml
+- Harness audit (/harness-audit): quarterly (90 days)
+- AI literacy assessment (/assess): quarterly (90 days)
+- Reflection review and promotion: monthly (30 days)
+- Cost capture (/cost-capture): quarterly (90 days)
+```
+
+Adjust the frequency (daily, weekly, monthly, quarterly) and the number of days to match your team's workflow.
+
+---
+
+## 4. Tune health thresholds
+
+Adjust these four thresholds to determine when the health status moves from Healthy to Attention to Degraded:
+
+```yaml
+- Minimum enforcement ratio for Healthy: 70%
+- Consecutive zero-finding GC snapshots before alert: 3
+- Unpromoted reflection age before learning flow is stalled: 60 days
+- Consecutive declining trend snapshots before alert: 3
+```
+
+Lower the thresholds to alert earlier; raise them to reduce noise.
+
+---
+
+## 5. Set regression detection thresholds
+
+Configure when the regression flag fires:
+
+```yaml
+- Cadence non-compliance threshold: 2 or more activities overdue
+- Reflection drought threshold: 4 consecutive weeks with zero reflections
+```
+
+---
+
+## 6. Verify
+
+Run the health check command to generate a snapshot using the new settings:
+
+```bash
+/harness-health
+```
+
+Check the Meta section of the output to confirm the thresholds are applied correctly.
+
+---
+
+## Prerequisites
+
+HARNESS.md must exist with an Observability section. If not, create it with:
+
+```bash
+/harness-init
+```
+
+---
+
+## What you have now
+
+Customized observability settings that match your team's cadence and risk tolerance.
+
+---
+
+## Next steps
+
+- Run `/harness-health` regularly to monitor snapshot health
+- Explore the harness-observability skill for deeper configuration
+- Adjust thresholds based on team feedback

--- a/docs/how-to/upgrade-your-harness.md
+++ b/docs/how-to/upgrade-your-harness.md
@@ -1,0 +1,83 @@
+---
+title: Upgrade Your Harness
+layout: default
+parent: How-to Guides
+nav_order: 34
+---
+
+# Upgrade Your Harness
+
+Run `/harness-upgrade` to adopt new template content after updating the plugin.
+
+## Prerequisites
+
+- The plugin is installed and active in your Claude Code session.
+- Your HARNESS.md exists in the `.claude/` directory (created by `/harness-init`).
+
+---
+
+## 1. Check for available upgrades
+
+Run the command:
+
+```bash
+/harness-upgrade
+```
+
+The command compares the `<!-- template-version: X.Y.Z -->` marker in your HARNESS.md against the installed plugin version. If versions match, no upgrade is needed. If they differ, the command displays a summary of changes.
+
+---
+
+## 2. Review new items
+
+The command categorises changes into three groups:
+
+- **New** — items in the latest template that aren't in your current HARNESS.md.
+- **Updated** — items that exist in both but have changed.
+- **Removed** — items in your HARNESS.md that are no longer in the template.
+
+Read through each category to understand what will change.
+
+---
+
+## 3. Accept or dismiss items
+
+For each new or updated item, you'll be prompted to accept or skip:
+
+- **Accept** — the item is written to your HARNESS.md.
+- **Skip** — the item is not added; you keep your current version.
+
+After you accept or skip all items, the template version marker in your HARNESS.md is updated to match the current plugin version.
+
+---
+
+## 4. Dismiss for later
+
+If you're not ready to upgrade, dismiss the prompt. A `.claude/.harness-upgrade-dismissed` marker is created. The SessionStart hook won't ask again until the next plugin update.
+
+To force the upgrade later, delete the marker file and run `/harness-upgrade` again.
+
+---
+
+## 5. Verify the result
+
+After the upgrade completes, run:
+
+```bash
+/harness-status
+```
+
+This confirms your HARNESS.md is up to date with the latest template content and shows the current version marker.
+
+---
+
+## What you have now
+
+Your HARNESS.md is in sync with the plugin's template. All new features and fixes in the latest template are now available in your harness.
+
+---
+
+## Next steps
+
+- Run `/harness-audit` to verify constraint enforcement.
+- Run `/harness-health` to generate a snapshot of your harness state.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,12 +46,12 @@ stays trustworthy at scale.
 
 It gives you:
 
-- **24 skills** — domain knowledge for security auditing, constraint
+- **27 skills** — domain knowledge for security auditing, constraint
   design, context engineering, fitness functions, model sovereignty, and more
-- **10 agents** — autonomous workers for orchestration, enforcement,
-  garbage collection, code review, and TDD
-- **15 commands** — slash commands for harness lifecycle, assessment,
-  portfolio assessment, reflection, and convention management
+- **11 agents** — autonomous workers for orchestration, enforcement,
+  garbage collection, code review, governance auditing, and TDD
+- **19 commands** — slash commands for harness lifecycle, assessment,
+  portfolio assessment, reflection, governance, and convention management
 - **3 enforcement loops** — advisory at edit time, strict at merge
   time, investigative on schedule
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Commands
 
-All 18 slash commands registered in `commands/`. Each command is
+All 19 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -92,6 +92,20 @@ Generate a comprehensive health snapshot. Two modes:
 
 Snapshots are saved to `observability/snapshots/` with a datestamped
 filename.
+
+### /harness-upgrade
+
+- **Skills read**: none
+- **Agents dispatched**: none
+
+Adopt new template content after a plugin upgrade. Compares the
+`<!-- template-version: X.Y.Z -->` marker in your `HARNESS.md` against
+the installed plugin version. Categorises changes as New (items in the
+template not in your HARNESS.md), Updated (changed items), and Removed
+(items you have that the template no longer includes). Each item can be
+accepted or dismissed individually. Dismissing writes a
+`.claude/.harness-upgrade-dismissed` marker so the SessionStart hook
+does not re-prompt until the next plugin update.
 
 ---
 

--- a/docs/reference/governance-summary-format.md
+++ b/docs/reference/governance-summary-format.md
@@ -1,0 +1,80 @@
+---
+title: Governance Summary Format
+layout: default
+parent: Reference
+nav_order: 8
+---
+
+# Governance Summary Format
+
+The machine-readable section in governance audit reports that the
+Habitat Observatory and other downstream consumers parse by regex.
+
+---
+
+## Location
+
+Written by the governance-auditor agent to
+`observability/governance/audit-YYYY-MM-DD.md`. Must appear
+immediately after the `# Governance Audit — YYYY-MM-DD` heading.
+
+---
+
+## Required Heading
+
+```text
+## Governance Summary
+```
+
+The heading must be exactly `## Governance Summary`. Not
+`## Summary`, not `## Overview`. The Observatory parses this
+heading by exact regex match.
+
+---
+
+## Required Fields
+
+All nine fields must appear in this order, each on its own line.
+Every field is mandatory even when the value is zero.
+
+```text
+## Governance Summary
+
+- Total constraints: N
+- Falsifiable: N (with verification criteria)
+- Vague: N (lacking operational meaning)
+- Falsifiability ratio: N%
+- Semantic drift stage: N/5
+- Drift velocity: stable/increasing/decreasing
+- Governance debt items: N
+- Aggregate debt score: N (sum of severity x blast radius)
+- Frame alignment score: N%
+```
+
+---
+
+## Field Computation
+
+| Field | How to compute |
+| --- | --- |
+| Total constraints | Count governance constraints in HARNESS.md (those with a `Governance requirement` field) |
+| Falsifiable | Count constraints scored "Falsifiable" in the audit |
+| Vague | Count constraints scored "Vague" in the audit. Report `0` if none |
+| Falsifiability ratio | `(falsifiable / total) * 100`, rounded to nearest integer |
+| Semantic drift stage | Integer 1-5, followed by `/5`. 1 = no drift. Never use 0 |
+| Drift velocity | Compare current drift stage with previous audit. `stable` if unchanged, `increasing` if rose, `decreasing` if fell. `stable` if no previous audit |
+| Governance debt items | Count of items in the debt inventory. `0` if empty |
+| Aggregate debt score | Sum of `severity x blast_radius` across debt items. `0` if none |
+| Frame alignment score | `(aligned / total) * 100`, rounded to nearest integer |
+
+---
+
+## Validation
+
+The `/governance-audit` command validates this section after the
+governance-auditor agent writes the report (step 5). If the heading
+is wrong, fields are missing, or values use the wrong format, the
+command fixes the output in place.
+
+See [Output Validation]({% link reference/output-validation.md %})
+for the general checkpoint pattern.

--- a/docs/reference/output-validation.md
+++ b/docs/reference/output-validation.md
@@ -1,0 +1,65 @@
+---
+title: Output Validation
+layout: default
+parent: Reference
+nav_order: 7
+---
+
+# Output Validation
+
+Output validation checkpoints verify that structured output matches expected formats before committing or proceeding. Seven commands in v0.19.4 implement this pattern to catch format deviations early.
+
+---
+
+## The Pattern
+
+Every checkpoint follows the same structure:
+
+1. Producer (agent or command logic) writes the output file
+2. Command reads the file back
+3. Structural requirements are checked against the format spec reference
+4. Deviations are fixed in place — no agent re-dispatch
+
+This verification layer runs synchronously within the command, ensuring consistent output without retry loops or re-delegation.
+
+---
+
+## Checkpoint Table
+
+| Command | Output File | Format Reference | Key Checks |
+| --- | --- | --- | --- |
+| /harness-health | `observability/snapshots/YYYY-MM-DD-snapshot.md` | `references/snapshot-format.md` | 12 section headings in order, no deprecated YAML block |
+| /assess | `assessments/YYYY-MM-DD-assessment.md` | `ai-literacy-assessment/references/assessment-template.md` | Required sections, parseable level number (1-5), discipline maturity table |
+| /reflect | `REFLECTION_LOG.md` (last entry) | Entry template in `commands/reflect.md` | 8 mandatory fields, 4 session metadata subfields, Signal enum validation |
+| /cost-capture | `observability/costs/YYYY-MM-DD-costs.md` | `cost-tracking/SKILL.md` | Period, total spend, model routing reference present |
+| /harness-constrain | `HARNESS.md` (new constraint block) | `templates/HARNESS.md` | Rule/Enforcement/Tool/Scope fields, enum values, governance fields if applicable |
+| /harness-init | `HARNESS.md` | `templates/HARNESS.md` | 4 top-level sections, subsections, Status fields, template version marker |
+| /superpowers-init | `CLAUDE.md`, `AGENTS.md`, `MODEL_ROUTING.md`, `REFLECTION_LOG.md` | Corresponding `templates/` files | Required sections per file |
+| /governance-audit | `observability/governance/audit-YYYY-MM-DD.md` | `governance-auditor.agent.md` | `## Governance Summary` heading, 9 structured fields, value format rules |
+
+---
+
+## Fix Strategy
+
+Checkpoints fix output in place rather than re-dispatching the agent. Common fixes include:
+
+- Adding missing sections from templates with placeholder content
+- Normalising enum values to valid options
+- Removing deprecated blocks that conflict with current specs
+- Reordering sections to match canonical order
+- Extracting and validating structured data (numbers, dates, references)
+
+In-place repair is preferred because it preserves agent intent, handles edge cases gracefully, and avoids cascading re-runs that compound errors.
+
+---
+
+## Why Checkpoints Exist
+
+Agents drift from format specs under cognitive load. Reference templates set intent but do not guarantee compliance at output time. Checkpoints are the verification layer — analogous to type checking in compiled code.
+
+They serve two purposes:
+
+- **Detection**: Catch format violations before they propagate downstream
+- **Repair**: Fix common deviations locally without human intervention
+
+This reduces friction in the harness loop and maintains data quality for observability, auditing, and report generation.


### PR DESCRIPTION
## Summary

Closes all 6 docs site gap issues identified by the documentation audit.

### New pages (5)

- `docs/how-to/upgrade-your-harness.md` — closes #149
- `docs/how-to/configure-observability.md` — closes #150
- `docs/reference/output-validation.md` — closes #151
- `docs/reference/governance-summary-format.md` — closes #152
- `docs/explanation/regression-detection.md` — closes #154

### Updated pages (2)

- `docs/reference/commands.md` — add /harness-upgrade entry, fix count 18→19 (part of #149)
- `docs/index.md` — fix counts: 24→27 skills, 10→11 agents, 15→19 commands — closes #153

## Test plan

- [ ] CI passes (markdownlint)
- [ ] All 5 new files have correct frontmatter
- [ ] Home page counts match actual plugin counts

Closes #149, #150, #151, #152, #153, #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)