### PR TITLE
Fix Copilot CLI install instructions (partial #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 0.22.0 — 2026-04-16
 
+### Copilot CLI install instructions
+
+- Fix README Copilot CLI install block — add missing
+  `copilot plugin marketplace add` step and correct the install
+  command to `copilot plugin install ai-literacy-superpowers@ai-literacy-superpowers`
+  so users on Copilot CLI can actually install the plugin without
+  hitting "plugin not found"
+- Mirror the corrected install block in `docs/index.md` Quick Install
+  so the docs site and README agree; Claude Code and Copilot CLI
+  steps are now shown side-by-side in both places
+- Partial fix for #168 (leaves `docs/how-to/install-the-plugin.md`
+  how-to page and `docs/tutorials/getting-started.md` tutorial-step
+  update for a follow-up)
+
 ### Marketplace cache auto-sync
 
 - Add `ai-literacy-superpowers/scripts/sync-marketplace-cache.sh` —

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ claude plugin install ai-literacy-superpowers
 ### GitHub Copilot CLI
 
 ```bash
-/plugin install ai-literacy-superpowers
+# Add the marketplace
+copilot plugin marketplace add Habitat-Thinking/ai-literacy-superpowers
+
+# Install the plugin
+copilot plugin install ai-literacy-superpowers@ai-literacy-superpowers
 ```
 
 Once installed, the plugin's skills, agents, hooks, and commands (or prompts) are available in any session within your project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,18 @@ session.
 
 ## Quick Install
 
+**Claude Code:**
+
 ```bash
 claude plugin marketplace add Habitat-Thinking/ai-literacy-superpowers
 claude plugin install ai-literacy-superpowers
+```
+
+**GitHub Copilot CLI:**
+
+```bash
+copilot plugin marketplace add Habitat-Thinking/ai-literacy-superpowers
+copilot plugin install ai-literacy-superpowers@ai-literacy-superpowers
 ```
 
 Then in any project:


### PR DESCRIPTION
## Summary

- Replace the broken Copilot CLI install snippet in `README.md` with the correct two-step flow: `copilot plugin marketplace add Habitat-Thinking/ai-literacy-superpowers` followed by `copilot plugin install ai-literacy-superpowers@ai-literacy-superpowers`.
- Add a parallel Copilot CLI block to `docs/index.md` Quick Install so the docs site's install instructions match the README.
- Previous text (`/plugin install ai-literacy-superpowers`) had no marketplace registration step and used the wrong command shape, so anyone following it on Copilot CLI would hit a plugin-not-found error.

## Scope

This is a **partial fix for #168**. It closes the first acceptance criterion (README Copilot steps match Claude Code in shape) and the spirit of the second (docs site shows the right commands in the most visible install location). The remaining work for #168 — a dedicated `docs/how-to/install-the-plugin.md`, cross-links from the how-to index, and parallel updates in `docs/tutorials/getting-started.md` Step 1 and `docs/how-to/update-the-plugin.md` — is intentionally left for a follow-up PR so this fix can ship quickly.

## Version bump

No plugin version bump required — all changes are outside `ai-literacy-superpowers/` (README, docs, CHANGELOG only).

## Test plan

- [ ] `markdownlint-cli2` clean on `README.md`, `docs/index.md`, `CHANGELOG.md` (verified locally)
- [ ] Lint Markdown workflow green in CI
- [ ] Manual render check: README Installation section shows both Claude Code and Copilot CLI two-step blocks in parallel
- [ ] Manual render check: docs/index.md Quick Install shows both runtimes