### PR TITLE
Fix marketplace.json source schema — restore ./ prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Russ Miles"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "plugin_version": "0.22.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
@@ -13,7 +13,7 @@
   "plugins": [
     {
       "name": "ai-literacy-superpowers",
-      "source": "ai-literacy-superpowers",
+      "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
       "version": "0.22.0"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 0.22.0 — 2026-04-16
 
+### Marketplace source schema fix
+
+- Fix `source` field in `.claude-plugin/marketplace.json` — bare string
+  form (`"ai-literacy-superpowers"`) from #164 is rejected by the
+  Claude Code marketplace schema with `plugins.0.source: Invalid input`;
+  restore the required `./` prefix (`"./ai-literacy-superpowers"`) so
+  `claude plugin marketplace add Habitat-Thinking/ai-literacy-superpowers`
+  parses again
+- Bump listing `version` 0.2.2 → 0.2.3 (source path is a listing
+  contract change per CLAUDE.md); `plugin_version` unchanged
+- Documented behaviour: marketplace `source` as a plain string must be
+  a relative path starting with `./`; the runtime resolves it to the
+  plugin directory and loads `.claude-plugin/plugin.json` from there
+
 ### Copilot CLI install instructions
 
 - Fix README Copilot CLI install block — add missing


### PR DESCRIPTION
## Summary

Users running \`claude plugin marketplace add Habitat-Thinking/ai-literacy-superpowers\` currently hit:

> Failed to parse marketplace file: Invalid schema: plugins.0.source: Invalid input

### Root cause

PR #164 changed \`plugins[0].source\` from \`"./ai-literacy-superpowers/.claude-plugin/plugin.json"\` to \`"ai-literacy-superpowers"\`, on the assumption that the runtime would resolve a bare plugin-directory name. That's half right — the runtime does resolve to the directory and append \`.claude-plugin/plugin.json\` — but the [marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces.md#plugin-sources) requires the relative-path string form to start with \`./\`. The bare string fails schema validation before the path is ever resolved.

### Fix

- \`"source": "./ai-literacy-superpowers"\` — keeps the plugin-directory semantics from #164, satisfies the schema.
- Bump listing \`version\` 0.2.2 → 0.2.3 (source path is a listing contract change per CLAUDE.md).
- \`plugin_version\` unchanged — no plugin code touched.

Closes the install regression introduced in #164.

## Test plan

- [ ] CI green (lint, version-consistency, spec-first auto-exempt via \`fix/\` branch prefix, PR constraints)
- [ ] After merge + marketplace cache sync: \`claude plugin marketplace add Habitat-Thinking/ai-literacy-superpowers\` parses without schema error
- [ ] \`claude plugin install ai-literacy-superpowers\` resolves the plugin directory and registers it