### PR TITLE
Auto-sync marketplace cache on merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.2",
-  "plugin_version": "0.21.0",
+  "plugin_version": "0.22.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.21.0"
+      "version": "0.22.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 - Add `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` —
   fast-forwards `~/.claude/plugins/marketplaces/ai-literacy-superpowers`
-  when the listing version on `origin/main` differs from the cached
-  one; no-ops silently when cache missing, offline, or already current
+  when `marketplace.json` on `origin/main` differs from the cached
+  copy (any byte difference — covers listing version, `plugin_version`,
+  and per-plugin version bumps); no-ops silently when cache missing,
+  offline, or already current
 - Complements the existing `sync-to-global-cache.sh` (plugin content
   sync); this script handles the marketplace-clone side
 - Wire via a `PostToolUse` hook on `Bash(gh pr merge*)` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.22.0 — 2026-04-16
+
+### Marketplace cache auto-sync
+
+- Add `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` —
+  fast-forwards `~/.claude/plugins/marketplaces/ai-literacy-superpowers`
+  when the listing version on `origin/main` differs from the cached
+  one; no-ops silently when cache missing, offline, or already current
+- Complements the existing `sync-to-global-cache.sh` (plugin content
+  sync); this script handles the marketplace-clone side
+- Wire via a `PostToolUse` hook on `Bash(gh pr merge*)` in
+  `.claude/settings.local.json` so the cache refreshes the moment a
+  marketplace-affecting PR is merged through the CLI
+- Document the rule under **Marketplace Cache Auto-Sync** in CLAUDE.md
+  so collaborators can opt in by adding the same hook locally
+
 ## 0.21.0 — 2026-04-15
 
 ### Observatory signal verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,23 @@ This plugin's reusable components originate from the
 `ai-literacy-for-software-engineers` repo. When syncing changes,
 use the `/sync-repos` command in that repo to identify what
 needs updating, then apply changes via the PR workflow above.
+
+## Marketplace Cache Auto-Sync
+
+Claude Code keeps a git clone of this repo at
+`~/.claude/plugins/marketplaces/ai-literacy-superpowers/`. When a PR
+that changes `.claude-plugin/marketplace.json` is merged, the clone is
+stale until someone pulls it.
+
+Two scripts handle cache freshness:
+
+- `ai-literacy-superpowers/scripts/sync-to-global-cache.sh` — rsyncs
+  plugin content into the versioned plugin cache (runs on every `Stop`)
+- `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` — fast-
+  forwards the marketplace clone when the listing version on
+  `origin/main` differs from the cached one (runs on `PostToolUse`
+  matching `Bash(gh pr merge*)`)
+
+The hooks that invoke these scripts live in `.claude/settings.local.json`
+(gitignored, per-machine). Collaborators who want the same behaviour
+should copy those entries into their own local settings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,10 @@ Two scripts handle cache freshness:
 - `ai-literacy-superpowers/scripts/sync-to-global-cache.sh` — rsyncs
   plugin content into the versioned plugin cache (runs on every `Stop`)
 - `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` — fast-
