### PR TITLE
Fix marketplace.json source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Russ Miles"
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "plugin_version": "0.21.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
@@ -13,7 +13,7 @@
   "plugins": [
     {
       "name": "ai-literacy-superpowers",
-      "source": "./ai-literacy-superpowers/.claude-plugin/plugin.json",
+      "source": "ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
       "version": "0.21.0"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-16
+
+### Marketplace listing fix
+
+- Correct marketplace.json `source` to point at the plugin directory
+  (`ai-literacy-superpowers`) instead of the full path to `plugin.json`;
+  Claude Code resolves `.claude-plugin/plugin.json` inside the
+  directory automatically
+- Bump listing version 0.2.1 → 0.2.2 (listing contract change; plugin
+  version unchanged)
+
 ## 0.21.0 — 2026-04-15
 
 ### Observatory signal verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## 2026-04-16
-
-### Marketplace listing fix
-
-- Correct marketplace.json `source` to point at the plugin directory
-  (`ai-literacy-superpowers`) instead of the full path to `plugin.json`;
-  Claude Code resolves `.claude-plugin/plugin.json` inside the
-  directory automatically
-- Bump listing version 0.2.1 → 0.2.2 (listing contract change; plugin
-  version unchanged)
-
 ## 0.21.0 — 2026-04-15
 
 ### Observatory signal verification


### PR DESCRIPTION
## Summary
- Correct `source` in `.claude-plugin/marketplace.json` to `ai-literacy-superpowers` (plugin directory) instead of the full path to `plugin.json`
- Bump listing version 0.2.1 → 0.2.2 (listing contract change per CLAUDE.md); `plugin_version` unchanged
- Update `CHANGELOG.md`

Closes #163.

## Test plan
- [ ] CI checks pass (lint, spec-first, version-bump)
- [ ] marketplace.json still parses and plugin still resolvable from the directory form