### PR TITLE
Add /observatory-verify — 82-signal contract verification (0.21.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.1",
-  "plugin_version": "0.20.0",
+  "plugin_version": "0.21.0",
   "plugins": [
     {
       "name": "ai-literacy-superpowers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.21.0 — 2026-04-15
+
+### Observatory signal verification
+
+- Add /observatory-verify command — runs the 82-signal checklist
+  against the latest output files, reporting PRESENT/PARTIAL/MISSING
+  status for each signal the Observatory expects to read
+- Add observatory-signals.md reference — the authoritative checklist
+  of all signals across 5 sources (snapshot, governance, reflections,
+  HARNESS.md, assessments)
+
 ## 0.20.0 — 2026-04-15
 
 ### Human-readable harness onboarding

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.20.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.21.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-28-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
-[![Commands](https://img.shields.io/badge/Commands-20-2E8B57?style=flat-square)](#commands-19)
+[![Commands](https://img.shields.io/badge/Commands-21-2E8B57?style=flat-square)](#commands-19)
 [![Harness](https://img.shields.io/badge/Harness-13%2F14_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -190,6 +190,7 @@ A coordinated team that handles the full development lifecycle.
 | `/governance-health` | Governance health pulse check and dashboard generation |
 | `/harness-upgrade` | Discover and adopt new template content after a plugin upgrade |
 | `/harness-onboarding` | Generate a human-readable onboarding guide from harness state |
+| `/observatory-verify` | Verify all Observatory signal contracts against latest output files |
 
 ### Templates (11)
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/observatory-verify.md
+++ b/ai-literacy-superpowers/commands/observatory-verify.md
@@ -1,0 +1,108 @@
+---
+name: observatory-verify
+description: Verify that all data signals the Habitat Observatory expects are present and correctly formatted — runs the 82-signal checklist against the latest output files
+---
+
+# /observatory-verify
+
+Run the Observatory signal contract verification. Checks that all
+data signals the plugin produces match what the Habitat Observatory
+expects to read.
+
+## Process
+
+### 1. Read the Signal Checklist
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/harness-observability/references/observatory-signals.md`.
+This is the authoritative list of all signals to verify — 82 signals
+across 5 sources.
+
+### 2. Find Latest Output Files
+
+For each signal source, find the latest output file:
+
+- **Snapshot**: most recent file in `observability/snapshots/`
+  matching `*-snapshot.md`
+- **Governance audit**: most recent file in
+  `observability/governance/` matching `audit-*.md`
+- **Reflection log**: `REFLECTION_LOG.md` at the project root
+- **HARNESS.md**: `HARNESS.md` at the project root
+- **Assessment**: most recent file in `assessments/` matching
+  `*-assessment.md`
+
+If a source file does not exist, mark all signals from that source
+as `NO_OUTPUT` and continue to the next source.
+
+### 3. Verify Each Signal
+
+For each signal in the checklist, read the output file and check:
+
+- **PRESENT** — the expected heading or field exists and contains
+  data in the expected format
+- **PARTIAL** — the heading or section exists but a required field
+  is missing or uses the wrong format
+- **MISSING** — the heading or field is not found in the output
+- **NO_OUTPUT** — no output file exists for this source
+
+For the Governance Summary, also verify the heading is exactly
+`## Governance Summary` (not a variant).
+
+For Reflection entries, check the most recent 3 entries (not all
+entries — older entries may predate format changes).
+
+### 4. Produce the Report
+
+Print a table to the session grouped by source:
+
+```text
+## Observatory Signal Verification
+
+### Source 1: Snapshot (N/M signals)
+
+| Signal | Expected Location | Status | Notes |
+| --- | --- | --- | --- |
+| Enforcement count | ## Enforcement | PRESENT | |
+| Tier breakdown | ## Enforcement | PRESENT | |
+| ... | ... | ... | ... |
+
+### Source 2: Governance Summary (N/M signals)
+
+| Signal | Expected Location | Status | Notes |
+| --- | --- | --- | --- |
+| ... | ... | ... | ... |
+
+[repeat for all 5 sources]
+```
+
+### 5. Print Summary
+
+```text
+## Summary
+
+| Source | Present | Partial | Missing | No Output | Total |
+| --- | --- | --- | --- | --- | --- |
+| Snapshot | N | N | N | N | 39 |
+| Governance | N | N | N | N | 9 |
+| Reflections | N | N | N | N | 12 |
+| HARNESS.md | N | N | N | N | 15 |
+| Assessment | N | N | N | N | 7 |
+| **Total** | **N** | **N** | **N** | **N** | **82** |
+```
+
+If any signals are PARTIAL or MISSING, list them with a brief note
+on what's missing and which file would need to change to fix it.
+
+### 6. Recommend Actions
+
+For MISSING signals, suggest the specific fix:
+
+- Missing snapshot section → run `/harness-health`
+- Missing governance summary field → run `/governance-audit`
+- Missing reflection fields → check `/reflect` command for format
+  updates
+- Missing HARNESS.md section → run `/harness-init` or
+  `/harness-upgrade`
+- Missing assessment section → run `/assess`
+
+For PARTIAL signals, describe what's incomplete and how to fix it
+in place.

--- a/ai-literacy-superpowers/skills/harness-observability/references/observatory-signals.md
+++ b/ai-literacy-superpowers/skills/harness-observability/references/observatory-signals.md
@@ -1,0 +1,157 @@
+# Observatory Signal Checklist
+
+The authoritative list of all data signals the Habitat Observatory
+expects to read from projects running ai-literacy-superpowers. The
+`/observatory-verify` command reads this file to determine what to
+check.
+
+Update this checklist when new signals are added to format specs
+or when the Observatory's expectations change.
+
+---
+
+## Source 1: Snapshot Sections
+
+**File**: `observability/snapshots/YYYY-MM-DD-snapshot.md`
+**Format reference**: `references/snapshot-format.md`
+
+| Signal | Section Heading | Key Fields |
+| --- | --- | --- |
+| Enforcement count | `## Enforcement` | `Constraints: N/M enforced (P%)` |
+| Tier breakdown | `## Enforcement` | `Deterministic: X \| Agent: Y \| Unverified: Z` |
+| Drift flag | `## Enforcement` | `Drift detected: yes/no` |
+| Advisory loop | `## Enforcement Loop History` | `Advisory (edit-time): active since YYYY-MM-DD` |
+| Strict loop | `## Enforcement Loop History` | `Strict (merge-time): active since YYYY-MM-DD` |
+| Investigative loop | `## Enforcement Loop History` | `Investigative (scheduled): active since YYYY-MM-DD` |
+| GC rules count | `## Garbage Collection` | `Rules active: N/M` |
+| GC findings | `## Garbage Collection` | `Findings since last snapshot: N` |
+| GC cadence | `## Garbage Collection` | `Cadence compliance: on schedule / overdue` |
+| Mutation rates | `## Mutation Testing` | Kill rate per language or "not applicable" |
+| Mutation trend | `## Mutation Testing` | `Trend: stable/improving/declining` |
+| Reflection count | `## Compound Learning` | `REFLECTION_LOG entries: N (M new)` |
+| AGENTS.md entries | `## Compound Learning` | `AGENTS.md entries: N (X gotchas, Y arch decisions)` |
+| Promotions | `## Compound Learning` | `Promotions since last snapshot: N` |
+| Signal coverage | `## Session Quality` | `Reflections with signal: N/M (P%)` |
+| Signal distribution | `## Session Quality` | `context: X \| instruction: Y \| workflow: Z \| failure: W` |
+| Quality trend | `## Session Quality` | `Quality trend: improving/stable/declining` |
+| Days since audit | `## Operational Cadence` | `Last /harness-audit: YYYY-MM-DD (N days ago)` |
+| Days since assess | `## Operational Cadence` | `Last /assess: YYYY-MM-DD (N days ago)` |
+| Days since reflect | `## Operational Cadence` | `Last /reflect: YYYY-MM-DD (N days ago)` |
+| Outer loop overdue | `## Operational Cadence` | `Outer loop overdue: yes/no` |
+| Model routing | `## Cost Indicators` | `Model routing configured: yes/no` |
+| Cost data | `## Cost Indicators` | `Last cost capture: YYYY-MM-DD / never` |
+| Snapshot currency | `## Meta` | `Snapshot cadence: on schedule / overdue` |
+| Cadence compliance | `## Meta` | `Cadence compliance: N/4 on schedule` |
+| Learning flow | `## Meta` | `Learning flow: active / stalled / inactive` |
+| GC effectiveness | `## Meta` | `GC effectiveness: productive / silent` |
+| Trend alerts | `## Meta` | `Trend alerts: none / [list]` |
+| Health status | `## Meta` | `Health: Healthy / Attention / Degraded` |
+| Snapshot stale | `## Regression Indicators` | `Snapshot stale: yes/no` |
+| Snapshot age | `## Regression Indicators` | `Snapshot age: N days` |
+| Cadence non-compliance | `## Regression Indicators` | `Cadence non-compliance: N of 4` |
+| Reflection drought | `## Regression Indicators` | `Consecutive weeks without reflections: N` |
+| Regression flag | `## Regression Indicators` | `Regression flag: yes/no` |
+| Constraints added | `## Changes Since Last Snapshot` | List or "none" |
+| Constraints promoted | `## Changes Since Last Snapshot` | List or "none" |
+| Constraints removed | `## Changes Since Last Snapshot` | List or "none" |
+| Assessments completed | `## Changes Since Last Snapshot` | Dates and levels or "none" |
+| Governance audits | `## Changes Since Last Snapshot` | Dates or "none" |
+| Trend table | `## Trends` | Per-metric comparison table |
+
+---
+
+## Source 2: Governance Summary
+
+**File**: `observability/governance/audit-YYYY-MM-DD.md`
+**Format reference**: `governance-auditor.agent.md`
+
+| Signal | Field | Format |
+| --- | --- | --- |
+| Total constraints | `- Total constraints: N` | Integer |
+| Falsifiable | `- Falsifiable: N (with verification criteria)` | Integer + annotation |
+| Vague | `- Vague: N (lacking operational meaning)` | Integer + annotation |
+| Falsifiability ratio | `- Falsifiability ratio: N%` | Percentage |
+| Drift stage | `- Semantic drift stage: N/5` | Integer 1-5 |
+| Drift velocity | `- Drift velocity: stable/increasing/decreasing` | Enum |
+| Debt items | `- Governance debt items: N` | Integer |
+| Debt score | `- Aggregate debt score: N (sum of severity x blast radius)` | Integer + annotation |
+| Frame alignment | `- Frame alignment score: N%` | Percentage |
+
+**Heading contract**: Must be exactly `## Governance Summary`.
+
+---
+
+## Source 3: Reflection Entries
+
+**File**: `REFLECTION_LOG.md`
+**Format reference**: `commands/reflect.md`
+
+| Signal | Field | Format |
+| --- | --- | --- |
+| Date | `- **Date**: YYYY-MM-DD` | Date |
+| Agent | `- **Agent**: [name]` | Free text |
+| Task | `- **Task**: [summary]` | Free text |
+| Surprise | `- **Surprise**: [text]` | Free text |
+| Proposal | `- **Proposal**: [text or "none"]` | Free text |
+| Improvement | `- **Improvement**: [text]` | Free text |
+| Signal | `- **Signal**: [type]` | Enum: context, instruction, workflow, failure, none |
+| Constraint | `- **Constraint**: [text or "none"]` | Free text |
+| Duration | `- Duration: [time or "unknown"]` | Free text |
+| Model tiers | `- Model tiers used: [distribution or "unknown"]` | Free text |
+| Pipeline stages | `- Pipeline stages completed: [stages or "unknown"]` | Free text |
+| Agent delegation | `- Agent delegation: [type or "unknown"]` | Enum: full pipeline, partial, manual, unknown |
+
+---
+
+## Source 4: HARNESS.md Structure
+
+**File**: `HARNESS.md`
+**Format reference**: `templates/HARNESS.md`
+
+| Signal | Location | Required |
+| --- | --- | --- |
+| Context section | `## Context` | yes |
+| Stack subsection | `### Stack` | yes |
+| Conventions subsection | `### Conventions` | yes |
+| Constraints section | `## Constraints` | yes |
+| GC section | `## Garbage Collection` | yes |
+| Observability section | `## Observability` | yes |
+| Operating cadence | `### Operating cadence` | yes |
+| Health thresholds | `### Health thresholds` | yes |
+| Regression detection | `### Regression detection` | yes |
+| Status section | `## Status` | yes |
+| Last audit field | `Last audit: YYYY-MM-DD` | yes |
+| Constraints enforced | `Constraints enforced: N/M` | yes |
+| GC active | `Garbage collection active: N/M` | yes |
+| Drift detected | `Drift detected: yes/no` | yes |
+| Template version | `<!-- template-version: X.Y.Z -->` | yes |
+
+---
+
+## Source 5: Assessment Document
+
+**File**: `assessments/YYYY-MM-DD-assessment.md`
+**Format reference**: `ai-literacy-assessment/references/assessment-template.md`
+
+| Signal | Section | Required |
+| --- | --- | --- |
+| Observable evidence | `## Observable Evidence` | yes |
+| Level assessment | `## Level Assessment` | yes |
+| Level number | Integer 1-5 in Level Assessment | yes |
+| Discipline maturity | `### Discipline Maturity` (table) | yes |
+| Strengths | `## Strengths` | yes |
+| Gaps | `## Gaps` | yes |
+| Recommendations | `## Recommendations` | yes |
+
+---
+
+## Signal Count
+
+| Source | Signals |
+| --- | --- |
+| Snapshot sections | 39 |
+| Governance summary | 9 |
+| Reflection entries | 12 |
+| HARNESS.md structure | 15 |
+| Assessment document | 7 |
+| **Total** | **82** |

--- a/docs/superpowers/specs/2026-04-15-observatory-verify-design.md
+++ b/docs/superpowers/specs/2026-04-15-observatory-verify-design.md
@@ -1,0 +1,112 @@
+# Observatory Signal Verification Command
+
+## Problem
+
+The Observatory plugin reads structured markdown from projects running
+ai-literacy-superpowers. When signal formats drift — wrong headings,
+missing fields, deprecated blocks — the Observatory silently gets
+incomplete data. The only way to detect these gaps today is a manual
+72-signal audit (done once in this session, found 13 gaps). A reusable
+command would let any session start with "what signals are we missing?"
+
+## Approach
+
+A new `/observatory-verify` command that runs the signal contract
+checklist on demand. Two verification layers:
+
+1. **Contract completeness** — are format specs and command checkpoints
+   covering all expected signals?
+2. **Output compliance** — do the latest generated files match their
+   contracts?
+
+## Signal Sources (5 categories)
+
+### Snapshot signals (12 sections)
+
+Reference: `references/snapshot-format.md`
+
+Sections: Enforcement, Enforcement Loop History, Garbage Collection,
+Mutation Testing, Compound Learning, Session Quality, Operational
+Cadence, Cost Indicators, Regression Indicators, Meta, Changes Since
+Last Snapshot, Trends.
+
+### Governance summary signals (9 fields)
+
+Reference: `governance-auditor.agent.md` Governance Summary section.
+
+Fields: Total constraints, Falsifiable, Vague, Falsifiability ratio,
+Semantic drift stage, Drift velocity, Governance debt items,
+Aggregate debt score, Frame alignment score.
+
+### Reflection entry signals (12 fields)
+
+Reference: `commands/reflect.md` entry template.
+
+8 mandatory fields + 4 session metadata subfields.
+
+### HARNESS.md signals (sections + subsections)
+
+Reference: `templates/HARNESS.md`
+
+4 top-level sections (Context, Constraints, GC, Observability) +
+Status section + template version marker.
+
+### Assessment signals (6 sections)
+
+Reference: `ai-literacy-assessment/references/assessment-template.md`
+
+Sections: Observable Evidence, Level Assessment, Discipline Maturity,
+Strengths, Gaps, Recommendations.
+
+## Components
+
+### 1. Signal checklist reference
+
+`skills/harness-observability/references/observatory-signals.md`
+
+The authoritative checklist of all signals the Observatory expects.
+Structured as a parseable table per source. This is the document the
+command reads — updating the checklist updates what gets verified.
+
+### 2. Command
+
+`commands/observatory-verify.md`
+
+Steps:
+
+1. Read the signal checklist reference
+2. For each signal source, find the latest output file
+3. Check each signal: PRESENT / PARTIAL / MISSING
+4. Produce a structured report table
+5. Print summary counts per source
+
+### 3. Validation checkpoint
+
+The command itself produces a report (to stdout, not a file), so no
+file-level validation checkpoint is needed. The report format is
+defined in the command spec.
+
+## Output format
+
+```text
+## Observatory Signal Verification
+
+| Signal | Source | Expected Location | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Enforcement count | Snapshot | ## Enforcement | PRESENT | |
+| ... | ... | ... | ... | ... |
+
+Summary: N PRESENT, N PARTIAL, N MISSING out of N total signals
+```
+
+Status values:
+- **PRESENT** — signal documented in format spec and present in latest output
+- **PARTIAL** — signal exists but incomplete (e.g. section present, field missing)
+- **MISSING** — signal not found in latest output
+- **NO_OUTPUT** — no output file exists yet (e.g. no snapshot generated)
+
+## Version
+
+0.20.0 — this is a new command but the version was already bumped for
+/harness-onboarding. If shipped in the same release, no additional
+bump needed. If shipped separately, bump to 0.21.0.


### PR DESCRIPTION
## Summary

New `/observatory-verify` command that runs the Observatory signal contract checklist against the latest output files. Reports PRESENT/PARTIAL/MISSING for each of 82 signals the Observatory expects to read.

### Components

- **Command**: `commands/observatory-verify.md` — 6-step verification process
- **Signal checklist**: `skills/harness-observability/references/observatory-signals.md` — authoritative list of all 82 signals across 5 sources

### Signal sources

| Source | Signals | File checked |
| --- | --- | --- |
| Snapshot sections | 39 | `observability/snapshots/*-snapshot.md` |
| Governance summary | 9 | `observability/governance/audit-*.md` |
| Reflection entries | 12 | `REFLECTION_LOG.md` |
| HARNESS.md structure | 15 | `HARNESS.md` |
| Assessment document | 7 | `assessments/*-assessment.md` |

### Origin

Improvement proposed in REFLECTION_LOG 2026-04-15: "A standing `/observatory-verify` command that runs the 72-signal checklist on demand would make signal contract auditing reusable."

Spec: `docs/superpowers/specs/2026-04-15-observatory-verify-design.md`

## Test plan

- [ ] CI passes (markdownlint, version-check, spec-first)
- [ ] Signal checklist totals match (39+9+12+15+7 = 82)
- [ ] README shows 21 commands, v0.21.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)