### PR TITLE
Add advocatus-diaboli adversarial spec review (v0.23.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.22.0",
+  "plugin_version": "0.23.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",

--- a/.github/prompts/diaboli.prompt.md
+++ b/.github/prompts/diaboli.prompt.md
@@ -1,0 +1,33 @@
+---
+name: diaboli
+description: Run the adversarial spec reviewer on a spec file — produces or regenerates the objection record at docs/superpowers/objections/<spec-slug>.md; use after spec-writer completes or when a spec is substantively edited
+---
+
+# Diaboli
+
+Run the advocatus-diaboli adversarial reviewer against a spec file.
+
+## Usage
+
+```
+/diaboli docs/superpowers/specs/<date>-<name>.md
+```
+
+## Steps
+
+1. Confirm the spec file exists at the path provided
+2. Derive the slug: strip the date prefix and `.md` extension from the filename
+3. Read the spec file in full
+4. Read `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` for the
+   charter, six categories, severity definitions, and output format
+5. Generate objection record content following the skill's output format:
+   - YAML frontmatter with all objections (`disposition: pending`, `disposition_rationale: null`)
+   - Prose sections per objection (`## O<N> — <category> — <severity>`)
+   - Closing "Explicitly not objecting to" section (at least three entries)
+6. Write to `docs/superpowers/objections/<slug>.md` (overwrite if exists)
+7. Validate the written file: check frontmatter structure, field presence,
+   pending dispositions, category/severity enum values, objection count (1–12),
+   prose sections, closing section
+8. Fix any validation failures in place
+9. Report: output path, objection count (major/minor), category distribution
+10. Remind the user to fill in dispositions before the plan-approval gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,24 @@
   (rejected — hooks are advisory-only with 30-second timeouts, too
   limited for format verification). (Source: REFLECTION_LOG 2026-04-15)
 
+- Decision: advocatus-diaboli is hard-wired into the spec-first pipeline as an
+  agent-enforced PR constraint from the outset (Option B — not optional, not
+  advisory). The agent is dispatched after spec-writer and before plan approval;
+  the plan-approval gate refuses progression while any disposition is `pending`;
+  the harness-enforcer checks objection record completeness at PR time.
+  Alternatives considered and rejected: (1) manual invocation only — discovers
+  utility in early PRs but never creates discipline; users skip it under pressure;
+  (2) advisory gate without constraint — same failure mode; the gate exists only
+  when someone remembers to run it; (3) deterministic schema check alone — can
+  verify no `pending` values remain but cannot detect rubber-stamping
+  (`disposition: accepted, rationale: "ok"` would pass). Agent enforcement is
+  chosen because "resolved" is a judgment call on rationale quality. Conditions
+  under which this would be revisited: if disposition distribution clusters on
+  `deferred — not material` over a meaningful sample (20+ PRs), tune the SKILL.md
+  charter (tighten evidence requirements, raise the evidence bar) before weakening
+  the constraint. Do not weaken the constraint at first friction — that builds
+  ceremony, not a gate.
+
 ## TEST_STRATEGY
 
 <!-- How tests are structured in this project. Helps agents write consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.23.0 — 2026-04-19
+
+### Feature — advocatus-diaboli adversarial spec review
+
+- Add `skills/advocatus-diaboli/SKILL.md` — charter for the adversarial
+  spec reviewer: six objection categories (premise, design, threat, failure,
+  operational, cost), severity levels (major/minor), 12-objection cap,
+  evidence requirement per objection, mandatory "Explicitly not objecting to"
+  section; intellectual foundations grounded in the historical Promoter of
+  the Faith, Popper on falsifiability, and an explicit anti-Schopenhauer
+  framing (no rhetorical tricks, no winning for its own sake)
+- Add `agents/advocatus-diaboli.agent.md` — read-only agent (Read/Glob/Grep
+  only) that reads a spec and returns objection record content to the
+  orchestrator; disposition fields cannot be written by any agent — this
+  constraint is the human-cognition gate
+- Add `commands/diaboli.md` — `/diaboli <spec-path>` for manual invocation
+  and regeneration; includes a 10-point validation checkpoint per the
+  output-validation-checkpoints constraint
+- Add `.github/prompts/diaboli.prompt.md` — Copilot CLI equivalent
+- Update `agents/orchestrator.agent.md` — pipeline is now: spec-writer →
+  advocatus-diaboli → GATE (objection adjudication, blocked on `pending`) →
+  GATE (plan approval with adjudicated record) → tdd-agent → …
+- Update `HARNESS.md` — add "Spec has adjudicated objections" constraint
+  (agent-enforced, scope pr) with pre-2026-04-19 exemption; add "Objection
+  record freshness" GC rule (deterministic, weekly)
+- Update `templates/HARNESS.md` — new projects scaffolded by `/superpowers-init`
+  inherit both the constraint and the GC rule
+- Update `MODEL_ROUTING.md` — advocatus-diaboli routed to most-capable tier
+  (judgment-heavy, not throughput-heavy)
+- Update `AGENTS.md` — ARCH_DECISION: diaboli hard-wired as PR constraint
+  from the outset; rejected alternatives documented (manual-only, advisory
+  gate, deterministic schema check alone)
+- Create `docs/superpowers/objections/` — directory for objection records
+
 ## 0.22.0 — 2026-04-17
 
 ### Docs — first-time tour tutorial

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -194,6 +194,20 @@
 - **Tool**: harness-enforcer agent
 - **Scope**: pr
 
+### Spec has adjudicated objections
+
+- **Rule**: Every feature or behaviour-change spec must have a corresponding
+  objection record at `docs/superpowers/objections/<spec-slug>.md` with all
+  dispositions resolved (no `pending` values). Bug fixes, dependency updates,
+  and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or
+  branch-prefixed `fix/`, `chore/`) are exempt on the same terms as
+  spec-first-commit-ordering. Specs created before 2026-04-19 are exempt —
+  add `diaboli: exempt-pre-existing` to their frontmatter or rely on the
+  dated cutoff in the constraint text.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer
+- **Scope**: pr
+
 ### Tests must pass
 
 - **Rule**: The project's test suite must pass with zero failures before
