### PR TITLE
Fix claude plugin update command to include marketplace specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When a new version is released, update your local installation:
 
 ```bash
 # Claude Code
-claude plugin update ai-literacy-superpowers
+claude plugin update ai-literacy-superpowers@ai-literacy-superpowers
 
 # Copilot CLI
 /plugin update ai-literacy-superpowers

--- a/docs/how-to/update-the-plugin.md
+++ b/docs/how-to/update-the-plugin.md
@@ -53,7 +53,7 @@ Pull the latest version into your local environment:
 
 ```bash
 # Claude Code
-claude plugin update ai-literacy-superpowers
+claude plugin update ai-literacy-superpowers@ai-literacy-superpowers
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

- Corrects `claude plugin update ai-literacy-superpowers` → `claude plugin update ai-literacy-superpowers@ai-literacy-superpowers` in README.md and `docs/how-to/update-the-plugin.md`
- Copilot CLI form (`/plugin update ai-literacy-superpowers`) is unchanged — only the Claude Code command needs the marketplace qualifier

## Test plan

- [ ] Verify both files show `claude plugin update ai-literacy-superpowers@ai-literacy-superpowers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)