### PR TITLE
Add reflection and document CHANGELOG heading format in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@
   installation walkthrough
 - Docs-only change; no plugin version bump (0.22.0 retained)
 
+### CLAUDE.md — CHANGELOG heading format made explicit
+
+- Rewrite the "CHANGELOG" section of `CLAUDE.md` to state the hard
+  invariant enforced by the `Check version consistency` CI step:
+  every top-level `## ...` heading MUST begin with a semver version
+  (`## X.Y.Z — YYYY-MM-DD`). Date-only headings silently parse as the
+  first token (for example `2026`) and fail CI with a cryptic
+  mismatch error.
+- Make the docs-only path explicit: append entries under the most
+  recent version's heading; do not create a new top-level heading
+  without a version. Closes the recommendation from the 2026-04-16
+  reflection that had gone unactioned and caused a repeat CI failure
+  on PR #173 (captured in the 2026-04-18 reflection).
+
 ### Harness template-version marker bump
 
 - Bump `HARNESS.md` template-version marker 0.21.0 → 0.22.0 after

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,20 @@ No postamble, trailer, or attribution lines.
 
 Before every PR, update `CHANGELOG.md`:
 
-- Add a dated section at the top if today's date is not already present
-- Group entries under a short theme heading
-- One bullet per change: what changed and why it matters
+- **Every top-level `## ...` heading MUST begin with a semver version
+  followed by a dash and date — `## X.Y.Z — YYYY-MM-DD`.** CI
+  (`Check version consistency`) reads the first whitespace-delimited
+  token after `##` and matches it against `plugin.json`. A date-only
+  heading like `## 2026-04-18` silently parses as `2026` and fails the
+  check with a cryptic version-mismatch error.
+- **For docs-only or other changes that do not bump the plugin
+  version**, append entries under the most recent version's heading.
+  Do not create a new top-level heading without a version.
+- **For plugin changes that warrant a version bump** (see "Semantic
+  Versioning" below), update the top heading to the new version and
+  today's date, then add your entries underneath.
+- Group entries under a short theme heading (`### ...`).
+- One bullet per change: what changed and why it matters.
 
 ## Semantic Versioning
 

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -260,3 +260,19 @@
   - Model tiers used: most-capable (main conversation, 100%; no subagents dispatched)
   - Pipeline stages completed: source fix (spec-first exempt via `chore` label), issue, branch, CI iteration, merge; spec-first design doc, hook script, settings wiring, CLAUDE.md rule, plugin bump, PR, rebase after first merge, broadening tweak, merge; 2 PRs (#164, #166), reflect
   - Agent delegation: manual (direct implementation; no orchestrator/spec-writer/tdd-agent invoked)
+
+---
+
+- **Date**: 2026-04-18
+- **Agent**: claude-opus-4-7 (main conversation, no subagents)
+- **Task**: Added docs/tutorials/first-time-tour.md — a single-route walk through all 21 plugin capabilities in the order most useful on a first run, organised into eight phases with the sequencing rationale made explicit. PR #173, merged to main. No plugin version bump (docs-only).
+- **Surprise**: The version-consistency CI failure that bit me today was explicitly documented in the 2026-04-16 reflection's Improvement field — "date-only heading silently extracts '2026' and fails with a cryptic mismatch; CLAUDE.md should call out the heading format." I hit the exact same bug two days later because REFLECTION_LOG.md Improvements are not load-bearing — they are captured but not routed anywhere that influences future sessions. The compound-learning loop has generation (we reflect) and storage (log grows) but no *retrieval* — future agents do not read the log for warnings before touching the relevant surface. This is a gap between "we captured the signal" and "the signal changed behaviour next time."
+- **Proposal**: CONTEXT: Update CLAUDE.md "CHANGELOG" section to state the hard invariant enforced by CI: "Every top-level `## ...` heading MUST begin with a semver version (e.g. `## 0.22.0 — YYYY-MM-DD`). For docs-only changes that do not bump the plugin version, append entries under the most recent version's heading — do not create a dated-only top-level heading." This is the fix the previous reflection recommended; it is still unactioned. WORKFLOW: When a session's Surprise field describes a failure mode, consider running `/harness-constrain` or editing CLAUDE.md in the same session rather than leaving the fix implicit in the log. The prior reflection shows that "improvements" left to propagate organically do not propagate.
+- **Improvement**: Reflections need a retrieval hook, not just a write hook. Candidate: a SessionStart-phase GC rule that scans recent REFLECTION_LOG.md Improvement fields for keywords matching the files/commands touched in the current session, and surfaces them as warnings before the work starts. The current architecture treats REFLECTION_LOG.md as a write-only audit trail; to close the learning loop it needs to be read at the right moments.
+- **Signal**: failure
+- **Constraint**: none
+- **Session metadata**:
+  - Duration: ~45 min
+  - Model tiers used: most-capable (main conversation, 100%; no subagents dispatched)
+  - Pipeline stages completed: manual tutorial draft, commit, push, PR, 2 CI failures (spec-first, version-consistency), fix-up commit, label add (chore), merge; no orchestrator pipeline used
+  - Agent delegation: manual


### PR DESCRIPTION
## Summary

Two related changes driven by today's `/reflect`:

1. **Reflection entry (2026-04-18)** — captures that PR #173 hit the exact version-consistency CI failure that the 2026-04-16 reflection had already documented in its Improvement field. That improvement went unactioned and the same bug bit again two days later. Signal: `failure`.
2. **CLAUDE.md CHANGELOG section rewrite** — action on the recommendation. The section now states the hard invariant explicitly: every top-level `## ...` heading MUST begin with a semver version. Date-only headings silently parse as the first token (`2026`) and fail CI with a cryptic mismatch error. The docs-only path — append under the most recent version's heading — is made explicit so future contributors do not repeat the mistake.

## Why this matters beyond the fix

The reflection also flags a deeper issue: REFLECTION_LOG.md Improvements are write-only. Future agents don't read them before touching the relevant surface, so captured signal doesn't change future behaviour. The follow-up candidate (outside this PR) is a retrieval hook — a SessionStart check that surfaces prior improvements relevant to files/commands about to be touched.

## Branch uses `chore/` prefix

Triggers the spec-first exemption — this is a docs/convention change, not feature work. No new commands, skills, agents, or behavioural changes.

## No version bump

Root-level docs (`CLAUDE.md`, `CHANGELOG.md`, `REFLECTION_LOG.md`). Nothing inside `ai-literacy-superpowers/` changed.

## Test plan

- [ ] `Check version consistency` passes (CHANGELOG entry added under existing `0.22.0` heading — no new top-level heading)
- [ ] `Check spec-first commit ordering` passes (branch prefix `chore/`)
- [ ] `markdownlint` passes
- [ ] `Enforce PR constraints` passes