### PR TITLE
Add /harness-onboarding — human-readable onboarding guide generator (0.20.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.19.4",
+  "plugin_version": "0.20.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.20.0 — 2026-04-15
+
+### Human-readable harness onboarding
+
+- Add /harness-onboarding command — generates ONBOARDING.md from
+  HARNESS.md, AGENTS.md, and REFLECTION_LOG.md for new team members
+- Add harness-onboarding skill — tone guidelines and section mapping
+  for human-readable onboarding document generation
+- Add ONBOARDING.md template with 10 section skeleton and placeholder
+  markers
+- Add onboarding document staleness GC rule (monthly) to both the
+  template and the project's own HARNESS.md
+- Command includes a validation checkpoint verifying all 10 sections
+  are present and no placeholder markers remain
+- Generated ONBOARDING.md is linked from the project README
+
+Closes #37.
+
 ## 0.19.4 — 2026-04-15
 
 ### Output validation checkpoints

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -304,6 +304,15 @@ Use /governance-constrain for guided authoring of governance constraints.
 - **Auto-fix**: true (creates missing tags pointing at the merge
   commit that introduced the version heading)
 
+### Onboarding document staleness
+
+- **What it checks**: Whether ONBOARDING.md is older than the most
+  recent change to HARNESS.md, AGENTS.md, or REFLECTION_LOG.md
+- **Frequency**: monthly
+- **Enforcement**: deterministic
+- **Tool**: file date comparison
+- **Auto-fix**: false
+
 ### Template currency
 
 - **What it checks**: Whether the HARNESS.md template-version marker
@@ -473,5 +482,5 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 
 Last audit: 2026-04-15
 Constraints enforced: 12/13
-Garbage collection active: 13/13
+Garbage collection active: 14/14
 Drift detected: yes

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.19.4-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
-[![Skills](https://img.shields.io/badge/Skills-27-2E8B57?style=flat-square)](#skills-27)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.20.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Skills](https://img.shields.io/badge/Skills-28-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
-[![Commands](https://img.shields.io/badge/Commands-19-2E8B57?style=flat-square)](#commands-19)
+[![Commands](https://img.shields.io/badge/Commands-20-2E8B57?style=flat-square)](#commands-19)
 [![Harness](https://img.shields.io/badge/Harness-12%2F13_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -189,8 +189,9 @@ A coordinated team that handles the full development lifecycle.
 | `/governance-audit` | Deep governance investigation — semantic drift, debt inventory, frame alignment |
 | `/governance-health` | Governance health pulse check and dashboard generation |
 | `/harness-upgrade` | Discover and adopt new template content after a plugin upgrade |
+| `/harness-onboarding` | Generate a human-readable onboarding guide from harness state |
 
-### Templates (10)
+### Templates (11)
 
 Opinionated defaults scaffolded by `/superpowers-init`:
 
@@ -203,6 +204,7 @@ Opinionated defaults scaffolded by `/superpowers-init`:
 - **ci-auto-enforcer.yml** — GitHub Actions workflow for agent-based PR constraint enforcement
 - **ci-mutation-testing.yml** — weekly mutation testing template
 - **ci-generic.sh** — fallback CI script for non-GitHub systems
+- **ONBOARDING.md** — human-readable onboarding guide skeleton for new team members
 - **harness-health-icon.svg** — monochrome shield icon for the README health badge
 
 **MODEL_ROUTING.md** guides cost-conscious model selection. It maps each agent to a model tier (most capable, standard, fast) based on the judgment required. The orchestrator consults it when dispatching agents — spec-writers and code-reviewers get the most capable model; implementers and integration agents get standard models. Token budget guidance prevents runaway costs.

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.19.4",
+  "version": "0.20.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-onboarding.md
+++ b/ai-literacy-superpowers/commands/harness-onboarding.md
@@ -1,0 +1,99 @@
+---
+name: harness-onboarding
+description: Generate a human-readable onboarding document from HARNESS.md, AGENTS.md, and REFLECTION_LOG.md — a friendly guide for new team members
+---
+
+# /harness-onboarding
+
+Generate `ONBOARDING.md` — a human-readable onboarding guide for new
+team members, synthesised from the project's harness state.
+
+Read the `harness-onboarding` skill from this plugin before proceeding.
+It provides the tone guidelines and section-by-section content mapping.
+
+## Process
+
+### 1. Check Prerequisites
+
+Verify `HARNESS.md` exists. If not, tell the user to run
+`/harness-init` first.
+
+Check whether `AGENTS.md` and `REFLECTION_LOG.md` exist. If either
+is missing, proceed with reduced sources — note which sections will
+be skipped.
+
+### 2. Read Sources
+
+Read three files:
+
+- **HARNESS.md** — extract Context (Stack, Conventions), Constraints
+  (all entries with Rule, Scope), Garbage Collection rules,
+  Observability cadence
+- **AGENTS.md** — extract GOTCHAS, ARCH_DECISIONS, TEST_STRATEGY,
+  DESIGN_DECISIONS sections
+- **REFLECTION_LOG.md** — extract recent entries (last 10) where
+  Signal is `context` or `workflow`
+
+### 3. Generate ONBOARDING.md
+
+Read the template from `${CLAUDE_PLUGIN_ROOT}/templates/ONBOARDING.md`.
+
+For each section, replace the placeholder content with generated
+prose following the tone and section guidelines from the
+`harness-onboarding` skill:
+
+1. **Welcome** — synthesise from README and stack info
+2. **Tech Stack** — from Context > Stack
+3. **How We Write Code** — from Context > Conventions
+4. **What's Enforced** — from Constraints, grouped by Scope
+5. **Common Pitfalls** — from GOTCHAS + filtered REFLECTION_LOG
+6. **Architecture Decisions** — from ARCH_DECISIONS
+7. **How We Test** — from TEST_STRATEGY
+8. **How the Harness Works** — from GC rules + Observability
+9. **Your First PR Checklist** — synthesised from Constraints +
+   Conventions
+10. **Where to Learn More** — links to source files
+
+Write the result to `ONBOARDING.md` at the project root.
+
+### 4. Validate Generated Document
+
+**This step is mandatory.** After writing ONBOARDING.md, read it and
+verify its structure against `templates/ONBOARDING.md`.
+
+**Structural checks:**
+
+1. All 10 section headings present: Welcome (as H1), Tech Stack,
+   How We Write Code, What's Enforced, Common Pitfalls, Architecture
+   Decisions, How We Test, How the Harness Works, Your First PR
+   Checklist, Where to Learn More
+2. What's Enforced section has subsections for at least one of:
+   At commit time, At PR time, On schedule
+3. Generated header comment present (the "Do not edit directly"
+   notice)
+4. No placeholder markers remain (`{{` or `}}`)
+
+If any check fails, fix the document in place:
+
+- Add missing sections with content from the corresponding source
+- Remove any remaining placeholder markers
+
+Do not regenerate the document. Fix the output directly.
+
+### 5. Update README
+
+Check whether README.md contains a link to ONBOARDING.md. If not,
+add one. Look for an existing "Onboarding" or "Getting Started" or
+"Contributing" section. If found, add the link there. If not, add
+a line after the project description:
+
+```text
+New to the project? Start with [ONBOARDING.md](ONBOARDING.md).
+```
+
+### 6. Commit
+
+```bash
+git add ONBOARDING.md README.md
+git commit -m "Generate onboarding guide from harness state"
+```

--- a/ai-literacy-superpowers/skills/harness-onboarding/SKILL.md
+++ b/ai-literacy-superpowers/skills/harness-onboarding/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: harness-onboarding
+description: Use when generating a human-readable onboarding document from HARNESS.md, AGENTS.md, and REFLECTION_LOG.md — produces a friendly guide for new team members joining a harnessed project
+---
+
+# Harness Onboarding Documentation
+
+## Overview
+
+HARNESS.md is written for agents and experienced team members.
+New contributors need something different — a friendly, practical
+guide that explains "here's how we work" without requiring them to
+parse constraint definitions and GC rule syntax.
+
+This skill generates `ONBOARDING.md` from three sources the project
+already maintains. No new data entry is needed — the onboarding
+document is a human-readable projection of existing harness state.
+
+---
+
+## Sources
+
+| Source | What it contributes |
+| --- | --- |
+| HARNESS.md | Stack, conventions, constraints, GC rules, observability cadence |
+| AGENTS.md | Gotchas, architecture decisions, test strategy, design decisions |
+| REFLECTION_LOG.md | Recent surprises with `context` or `workflow` signal |
+
+HARNESS.md, AGENTS.md, and REFLECTION_LOG.md are the single source
+of truth. Sync is one-way only — these files drive ONBOARDING.md.
+The generated document is never edited directly.
+
+---
+
+## Tone
+
+Write for a human who just joined the team and needs to ship their
+first PR. The reader is a skilled developer who knows nothing about
+this specific project.
+
+- **Friendly, not formal.** "We use markdownlint to keep files
+  consistent" not "All markdown files must pass markdownlint."
+- **Practical, not theoretical.** Focus on what the contributor
+  needs to do, not why the framework exists.
+- **Grouped by action.** Constraints grouped by when they fire
+  (commit-time, PR-time), not by enforcement type.
+- **Warnings are stories.** Gotchas should explain what happened
+  and how to avoid it, not just state the rule.
+
+---
+
+## Section Guidelines
+
+### Welcome
+
+One paragraph. What this project is, why it matters, what a new
+contributor should expect. Pull from the README if it has a good
+description; otherwise synthesise from the stack and conventions.
+
+### Tech Stack
+
+From HARNESS.md Context > Stack. List each technology with a
+brief note on how it's used. Don't just repeat the HARNESS.md
+bullets — add context about what each tool does in this project.
+
+### How We Write Code
+
+From HARNESS.md Context > Conventions. Transform the terse bullet
+format into readable prose. Explain not just the rule but why the
+team follows it. Use examples where helpful.
+
+### What's Enforced
+
+From HARNESS.md Constraints. Group by when they fire:
+
+- **At commit time** — warnings during editing
+- **At PR time** — CI gates that block merges
+- **On schedule** — periodic checks
+
+For each constraint, explain in plain English what it checks and
+what happens if it fails. Skip the Tool and Enforcement fields —
+those are implementation details for the harness, not for the
+contributor.
+
+### Common Pitfalls
+
+From AGENTS.md GOTCHAS + recent REFLECTION_LOG entries where
+Signal is `context` or `workflow`. Present as practical warnings:
+"what happened" and "how to avoid it". Limit to the 5-7 most
+relevant entries — the onboarding doc should not be exhaustive.
+
+### Architecture Decisions
+
+From AGENTS.md ARCH_DECISIONS. Each entry: what was decided, why,
+and what the alternatives were. Frame as "the team already decided
+this — here's why."
+
+### How We Test
+
+From AGENTS.md TEST_STRATEGY. Explain how quality is assured.
+What tools run, what they check, how to run them locally.
+
+### How the Harness Works
+
+Brief explanation of the three enforcement loops. One sentence
+each for advisory (hooks), strict (CI), and investigative (GC).
+Mention the observability cadence from HARNESS.md Observability.
+Don't explain the framework — just explain what the contributor
+will encounter.
+
+### Your First PR Checklist
+
+Synthesise from Constraints and Conventions. Include only items
+the contributor needs to check before pushing. Format as a
+numbered list they can work through. Example items:
+
+1. Run the linter
+2. Check for secrets
+3. Update CHANGELOG.md
+4. Ensure commit message format
+
+### Where to Learn More
+
+Links to HARNESS.md, AGENTS.md, REFLECTION_LOG.md, and the docs
+site if one exists.
+
+---
+
+## Validation
+
+The generated document must match the section structure of
+`templates/ONBOARDING.md`. The `/harness-onboarding` command
+includes a validation checkpoint that verifies all 10 sections
+are present and fixes missing sections in place.
+
+---
+
+## Regeneration
+
+A GC rule checks monthly whether ONBOARDING.md is stale — whether
+any of its three sources (HARNESS.md, AGENTS.md, REFLECTION_LOG.md)
+have been modified more recently than ONBOARDING.md. When stale,
+the GC rule flags it and suggests re-running `/harness-onboarding`.

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -181,6 +181,15 @@ Use /governance-constrain for guided authoring of governance constraints.
 - **Tool**: harness-gc agent
 - **Auto-fix**: false
 
+### Onboarding document staleness
+
+- **What it checks**: Whether ONBOARDING.md is older than the most
+  recent change to HARNESS.md, AGENTS.md, or REFLECTION_LOG.md
+- **Frequency**: monthly
+- **Enforcement**: deterministic
+- **Tool**: file date comparison
+- **Auto-fix**: false
+
 ### Template currency
 
 - **What it checks**: Whether the HARNESS.md template-version marker

--- a/ai-literacy-superpowers/templates/ONBOARDING.md
+++ b/ai-literacy-superpowers/templates/ONBOARDING.md
@@ -1,0 +1,95 @@
+<!-- Generated from HARNESS.md, AGENTS.md, and REFLECTION_LOG.md.
+     Do not edit directly — regenerate with /harness-onboarding. -->
+
+# Welcome to {{PROJECT_NAME}}
+
+{{One paragraph: what this project is, why it matters, and what a new
+contributor should expect.}}
+
+---
+
+## Tech Stack
+
+{{From HARNESS.md Context > Stack. List each technology with a brief
+note on how it's used in this project.}}
+
+---
+
+## How We Write Code
+
+{{From HARNESS.md Context > Conventions. Transform the terse bullet
+format into readable prose — explain not just the rule but why the
+team follows it.}}
+
+---
+
+## What's Enforced
+
+{{From HARNESS.md Constraints. Group by when they fire:}}
+
+### At commit time
+
+{{Constraints with Scope: commit — these warn while you edit.}}
+
+### At PR time
+
+{{Constraints with Scope: pr — these block merges.}}
+
+### On schedule
+
+{{Constraints with Scope: weekly or monthly — these run periodically.}}
+
+---
+
+## Common Pitfalls
+
+{{From AGENTS.md GOTCHAS + recent REFLECTION_LOG entries with Signal:
+context or workflow. Present as practical warnings with "what happened"
+and "how to avoid it".}}
+
+---
+
+## Architecture Decisions
+
+{{From AGENTS.md ARCH_DECISIONS. Each entry: what was decided, why,
+and what the alternatives were. These are choices the team has made —
+don't second-guess them without good reason.}}
+
+---
+
+## How We Test
+
+{{From AGENTS.md TEST_STRATEGY. Explain how quality is assured in this
+project — what tools run, what they check, where to find test configs.}}
+
+---
+
+## How the Harness Works
+
+{{Brief explanation of the three enforcement loops and how they protect
+the codebase:}}
+
+- **Advisory loop** — hooks that warn during editing (never block)
+- **Strict loop** — CI gates that block merges
+- **Investigative loop** — scheduled GC rules that catch slow drift
+
+{{Mention the observability cadence: how often audits, assessments,
+reflections, and cost captures run.}}
+
+---
+
+## Your First PR Checklist
+
+{{Synthesised from Constraints and Conventions into a practical
+pre-flight list. Include only commit-scoped and PR-scoped items
+that a contributor would need to check before pushing.}}
+
+---
+
+## Where to Learn More
+
+{{Links to key project files and documentation:}}
+
+- [HARNESS.md](HARNESS.md) — the full constraint and convention reference
+- [AGENTS.md](AGENTS.md) — accumulated team knowledge and gotchas
+- [REFLECTION_LOG.md](REFLECTION_LOG.md) — session-by-session learnings

--- a/docs/superpowers/specs/2026-04-15-harness-onboarding-design.md
+++ b/docs/superpowers/specs/2026-04-15-harness-onboarding-design.md
@@ -1,0 +1,96 @@
+# Harness Onboarding Documentation Generator
+
+## Problem
+
+Teams use HARNESS.md for agents but need plain-language onboarding
+docs for humans. There's no way to generate a "here's how we work"
+document from the harness state.
+
+## Approach
+
+A new `/harness-onboarding` command that reads HARNESS.md, AGENTS.md,
+and REFLECTION_LOG.md and generates a human-readable `ONBOARDING.md`.
+Follows the convention-sync pattern: sources are the single source of
+truth, sync is one-way only, regeneration replaces the output.
+
+Three user requirements beyond the original proposal:
+
+1. **README link** — the generated ONBOARDING.md is linked from the
+   project README
+2. **Monthly GC rule** — a garbage collection rule checks whether
+   ONBOARDING.md is stale (sources changed since last generation)
+3. **Validation checkpoint** — the command includes a validate-and-
+   fix-in-place step that verifies the generated document matches the
+   template structure, following the pattern established for 8 other
+   commands in v0.19.4
+
+## Components
+
+### 1. Skill: `skills/harness-onboarding/SKILL.md`
+
+Defines:
+
+- The tone: friendly, practical, written for a human who just joined
+  the team and needs to ship their first PR
+- Section guidelines: what content goes in each section, how to
+  transform terse HARNESS.md bullets into readable prose
+- Source mapping: which file feeds which section
+
+### 2. Command: `commands/harness-onboarding.md`
+
+Steps:
+
+1. Check HARNESS.md exists
+2. Read sources (HARNESS.md, AGENTS.md, REFLECTION_LOG.md)
+3. Generate ONBOARDING.md from template
+4. **Validate generated document** — verify structure against
+   `templates/ONBOARDING.md` (same checkpoint pattern as other
+   commands)
+5. Add README link if not present
+6. Commit
+
+### 3. Template: `templates/ONBOARDING.md`
+
+Skeleton with 10 section headings and placeholder markers. The
+validation checkpoint verifies all sections are present.
+
+Sections:
+
+1. Welcome
+2. Tech Stack
+3. How We Write Code
+4. What's Enforced
+5. Common Pitfalls
+6. Architecture Decisions
+7. How We Test
+8. How the Harness Works
+9. Your First PR Checklist
+10. Where to Learn More
+
+### 4. GC rule addition to `templates/HARNESS.md`
+
+```markdown
+### Onboarding document staleness
+
+- **What it checks**: Whether ONBOARDING.md is older than the most
+  recent change to HARNESS.md, AGENTS.md, or REFLECTION_LOG.md
+- **Frequency**: monthly
+- **Enforcement**: deterministic
+- **Tool**: file date comparison
+- **Auto-fix**: false
+```
+
+### 5. Project HARNESS.md update
+
+Add the same GC rule to the project's own HARNESS.md.
+
+## Version
+
+0.20.0 — new command added.
+
+## Out of Scope
+
+- CONTRIBUTING.md generation (different concern: process, licensing,
+  code of conduct)
+- Docs site page for the generated content (ONBOARDING.md is a
+  repo-level file, not a docs site page)


### PR DESCRIPTION
## Summary

New `/harness-onboarding` command that generates `ONBOARDING.md` — a human-readable onboarding guide for new team members, synthesised from the project's harness state.

Closes #37.

### Components

- **Skill**: `skills/harness-onboarding/SKILL.md` — tone guidelines and section-by-section content mapping
- **Command**: `commands/harness-onboarding.md` — 6-step generation process with validation checkpoint
- **Template**: `templates/ONBOARDING.md` — 10-section skeleton with placeholder markers

### Key features

- Reads HARNESS.md + AGENTS.md + REFLECTION_LOG.md (single source of truth, one-way sync)
- Validation checkpoint verifies all 10 sections present and no placeholders remain
- Monthly GC rule detects when ONBOARDING.md is stale (sources changed since last generation)
- Adds a link to ONBOARDING.md in the project README

Spec: `docs/superpowers/specs/2026-04-15-harness-onboarding-design.md`

## Test plan

- [ ] CI passes (markdownlint, version-check, spec-first)
- [ ] Skill, command, and template files have correct frontmatter
- [ ] HARNESS.md GC rule count updated (14/14)
- [ ] README badges updated (28 skills, 20 commands, 11 templates, v0.20.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)