### PR TITLE
Add docs for advocatus-diaboli and update SKILL.md taxonomy (v0.24.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.23.0",
+  "plugin_version": "0.24.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.22.0"
+      "version": "0.24.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.24.0 — 2026-04-19
+
+### Docs and taxonomy — advocatus-diaboli coverage and SKILL.md update
+
+- Add `docs/explanation/adversarial-review.md` — standalone explanation of
+  the Promoter Fidei precedent, Popperian falsifiability, the Schopenhauer
+  non-goal, the human-cognition gate, and disposition patterns as signals
+- Add `docs/how-to/review-a-spec-adversarially.md` — practical guide for
+  running `/diaboli`, reading the objection record, and writing dispositions
+- Update `docs/reference/commands.md` — add `/diaboli` entry with correct
+  taxonomy; count updated to 22
+- Update `docs/reference/agents.md` — add `advocatus-diaboli` agent entry;
+  count updated to 12; pipeline description updated to six-stage sequence
+- Update `docs/explanation/agent-orchestration.md` — pipeline diagram now
+  shows advocatus-diaboli and two human gates; "Where This Breaks Down"
+  names the structural solution; duplicate link removed from Further Reading
+- Update `docs/tutorials/first-time-tour.md` — `/diaboli` section added;
+  count updated to twenty-two
+- Update `skills/advocatus-diaboli/SKILL.md` — category taxonomy updated
+  to premise/scope/implementation/risk/alternatives/specification quality;
+  severity updated to critical/high/medium/low (replaces major/minor);
+  change driven by spec-first review of the docs work itself via /diaboli
+
 ## 0.23.0 — 2026-04-19
 
 ### Feature — advocatus-diaboli adversarial spec review

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.22.0 -->
+<!-- template-version: 0.23.0 -->
 
 ## Context
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.23.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.24.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
 [![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -276,3 +276,19 @@
   - Model tiers used: most-capable (main conversation, 100%; no subagents dispatched)
   - Pipeline stages completed: manual tutorial draft, commit, push, PR, 2 CI failures (spec-first, version-consistency), fix-up commit, label add (chore), merge; no orchestrator pipeline used
   - Agent delegation: manual
+
+---
+
+- **Date**: 2026-04-19
+- **Agent**: claude-sonnet-4-6 (main conversation, no subagents)
+- **Task**: Added advocatus-diaboli adversarial spec review — skill, agent, command, Copilot CLI prompt, orchestrator wiring, HARNESS.md constraint + GC rule, MODEL_ROUTING.md update, AGENTS.md ARCH_DECISION, README badge/table/pipeline-diagram updates, plugin v0.22.0 → v0.23.0. PR #177 merged; follow-up PR #178 added .gitkeep to docs/superpowers/objections/.
+- **Surprise**: All 5 CI checks (spec-first commit ordering, version consistency, constraint enforcement, markdownlint ×2) passed on the first push — no iteration required for a 14-file, 693-insertion PR. The deeper surprise was structural: `docs/superpowers/objections/` was created with `mkdir -p` and staged, but git does not track empty directories. The directory was absent from the repo after merge, meaning the harness-enforcer's path reference and the constraint wording pointed into a location that would not exist until the first `/diaboli` run. The fix (a `.gitkeep`) is one file, but discovering the gap required a post-merge reflection — not CI.
+- **Proposal**: STYLE: When a PR introduces a new directory that must exist for a constraint or agent to function correctly, always commit a `.gitkeep` in that directory as part of the implementation commit — not as a follow-up. Git's empty-directory behaviour is a well-known gotcha but easy to forget under implementation load. This applies to any `docs/`, `observability/`, or `objections/`-style directory referenced in a constraint rule.
+- **Improvement**: The read-only tool boundary on the advocatus-diaboli agent (`tools: [Read, Glob, Grep]`) is the cognitive-engagement mechanism, not a security afterthought. Future agents or contributors modifying the agent definition should understand that adding Write access would silently bypass the human-disposition gate. This design intent is not obvious from the file alone — it is explained in the skill and the orchestrator, but the agent file would benefit from a short note in its Trust Boundary section (already present, but worth reinforcing in AGENTS.md if the pattern is adopted elsewhere).
+- **Signal**: workflow
+- **Constraint**: none
+- **Session metadata**:
+  - Duration: ~60 min
+  - Model tiers used: most-capable (main conversation, 100%; no subagents dispatched)
+  - Pipeline stages completed: spec (commit 1), implementation (commit 2), version bump (commit 3), PR #177, CI pass, merge; follow-up fix PR #178, CI pass, merge; reflect
+  - Agent delegation: manual (direct implementation; no orchestrator pipeline invoked)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
@@ -50,7 +50,16 @@ a premise objection invalidates all implementation artefacts downstream.
 *Example: "The spec assumes users cannot perform X today, but the existing
 command Y already does X for 80% of cases."*
 
-### design
+### scope
+
+The spec includes work that is unnecessary for the problem, or excludes work
+that is necessary. Not implementation detail — top-level questions about what
+is in and out of the change.
+
+*Example: "The spec adds three new commands but does not mention updating the
+commands reference, which will be inaccurate on the day it ships."*
+
+### implementation
 
 The chosen approach has a structural flaw independent of the problem being real.
 Do not nit-pick implementation choices. Challenge design decisions that will
@@ -59,51 +68,47 @@ produce wrong outcomes even when correctly executed.
 *Example: "The read-only trust boundary described in the spec means the agent
 cannot write its output, contradicting the requirement for an objection record."*
 
-### threat
+### risk
 
-The spec's design creates or ignores a trust, safety, or abuse-model gap.
-Not CVE-level detail — structural gaps in how the design handles adversarial
-conditions, misuse, or unexpected inputs.
+The spec's design creates or ignores a trust, safety, operational, or failure
+risk. Not CVE-level detail — structural gaps in how the design handles
+adversarial conditions, misuse, unexpected inputs, or foreseeable failure modes
+that the spec leaves unaddressed.
 
-*Example: "The disposition field allows any string value; a bad actor or
-careless human could write 'pending-ish' and pass the gate check."*
+*Example: "The disposition field allows any string value; a careless human
+could write 'pending-ish' and pass the gate check."*
 
-### failure
+### alternatives
 
-The spec does not account for a realistic failure mode. Not hypothetical
-catastrophising — foreseeable failures that the design leaves unaddressed.
+A materially better approach exists and the spec does not acknowledge it. Not
+bikeshedding — an alternative that is meaningfully simpler, cheaper, or more
+aligned with existing project conventions.
 
-*Example: "If spec-writer produces a spec with no frontmatter, the diaboli
-agent has no slug to derive the output path from."*
+*Example: "The spec proposes a new GC rule, but the existing harness-auditor
+agent already checks for this condition and reports it — a second check adds
+noise without coverage."*
 
-### operational
+### specification quality
 
-The described system will be difficult or impossible to operate correctly at
-the scale or cadence implied by the spec. Deployment, monitoring, on-call,
-rollback, and degraded-mode concerns belong here.
+The spec is ambiguous, incomplete, or internally inconsistent in ways that
+would cause divergent implementations. Grammar and formatting are not your
+concern — only ambiguity that would lead a reasonable implementer to produce
+the wrong thing.
 
-*Example: "The weekly GC rule compares file mtimes, but mtime is reset on
-git checkout — a fresh clone will flag every objection record as stale."*
-
-### cost
-
-The approach has a cost (token, latency, human time, infrastructure) that is
-materially disproportionate to the value described, and the spec does not
-acknowledge this trade-off.
-
-*Example: "Dispatching the most-capable tier for every spec review adds
-~$0.50–$2.00 per feature PR. At 20 PRs/month this is $120–$480/year — not
-prohibitive but not free, and the spec does not mention it."*
+*Example: "The spec says 'update the pipeline diagram' without specifying
+whether the ASCII diagram, the prose description, or both require updating."*
 
 ## Severity
 
 Every objection has a severity:
 
-- **major** — if unaddressed, this objection means the feature should not
-  be built as described. The disposition must be `accepted` (spec changes)
-  or `rejected` with a substantive rationale before the pipeline proceeds.
-- **minor** — a real concern that warrants acknowledgement, but does not
-  by itself block the approach. The human may `defer` with a note.
+- **critical** — if unaddressed, the feature should not proceed as described.
+  The human must engage substantively before the pipeline can continue.
+- **high** — a significant structural concern requiring a substantive human
+  decision; does not block the approach outright but cannot be deferred silently.
+- **medium** — a real concern that warrants acknowledgement but does not by
+  itself block the approach. The human may note and continue.
+- **low** — a minor note; informational. No action required before proceeding.
 
 ## Evidence Requirement
 
@@ -148,8 +153,8 @@ date: <ISO date>
 diaboli_model: <model-id used>
 objections:
   - id: O1
-    category: premise|design|threat|failure|operational|cost
-    severity: major|minor
+    category: premise|scope|implementation|risk|alternatives|specification quality
+    severity: critical|high|medium|low
     claim: "one sentence"
     evidence: "direct quote or citation from spec"
     disposition: pending

--- a/docs/explanation/adversarial-review.md
+++ b/docs/explanation/adversarial-review.md
@@ -1,0 +1,161 @@
+---
+title: Adversarial Review
+layout: default
+parent: Explanation
+nav_order: 19
+---
+
+# Adversarial Review
+
+The advocatus-diaboli agent raises objections to a spec before any implementation
+artefacts exist. This page explains why the mechanism is designed the way it is —
+the structural sycophancy problem it addresses, its historical and philosophical roots,
+and what the human-cognition gate actually does.
+
+---
+
+## The sycophancy problem
+
+Agentic pipelines structurally suppress disagreement.
+
+The spec-writer agent produces a plan. The orchestrator presents it. The tdd-agent
+translates it into tests. At no point does any agent in that sequence have a charter to
+disagree. Disagreement is structurally absent — not because agents are incapable of it,
+but because no component has been given the role of adversary.
+
+When you ask spec-writer to review its own spec, or orchestrator to critique the plan it
+just presented, you do not get adversarial review. You get refinement. The agent's prior
+output becomes the anchor; subsequent reasoning adjusts around it. This is not a flaw in
+any particular agent — it is a structural property of single-agent self-review. The only
+remedy is a separate agent with a different charter.
+
+The third structural problem is timing. Once tdd-agent has written tests, once
+implementers have written code, the cost of a premise-level objection rises sharply.
+"The spec solves the wrong problem" becomes "we'd have to throw away the tests and the
+implementation." Human reviewers and agents alike are subject to sunk-cost pressure. The
+premise-level objection must be raised before any implementation artefacts exist.
+
+---
+
+## The Promoter of the Faith
+
+The advocatus-diaboli takes its name from the *Promotor Fidei* — the Vatican official
+appointed to argue against a candidate's beatification. The role existed to prevent
+hagiographic bias from corrupting consequential decisions: to find reasons to doubt, to
+challenge miracles, to expose the motivated reasoning of the faithful.
+
+The role was abolished in 1983 under John Paul II. After its abolition, the rate of
+beatifications increased sharply. This history is instructive: removing the adversarial
+gate did not improve the quality of decisions. It accelerated them. The correlation
+between the absence of adversarial review and the acceleration of commitments is not a
+coincidence. It is the mechanism working in reverse.
+
+We are reinstating the gate in a different domain.
+
+---
+
+## Popperian falsifiability
+
+The epistemic basis for adversarial review is Popperian. A claim is only meaningful if
+it can be falsified. A spec that has not been challenged is not a strong spec — it is
+an unchallenged assertion. The adversarial agent's job is to attempt falsification
+before commitment.
+
+What survives adversarial review is not necessarily correct. But it is stronger than
+what has not been reviewed. The value is not in finding objections — it is in forcing
+the spec to survive a systematic attempt to find them.
+
+A spec with ten objections, all of which were considered and rejected with substantive
+rationale, is stronger than a spec with no objections that was never challenged. The
+objection record is a record of that strength.
+
+---
+
+## What the agent must not do
+
+Schopenhauer's *Art of Being Right* (*Eristische Dialektik*) catalogues 38 rhetorical
+stratagems for winning arguments regardless of truth — strawmanning, shifting the burden
+of proof, exploiting ambiguity, appealing to authority, exhausting the opponent through
+volume. These are the tools of debate-club victory, not truth-seeking.
+
+The advocatus-diaboli is explicitly not that.
+
+Every objection must be grounded in evidence from the spec itself. If the evidence
+cannot be quoted or directly cited, the objection is inadmissible. The agent wins
+nothing by raising objections that do not survive scrutiny — a hollow objection list
+that the human dismisses in two minutes is a failure of the adversarial review, not a
+success.
+
+Winning for its own sake is a failure mode. The goal is not maximum objections. The
+goal is maximum quality of engagement with the objections that are raised.
+
+---
+
+## The human-cognition gate
+
+The agent's trust boundary is read-only. It cannot modify the spec. It cannot write
+its own objection dispositions.
+
+The second constraint is the load-bearing one. If the agent could write `accepted` or
+`rejected` next to its own objections, a human could delegate the entire adjudication
+step back to an agent. The gate would be nominal — present in structure, absent in
+practice. By making disposition-writing physically impossible for the agent, the
+mechanism forces a human to open the record, read each objection, and write a rationale.
+
+That act of writing is the cognitive engagement. It is not a checkbox. A human who
+writes `rejected — this concern is addressed by the constraint already in HARNESS.md`
+has engaged with the objection. A human who writes `looks fine` has not. The format
+requires a rationale precisely because a blank approval is indistinguishable from a
+thoughtful approval.
+
+The pipeline gate checks for `pending` dispositions. While any are `pending`, the
+plan-approval step will not advance. This is not punitive — it is the mechanism that
+makes the adversarial review load-bearing rather than advisory.
+
+---
+
+## Disposition patterns as a signal
+
+Over time, the distribution of dispositions across objection records becomes observable.
+Patterns carry information:
+
+**Clustering of `low` severity objections that are all deferred:** The agent is raising
+real but unimportant concerns. The objection charter in SKILL.md may need tuning toward
+higher-leverage categories.
+
+**Clustering of `critical` objections that are all accepted:** Specs are consistently
+underprepared when they reach adversarial review. The spec-writer process may need
+strengthening upstream — more explicit requirements gathering, or earlier human review
+of the problem statement.
+
+**Consistently empty objection records:** Either the specs are genuinely strong, or the
+agent is not challenging them. Read a few objection records against their specs
+side-by-side and judge.
+
+**High rejection rate with substantive rationale:** The adversarial review is working —
+the agent is raising real concerns, and the humans are engaging with them and deciding
+against them with reasons. This is the healthy pattern.
+
+---
+
+## How this fits the three loops
+
+Adversarial review operates in the commit-time loop — it fires once per feature spec,
+before implementation begins.
+
+Objection records accumulate in `docs/superpowers/objections/` and feed the other loops:
+
+- **GC loop**: A weekly GC rule checks whether any spec has been modified more recently
+  than its corresponding objection record. A stale record is flagged for regeneration.
+- **Reflection loop**: Recurring patterns in objection types — `scope` objections
+  appearing on every PR, for example — are candidates for HARNESS.md constraints or
+  CLAUDE.md conventions. When a pattern repeats, it belongs in the harness.
+
+---
+
+## Further reading
+
+- [How to: Review a Spec Adversarially]({% link how-to/review-a-spec-adversarially.md %}) — the practical steps for running `/diaboli` and adjudicating the record
+- [Agent Orchestration]({% link explanation/agent-orchestration.md %}) — the full pipeline in which adversarial review sits
+- [Agents Reference]({% link reference/agents.md %}) — the advocatus-diaboli agent's tools and trust boundary
+- [Commands Reference: /diaboli]({% link reference/commands.md %}) — command invocation and output format

--- a/docs/explanation/agent-orchestration.md
+++ b/docs/explanation/agent-orchestration.md
@@ -98,6 +98,12 @@ Requirements
 [Spec Writer] --> Spec document
     |
     v
+[Advocatus Diaboli] --> Objection record
+    |
+    v
+*** HUMAN ADJUDICATES OBJECTIONS ***
+    |
+    v
 *** HUMAN REVIEWS AND APPROVES SPEC ***
     |
     v
@@ -127,7 +133,7 @@ Requirements
 
 Two things matter here.
 
-**The human gate.** You review and approve the *spec*, before any code is written. Not line 47 of a 200-line diff — the plan. "Is this what I actually want? Does this approach make sense? Are we building the right thing?" That is the highest-leverage decision in the process. Once you approve the spec, the pipeline can run without you.
+**The human gates.** There are now two. First, the advocatus-diaboli reviews the spec and produces an objection record — you adjudicate each objection, writing your disposition and rationale inline. The agent cannot do this for you: its trust boundary is read-only. Second, you review and approve the *spec* itself. Not line 47 of a 200-line diff — the plan. "Is this what I actually want? Does this approach make sense? Are we building the right thing?" That is the highest-leverage decision in the process. Once you approve the spec, the pipeline can run without you.
 
 **The cycle limit.** When the reviewer rejects and the implementer fixes, there is a maximum of three cycles. Without a limit, you get agent ping-pong: the reviewer keeps finding issues, the implementer keeps introducing new ones, and the token cost keeps climbing. Three cycles is enough for genuine iteration. If it is not resolved in three, a human needs to look — and the problem is usually in the spec, not the code.
 
@@ -162,6 +168,8 @@ The pipeline assumes clean handoffs. In practice, specs are ambiguous. The test 
 
 **Agents that agree too easily.** A reviewer that approves everything is worse than no reviewer, because it gives you false confidence. You need to tune your reviewer's instructions to be genuinely adversarial — not hostile, but sceptical. "What is wrong with this?" is a better reviewer prompt than "Is this OK?"
 
+The structural solution to sycophantic reviewers is not better instructions — it is a separate agent whose entire charter is disagreement, dispatched before any implementation artefacts exist. This is the advocatus-diaboli: a read-only agent that reviews the spec, raises evidence-grounded objections, and cannot write its own dispositions. The last constraint is structural: a human must open the objection record and adjudicate before the pipeline proceeds. This is not a quality filter — it is a cognitive-engagement gate. See [Adversarial Review]({% link explanation/adversarial-review.md %}) for the full conceptual background.
+
 **Context loss between agents.** Each agent starts fresh. That is the point — fresh eyes. But it also means the implementer's reasoning about *why* it made a particular trade-off does not reach the reviewer. The reviewer sees a choice and flags it as wrong without knowing the constraint that forced it. Good pipeline design mitigates this with structured handoff documents, but it does not eliminate it.
 
 > **The Pragmatist:** "OK but what do I actually do on Monday?"
@@ -187,7 +195,7 @@ That is the review process working. The reviewer can reject, and the implementer
 ## Key Takeaways
 
 - **The single-agent bottleneck** — one agent doing everything makes *you* the only quality gate. That does not scale.
-- **Specialised agents** — spec writer, test writer, implementer, reviewer, integrator. Five focused jobs, no overlap.
+- **Specialised agents** — spec writer, adversarial reviewer, test writer, implementer, reviewer, integrator. Six focused jobs, no overlap.
 - **Trust boundaries** — each agent gets exactly the permissions it needs. The reviewer cannot write code. The implementer cannot merge. The implementer cannot edit tests. This is least privilege applied to AI.
 - **The pipeline** — agents work in sequence with gates. The most important gate is the human approving the spec before any code is written.
 - **Where it breaks** — ambiguous specs, compliant reviewers, and context loss between agents. The architecture helps; it does not solve everything.
@@ -197,7 +205,7 @@ That is the review process working. The reviewer can reject, and the implementer
 ## Further reading
 
 - [Agents Reference]({% link reference/agents.md %}) — detailed catalogue of all agents in this plugin
+- [Adversarial Review]({% link explanation/adversarial-review.md %}) — the concepts behind the advocatus-diaboli and the human-cognition gate
 - [Compound Learning]({% link explanation/compound-learning.md %}) — how agent output feeds the learning loop
 - [Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %}) — the constraints agents enforce
 - [Harness Engineering]({% link explanation/harness-engineering.md %}) — the broader framework that agent orchestration fits within
-- [Agents Reference]({% link reference/agents.md %}) — detailed catalogue of all agents in this plugin

--- a/docs/how-to/review-a-spec-adversarially.md
+++ b/docs/how-to/review-a-spec-adversarially.md
@@ -1,0 +1,117 @@
+---
+title: Review a Spec Adversarially
+layout: default
+parent: How-to Guides
+nav_order: 38
+---
+
+# Review a Spec Adversarially
+
+Run `/diaboli` to get an adversarial review of a spec file before approving the implementation plan.
+
+## When to use this
+
+- After `/spec-writer` completes and before you approve the plan
+- When a spec is substantially edited after an objection record already exists
+  (the command regenerates the record; prior dispositions are lost — this is intentional)
+- When working outside the full orchestrator pipeline and you want adversarial review on demand
+
+Do not use this as a quality check on your own reasoning. The point of the agent is that it
+disagrees with you from a clean context. Running it after you have already decided to proceed
+removes the gate it is meant to enforce.
+
+---
+
+## 1. Run `/diaboli <spec-path>`
+
+Pass the path to a spec file under `docs/superpowers/specs/`:
+
+```text
+/diaboli docs/superpowers/specs/2026-04-19-my-feature.md
+```
+
+The command dispatches the advocatus-diaboli agent, which reads the spec and produces a
+structured objection record at `docs/superpowers/objections/<spec-slug>.md`.
+
+The slug is derived from the spec filename by stripping the date prefix and `.md` extension.
+For example, `2026-04-19-my-feature.md` → `my-feature`.
+
+---
+
+## 2. Read the objection record
+
+The record has two parts:
+
+**YAML frontmatter** — a machine-readable list of objections, each with:
+
+- `id` — O1, O2, … in order of severity
+- `category` — one of: `premise`, `scope`, `implementation`, `risk`, `alternatives`,
+  `specification quality`
+- `severity` — one of: `critical`, `high`, `medium`, `low`
+- `claim` — one sentence stating the objection
+- `evidence` — a quote or citation from the spec that grounds the objection
+- `disposition` — starts as `pending`; you fill this in
+- `disposition_rationale` — starts as `null`; you write this
+
+**Prose body** — one `## O<N>` section per objection with the claim restated, the
+evidence expanded, and an explanation of why the objection matters if unaddressed.
+
+Read the prose sections, not just the frontmatter. The prose is where the reasoning lives.
+
+---
+
+## 3. Write dispositions inline
+
+Open the objection record and fill in `disposition` and `disposition_rationale` for each
+objection in the YAML frontmatter.
+
+Valid disposition values:
+
+- `accepted` — the objection is valid; the spec or approach will change
+- `rejected` — the objection is not valid; the rationale must explain why
+- `deferred` — acknowledged; the concern is real but will be addressed separately
+- `fix` — shorthand for accepted with a planned correction (same weight as `accepted`)
+- `leave` — shorthand for rejected with a deliberate choice to keep the current approach
+
+**This step cannot be delegated back to an agent.** The agent's trust boundary is
+read-only — it cannot write dispositions. This is structural: a human must engage
+with the objections and write a rationale before the pipeline proceeds. That engagement
+is the mechanism. If you find yourself wanting to have an agent fill in the dispositions,
+the gate is not working.
+
+For `critical` and `high` severity objections, the rationale must be substantive. "Looks
+fine" is not a rationale. "This will be addressed by X change to the spec" is.
+
+---
+
+## 4. Update the spec if needed
+
+If objections are `accepted` or `fix`, update the spec to reflect what changes. The
+objection record stays as written — it is a permanent record of the adversarial review
+at a point in time.
+
+If the spec changes substantially (new approach, different scope, different artefact
+list), re-run `/diaboli` on the updated spec. The old record will be overwritten; old
+dispositions are not preserved. This is intentional: a substantially revised spec is a
+new thing and deserves a fresh adversarial review.
+
+---
+
+## 5. What you have now
+
+An adjudicated objection record with all dispositions filled and all rationales written.
+The plan-approval gate will not advance while any disposition is `pending`.
+
+The record lives at `docs/superpowers/objections/<slug>.md` and accumulates alongside
+other objection records over time. A GC rule checks weekly whether any spec has been
+modified more recently than its objection record — if so, it flags the record as stale.
+
+---
+
+## Next steps
+
+- Present the plan for approval — once all dispositions are filled, return to the
+  orchestrator pipeline and approve the spec
+- Proceed to tdd-agent only after plan approval
+- See [Adversarial Review]({% link explanation/adversarial-review.md %}) for the
+  conceptual background on why this gate exists and what the agent is not allowed to do

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Agents
 
-The plugin ships 11 agents organised into four groups: the
+The plugin ships 12 agents organised into four groups: the
 **spec-first pipeline** that coordinates feature work end to end,
 the **harness agents** that verify and maintain infrastructure
 conventions, and the **assessor** that measures AI literacy.
@@ -21,9 +21,11 @@ makes this explicit.
 
 ## Pipeline Agents
 
-These five agents form the spec-first development pipeline.
-The orchestrator dispatches them in sequence: spec, test, implement,
-review, integrate.
+These six agents form the spec-first development pipeline. After
+spec-writer produces the spec, the advocatus-diaboli reviews it
+adversarially and a human adjudicates the objections before plan
+approval; only then do tdd-agent, code-reviewer, and
+integration-agent run.
 
 ### orchestrator
 
@@ -50,6 +52,24 @@ First specialist in every pipeline run. Updates `spec.md` and
 written. Produces user stories, acceptance scenarios in
 Given/When/Then format, and numbered functional requirements that
 the TDD agent will translate into tests.
+
+### advocatus-diaboli
+
+- **Tools**: Read, Glob, Grep
+- **Dispatched by**: orchestrator (after spec-writer, before plan approval)
+- **Trust boundary**: Read-only
+
+Adversarial spec reviewer. Reads the spec file produced by spec-writer and
+raises steel-manned objections across six categories: premise, scope,
+implementation, risk, alternatives, and specification quality. Produces a
+structured objection record at `docs/superpowers/objections/<spec-slug>.md`.
+
+Cannot modify the spec. Cannot write objection dispositions. Both
+constraints are structural: the read-only boundary makes it impossible to
+alter the problem statement, and the absence of a disposition-writing tool
+forces a human to open the record and adjudicate before the pipeline
+proceeds. This human-cognition gate is the primary purpose of the agent —
+not finding objections, but ensuring a human engages with them.
 
 ### tdd-agent
 
@@ -206,6 +226,7 @@ governance analysis requires nuanced judgement about meaning.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | orchestrator | x | x | x | x | x | x | x | x | read-write |
 | spec-writer | x | x | x | x | x | | | | read-write |
+| advocatus-diaboli | x | | | x | x | | | | read-only |
 | tdd-agent | x | x | x | x | x | x | | | read-write |
 | code-reviewer | x | | | x | x | x | | | read-only |
 | integration-agent | x | x | x | | | x | | | read-write |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Commands
 
-All 21 slash commands registered in `commands/`. Each command is
+All 22 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -267,6 +267,30 @@ Context and Constraints sections of `HARNESS.md` and generates
 tool-specific convention files for Cursor, Copilot, and Windsurf.
 Ensures all AI coding tools in the team share the same project rules
 regardless of which editor is used.
+
+### /diaboli
+
+- **Skills read**: advocatus-diaboli
+- **Agents dispatched**: advocatus-diaboli
+
+Run the adversarial spec reviewer on a spec file. Takes a path to a spec
+file under `docs/superpowers/specs/` and produces a structured objection
+record at `docs/superpowers/objections/<spec-slug>.md`.
+
+The record contains up to 12 objections across six categories — premise,
+scope, implementation, risk, alternatives, and specification quality — each
+rated critical, high, medium, or low severity. Every objection must include
+evidence quoted from the spec. The agent cannot raise objections without
+grounding them in the spec text.
+
+Objection dispositions must be written by a human before the plan-approval
+gate allows the pipeline to proceed. The agent's trust boundary is
+read-only — it cannot write dispositions for itself. This is the structural
+mechanism that enforces human cognitive engagement before implementation
+begins.
+
+Run `/diaboli <spec-path>` after spec-writer completes and before approving
+the plan. Re-run it if the spec is substantively edited after initial review.
 
 ### /worktree
 

--- a/docs/superpowers/objections/docs-advocatus-diaboli-and-harness-upgrade.md
+++ b/docs/superpowers/objections/docs-advocatus-diaboli-and-harness-upgrade.md
@@ -1,0 +1,175 @@
+---
+spec: docs-advocatus-diaboli-and-harness-upgrade
+date: 2026-04-19
+diaboli_model: claude-sonnet-4-6
+objections:
+  - id: O1
+    category: design
+    severity: major
+    claim: "The proposed /diaboli commands-reference entry describes the wrong six categories and a wrong four-point severity scale, directly contradicting the SKILL.md it is documenting."
+    evidence: "Spec lines 49-51: 'up to six objections across six categories (premise, scope, implementation, risk, alternatives, specification quality), each with a severity rating (critical / high / medium / low).' SKILL.md defines the categories as premise, design, threat, failure, operational, cost — and severity as the binary major/minor."
+    disposition: fix
+    disposition_rationale: Align SKILL.md with spec for objections as a different taxonomy only for objections.
+  - id: O2
+    category: design
+    severity: major
+    claim: "The proposed agents.md entry for advocatus-diaboli lists the same wrong six categories, meaning the reference documentation for the agent will contradict the SKILL.md that governs it."
+    evidence: "Spec lines 78-79: 'steel-manned objections across six categories: premise validity, scope creep, implementation risk, unaddressed alternatives, specification quality, and systemic risk.' None of these names match the SKILL.md category set (premise, design, threat, failure, operational, cost)."
+    disposition: fix
+    disposition_rationale: Make the SKILL.md match the spec as part of the work.
+  - id: O3
+    category: design
+    severity: major
+    claim: "The proposed /diaboli commands-reference entry states the agent produces 'up to six objections,' but SKILL.md caps the objection record at twelve."
+    evidence: "Spec line 48: 'The record contains up to six objections across six categories.' SKILL.md states: 'Cap at 12 objections per spec.'"
+    disposition: fix
+    disposition_rationale: Correct the commsnds reference.
+  - id: O4
+    category: failure
+    severity: major
+    claim: "The spec does not list commands.md's intro sentence ('All 21 slash commands') as a location requiring updating, which means the artefact list is incomplete and the intro will be stale after /diaboli is added."
+    evidence: "Spec 'Artefacts' section (lines 145-146): 'docs/reference/commands.md — /diaboli entry added, command count updated in intro if present.' The actual commands.md line 10 reads 'All 21 slash commands registered in commands/.' The qualifier 'if present' is incorrect — the count is unambiguously present — and the spec's expected outcome says 'The commands reference lists all 22 commands' without resolving the ambiguity."
+    disposition: fix
+    disposition_rationale: make sure the spec aligns with /diaboli addition.
+  - id: O5
+    category: failure
+    severity: minor
+    claim: "The first-time-tour.md opens by stating 'The plugin ships with twenty-one slash commands' — this sentence is not listed as a required update, but it becomes inaccurate once /diaboli is added."
+    evidence: "first-time-tour.md line 10: 'The plugin ships with twenty-one slash commands, a dozen agents.' The spec's tour update instructions (lines 107-113) address only the workflow-phase section and 'What Happens Next,' not the opening count sentence."
+    disposition: fix
+    disposition_rationale: Make the documentation match the real state of things.
+  - id: O6
+    category: failure
+    severity: minor
+    claim: "The agent-orchestration.md pipeline diagram is concrete and present in the file but the spec hedges its update with 'if one exists,' creating risk that the implementer leaves the five-agent diagram unchanged."
+    evidence: "Spec line 132: 'Also update the pipeline description and the sequence diagram (if one exists) to show the updated 6-step pipeline.' The diagram exists at agent-orchestration.md lines 94-126 and explicitly shows a five-agent sequence. The hedge 'if one exists' is factually wrong."
+    disposition: fix
+    disposition_rationale: remove the conditional in the spec.
+  - id: O7
+    category: design
+    severity: minor
+    claim: "The spec instructs adding a further-reading link to agent-orchestration.md without noting that the file already has a duplicate 'Agents Reference' link in that section, leaving the implementer to reproduce the duplication."
+    evidence: "Spec line 130: 'Update the Further Reading section to link to adversarial-review.md.' agent-orchestration.md lines 199 and 203 both read '- [Agents Reference]({% link reference/agents.md %}) — detailed catalogue of all agents in this plugin' — an existing duplication the spec does not acknowledge."
+    disposition: fix
+    disposition_rationale: remove the duplication
+  - id: O8
+    category: operational
+    severity: minor
+    claim: "The two new explanation pages and the new how-to are specified without YAML frontmatter metadata, making deterministic sidebar navigation positioning impossible to implement from the spec alone."
+    evidence: "File 5 (spec lines 115-127) and File 3 (spec lines 94-105) describe page content in full but include no frontmatter. Every existing docs page carries frontmatter with title, layout, parent, and nav_order fields."
+    disposition: fix
+    disposition_rationale: add tbe YAML frontmatter to the spec.
+  - id: O9
+    category: design
+    severity: minor
+    claim: "The proposed adversarial-review.md explanation page includes 'disposition distribution as a signal' as a content item, but no aggregate view of dispositions is defined anywhere in the plugin at v0.23.0, making this content speculative."
+    evidence: "Spec line 125: 'Disposition distribution as a signal: what deferred — not material clustering means.' No command, agent, or dashboard aggregates disposition values across objection records at v0.23.0."
+    disposition: leave
+    disposition_rationale: Leave this as the extra functionality is coming very, very soon.
+---
+
+## O1 — Wrong categories and severity scale in /diaboli commands entry
+
+The proposed `/diaboli` commands-reference entry describes the wrong six objection categories and a four-point severity scale that does not exist, directly contradicting the SKILL.md the entry is meant to document.
+
+The spec's proposed commands.md entry reads: "The record contains up to six objections across six categories (premise, scope, implementation, risk, alternatives, specification quality), each with a severity rating (critical / high / medium / low)."
+
+SKILL.md defines the six categories as `premise`, `design`, `threat`, `failure`, `operational`, `cost`. The severity scale is strictly binary: `major` or `minor`. Neither the category names nor the severity vocabulary in the spec match the actual skill.
+
+Commands reference entries are the primary source of truth consulted before running a command. A reader who runs `/diaboli` and then reads the objection record will find categories like `design` and `threat` that are nowhere in the entry they just read. A reader trying to interpret a `major` severity finding will search the commands page for what `major` means and find only `critical / high / medium / low`. The documentation will actively mislead users about the tool they are using from the first day it ships.
+
+---
+
+## O2 — Wrong categories in agents.md advocatus-diaboli entry
+
+The proposed agents.md entry for advocatus-diaboli lists the same wrong six categories, meaning both reference pages will describe a different agent from the one that is actually deployed.
+
+The spec's proposed agents.md entry reads: "steel-manned objections across six categories: premise validity, scope creep, implementation risk, unaddressed alternatives, specification quality, and systemic risk."
+
+The actual SKILL.md categories are `premise`, `design`, `threat`, `failure`, `operational`, `cost`. None of the six names in the spec match any of the six names in the skill. This is not a paraphrase — `scope creep`, `specification quality`, and `systemic risk` do not correspond to any SKILL.md category at all.
+
+A user who reads the agents reference to understand what advocatus-diaboli produces, then receives an objection record containing an `operational` or `cost` category, will have no framework for interpreting it. The mismatch between both reference pages and the actual output will generate confusion on every first use. Because the error appears in two separate files, it cannot be dismissed as a typo — it reflects a systematic confusion between the spec's own invented taxonomy and the one the skill actually implements.
+
+---
+
+## O3 — Wrong objection cap in /diaboli commands entry
+
+The proposed `/diaboli` entry caps the objection record at six objections; SKILL.md caps it at twelve. Any reader who relies on the commands reference will have a false ceiling when reviewing an objection record.
+
+Spec line 48: "The record contains up to six objections across six categories." SKILL.md states: "Cap at **12 objections** per spec." The justification for the twelve-cap is also given in SKILL.md and is non-trivial — it exists because more than twelve signals the spec is not ready for review.
+
+A reader told to expect at most six will incorrectly conclude that a seven-objection record is malformed or that the agent misfired. The cap is a meaningful operational signal, not an implementation detail. Twelve versus six is a factor of two — large enough that no reader would assume it is a minor rounding error.
+
+---
+
+## O4 — Artefact list hedges on commands.md count update that is not optional
+
+The spec's artefact description for commands.md uses the hedge "if present" for the count update, but the count sentence unambiguously exists; this ambiguity risks the implementer leaving "All 21 slash commands" unchanged after adding `/diaboli`.
+
+Spec artefact entry: "docs/reference/commands.md — /diaboli entry added, command count updated in intro if present." The actual commands.md line 10 reads: "All 21 slash commands registered in `commands/`." The count is present. The spec's expected outcome states: "The commands reference lists all 22 commands including /diaboli." There is a direct contradiction between an artefact description that hedges ("if present") and an outcome statement that is unhedged.
+
+A commands reference that opens by declaring 21 commands and then lists 22 is incorrect from line 10. The count sentence is the first substantive claim the reader encounters. Leaving it at 21 after adding `/diaboli` means every subsequent reader is immediately given wrong information before they reach the new entry.
+
+---
+
+## O5 — First-time-tour opening count sentence not flagged for update
+
+The first-time-tour.md opening sentence states "The plugin ships with twenty-one slash commands" but the spec's tour update instructions do not include updating this sentence, leaving it stale after `/diaboli` is added.
+
+first-time-tour.md line 10 reads: "The plugin ships with twenty-one slash commands, a dozen agents, and dozens of skills." The spec's instructions for updating the tour address only the workflow-phase section and the "What Happens Next" paragraph. The opening count sentence is not mentioned.
+
+The first-time-tour is the primary onboarding path. A new user whose first encounter with the plugin is this tutorial will be told there are twenty-one commands, then later see `/diaboli` in the commands reference as a twenty-second entry. Since the spec already correctly identifies the analogous agent count error in agents.md as "critical," omitting the equivalent tour fix is inconsistent with the spec's own severity judgements.
+
+---
+
+## O6 — Pipeline diagram update hedged as optional when diagram concretely exists
+
+The agent-orchestration.md pipeline diagram showing a five-agent sequence exists concretely in the file, but the spec hedges its update requirement with "if one exists," creating risk that an implementer treats the diagram as optional to update.
+
+Spec line 132: "Also update the pipeline description and the sequence diagram (if one exists) to show the updated 6-step pipeline." The diagram exists at agent-orchestration.md lines 94-126, beginning with `Requirements` and ending with `[Integrator] --> Changelog, commit, PR, CI` — a specific, labelled five-agent ASCII flow with gates and cycle annotations. The hedge "if one exists" is factually false for this file.
+
+The pipeline diagram in agent-orchestration.md is the most concrete visual representation of the pipeline in the entire docs site. If it continues to show five agents after the advocatus-diaboli is added, a reader who follows the diagram to understand how the pipeline works will have an incorrect mental model. The "Key Takeaways" section also summarises "five focused jobs" — both require updating.
+
+---
+
+## O7 — Further-reading update doesn't address existing duplicate link
+
+The spec instructs adding a link to agent-orchestration.md's further-reading section without acknowledging the duplicate "Agents Reference" entry that already exists there, leaving the implementer to reproduce the duplication.
+
+Spec line 130: "Update the 'Further Reading' section to link to adversarial-review.md." agent-orchestration.md lines 199 and 203 are identical: both read `- [Agents Reference]({% link reference/agents.md %}) — detailed catalogue of all agents in this plugin`. The spec asks the implementer to add a third link to an already-duplicated section.
+
+Adding a link to a further-reading section that already has a broken duplicate is a missed cleanup opportunity that an implementer with the file open will notice but may not feel authorised to fix without spec coverage. The net result is a section with one duplicated entry and one new entry, leaving the section's quality worse than when it started.
+
+---
+
+## O8 — New pages specified without Jekyll frontmatter nav_order values
+
+The two new explanation pages and the new how-to are specified without YAML frontmatter metadata, making deterministic sidebar navigation positioning impossible to implement from the spec alone.
+
+File 5 and File 3 describe page content in detail but include no frontmatter block. Every existing docs page carries frontmatter specifying `title`, `layout`, `parent`, and `nav_order`. The spec references other how-tos as patterns but does not specify nav_order values for the new pages, which are required for deterministic sidebar positioning.
+
+Without explicit nav_order values, the implementer must inspect every sibling page to determine the next available slot, or guess — either of which may place the new pages in an unintended position in the sidebar. A page placed at the wrong nav_order slot may be buried or may displace an existing page, and no CI check will catch it.
+
+---
+
+## O9 — Disposition distribution as a signal has no tooling affordance at v0.23.0
+
+The proposed adversarial-review.md explanation page includes "disposition distribution as a signal" as a content item, but no aggregate view of dispositions is defined anywhere in the plugin at v0.23.0, making this content speculative and potentially misleading.
+
+Spec line 125: "Disposition distribution as a signal: what `deferred — not material` clustering means." The SKILL.md objection record format defines individual disposition fields per objection. No command, agent, or dashboard aggregates disposition values across objection records. No GC rule, health check, or observatory signal references disposition distributions.
+
+Writing an explanation page that teaches readers to interpret a signal — clustering of `deferred — not material` dispositions — before the tooling to observe that signal exists requires manual counting across multiple markdown files. The explanation page would be more accurate if it either scoped this item to a future affordance or described the current manual approach explicitly.
+
+---
+
+## Explicitly not objecting to
+
+- **The decision to create adversarial-review.md as a standalone page rather than a section in agent-orchestration.md**: The intellectual foundations (Promoter Fidei, Popper, Schopenhauer) are substantive enough to warrant their own page, and splitting them out avoids bloating the orchestration page.
+
+- **The gap inventory table's identification of harness-upgrade as already-covered in commands.md**: The spec correctly identifies (lines 30-34) that `/harness-upgrade` is present at line 125 of commands.md and removes it from the gap list. This is accurate and appropriately removes unnecessary work.
+
+- **The placement of the /diaboli mention in the first-time-tour's "What Happens Next" section and the workflow phase**: The spec's proposed addition ("after spec-writer when starting any feature — before plan approval") is correctly placed — it belongs in a workflow-cadence section, not a one-time setup phase.
+
+- **The choice not to bump the plugin version**: The CLAUDE.md conventions explicitly state that docs-only changes outside `ai-literacy-superpowers/` do not require a version bump. The spec's exemption section correctly applies this rule.
+
+- **The two-sentence description of the human-cognition gate in both the commands and agents entries**: Explaining why the agent cannot write its own dispositions is the load-bearing pedagogical point of the feature. Including it in both reference pages, even at the cost of repetition, is the right call for a concept that is deliberately counter-intuitive.

--- a/docs/superpowers/specs/2026-04-19-docs-advocatus-diaboli-and-harness-upgrade.md
+++ b/docs/superpowers/specs/2026-04-19-docs-advocatus-diaboli-and-harness-upgrade.md
@@ -1,0 +1,318 @@
+---
+name: docs-advocatus-diaboli-and-harness-upgrade
+description: Spec for docs site additions covering the advocatus-diaboli (v0.23.0) and harness-upgrade features plus gap-fill for the updated pipeline
+date: 2026-04-19
+status: approved
+---
+
+# Docs: Advocatus Diaboli and Harness Upgrade Coverage
+
+## Problem
+
+The v0.23.0 plugin release shipped the `advocatus-diaboli` adversarial spec review feature. The docs site has no coverage for it — `/diaboli` is absent from the commands reference, the `advocatus-diaboli` agent is missing from the agents reference (count is wrong: says 11, is 12), the orchestrator pipeline description is outdated (still shows 5-agent linear sequence), no how-to exists for running adversarial review, and the first-time tour never mentions the command.
+
+`/harness-upgrade` (added at v0.22.0) has a how-to and appears in the tour, but the commands reference entry was already present and does not need updating.
+
+Additionally, the agent-orchestration explanation page mentions sycophantic agents and adversarial review in passing but never names the mechanism or connects it to the diaboli feature. The intellectual foundations in the spec (Promoter Fidei, Popper, Schopenhauer) are distinctive enough to warrant a standalone explanation page.
+
+## Objection resolution notes
+
+*Applied after advocatus-diaboli review of this spec:*
+
+- **O1/O2 (design/major):** The spec had used wrong category names and severity scale in proposed reference entries. The correct taxonomy (adopted by the implementation's SKILL.md update) is: categories — `premise`, `scope`, `implementation`, `risk`, `alternatives`, `specification quality`; severity — `critical`, `high`, `medium`, `low`. Reference entries below have been corrected. SKILL.md is added to the artefact list.
+- **O3 (design/major):** Cap corrected to 12 in the commands reference entry (SKILL.md cap unchanged at 12). The spec had incorrectly stated "up to six."
+- **O4 (failure/major):** "If present" hedge removed from artefact description of commands.md count update. It is present; it must be updated.
+- **O5 (failure/minor):** First-time-tour opening count sentence added to the list of required updates.
+- **O6 (failure/minor):** "If one exists" hedge removed from pipeline diagram update instruction. The diagram exists at lines 94–126 of agent-orchestration.md and must be updated.
+- **O7 (design/minor):** Instruction to remove duplicate "Agents Reference" link added to agent-orchestration.md update.
+- **O8 (operational/minor):** YAML frontmatter specifications (title, layout, parent, nav_order) added for all new pages.
+- **O9 (design/minor):** Disposition distribution content retained — additional tooling is expected imminently.
+
+## Approach
+
+Add all missing docs in the smallest number of well-scoped files. Each gap maps to exactly one file addition or update.
+
+### Gap inventory
+
+| Gap | File | Action |
+|---|---|---|
+| `/diaboli` missing from commands ref | `docs/reference/commands.md` | Add entry; update count from 21 to 22 |
+| Agent count wrong; advocatus-diaboli absent | `docs/reference/agents.md` | Add entry; update count; update pipeline prose and diagram |
+| SKILL.md uses old category taxonomy | `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` | Update categories and severity vocabulary |
+| No how-to for adversarial spec review | `docs/how-to/review-a-spec-adversarially.md` | Create |
+| First-time tour missing `/diaboli` | `docs/tutorials/first-time-tour.md` | Update opening count; add to workflow phase and "What Happens Next" |
+| No explanation for adversarial review concept | `docs/explanation/adversarial-review.md` | Create |
+| `agent-orchestration.md` doesn't name diaboli | `docs/explanation/agent-orchestration.md` | Update pipeline diagram; update "Where This Breaks Down"; update "Further Reading" |
+
+---
+
+## File specifications
+
+### 1. `docs/reference/commands.md` — add `/diaboli`
+
+**Count update:** Change "All 21 slash commands" (line 10) to "All 22 slash commands".
+
+**New entry** — add to the Workflow section, after `/convention-sync` and before `/worktree`:
+
+```markdown
+### /diaboli
+
+- **Skills read**: advocatus-diaboli
+- **Agents dispatched**: advocatus-diaboli
+
+Run the adversarial spec reviewer on a spec file. Takes a path to a spec
+file under `docs/superpowers/specs/` and produces a structured objection
+record at `docs/superpowers/objections/<spec-slug>.md`.
+
+The record contains up to 12 objections across six categories — premise,
+scope, implementation, risk, alternatives, and specification quality — each
+rated critical, high, medium, or low severity. Every objection must include
+evidence quoted from the spec. The agent cannot raise objections without
+grounding them in the spec text.
+
+Objection dispositions must be written by a human before the plan-approval
+gate allows the pipeline to proceed. The agent's trust boundary is
+read-only — it cannot write dispositions for itself. This is the structural
+mechanism that enforces human cognitive engagement before implementation
+begins.
+
+Run `/diaboli <spec-path>` after spec-writer completes and before approving
+the plan. Re-run it if the spec is substantively edited after initial review.
+```
+
+### 2. `docs/reference/agents.md` — add advocatus-diaboli
+
+**Four changes:**
+
+**a. Count:** "11 agents" → "12 agents" in the header paragraph.
+
+**b. Pipeline intro:** "These five agents form the spec-first development pipeline. The orchestrator dispatches them in sequence: spec, test, implement, review, integrate." →
+
+```
+These six agents form the spec-first development pipeline. The orchestrator
+dispatches them in sequence: after spec-writer produces the spec, the
+advocatus-diaboli reviews it adversarially and a human adjudicates the
+objections before plan approval; only then do tdd-agent, code-reviewer,
+and integration-agent run.
+```
+
+**c. New agent entry** — insert after spec-writer and before tdd-agent:
+
+```markdown
+### advocatus-diaboli
+
+- **Tools**: Read, Glob, Grep
+- **Dispatched by**: orchestrator (after spec-writer, before plan approval)
+- **Trust boundary**: Read-only
+
+Adversarial spec reviewer. Reads the spec file produced by spec-writer and
+raises steel-manned objections across six categories: premise, scope,
+implementation, risk, alternatives, and specification quality. Produces a
+structured objection record at `docs/superpowers/objections/<spec-slug>.md`.
+
+Cannot modify the spec. Cannot write objection dispositions. Both
+constraints are structural: the read-only boundary makes it impossible to
+alter the problem statement, and the absence of a disposition-writing tool
+forces a human to open the record and adjudicate before the pipeline
+proceeds. This human-cognition gate is the primary purpose of the agent —
+not finding objections, but ensuring a human engages with them.
+```
+
+**d. Tool summary table** — add row after spec-writer:
+
+```
+| advocatus-diaboli | x | | | x | x | | | | read-only |
+```
+
+### 3. `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` — update taxonomy
+
+The existing SKILL.md uses categories `premise`, `design`, `threat`, `failure`, `operational`, `cost` and severity `major`/`minor`. Update to align with the user-facing taxonomy that the docs establish:
+
+**Categories** — replace the six `### heading` blocks and their examples with:
+
+- **premise** — the spec solves the wrong problem, or assumes the problem exists when it may not
+- **scope** — the spec includes work that is unnecessary for the problem, or excludes work that is necessary
+- **implementation** — the chosen approach has a structural flaw independent of the problem being real
+- **risk** — the design creates or ignores a trust, safety, or operational risk gap
+- **alternatives** — a materially better approach exists and the spec does not acknowledge it
+- **specification quality** — the spec is ambiguous, incomplete, or internally inconsistent in ways that would cause divergent implementations
+
+**Severity** — replace `major`/`minor` with `critical`, `high`, `medium`, `low`:
+
+- **critical** — if unaddressed, the feature should not proceed as described
+- **high** — significant structural concern requiring substantive human decision
+- **medium** — real concern warranting acknowledgement; does not block the approach
+- **low** — minor note; informational, no action required before proceeding
+
+**Cap:** Unchanged at 12 objections per spec.
+
+**YAML frontmatter schema:** Update `severity: major|minor` to `severity: critical|high|medium|low` and `category: premise|design|threat|failure|operational|cost` to `category: premise|scope|implementation|risk|alternatives|specification quality`.
+
+### 4. `docs/how-to/review-a-spec-adversarially.md` (new)
+
+```yaml
+---
+title: Review a Spec Adversarially
+layout: default
+parent: How-to Guides
+nav_order: 38
+---
+```
+
+Structure following the pattern of `review-code-with-cupid.md` and `run-a-harness-audit.md`:
+
+1. **When to use this** — after spec-writer completes, before approving the plan; also when a spec is substantially edited after an objection record already exists
+2. **Run `/diaboli <spec-path>`** — what the command does, where the output goes
+3. **Read the objection record** — structure of the record (frontmatter + prose per objection); how to interpret categories and severities
+4. **Write dispositions inline** — the four disposition values; that this cannot be delegated back to an agent; why the gate exists
+5. **Re-run when the spec changes** — old dispositions are lost on regeneration (intentional)
+6. **What you have now** — an adjudicated objection record that unblocks the pipeline
+7. **Next steps** — present the plan for approval, link to `adversarial-review.md`
+
+The how-to must make the human-cognition gate explicit — this is not a task to delegate back to an agent.
+
+### 5. `docs/tutorials/first-time-tour.md` — add diaboli
+
+**Opening count:** Change "The plugin ships with twenty-one slash commands" to "The plugin ships with twenty-two slash commands" in the intro paragraph.
+
+**Workflow phase** — add a new `/diaboli` section alongside `/worktree` and `/harness-upgrade` in Phase 7 (or the applicable workflow capabilities phase):
+
+```
+### `/diaboli`
+
+**What it does.** Dispatches the advocatus-diaboli agent against a spec file
+to produce a structured objection record at
+`docs/superpowers/objections/<slug>.md`. The agent raises up to 12 objections
+across six categories, each with a severity rating. Objection dispositions
+must be written by a human — the agent cannot do this for itself.
+
+**When to reach for it.** After spec-writer produces a spec and before you
+approve the plan. The orchestrator invokes it automatically in the pipeline;
+run it manually when working outside the full pipeline or when a spec is
+substantively revised after initial review.
+```
+
+**"What Happens Next" section** — add to the between-quarters list:
+
+```
+- `/diaboli <spec-path>` after spec-writer when starting any feature — before plan approval
+```
+
+### 6. `docs/explanation/adversarial-review.md` (new)
+
+```yaml
+---
+title: Adversarial Review
+layout: default
+parent: Explanation
+nav_order: 19
+---
+```
+
+Content sections:
+
+1. **The sycophancy problem** — why agentic pipelines structurally suppress disagreement; confirmation bias in same-agent review; sunk-cost pressure on premise-level objections once artefacts exist
+2. **The Promoter of the Faith** — historical precedent; the role, its abolition in 1983, and the acceleration of beatifications; the lesson: removing adversarial gates does not improve decision quality, it removes the friction quality requires
+3. **Popperian falsifiability** — a spec is only as strong as the attempts to falsify it that it survives; an unchallenged spec is an untested assertion
+4. **Schopenhauer's non-goal** — what the agent must not do; the 38 rhetorical stratagems for winning arguments regardless of truth are explicitly off-limits; every objection requires evidence grounded in the spec
+5. **The gate mechanism** — why the agent cannot write dispositions; the read-only trust boundary; the human-cognition gate as the structural mechanism; it is not about finding objections but ensuring a human engages with them
+6. **Disposition distribution as a signal** — what the pattern of dispositions over time reveals about spec quality and charter tuning; clustering of `low` severity responses signals the objection charter needs tuning; clustering of `critical` accepted signals the spec pipeline needs strengthening upstream
+7. **How this fits the three loops** — adversarial review is part of the commit-time loop; objection records accumulate in `docs/superpowers/objections/` and feed the reflection and GC loops
+
+### 7. `docs/explanation/agent-orchestration.md` — three updates
+
+**a. Pipeline diagram** (lines 94–126) — update to show the 6-stage pipeline including the advocatus-diaboli and the human-cognition gate between spec-writer and tdd-agent:
+
+```text
+Requirements
+    |
+    v
+[Spec Writer] --> Spec document
+    |
+    v
+[Advocatus Diaboli] --> Objection record
+    |
+    v
+*** HUMAN ADJUDICATES OBJECTIONS ***
+    |
+    v
+*** HUMAN REVIEWS AND APPROVES SPEC ***
+    |
+    v
+[Test Writer] --> Failing tests
+    |
+    v
+(tests run automatically to confirm they fail)
+    |
+    v
+[Implementer] --> Implementation code
+    |
+    v
+(tests run automatically to confirm they pass)
+    |
+    v
+[Reviewer] --> Approve / Request changes
+    |                       |
+    |                       v
+    |               [Implementer fixes]
+    |                       |
+    |               [Reviewer re-checks]
+    |               (max 3 cycles!)
+    |                       |
+    v                       v
+[Integrator] --> Changelog, commit, PR, CI
+```
+
+Also update the human-gate description below the diagram: the original text focuses on spec approval; add a sentence explaining that spec approval is now preceded by an adversarial review and human adjudication of the objections.
+
+**b. "Where This Breaks Down" section** — after the existing paragraph on "Agents that agree too easily," add:
+
+```
+The structural solution to sycophantic reviewers is not better instructions — it is a
+separate agent whose entire charter is disagreement, dispatched before any
+implementation artefacts exist. This is the advocatus-diaboli: a read-only agent that
+reviews the spec, raises evidence-grounded objections, and cannot write its own
+dispositions. The last constraint is structural: a human must open the objection record
+and adjudicate before the pipeline proceeds. This is not a quality filter — it is a
+cognitive-engagement gate.
+```
+
+**c. Further Reading section** — remove the duplicate "Agents Reference" link (both line 199 and 203 are identical). Add:
+
+```
+- [Adversarial Review]({% link explanation/adversarial-review.md %}) — the concepts behind the advocatus-diaboli and the human-cognition gate
+```
+
+Also update the "Key Takeaways" bullet that says "Five focused jobs, no overlap" to reflect the six-agent pipeline.
+
+---
+
+## Expected outcome
+
+After this work:
+
+- The commands reference lists all 22 commands including `/diaboli`, with correct category taxonomy and 12-objection cap
+- The agents reference counts 12 agents; the pipeline intro and diagram show the 6-stage sequence with two human gates
+- SKILL.md uses the established category taxonomy (premise, scope, implementation, risk, alternatives, specification quality) and severity vocabulary (critical, high, medium, low)
+- A reader who runs `/diaboli` for the first time can find a how-to at `docs/how-to/review-a-spec-adversarially.md`
+- The first-time tour mentions `/diaboli` with an accurate command count (22) and plugin description
+- The adversarial review concept has a standalone explanation page at `docs/explanation/adversarial-review.md`
+- The agent-orchestration page names the advocatus-diaboli, shows the updated pipeline, and links to the explanation page
+
+---
+
+## Artefacts
+
+1. `docs/reference/commands.md` — count updated to 22; `/diaboli` entry added
+2. `docs/reference/agents.md` — count updated to 12; pipeline intro updated; advocatus-diaboli entry added; tool table updated; Key Takeaways updated
+3. `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` — categories and severity vocabulary updated
+4. `docs/how-to/review-a-spec-adversarially.md` — new how-to (nav_order: 38)
+5. `docs/tutorials/first-time-tour.md` — opening count updated; `/diaboli` section added to workflow phase; "What Happens Next" updated
+6. `docs/explanation/adversarial-review.md` — new explanation page (nav_order: 19)
+7. `docs/explanation/agent-orchestration.md` — pipeline diagram updated; "Where This Breaks Down" updated; "Further Reading" de-duplicated and extended; "Key Takeaways" updated
+
+---
+
+## Exemptions
+
+Docs-only change. The SKILL.md update is internal to the plugin directory — it changes category vocabulary and severity vocabulary only, with no behavioural change to the command or agent flow. Per CLAUDE.md: "If the change is a fix or doc update to plugin files only, bump the patch version." However, the taxonomy change may warrant a minor bump review — check whether the frontmatter schema change in SKILL.md constitutes a behavioural change. Apply `no-bump` label if judged cosmetic-only.

--- a/docs/tutorials/first-time-tour.md
+++ b/docs/tutorials/first-time-tour.md
@@ -7,7 +7,7 @@ nav_order: 7
 
 # A First-Time Tour of Every Capability
 
-The plugin ships with twenty-one slash commands, a dozen agents, and
+The plugin ships with twenty-two slash commands, a dozen agents, and
 dozens of skills. Opened all at once, that is a lot of surface area.
 This tutorial gives you a single route through it — every capability
 in the order it is most useful on a first run, with the reason each
@@ -508,6 +508,26 @@ removes it.
 agents on independent work streams, or run a risky refactor in
 isolation from your main workspace.
 
+### `/diaboli`
+
+**What it does.** Dispatches the advocatus-diaboli agent against a
+spec file and produces a structured objection record at
+`docs/superpowers/objections/<slug>.md`. The agent raises up to 12
+objections across six categories (premise, scope, implementation,
+risk, alternatives, specification quality), each with a severity
+rating (critical, high, medium, low). Objection dispositions must
+be written by a human — the agent cannot do this for itself.
+
+**When to reach for it.** After spec-writer produces a spec and
+before you approve the plan. The orchestrator invokes it
+automatically in the pipeline; run it manually when working outside
+the full pipeline or when a spec is substantially revised after
+initial review.
+
+```text
+/diaboli docs/superpowers/specs/2026-04-19-my-feature.md
+```
+
 ### `/harness-upgrade`
 
 **What it does.** Compares the template version marker in your
@@ -557,7 +577,9 @@ it is short:
 
 Between quarters: `/reflect` after meaningful sessions,
 `/harness-constrain` to promote unverified constraints as tooling
-arrives, `/harness-upgrade` when plugin updates land.
+arrives, `/harness-upgrade` when plugin updates land,
+`/diaboli <spec-path>` after spec-writer when starting any feature —
+before plan approval.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `docs/explanation/adversarial-review.md` — standalone explanation page covering the Promoter Fidei historical precedent, Popperian falsifiability, the Schopenhauer non-goal, the human-cognition gate mechanism, and disposition patterns as a signal
- Add `docs/how-to/review-a-spec-adversarially.md` — practical guide for running `/diaboli`, reading the objection record, and writing dispositions
- Update `docs/reference/commands.md` — `/diaboli` entry added, count 21→22
- Update `docs/reference/agents.md` — `advocatus-diaboli` agent added, count 11→12, pipeline updated to six-stage sequence
- Update `docs/explanation/agent-orchestration.md` — pipeline diagram updated, human-gate description updated, adversarial-review.md linked, duplicate link removed
- Update `docs/tutorials/first-time-tour.md` — `/diaboli` section added, count twenty-one→twenty-two
- Update `skills/advocatus-diaboli/SKILL.md` — category taxonomy updated (design/threat/failure/operational/cost → scope/implementation/risk/alternatives/specification quality); severity updated (major/minor → critical/high/medium/low)

Closes #179

Upstream spec: `docs/superpowers/specs/2026-04-19-docs-advocatus-diaboli-and-harness-upgrade.md`
Objection record: `docs/superpowers/objections/docs-advocatus-diaboli-and-harness-upgrade.md` (9 objections adjudicated before implementation)

The SKILL.md taxonomy change is a behavioural change (observable output format) and warrants a minor bump: 0.23.0 → 0.24.0.

## Test plan

- [ ] CI lint passes (markdownlint, version-check, spec-first)
- [ ] `/diaboli` entry visible in commands reference
- [ ] `advocatus-diaboli` agent entry visible in agents reference with correct tool table row
- [ ] Pipeline diagram in agent-orchestration.md shows 6-stage sequence with two human gates
- [ ] New pages render correctly in docs site (adversarial-review.md, review-a-spec-adversarially.md)
- [ ] Version consistent: plugin.json, README badge, CHANGELOG heading all show 0.24.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)