### PR TITLE
Add constraint: reflections via PR workflow

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -216,6 +216,18 @@
 - **Tool**: none yet
 - **Scope**: pr
 
+### Reflections via PR workflow
+
+- **Rule**: Every addition to `REFLECTION_LOG.md` must be committed on a
+  branch and merged to `main` via a PR with CI passing. Direct commits to
+  `main` that modify `REFLECTION_LOG.md` are prohibited. Applies to all
+  `/reflect` invocations. Effective from 2026-04-20 — commits before that
+  date are exempt (historical pattern pre-dates this constraint).
+- **Enforcement**: deterministic
+- **Tool**: `! git log --no-merges --format="%H %s" --since="2026-04-20"
+  origin/main -- REFLECTION_LOG.md | grep -v "#[0-9]" | grep -q .`
+- **Scope**: weekly
+
 <!-- Uncomment if using spec-first development:
 
 ### Spec conformance


### PR DESCRIPTION
## Summary

- Adds a new HARNESS.md constraint requiring all additions to `REFLECTION_LOG.md` to go through the PR workflow (branch → PR → CI → merge)
- Direct commits to `main` touching `REFLECTION_LOG.md` are prohibited from 2026-04-20 onwards
- Enforcement: deterministic weekly check — `git log` scans for commits without a PR reference in the message
- Test run against current state: **PASS** (no violations since 2026-04-20)

Closes #181

Context: git history showed 19 direct reflection commits in the last 90 days. The constraint makes the existing "Always Work on a Branch" expectation explicit and measurable for reflections specifically.

HARNESS.md is outside the plugin directory — no version bump required (docs-only per CLAUDE.md). Add `no-bump` label once available.

## Test plan

- [ ] CI passes (markdownlint, version-check)
- [ ] Constraint block has all required fields (Rule, Enforcement, Tool, Scope)
- [ ] Tool command returns PASS locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)