@@ -374,6 +388,17 @@ Use /governance-constrain for guided authoring of governance constraints.
 - **Tool**: harness-gc agent
 - **Auto-fix**: false
 
+### Objection record freshness
+
+- **What it checks**: Whether any spec file in `docs/superpowers/specs/`
+  has been modified more recently than its corresponding objection record
+  in `docs/superpowers/objections/` — a spec edited without re-running
+  `/diaboli` produces a stale objection record
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: find docs/superpowers/specs -name "*.md" -newer docs/superpowers/objections/$(basename "$f" .md | sed 's/^[0-9-]*-//').md 2>/dev/null | grep .
+- **Auto-fix**: false
+
 <!-- Uncomment if governance constraints are declared above:
 
 ### Governance constraint freshness
@@ -493,6 +518,6 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
 Last audit: 2026-04-15
-Constraints enforced: 13/14
-Garbage collection active: 14/14
+Constraints enforced: 13/15
+Garbage collection active: 15/15
 Drift detected: yes

--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -9,6 +9,7 @@
 | --- | --- | --- |
 | orchestrator | Most capable | Coordination, judgment, decomposition |
 | spec-writer | Most capable | Design judgment, specification quality |
+| advocatus-diaboli | Most capable | Adversarial reasoning, evidence-grounded objection — judgment-heavy, not throughput-heavy |
 | tdd-agent | Standard | Structured output from specs |
 | {{LANGUAGE}}-implementer | Standard / Capable | Depends on task complexity |
 | code-reviewer | Most capable | Nuance, quality judgment |

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Plugin Version](https://img.shields.io/badge/Plugin-v0.22.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
-[![Skills](https://img.shields.io/badge/Skills-28-2E8B57?style=flat-square)](#skills-27)
-[![Agents](https://img.shields.io/badge/Agents-11-2E8B57?style=flat-square)](#agents-11)
-[![Commands](https://img.shields.io/badge/Commands-21-2E8B57?style=flat-square)](#commands-19)
+[![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
+[![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
+[![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)
 [![Harness](https://img.shields.io/badge/Harness-13%2F14_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -120,7 +120,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 ## What You Get
 
-### Skills (27)
+### Skills (29)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -153,8 +153,9 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | governance-constraint-design | Falsifiable governance constraint authoring — three-frame translation, anti-patterns gallery, governance constraint template |
 | governance-audit-practice | Governance audit methodology — five-stage semantic drift model, debt scoring matrix, frame alignment review |
 | governance-observability | Governance metrics catalogue, snapshot format extension, and HTML dashboard specification |
+| advocatus-diaboli | Adversarial spec review — six-category objection framework, evidence requirements, steel-manned challenge before plan approval |
 
-### Agents (11)
+### Agents (12)
 
 A coordinated team that handles the full development lifecycle.
 
@@ -171,8 +172,9 @@ A coordinated team that handles the full development lifecycle.
 | harness-auditor | Meta-agent — checks whether the harness matches reality | Write to Status only |
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
+| advocatus-diaboli | Adversarial spec reviewer — six-category objection record, read-only trust boundary, human-cognition gate on dispositions | Read only |
 
-### Commands (19)
+### Commands (22)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -197,6 +199,7 @@ A coordinated team that handles the full development lifecycle.
 | `/harness-upgrade` | Discover and adopt new template content after a plugin upgrade |
 | `/harness-onboarding` | Generate a human-readable onboarding guide from harness state |
 | `/observatory-verify` | Verify all Observatory signal contracts against latest output files |
+| `/diaboli` | Run the adversarial spec reviewer — produces objection record at `docs/superpowers/objections/<slug>.md` |
 
 ### Templates (11)
 
@@ -347,7 +350,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (27)                     Domain knowledge for agents
+│   └── Skills (29)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings
@@ -364,9 +367,11 @@ STRICT LOOP (merge time — block until green)
 │
 ├── Agent Pipeline
 │   ├── orchestrator                    Coordinates full pipeline
-│   │   ├── GATE: plan approval         User reviews spec before implementation
+│   │   ├── GATE: objection adjudication User resolves objections before proceeding
+│   │   ├── GATE: plan approval         User reviews spec + adjudicated objections
 │   │   └── GUARDRAIL: MAX_REVIEW_CYCLES=3
 │   ├── spec-writer                     Spec + plan updates (no Bash)
+│   ├── advocatus-diaboli               Adversarial spec review (read-only)
 │   ├── tdd-agent                       Failing tests from spec scenarios
 │   ├── implementer(s)                  Makes tests green — user-created per
 │   │                                   language, not shipped by the plugin
@@ -473,7 +478,9 @@ When you use the orchestrator agent, it runs this pipeline:
 ```text
 orchestrator
   → spec-writer
-  → GATE: plan approval (user reviews before proceeding)
+  → advocatus-diaboli (adversarial review — read-only, produces objection record)
+  → GATE: objection adjudication (user writes dispositions; gate blocked while any is `pending`)
+  → GATE: plan approval (user reviews plan + adjudicated objection record)
   → tdd-agent
   → implementer(s) (parallel, one per language — user-created per project)
   → code-reviewer
@@ -481,7 +488,7 @@ orchestrator
   → integration-agent (includes reflection step)
 ```
 
-The plan approval gate catches bad plans before they become bad code. The loop guardrail prevents unbounded reviewer cycles. Both keep the orchestration from running away.
+The objection adjudication gate raises premise-level challenges before any tests or code exist — the cheapest moment to change course. The plan approval gate catches bad plans before they become bad code. The loop guardrail prevents unbounded reviewer cycles.
 
 The plugin ships the orchestrator, spec-writer, tdd-agent, code-reviewer, and integration-agent. Language-specific implementers are not included — each project creates its own based on the stack. See [How to Extend](#how-to-extend) for instructions.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.22.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.23.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
 [![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
+++ b/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
@@ -1,0 +1,91 @@
+---
+name: advocatus-diaboli
+description: Use after spec-writer completes and before plan approval — reads a spec file and produces a structured objection record at docs/superpowers/objections/<spec-slug>.md; read-only trust boundary enforces the human-cognition gate on dispositions
+tools: [Read, Glob, Grep]
+---
+
+# Advocatus Diaboli Agent
+
+You are the adversarial reviewer in the spec-first pipeline. You read a spec,
+raise the strongest honest objections you can find, and write a structured
+objection record. You do not write code. You do not modify specs. You do not
+write dispositions — that is the human's job, and your tool boundary enforces it.
+
+## Your first action
+
+Read the `advocatus-diaboli` skill:
+
+```
+ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+```
+
+The skill defines your charter, the six objection categories, severity levels,
+evidence requirements, the 12-objection cap, and the output format. Follow it
+exactly.
+
+## Input
+
+You receive a spec file path. Read the spec in full before raising any objections.
+Also read any referenced files the spec explicitly points to (linked designs,
+existing constraints, related specs) — objections grounded only in the spec text
+may miss context the spec assumed the reader already had.
+
+## Trust Boundary
+
+You have **Read, Glob, and Grep only**. You cannot write files. You cannot
+execute shell commands. You cannot modify the spec or any implementation file.
+
+This is not a limitation — it is the mechanism. The objection record must be
+written by the orchestrator using content you return in your output message.
+The disposition fields cannot be filled by any agent. They can only be filled
+by a human opening the file and editing it. That constraint IS the
+cognitive-engagement gate.
+
+## Reasoning Protocol
+
+Work through each of the six categories in order:
+
+1. **premise** — does the spec solve the right problem?
+2. **design** — does the chosen approach have structural flaws?
+3. **threat** — does the design create or ignore trust/abuse-model gaps?
+4. **failure** — what foreseeable failures does the design not address?
+5. **operational** — will this be difficult to operate correctly?
+6. **cost** — is the cost disproportionate and unacknowledged?
+
+For each category, ask: "What is the strongest honest objection I can make?"
+If the answer is "none that meets the evidence bar," skip that category.
+Do not manufacture objections. An empty category is not a failure.
+
+Assign severity (`major` or `minor`) before writing the objection. If you
+cannot assign a severity, the objection is not ready.
+
+Cap at 12 objections. If you have more than 12 candidates, select the 12 with
+the highest severity and strongest evidence.
+
+## Output
+
+Return the full content of the objection record in your response to the
+orchestrator. The orchestrator writes it to
+`docs/superpowers/objections/<spec-slug>.md`.
+
+The slug is derived from the spec filename: strip the date prefix and `.md`
+extension. Example:
+`docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → `advocatus-diaboli`.
+
+Use the exact output format specified in the skill:
+
+- YAML frontmatter with all objections, each having `disposition: pending` and
+  `disposition_rationale: null`
+- One prose section per objection (`## O<N> — <category> — <severity>`)
+- A closing "Explicitly not objecting to" section with at least three entries
+
+## What you report to the orchestrator
+
+Return:
+
+1. The full objection record content (to be written to the objections file)
+2. A summary: number of objections by category and severity
+3. Whether any major objections were raised (yes/no)
+4. The slug used for the output path
+
+The orchestrator writes the file; you provide the content.

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -40,7 +40,14 @@ Run the agents in this order. Steps marked PARALLEL may be dispatched in a singl
 message with multiple Agent tool calls.
 
   1. SEQUENTIAL  — spec-writer        Update spec and plan files first.
-     GATE: Plan Approval — present plan summary to user; wait for approval.
+  1a. SEQUENTIAL — advocatus-diaboli  Read the spec; produce objection record.
+     GATE: Objection Adjudication — surface the objection record to the user.
+           Refuse to proceed while any disposition is `pending`. The user writes
+           dispositions (`accepted`/`deferred`/`rejected`) and rationales inline
+           in docs/superpowers/objections/<spec-slug>.md. Do NOT let any agent
+           write dispositions — this is the cognitive-engagement mechanism.
+     GATE: Plan Approval — once all dispositions are resolved, present the plan
+           summary alongside the adjudicated objection record; wait for approval.
   2. SEQUENTIAL  — tdd-agent          Write failing tests from the new scenarios.
   3. PARALLEL    — (implementers)     Make tests green — dispatch one agent per
                                        language or implementation domain as needed.
@@ -65,19 +72,61 @@ message with multiple Agent tool calls.
    `gh issue create --title "TITLE" --body "DESCRIPTION"`
    Record the issue number — pass it to integration-agent at the end.
 
-## After spec-writer completes — Plan Approval Gate
+## After spec-writer completes — Diaboli and Plan Approval Gate
 
-Before dispatching tdd-agent, PAUSE and present the plan to the user for approval.
-Show:
+### Step 1: Dispatch advocatus-diaboli
+
+Dispatch the advocatus-diaboli agent with the spec file path as input. The agent
+returns the full objection record content. Write that content to
+`docs/superpowers/objections/<spec-slug>.md`.
+
+The spec slug is derived from the spec filename: strip the date prefix and `.md`
+extension. Example:
+`docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → `advocatus-diaboli`
+
+### Step 2: Validate the objection record
+
+Read back the written file and verify:
+
+1. YAML frontmatter present with `spec`, `date`, `diaboli_model`, `objections` fields
+2. Each objection has `id`, `category`, `severity`, `claim`, `evidence`,
+   `disposition: pending`, `disposition_rationale: null`
+3. Categories are one of: `premise`, `design`, `threat`, `failure`, `operational`, `cost`
+4. Severities are one of: `major`, `minor`
+5. Objection count is between 1 and 12 inclusive
+6. Prose sections present for each objection
+7. "Explicitly not objecting to" section present with at least three entries
+
+Fix any deviations in place. Do not re-dispatch the agent.
+
+### Step 3: Surface the objection record
+
+PAUSE and present the objection record to the user. Show:
+
+- Total objections (major / minor split)
+- Category distribution
+- Each objection's claim and evidence
+
+Tell the user: "Fill in `disposition` and `disposition_rationale` for each
+objection in `docs/superpowers/objections/<slug>.md` before proceeding."
+
+Do NOT proceed while any `disposition` is `pending`.
+
+### Step 4: Plan Approval Gate
+
+Once the user confirms all dispositions are resolved, PAUSE and present the
+plan alongside the adjudicated objection record. Show:
 
 - What spec changes were made (new/modified user stories, scenarios, requirements)
 - What the implementation plan proposes (modules, files, approach)
 - Estimated scope (number of files, languages affected)
+- Summary of objection dispositions (how many accepted, deferred, rejected)
 
 Then ask the user to choose:
 
 - **Approve** — proceed to tdd-agent
 - **Request changes** — re-dispatch spec-writer with the user's feedback
+  (if major objections were accepted, re-run advocatus-diaboli on the revised spec)
 - **Take over** — exit the pipeline; the user will work manually
 
 Do NOT dispatch tdd-agent without user approval. This gate exists because it is

--- a/ai-literacy-superpowers/commands/diaboli.md
+++ b/ai-literacy-superpowers/commands/diaboli.md
@@ -1,0 +1,84 @@
+---
+name: diaboli
+description: Run the adversarial spec reviewer on a spec file — produces or regenerates the objection record at docs/superpowers/objections/<spec-slug>.md; use after spec-writer completes or when a spec is substantively edited
+---
+
+# /diaboli \<spec-path\>
+
+Run the advocatus-diaboli agent against a spec file and write the objection record.
+
+## When to use
+
+- Manually after `/spec-writer` completes, before presenting the plan
+- When a spec is substantively edited after an objection record already exists
+  (regenerates the record — old dispositions are lost; this is intentional)
+- When the orchestrator is not in use and you want adversarial review on demand
+
+## Process
+
+### 1. Validate input
+
+Confirm the spec file exists at the given path. If not, abort with:
+
+```
+Error: spec file not found at <path>. Pass a valid path under docs/superpowers/specs/.
+```
+
+### 2. Derive the slug
+
+Strip the date prefix and `.md` extension from the filename.
+
+Example: `docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → `advocatus-diaboli`
+
+The output path will be `docs/superpowers/objections/<slug>.md`.
+
+### 3. Dispatch the advocatus-diaboli agent
+
+Pass the spec file path. The agent reads the spec and returns the full objection
+record content. Do not pass any prior objection record — the agent reviews the
+spec fresh.
+
+### 4. Write the objection record
+
+Write the agent's output to `docs/superpowers/objections/<slug>.md`.
+
+If a file already exists at that path, overwrite it. Warn the user that any
+prior dispositions are replaced and they will need to re-adjudicate.
+
+### 5. Validation checkpoint
+
+Read back `docs/superpowers/objections/<slug>.md` and verify:
+
+1. YAML frontmatter is present and parseable (opens with `---`)
+2. Required frontmatter fields present: `spec`, `date`, `diaboli_model`, `objections`
+3. Each objection entry has: `id`, `category`, `severity`, `claim`, `evidence`,
+   `disposition`, `disposition_rationale`
+4. `disposition` value is `pending` for all entries (not pre-filled)
+5. `disposition_rationale` value is `null` for all entries (not pre-filled)
+6. Category values are one of: `premise`, `design`, `threat`, `failure`,
+   `operational`, `cost`
+7. Severity values are one of: `major`, `minor`
+8. Objection count is between 1 and 12 inclusive
+9. Prose body contains one `## O<N>` section per objection
+10. File ends with an `## Explicitly not objecting to` section containing
+    at least three entries
+
+If any check fails, fix the deviation in place. Do not re-dispatch the agent.
+
+### 6. Present the record to the user
+
+Show:
+
+- Output path
+- Number of objections (major / minor split)
+- Category distribution
+- A reminder: "Fill in `disposition` and `disposition_rationale` for each
+  objection before proceeding. The plan-approval gate will not advance while
+  any disposition is `pending`."
+
+### 7. Suggest next steps
+
+If this was invoked manually (not via orchestrator):
+
+- Once all dispositions are filled, present the plan for approval
+- Proceed to tdd-agent only after plan approval

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: advocatus-diaboli
+description: Use when acting as the adversarial spec reviewer — raises steel-manned objections across six categories before plan approval, requires evidence per objection, and discloses what was not challenged
+---
+
+# Advocatus Diaboli
+
+You are the adversary of premature commitment. Your charter is to raise the
+strongest possible objections to a spec before any implementation artefacts
+exist. You do not refine, improve, or endorse. You challenge.
+
+## Intellectual Foundations
+
+The role of Promoter of the Faith (*Promotor Fidei*) — the Vatican official
+appointed to argue against beatification candidates — gives this skill its name.
+The role existed to prevent hagiographic bias from corrupting consequential
+decisions. It was abolished in 1983. Beatifications accelerated. The lesson:
+removing adversarial review does not improve decision quality; it removes the
+friction that quality requires.
+
+The epistemic basis is Popperian: a spec is only as strong as the attempts to
+falsify it that it survives. An unchallenged spec is not a good spec — it is an
+untested assertion.
+
+Schopenhauer's *Art of Being Right* (*Eristische Dialektik*) catalogues 38
+rhetorical stratagems for winning arguments regardless of truth. This skill is
+**explicitly not that**. No strawmanning. No shifting the burden of proof. No
+exploiting ambiguity. No winning for its own sake. Every objection must be
+grounded in evidence from the spec itself. Rhetorical tricks are a failure mode.
+
+## Non-Goals
+
+- **Not a code reviewer.** You read specs, not implementations.
+- **Not a security auditor.** The threat model category surfaces structural
+  threat gaps in the design; it does not audit CVEs or run scanners.
+- **Not a linter.** Grammar, formatting, and naming are not your concern.
+- **Not a rewriter.** You raise objections; you do not rewrite the spec.
+- **Not a second spec-writer.** You do not produce alternative designs.
+
+## The Six Categories
+
+Every objection must belong to one of these categories:
+
+### premise
+
+The spec solves the wrong problem, or assumes the problem exists when it may not.
+Challenge the "why" before the "what." This is the highest-leverage category —
+a premise objection invalidates all implementation artefacts downstream.
+
+*Example: "The spec assumes users cannot perform X today, but the existing
+command Y already does X for 80% of cases."*
+
+### design
+
+The chosen approach has a structural flaw independent of the problem being real.
+Do not nit-pick implementation choices. Challenge design decisions that will
+produce wrong outcomes even when correctly executed.
+
+*Example: "The read-only trust boundary described in the spec means the agent
+cannot write its output, contradicting the requirement for an objection record."*
+
+### threat
+
+The spec's design creates or ignores a trust, safety, or abuse-model gap.
+Not CVE-level detail — structural gaps in how the design handles adversarial
+conditions, misuse, or unexpected inputs.
+
+*Example: "The disposition field allows any string value; a bad actor or
+careless human could write 'pending-ish' and pass the gate check."*
+
+### failure
+
+The spec does not account for a realistic failure mode. Not hypothetical
+catastrophising — foreseeable failures that the design leaves unaddressed.
+
+*Example: "If spec-writer produces a spec with no frontmatter, the diaboli
+agent has no slug to derive the output path from."*
+
+### operational
+
+The described system will be difficult or impossible to operate correctly at
+the scale or cadence implied by the spec. Deployment, monitoring, on-call,
+rollback, and degraded-mode concerns belong here.
+
+*Example: "The weekly GC rule compares file mtimes, but mtime is reset on
+git checkout — a fresh clone will flag every objection record as stale."*
+
+### cost
+
+The approach has a cost (token, latency, human time, infrastructure) that is
+materially disproportionate to the value described, and the spec does not
+acknowledge this trade-off.
+
+*Example: "Dispatching the most-capable tier for every spec review adds
+~$0.50–$2.00 per feature PR. At 20 PRs/month this is $120–$480/year — not
+prohibitive but not free, and the spec does not mention it."*
+
+## Severity
+
+Every objection has a severity:
+
+- **major** — if unaddressed, this objection means the feature should not
+  be built as described. The disposition must be `accepted` (spec changes)
+  or `rejected` with a substantive rationale before the pipeline proceeds.
+- **minor** — a real concern that warrants acknowledgement, but does not
+  by itself block the approach. The human may `defer` with a note.
+
+## Evidence Requirement
+
+Every objection must include an `evidence` field that quotes or cites the
+specific part of the spec that grounds the objection. Objections without
+evidence are inadmissible — they are assertions, not challenges.
+
+## Maximum Objections
+
+Cap at **12 objections** per spec. Justification: more than 12 objections
+signals either that the spec is not ready for review (send it back to
+spec-writer) or that the adversarial agent is pattern-matching rather than
+reasoning. Quality over quantity. If you have more than 12 candidate
+objections, select the 12 with the highest severity and strongest evidence.
+A review with 3 major objections is more valuable than one with 12 minor ones.
+
+## The "Explicitly Not Objecting To" Section
+
+Every objection record **must** end with an "Explicitly not objecting to"
+section. List at least three things you considered challenging but chose not
+to, with a one-sentence reason for each omission.
+
+This section exists to expose shallow passes. If an agent cannot name things
+it chose not to challenge, it did not engage with the spec at the depth
+required. The human can use this section to probe whether the omissions were
+deliberate or missed.
+
+## Output Format
+
+Produce the output at `docs/superpowers/objections/<spec-slug>.md`.
+
+The spec slug is derived from the spec filename: strip the date prefix and
+the `.md` extension. For example:
+`docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → slug `advocatus-diaboli`.
+
+### YAML Frontmatter
+
+```yaml
+---
+spec: <path to spec file>
+date: <ISO date>
+diaboli_model: <model-id used>
+objections:
+  - id: O1
+    category: premise|design|threat|failure|operational|cost
+    severity: major|minor
+    claim: "one sentence"
+    evidence: "direct quote or citation from spec"
+    disposition: pending
+    disposition_rationale: null
+---
+```
+
+`disposition` starts as `pending`. The human fills it in:
+`accepted`, `deferred`, or `rejected`. `disposition_rationale` is a
+free-text string the human writes. Do not pre-fill either field.
+
+### Prose Body
+
+After the frontmatter, write one prose section per objection:
+
+```markdown
+## O1 — [category] — [severity]
+
+### Claim
+
+[Restate the claim in full prose.]
+
+### Evidence
+
+[Quote or cite the specific part of the spec. Use block quotes where helpful.]
+
+### Why this matters
+
+[Explain the consequence if this objection is valid and unaddressed.]
+```
+
+### Closing Section
+
+```markdown
+## Explicitly not objecting to
+
+- **[Topic]**: [One sentence explaining why this was not challenged.]
+- **[Topic]**: [One sentence explaining why this was not challenged.]
+- **[Topic]**: [One sentence explaining why this was not challenged.]
+```
+
+At least three entries required. More is better.

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -60,6 +60,19 @@
 - **Tool**: gitleaks detect --source . --no-banner --exit-code 1
 - **Scope**: commit
 
+### Spec has adjudicated objections
+
+- **Rule**: Every feature or behaviour-change spec must have a corresponding
+  objection record at `docs/superpowers/objections/<spec-slug>.md` with all
+  dispositions resolved (no `pending` values). Bug fixes, dependency updates,
+  and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or
+  branch-prefixed `fix/`, `chore/`) are exempt on the same terms as
+  spec-first-commit-ordering. Specs created before the constraint was added
+  are exempt — add `diaboli: exempt-pre-existing` to their frontmatter.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer
+- **Scope**: pr
+
 ### Tests must pass
 
 - **Rule**: The project's test suite must pass with zero failures before
@@ -179,6 +192,17 @@ Use /governance-constrain for guided authoring of governance constraints.
 - **Frequency**: weekly
 - **Enforcement**: agent
 - **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Objection record freshness
+
+- **What it checks**: Whether any spec file in `docs/superpowers/specs/`
+  has been modified more recently than its corresponding objection record
+  in `docs/superpowers/objections/` — a spec edited without re-running
+  `/diaboli` produces a stale objection record
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: file mtime comparison between spec and objection record
 - **Auto-fix**: false
 
 ### Onboarding document staleness

--- a/docs/superpowers/specs/2026-04-19-advocatus-diaboli.md
+++ b/docs/superpowers/specs/2026-04-19-advocatus-diaboli.md
@@ -1,0 +1,114 @@
+---
+name: advocatus-diaboli
+description: Spec for the adversarial spec-review agent hard-wired into the spec-first pipeline
+date: 2026-04-19
+status: approved
+---
+
+# Advocatus Diaboli — Adversarial Spec Review
+
+## Problem
+
+### 1. Sycophantic acceptance in agentic workflows
+
+The spec-writer agent produces a plan. The orchestrator presents that plan. The
+tdd-agent translates it into tests. At no point does any agent in the pipeline
+have a charter to disagree. Disagreement is structurally absent — not because
+agents are incapable of it, but because no component has been given the role of
+adversary. The result is a pipeline that surfaces assumptions only when they
+collide with reality during implementation, which is the most expensive moment
+to discover them.
+
+### 2. Confirmation bias in same-agent review
+
+Asking spec-writer to review its own spec, or asking orchestrator to critique
+the plan it just presented, does not produce adversarial review. It produces
+refinement. The agent's prior output becomes the anchor; subsequent reasoning
+adjusts around it. This is not a flaw in any particular agent — it is a
+structural property of single-agent self-review. The only remedy is a separate
+agent with a different charter.
+
+### 3. Premise-level objections suppressed by sunk cost
+
+Once tdd-agent has written tests, once implementers have written code, the cost
+of a premise-level objection rises sharply. "The spec solves the wrong problem"
+becomes "we'd have to throw away the tests and the implementation." Human
+reviewers and agents alike are subject to sunk-cost pressure. The premise-level
+objection must be raised before any implementation artefacts exist — specifically,
+before plan approval.
+
+## Approach
+
+A chartered adversarial agent — the advocatus diaboli — is dispatched immediately
+after spec-writer and before plan approval. Its charter is to raise steel-manned
+objections, not nits. It operates with a read-only trust boundary: it cannot write
+code, cannot modify the spec, and cannot write its own objection dispositions. This
+last constraint is structural: it forces a human to open the objection record and
+write dispositions before the pipeline can proceed.
+
+The plan-approval gate is extended to surface the objection record alongside the
+plan summary. While any disposition is `pending`, the gate refuses progression.
+The human writes dispositions inline — `accepted`, `deferred`, or `rejected` —
+with a rationale. This is the cognitive-engagement mechanism; it cannot be
+delegated.
+
+The agent takes a single input (a spec file path) and produces a structured
+objection record at `docs/superpowers/objections/<spec-slug>.md`. The record
+uses YAML frontmatter for machine-readable dispositions and prose sections for
+human-readable elaboration.
+
+## Intellectual Foundations
+
+The name and role derive from the historical Promoter of the Faith
+(*Promotor Fidei*), the Vatican official appointed to argue against a candidate's
+beatification — to find reasons to doubt, to challenge miracles, to expose
+hagiographic bias. The role was abolished in 1983 under John Paul II, after which
+the rate of beatifications increased sharply. This history is instructive: removing
+the adversarial gate did not improve the quality of decisions; it accelerated them.
+We are reinstating the gate in a different domain.
+
+The epistemic basis is Popperian: a claim is only meaningful if it can be falsified.
+A spec that has not been challenged is not a strong spec — it is an unchallenged
+assertion. The adversarial agent's job is to attempt falsification before
+commitment.
+
+Schopenhauer's *Art of Being Right* (*Eristische Dialektik*) names what this is
+explicitly **not**. Schopenhauer catalogued 38 rhetorical stratagems for winning
+arguments regardless of truth. The advocatus diaboli must not use them. No
+strawmanning, no shifting the burden of proof, no exploiting ambiguity. Every
+objection requires evidence grounded in the spec itself. Winning for its own sake
+is a failure mode, not a success criterion.
+
+## Expected Outcome
+
+Every feature PR arrives at the plan-approval gate with a structured objection
+record that the human has adjudicated. The quality gate is not whether the
+adversarial agent found objections — it is whether the human engaged with them.
+Disposition distribution becomes observable over time: a cluster of
+`deferred — not material` responses signals that the SKILL.md charter needs
+tuning, not that the constraint needs weakening.
+
+## Artefacts
+
+1. `skills/advocatus-diaboli/SKILL.md` — charter, six categories, severity
+   definitions, max-objection cap, "Explicitly not objecting to" requirement,
+   intellectual foundations, non-goals
+2. `agents/advocatus-diaboli.agent.md` — read-only agent, objection record
+   output schema, disposition gate
+3. `commands/diaboli.md` — `/diaboli <spec-path>` for manual invocation and
+   regeneration when a spec is substantively edited
+4. `.github/prompts/diaboli.prompt.md` — Copilot CLI equivalent
+5. `agents/orchestrator.agent.md` — pipeline updated: spec-writer → diaboli →
+   GATE (objections adjudicated) → plan approval → tdd-agent
+6. `HARNESS.md` — constraint (agent, scope pr) + GC rule (deterministic, weekly)
+7. `MODEL_ROUTING.md` — advocatus-diaboli routed to most-capable tier
+8. `templates/HARNESS.md` — constraint + GC rule for new projects
+9. `AGENTS.md` — ARCH_DECISION: hard-wired from the outset (Option B)
+10. `README.md`, `plugin.json`, `marketplace.json`, `CHANGELOG.md` — version 0.23.0
+
+## Exemptions
+
+Specs created before 2026-04-19 are exempt from the objection-record constraint.
+Mark with `diaboli: exempt-pre-existing` in frontmatter, or rely on the dated
+cutoff in the constraint text. Bug fixes, dependency updates, and maintenance PRs
+are exempt on the same terms as spec-first-commit-ordering.


### PR DESCRIPTION
Closes #176

## Summary

- **Spec first**: `docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` — committed alone as the first commit per spec-first-commit-ordering
- **Skill**: `skills/advocatus-diaboli/SKILL.md` — six-category charter (premise, design, threat, failure, operational, cost), 12-objection cap, evidence requirement, "Explicitly not objecting to" section; founded on Promoter of the Faith history, Popper, anti-Schopenhauer
- **Agent**: `agents/advocatus-diaboli.agent.md` — read-only (Read/Glob/Grep only); cannot write dispositions; returns content to orchestrator for writing; trust boundary IS the human-cognition gate
- **Command**: `commands/diaboli.md` — `/diaboli <spec-path>` with 10-point validation checkpoint
- **Copilot CLI**: `.github/prompts/diaboli.prompt.md`
- **Orchestrator**: wired after spec-writer; two gates added — objection adjudication (blocked on `pending`) then plan approval with adjudicated record
- **HARNESS.md**: "Spec has adjudicated objections" constraint (agent, pr) + "Objection record freshness" GC rule (deterministic, weekly); pre-2026-04-19 exemption
- **templates/HARNESS.md**: same constraint + GC rule for new projects
- **MODEL_ROUTING.md**: advocatus-diaboli → most-capable tier
- **AGENTS.md**: ARCH_DECISION with rejected alternatives documented
- **README.md**: badge counts updated (29 skills, 12 agents, 22 commands), tables, pipeline diagram
- **Version**: 0.22.0 → 0.23.0 across plugin.json, marketplace.json, README badge, CHANGELOG

## Test plan

- [ ] Verify `docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` is the first commit on this branch (spec-first-commit-ordering constraint)
- [ ] Verify `skills/advocatus-diaboli/SKILL.md` has YAML frontmatter with `name` and `description` (frontmatter constraint)
- [ ] Verify `agents/advocatus-diaboli.agent.md` has YAML frontmatter with `name`, `description`, and `tools: [Read, Glob, Grep]`
- [ ] Verify `commands/diaboli.md` has YAML frontmatter with `name` and `description`
- [ ] Verify `plugin.json`, README badge, and CHANGELOG top heading all read `0.23.0` (version-consistency constraint)
- [ ] Verify `marketplace.json` `plugin_version` is `0.23.0` (marketplace-plugin-version-sync constraint)
- [ ] CI markdownlint passes on all new `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)