### PR TITLE
Bump HARNESS.md template-version marker to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.22.0 — 2026-04-16
 
+### Harness template-version marker bump
+
+- Bump `HARNESS.md` template-version marker 0.21.0 → 0.22.0 after
+  running `/harness-upgrade`; no new constraints, GC rules, or sections
+  to adopt (template content is unchanged since 0.19.0 — the plugin
+  version advanced three releases without template edits)
+- Silences the template-currency GC finding until the next plugin
+  upgrade introduces new template content
+
 ### Marketplace source schema fix
 
 - Fix `source` field in `.claude-plugin/marketplace.json` — bare string

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.21.0 -->
+<!-- template-version: 0.22.0 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Ran `/harness-upgrade` with plugin 0.22.0 against HARNESS.md at 0.21.0
- No new constraints, GC rules, sections, or commented-out blocks to adopt — template content is unchanged since 0.19.0
- Bumps the `template-version` marker 0.21.0 → 0.22.0 and adds a CHANGELOG note under today's existing 0.22.0 section

## Why

The template-currency GC rule and SessionStart upgrade nudge compare the in-file marker to the plugin's declared version, not to actual template content. Since 0.20, 0.21, and 0.22 shipped without template edits, every release produces a phantom "upgrade available" signal until the marker catches up.

## Scope

- Changes outside `ai-literacy-superpowers/`, so no plugin version bump (per CLAUDE.md)
- Maintenance change, not feature work — `chore` label applied so the spec-first CI gate is exempt

## Test plan

- [x] `npx markdownlint-cli2 HARNESS.md CHANGELOG.md` passes
- [ ] CI green
- [ ] Merge, then confirm template-currency GC no longer flags on next snapshot

Closes #171