### PR TITLE
Add update-the-plugin docs and README check-for-updates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Once installed, the plugin's skills, agents, hooks, and commands (or prompts) ar
 
 ### Updating
 
+#### Check if an update is available
+
+Three signals surface new versions without manual polling:
+
+- **SessionStart hook** — if your project has a HARNESS.md, the hook compares
+  its `template-version` marker against the installed plugin version and emits
+  a nudge if they differ. This fires once per upgrade and goes silent after you
+  run `/harness-upgrade`.
+- **Weekly GC rule** — the `Template currency` rule checks the same marker on
+  its weekly schedule and includes any mismatch in the `/harness-health` report.
+- **Manual check** — compare installed vs latest at any time:
+
+```bash
+claude plugin list
+```
+
 #### Update the plugin
 
 When a new version is released, update your local installation:
@@ -62,6 +78,9 @@ claude plugin update ai-literacy-superpowers
 ```
 
 Check the [CHANGELOG](CHANGELOG.md) for what changed between versions.
+
+After updating, run `/harness-upgrade` to review and adopt any new template
+content (constraints, GC rules, optional blocks) into your HARNESS.md.
 
 #### Update the marketplace listing
 

--- a/docs/how-to/update-the-plugin.md
+++ b/docs/how-to/update-the-plugin.md
@@ -7,36 +7,47 @@ nav_order: 27
 
 # Update the Plugin
 
-Keep the plugin and marketplace listing current when new versions are
-released.
+Keep the plugin current when new versions are released, and adopt new
+template content into your HARNESS.md after each update.
 
 ---
 
-## Prerequisites
+## How you find out an update is available
 
-- The plugin is already installed (see [Installation](../../README.md#installation))
-- For marketplace updates: you maintain a marketplace that includes
-  this plugin
+You don't need to check manually. Three signals surface new versions:
 
----
+**SessionStart hook.** When you start a Claude Code session in a
+project that has a HARNESS.md, the hook compares the `template-version`
+marker in your file against the installed plugin version. If they differ
+it emits:
 
-## 1. Check for a new version
+```
+Plugin template has been updated (your harness: vX.Y.Z, plugin: vA.B.C).
+Run /harness-upgrade to see what's new.
+```
 
-Compare your installed version against the latest release:
+This fires once per plugin upgrade and goes silent after you run
+`/harness-upgrade`.
+
+**Weekly GC rule.** The `Template currency` GC rule checks the same
+marker on its weekly schedule and reports the mismatch in the
+`/harness-health` snapshot, giving it visibility in the observability
+loop even if you dismissed the SessionStart nudge.
+
+**Manual check.** Compare your installed version against the latest
+release at any time:
 
 ```bash
 claude plugin list
 ```
 
-Look for `ai-literacy-superpowers` in the output. The version shown is
-what you have locally. Check the
-[CHANGELOG](../../CHANGELOG.md) or the
-[releases page](https://github.com/Habitat-Thinking/ai-literacy-superpowers/releases)
-for the latest version.
+Look for `ai-literacy-superpowers` in the output and compare the version
+shown against the [releases page](https://github.com/Habitat-Thinking/ai-literacy-superpowers/releases)
+or the [CHANGELOG](../../CHANGELOG.md).
 
 ---
 
-## 2. Update the installed plugin
+## 1. Update the installed plugin
 
 Pull the latest version into your local environment:
 
@@ -56,23 +67,47 @@ not overwritten; only the plugin itself is updated.
 
 ---
 
-## 3. Review what changed
+## 2. Review what changed
 
-After updating, check the changelog for anything that affects your
-workflow:
+Check the changelog for anything that affects your workflow:
 
 ```bash
-# In Claude Code, read the changelog
-cat node_modules/.claude/plugins/ai-literacy-superpowers/CHANGELOG.md
+# Read the installed changelog directly
+cat ~/.claude/plugins/cache/ai-literacy-superpowers/ai-literacy-superpowers/<version>/CHANGELOG.md
 ```
 
-Or check the [CHANGELOG](../../CHANGELOG.md) on GitHub. Pay attention
+Or browse the [CHANGELOG](../../CHANGELOG.md) on GitHub. Pay attention
 to:
 
-- **New skills or agents** that you may want to use
+- **New skills or agents** you may want to use
 - **Changed hooks** that may alter advisory behaviour
-- **Version bumps** that indicate breaking changes (minor bumps in
-  pre-1.0 may include behavioural changes)
+- **New template content** (new constraints, GC rules, or optional
+  blocks) — these are adopted via `/harness-upgrade` in the next step
+- **Minor version bumps** — in pre-1.0, minor bumps may include
+  behavioural changes
+
+---
+
+## 3. Upgrade your HARNESS.md
+
+Updating the plugin does not automatically update your HARNESS.md. New
+template content — constraints, GC rules, optional blocks — must be
+adopted explicitly:
+
+```text
+/harness-upgrade
+```
+
+The command compares the `<!-- template-version: X.Y.Z -->` marker in
+your HARNESS.md against the installed plugin version. It presents each
+new or changed item with a summary of what it does and lets you accept
+or skip each one individually.
+
+After you finish, the marker is updated to the current plugin version
+and the SessionStart nudge goes silent until the next release.
+
+See [Upgrade Your Harness](upgrade-your-harness.md) for the full
+step-by-step guide to the upgrade menu.
 
 ---
 
@@ -118,14 +153,16 @@ claude plugin install ai-literacy-superpowers
 
 ## What you have now
 
-Your plugin is at the latest version. All skills, agents, hooks, and
-commands reflect the newest release. If you maintain a marketplace, it
-now advertises the current version to other users.
+Your plugin is at the latest version and your HARNESS.md has been
+reviewed for new template content. All skills, agents, hooks, and
+commands reflect the newest release.
+
+---
 
 ## Next steps
 
-- [Check harness health](run-a-harness-audit.md) after major version
-  updates
+- [Run a harness audit](run-a-harness-audit.md) after major version
+  updates to verify nothing has drifted
 - [Review the CHANGELOG](../../CHANGELOG.md) for migration notes
 - [Run an assessment](run-an-assessment.md) to see if new skills
   unlock higher literacy levels


### PR DESCRIPTION
## Summary

- Rewrites `docs/how-to/update-the-plugin.md` to cover all three signals that surface new plugin versions (SessionStart hook, weekly GC rule, `claude plugin list`), adds `/harness-upgrade` as step 3 in the update workflow, and fixes the CHANGELOG cache path
- Extends README `Updating` section with the same three-signal discovery block and a post-update `/harness-upgrade` reminder

## Test plan

- [ ] Read `docs/how-to/update-the-plugin.md` — verify three discovery signals, correct CHANGELOG path, harness-upgrade step present
- [ ] Read README `Updating` section — verify three-signal block and harness-upgrade mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)