-  forwards the marketplace clone when the listing version on
-  `origin/main` differs from the cached one (runs on `PostToolUse`
-  matching `Bash(gh pr merge*)`)
+  forwards the marketplace clone whenever `marketplace.json` on
+  `origin/main` differs from the cached copy (runs on `PostToolUse`
+  matching `Bash(gh pr merge*)`; catches listing version,
+  `plugin_version`, and per-plugin version bumps alike)
 
 The hooks that invoke these scripts live in `.claude/settings.local.json`
 (gitignored, per-machine). Collaborators who want the same behaviour

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.21.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.22.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-28-2E8B57?style=flat-square)](#skills-27)
 [![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
 [![Commands](https://img.shields.io/badge/Commands-21-2E8B57?style=flat-square)](#commands-19)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
+++ b/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Pull the global marketplace cache when marketplace.json changes upstream.
 #
 # Claude Code keeps ~/.claude/plugins/marketplaces/ai-literacy-superpowers
@@ -14,8 +15,6 @@
 # to block further work.
 #
 # Usage: bash sync-marketplace-cache.sh
-
-set -euo pipefail
 
 CACHE="${HOME}/.claude/plugins/marketplaces/ai-literacy-superpowers"
 

--- a/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
+++ b/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Pull the global marketplace cache when marketplace.json changes upstream.
+#
+# Claude Code keeps ~/.claude/plugins/marketplaces/ai-literacy-superpowers
+# as a git clone of this repo. When a PR that touches the top-level
+# marketplace version is merged, that clone is stale until someone pulls.
+# This script is invoked by a PostToolUse hook on `gh pr merge` and
+# fast-forwards the clone if the listing version on origin/main differs
+# from the cached one.
+#
+# Silent no-op when: cache directory missing, not a git repo, offline,
+# cache has local/ahead state that blocks fast-forward. The script never
+# fails the hook — a failed sync is a diagnostic annoyance, not a reason
+# to block further work.
+#
+# Usage: bash sync-marketplace-cache.sh
+
+set -euo pipefail
+
+CACHE="${HOME}/.claude/plugins/marketplaces/ai-literacy-superpowers"
+
+# Guard: cache must exist and be a git clone.
+[ -d "${CACHE}/.git" ] || exit 0
+
+# Fetch quietly; exit cleanly if offline or the remote is unreachable.
+git -C "${CACHE}" fetch --quiet origin 2>/dev/null || exit 0
+
+MARKETPLACE=".claude-plugin/marketplace.json"
+parse_version() {
+  # Extract the first top-level `"version": "X.Y.Z"` match — this is the
+  # listing version (plugin_version and per-plugin versions appear later).
+  sed -n 's/.*"version": "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' | head -1
+}
+
+CACHE_VER=$(parse_version < "${CACHE}/${MARKETPLACE}" || true)
+REMOTE_VER=$(git -C "${CACHE}" show "origin/main:${MARKETPLACE}" 2>/dev/null | parse_version || true)
+
+# Nothing to do if we can't read both, or versions already match.
+[ -n "${CACHE_VER}" ] && [ -n "${REMOTE_VER}" ] || exit 0
+[ "${CACHE_VER}" != "${REMOTE_VER}" ] || exit 0
+
+# Fast-forward only — refuse to rewrite cache history if it has diverged.
+if git -C "${CACHE}" pull --ff-only --quiet origin main 2>/dev/null; then
+  printf '{"systemMessage":"Marketplace cache synced: v%s \\u2192 v%s"}\n' \
+    "${CACHE_VER}" "${REMOTE_VER}"
+fi
+
+exit 0

--- a/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
+++ b/ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
@@ -3,20 +3,22 @@ set -euo pipefail
 # Pull the global marketplace cache when marketplace.json changes upstream.
 #
 # Claude Code keeps ~/.claude/plugins/marketplaces/ai-literacy-superpowers
-# as a git clone of this repo. When a PR that touches the top-level
-# marketplace version is merged, that clone is stale until someone pulls.
+# as a git clone of this repo. When a PR that touches marketplace.json is
+# merged — whether the change is the listing version, the plugin_version
+# pointer, or any other field — the clone is stale until someone pulls it.
 # This script is invoked by a PostToolUse hook on `gh pr merge` and
-# fast-forwards the clone if the listing version on origin/main differs
-# from the cached one.
+# fast-forwards the clone whenever marketplace.json on origin/main differs
+# from the cached copy.
 #
 # Silent no-op when: cache directory missing, not a git repo, offline,
-# cache has local/ahead state that blocks fast-forward. The script never
-# fails the hook — a failed sync is a diagnostic annoyance, not a reason
-# to block further work.
+# marketplace.json already matches origin/main, or cache has diverged
+# from origin (fast-forward refused). The script never fails the hook —
+# a failed sync is a diagnostic annoyance, not a reason to block work.
 #
 # Usage: bash sync-marketplace-cache.sh
 
 CACHE="${HOME}/.claude/plugins/marketplaces/ai-literacy-superpowers"
+MARKETPLACE=".claude-plugin/marketplace.json"
 
 # Guard: cache must exist and be a git clone.
 [ -d "${CACHE}/.git" ] || exit 0
@@ -24,24 +26,30 @@ CACHE="${HOME}/.claude/plugins/marketplaces/ai-literacy-superpowers"
 # Fetch quietly; exit cleanly if offline or the remote is unreachable.
 git -C "${CACHE}" fetch --quiet origin 2>/dev/null || exit 0
 
-MARKETPLACE=".claude-plugin/marketplace.json"
+# Gate: pull only if marketplace.json on origin/main differs from HEAD.
+# `diff --quiet` exits 0 when identical, 1 when different, 2+ on error.
+if git -C "${CACHE}" diff --quiet HEAD "origin/main" -- "${MARKETPLACE}"; then
+  exit 0
+fi
+
 parse_version() {
   # Extract the first top-level `"version": "X.Y.Z"` match — this is the
   # listing version (plugin_version and per-plugin versions appear later).
   sed -n 's/.*"version": "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' | head -1
 }
 
-CACHE_VER=$(parse_version < "${CACHE}/${MARKETPLACE}" || true)
-REMOTE_VER=$(git -C "${CACHE}" show "origin/main:${MARKETPLACE}" 2>/dev/null | parse_version || true)
-
-# Nothing to do if we can't read both, or versions already match.
-[ -n "${CACHE_VER}" ] && [ -n "${REMOTE_VER}" ] || exit 0
-[ "${CACHE_VER}" != "${REMOTE_VER}" ] || exit 0
+BEFORE_VER=$(parse_version < "${CACHE}/${MARKETPLACE}" || true)
 
 # Fast-forward only — refuse to rewrite cache history if it has diverged.
-if git -C "${CACHE}" pull --ff-only --quiet origin main 2>/dev/null; then
+git -C "${CACHE}" pull --ff-only --quiet origin main 2>/dev/null || exit 0
+
+AFTER_VER=$(parse_version < "${CACHE}/${MARKETPLACE}" || true)
+
+if [ -n "${BEFORE_VER}" ] && [ -n "${AFTER_VER}" ] && [ "${BEFORE_VER}" != "${AFTER_VER}" ]; then
   printf '{"systemMessage":"Marketplace cache synced: v%s \\u2192 v%s"}\n' \
-    "${CACHE_VER}" "${REMOTE_VER}"
+    "${BEFORE_VER}" "${AFTER_VER}"
+else
+  printf '{"systemMessage":"Marketplace cache synced (marketplace.json updated)."}\n'
 fi
 
 exit 0

--- a/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
+++ b/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
@@ -1,0 +1,72 @@
+# Marketplace Cache Auto-Sync — Design Spec
+
+## Problem
+
+Claude Code keeps the marketplace listing for this plugin as a git
+clone at `~/.claude/plugins/marketplaces/ai-literacy-superpowers/`.
+When a PR that changes `.claude-plugin/marketplace.json` is merged,
+that clone is stale until a human (or another tool) runs `git pull`
+against it. Stale clones serve the old `source` path, the old
+`plugin_version`, and the old listing metadata — all invisible
+failures that surface only when users try to install or update the
+plugin on a fresh machine.
+
+The existing `sync-to-global-cache.sh` handles the other half of the
+cache (`~/.claude/plugins/cache/ai-literacy-superpowers/<version>/`),
+but it only syncs plugin *content* from the local working tree — it
+does nothing for the marketplace clone.
+
+## Decision
+
+Add a companion script, `sync-marketplace-cache.sh`, invoked by a
+`PostToolUse` hook that matches `Bash(gh pr merge*)`. When a merge
+happens through the Claude Code CLI, the hook fires, the script
+fetches `origin`, compares the listing version in the clone's
+`marketplace.json` to the one on `origin/main`, and fast-forwards
+the clone if they differ.
+
+Three properties are non-negotiable:
+
+1. **Silent no-op when state is unusual.** Missing cache directory,
+   offline, non-fast-forward state, or already-current versions all
+   exit 0 without output. A failed sync is a diagnostic annoyance,
+   never a reason to block the parent hook chain or the user's work.
+2. **Version-gated pull.** The script compares the top-level
+   `version` field (listing version) between cache and
+   `origin/main`. It only pulls when they differ. This matches the
+   user's request ("when the marketplace version changes") and
+   avoids pulling on every merge.
+3. **Fast-forward only.** If the cache has diverged from
+   `origin/main` (unexpected), the script refuses to rewrite its
+   history and exits silently. The user investigates manually.
+
+## Scope
+
+In scope:
+
+- `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh`
+  (committed in the plugin directory so anyone installing the
+  plugin has the script available)
+- Hook wiring in `.claude/settings.local.json` (gitignored, per-
+  machine) so the author's setup invokes it automatically
+- Documentation in `CLAUDE.md` so collaborators know how to opt in
+
+Out of scope for this spec:
+
+- A `SessionStart` hook to catch PRs merged through the GitHub web
+  UI (belt-and-braces; deferrable follow-up)
+- Project-level settings.json enforcement (would require confirming
+  the hook is safe for all collaborators regardless of their plugin
+  install state)
+- Telemetry or metrics on how often the sync fires
+
+## Consequences
+
+- One more script to maintain; mirrored structure to the existing
+  sync-to-global-cache script limits the cost.
+- The rule only fires for CLI-driven merges. Web-UI merges remain
+  the user's manual responsibility until a SessionStart companion
+  hook lands.
+- The cache pull depends on network availability at merge time; the
+  script silently skips when offline, so the cache stays at the
+  pre-merge state until the next successful run.

--- a/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
+++ b/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
@@ -28,14 +28,17 @@ the clone if they differ.
 Three properties are non-negotiable:
 
 1. **Silent no-op when state is unusual.** Missing cache directory,
-   offline, non-fast-forward state, or already-current versions all
+   offline, non-fast-forward state, or already-current file all
    exit 0 without output. A failed sync is a diagnostic annoyance,
    never a reason to block the parent hook chain or the user's work.
-2. **Version-gated pull.** The script compares the top-level
-   `version` field (listing version) between cache and
-   `origin/main`. It only pulls when they differ. This matches the
-   user's request ("when the marketplace version changes") and
-   avoids pulling on every merge.
+2. **File-diff-gated pull.** The script pulls when
+   `marketplace.json` on `origin/main` differs from the cached
+   copy — any byte difference qualifies. The narrower "listing
+   version changed" reading was considered and rejected: most
+   plugin release PRs change `plugin_version` (or the per-plugin
+   version) but leave the listing version untouched, which would
+   leave the cache stale after every ordinary release. Gating on
+   the whole file catches all cases at negligible extra cost.
 3. **Fast-forward only.** If the cache has diverged from
    `origin/main` (unexpected), the script refuses to rewrite its
    history and exits silently. The user investigates manually.


### PR DESCRIPTION
## Summary
- Add `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` — fast-forwards `~/.claude/plugins/marketplaces/ai-literacy-superpowers` when the listing version on `origin/main` differs from the cached one
- Wire via a `PostToolUse` hook on `Bash(gh pr merge*)` in `.claude/settings.local.json` (gitignored, per-machine)
- Document the rule under **Marketplace Cache Auto-Sync** in `CLAUDE.md` so collaborators can opt in
- Bump plugin 0.21.0 → 0.22.0 (behavioural change) and sync `marketplace.json` `plugin_version`

Design spec: `docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md`

Closes #165.

## Test plan
- [ ] CI checks pass (lint, spec-first, version-consistency, PR constraints)
- [ ] `bash ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` runs silently when cache version already matches `origin/main`
- [ ] Script is a no-op when `~/.claude/plugins/marketplaces/ai-literacy-superpowers` is absent
- [ ] Hook schema validates via `jq -e` on `.claude/settings.local.json`

## Known follow-ups
- A `SessionStart` companion hook would catch web-UI merges; deliberately out of scope for this PR (noted in spec).