### PR TITLE
Add diaboli observability panel to status and health commands (v0.25.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.24.0",
+  "plugin_version": "0.25.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.24.0"
+      "version": "0.25.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,22 @@
   the constraint. Do not weaken the constraint at first friction — that builds
   ceremony, not a gate.
 
+- Decision: diaboli activity is surfaced as descriptive stats in existing
+  observability surfaces (`/superpowers-status` Section 7 and the harness-health
+  snapshot Diaboli panel) without thresholds or new enforcement, pending a
+  reflection-informed evaluation. Alternatives considered and rejected:
+  (1) adding a disposition-balance GC rule now — rejected because no data yet
+  exists on what healthy looks like, and a premature threshold creates
+  rubber-stamping pressure (the exact failure mode the mechanism is designed to
+  prevent); (2) adding a separate `/diaboli-status` command — rejected because it
+  fragments the observability surface; status and health are already the canonical
+  panels and adding a third creates a maintenance surface with no corresponding
+  benefit. Conditions under which this is revisited: after 10 fully-resolved
+  objection records OR by 2026-07-19, whichever comes first — write a reflection
+  on the observed patterns (disposition distribution, mean objections, median
+  days) and decide whether a threshold or GC rule is warranted. The revisit
+  output is a reflection entry, not an automatic constraint.
+
 ## TEST_STRATEGY
 
 <!-- How tests are structured in this project. Helps agents write consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.25.0 — 2026-04-19
+
+### Feature — diaboli observability panel
+
+- Add Diaboli panel to `commands/superpowers-status.md` (Section 7) — surfaces
+  in-scope vs exempt spec count, objection records present, in-scope specs without
+  a record, fully-resolved record rate, objections total with severity breakdown,
+  mean objections per spec, disposition distribution, and median days
+  spec-to-disposition; summary uses standard `OK`/`MISSING` tokens; error handling
+  for malformed YAML frontmatter
+- Add Diaboli section to snapshot format (`skills/harness-observability/references/
+  snapshot-format.md`) after Session Quality and before Operational Cadence, with
+  field computation table
+- Update `commands/harness-health.md` — Diaboli included in required section list;
+  step 7 validation updated from 12 to 13 required section headings with Diaboli
+  in enumerated list
+- Update `skills/harness-observability/SKILL.md` — reference to Diaboli panel added
+- Add `skills/advocatus-diaboli/references/observability.md` — metric computation
+  definitions, interpretive notes, and watch-for patterns (what each field means
+  and what it does NOT mean)
+- Fix `commands/diaboli.md` validation checkpoint — category and severity taxonomy
+  corrected to match SKILL.md: premise/scope/implementation/risk/alternatives/
+  specification quality and critical/high/medium/low
+- Add ARCH_DECISION to `AGENTS.md` — observability-before-enforcement principle,
+  revisit conditions (10 fully-resolved records or 2026-07-19)
+- Update `docs/explanation/adversarial-review.md` — disposition patterns section
+  now references Diaboli panel surfaces; three-loops section adds observability loop
+- Update `docs/how-to/review-a-spec-adversarially.md` — "What you have now" notes
+  that disposition patterns accumulate and are visible in status/health surfaces
+
 ## 0.24.0 — 2026-04-19
 
 ### Docs and taxonomy — advocatus-diaboli coverage and SKILL.md update

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.24.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.25.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
 [![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/diaboli.md
+++ b/ai-literacy-superpowers/commands/diaboli.md
@@ -55,9 +55,9 @@ Read back `docs/superpowers/objections/<slug>.md` and verify:
    `disposition`, `disposition_rationale`
 4. `disposition` value is `pending` for all entries (not pre-filled)
 5. `disposition_rationale` value is `null` for all entries (not pre-filled)
-6. Category values are one of: `premise`, `design`, `threat`, `failure`,
-   `operational`, `cost`
-7. Severity values are one of: `major`, `minor`
+6. Category values are one of: `premise`, `scope`, `implementation`, `risk`,
+   `alternatives`, `specification quality`
+7. Severity values are one of: `critical`, `high`, `medium`, `low`
 8. Objection count is between 1 and 12 inclusive
 9. Prose body contains one `## O<N>` section per objection
 10. File ends with an `## Explicitly not objecting to` section containing

--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -93,8 +93,8 @@ using the format defined in `references/snapshot-format.md`.
 
 Include all sections: Enforcement, Enforcement Loop History, Garbage
 Collection, Mutation Testing, Compound Learning, Session Quality,
-Operational Cadence, Cost Indicators, Regression Indicators, Meta,
-Changes Since Last Snapshot, and Trends (if previous snapshot exists).
+Diaboli, Operational Cadence, Cost Indicators, Regression Indicators,
+Meta, Changes Since Last Snapshot, and Trends (if previous snapshot exists).
 
 ### 7. Validate Snapshot Structure
 
@@ -104,9 +104,9 @@ structure against `references/snapshot-format.md`.
 
 **Structural checks:**
 
-1. All 12 section headings present in order: Enforcement,
+1. All 13 section headings present in order: Enforcement,
    Enforcement Loop History, Garbage Collection, Mutation Testing,
-   Compound Learning, Session Quality, Operational Cadence,
+   Compound Learning, Session Quality, Diaboli, Operational Cadence,
    Cost Indicators, Regression Indicators, Meta,
    Changes Since Last Snapshot, Trends
 2. Trends section is conditional — required only when a previous

--- a/ai-literacy-superpowers/commands/superpowers-status.md
+++ b/ai-literacy-superpowers/commands/superpowers-status.md
@@ -85,6 +85,41 @@ Check for CI configuration:
 - If on a branch with an open PR, show the PR check status:
   `gh pr checks --json name,status,conclusion 2>/dev/null || echo "No open PR"`
 
+### Section 7: Diaboli activity
+
+Check `docs/superpowers/specs/` and `docs/superpowers/objections/`.
+
+A spec is **in-scope** if its filename date is on or after `2026-04-19` (the date
+advocatus-diaboli shipped). Specs with earlier dates are **exempt**. A spec slug is
+the filename with the `YYYY-MM-DD-` date prefix and `.md` extension stripped. A
+matching objection record is `docs/superpowers/objections/<slug>.md`.
+
+Compute and report these fields. All are descriptive — no pass/fail status:
+
+- **In-scope specs**: count of `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19
+- **Exempt specs (pre-feature)**: count of specs with filename date < 2026-04-19
+- **Objection records present**: count of `docs/superpowers/objections/*.md`,
+  excluding `.gitkeep`
+- **In-scope specs without a record**: in-scope spec slugs with no matching file in
+  `docs/superpowers/objections/`
+- **Fully-resolved record rate**: records where every `disposition` field is
+  non-`pending` / total records (record-level ratio)
+- **Objections total**: sum of `objections` list lengths across all records
+- **Severity breakdown**: count of critical / high / medium / low across all objections
+- **Mean objections per spec**: total objections / count of records (1 decimal)
+- **Disposition distribution**: among non-`pending` dispositions — accepted% / deferred% /
+  rejected%
+- **Median days spec-to-disposition**: spec date from filename; resolution date from
+  `git log` on the objection file; median across fully-resolved records. Report
+  "insufficient data" if fewer than 3 fully-resolved records exist.
+
+**Error handling**: if a file at `docs/superpowers/objections/` fails YAML parse,
+report it by name in the Details section as "parse error" and exclude it from all
+metrics.
+
+Summary line: `Diaboli [OK]` when at least one in-scope objection record is present;
+`Diaboli [MISSING]` when none exist. No `WARNING` state — no threshold is defined yet.
+
 ## Output format
 
 Print the dashboard as a structured report:
@@ -99,14 +134,17 @@ Agent team       [OK / WARNING / MISSING]
 Compound learning [OK / WARNING / MISSING]
 Model routing    [OK / WARNING / MISSING]
 CI               [OK / WARNING / MISSING]
+Diaboli          [OK / MISSING]
 
 --- Details ---
 
-[Section-by-section findings, flagging anything that is WARNING or MISSING]
+[Section-by-section findings, flagging anything that is WARNING or MISSING;
+ Diaboli section always shown as descriptive stats with no pass/fail colouring]
 
 --- Recommendations ---
 
 [Prioritised list of actions to reach full green, if any]
 ```
 
-If all sections are OK, end with: "Habitat is healthy. All checks passed."
+If all sections are OK and Diaboli has at least one record, end with:
+"Habitat is healthy. All checks passed."

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md
@@ -1,0 +1,163 @@
+---
+name: diaboli-observability-reference
+description: Metric computation definitions and interpretive notes for the Diaboli panel in /superpowers-status and the harness-health snapshot — what each field means, what it does NOT mean, and watch-for patterns
+---
+
+# Diaboli Observability Reference
+
+The Diaboli panel surfaces advocatus-diaboli activity as descriptive stats in
+`/superpowers-status` (Section 7) and the harness-health snapshot. This reference
+documents how each metric is computed, how to interpret it, and what it does not tell you.
+
+For the arch decision behind this approach (observability-before-enforcement, revisit
+conditions), see `AGENTS.md` → ARCH_DECISIONS.
+
+---
+
+## Scope boundary
+
+A spec is **in-scope** for diaboli coverage if its filename date is on or after
+`2026-04-19` — the date the advocatus-diaboli feature shipped. Specs predating this
+date are **exempt** and counted separately. All metrics that compare specs to objection
+records use only in-scope specs.
+
+A **spec slug** is the filename with the `YYYY-MM-DD-` date prefix and `.md` extension
+stripped. A matching **objection record** is the file at
+`docs/superpowers/objections/<slug>.md`.
+
+---
+
+## Field definitions
+
+### In-scope specs
+
+Count of `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19.
+
+**Does not mean:** that all in-scope specs have been reviewed. Use "In-scope specs
+without a record" to see gaps.
+
+### Exempt specs (pre-feature)
+
+Count of specs with filename date < 2026-04-19. These predate the feature and were
+never intended to have objection records.
+
+**Does not mean:** these specs are low quality. They were written before the practice
+existed.
+
+### Objection records present
+
+Count of `docs/superpowers/objections/*.md`, excluding `.gitkeep`.
+
+**Does not mean:** all records are adjudicated. Use "Fully-resolved record rate" to
+distinguish records with `pending` dispositions.
+
+### In-scope specs without a record
+
+In-scope spec slugs with no matching file in `docs/superpowers/objections/`. Should be 0
+given the harness-enforcer PR constraint, but surfaced here for drift detection.
+
+**Does not mean:** a gap of 0 guarantees review quality — only that a record exists.
+Rubber-stamped records (all dispositions filled with minimal rationale) pass this check.
+
+### Fully-resolved record rate
+
+Records where every `disposition` field is non-`pending` / total records. This is a
+**record-level** ratio: a record counts only when every objection within it is resolved.
+A record with 9 of 10 dispositions filled counts as unresolved.
+
+**Does not mean:** the resolved records were adjudicated carefully. A human can fill all
+fields with minimal rationale and the count will increase. The metric measures completion,
+not quality of engagement.
+
+### Objections total
+
+Sum of `objections` list lengths across all objection records.
+
+**Does not mean:** more objections is better or worse. The agent is capped at 12 per spec
+and instructed to prioritise quality over quantity. A record with 3 high-severity objections
+may be more valuable than one with 10 low-severity ones.
+
+### Severity breakdown
+
+Count of `critical` / `high` / `medium` / `low` across all objection entries
+(including `pending`).
+
+**Does not mean:** a high count of `critical` objections indicates poor spec quality alone
+— it may also indicate the agent's charter is tuned to fire at a high severity. Compare
+severity distribution to disposition distribution when interpreting.
+
+### Mean objections per spec
+
+Total objections / count of objection records, rounded to 1 decimal.
+
+**Does not mean:** a low mean indicates strong specs. The agent may be configured to raise
+fewer, higher-quality objections (correct behaviour) or may be under-challenging specs
+(failure mode). Read objection records alongside the metric to distinguish.
+
+### Disposition distribution
+
+Among non-`pending` dispositions only: percentage `accepted` / `deferred` / `rejected`.
+Disposition values `fix` and `leave` are treated as `accepted` and `rejected` respectively
+for this computation.
+
+**Does not mean:** a high `rejected` rate indicates the agent is wrong — it may mean the
+agent is raising legitimate concerns and the team is engaging carefully and deciding against
+them (healthy pattern). A high `deferred` rate may mean the charter is firing on nits, or
+may mean specs are genuinely mature — the metric alone cannot distinguish.
+
+### Median days spec-to-disposition
+
+For each fully-resolved record: days between the spec filename date and the date of the
+most recent commit on the objection file (`git log --format=%as -1`). Median across all
+fully-resolved records.
+
+Reports "insufficient data" when fewer than 3 fully-resolved records exist.
+
+**Does not mean:** a short median is necessarily healthy. Fast adjudication that involves
+minimal engagement is worse than slow adjudication that involves careful reasoning. The
+median measures throughput, not quality.
+
+**Implementation note:** if a spec is revised and `/diaboli` is re-run, the objection file
+is overwritten. The git date then reflects the post-revision fill date, not the original
+one. This makes the metric an approximation of disposition speed rather than a precise
+measurement. It is useful as an order-of-magnitude indicator of friction, not as a precise
+SLA metric.
+
+---
+
+## Watch-for patterns
+
+These patterns in the Diaboli panel are candidates for a reflection entry when observed
+over multiple snapshots:
+
+**Disposition distribution collapsing to a single bucket**
+All dispositions are `accepted`, or all are `rejected`. A genuine spec process produces
+a mix: some objections land, some are legitimately rejected. A distribution collapsed to
+one bucket suggests the agent is not raising meaningful objections (if all `rejected`) or
+the specs are consistently underprepared (if all `accepted`).
+
+**Objection count trending toward zero**
+Mean objections per spec falling toward 0 over consecutive snapshots. The agent should
+consistently find something to challenge in a well-scoped spec. Trend toward 0 suggests
+the charter is becoming toothless — either SKILL.md has been softened, or specs have
+become genuinely trivial. Both warrant a look at recent records.
+
+**Objection count trending toward 12 (the cap)**
+Mean objections per spec approaching 12 consistently. The cap exists because above 12
+the agent is pattern-matching rather than reasoning. A consistent mean of 11–12 suggests
+the agent's charter may need tightening, or the specs arriving for review are genuinely
+underprepared.
+
+**Median days spec-to-disposition trending up**
+Increasing time between spec creation and fully-resolved adjudication. May indicate the
+human-cognition gate is creating friction beyond its intended effect, or that specs are
+being revised frequently (resetting the clock). Investigate which before treating as
+a problem.
+
+---
+
+## Error handling
+
+If a file at `docs/superpowers/objections/` fails YAML parse during metric computation,
+report it by name in the Details section as "parse error" and exclude it from all metrics.
+Do not silently skip it — a parse error in an objection record should be visible.

--- a/ai-literacy-superpowers/skills/harness-observability/SKILL.md
+++ b/ai-literacy-superpowers/skills/harness-observability/SKILL.md
@@ -19,7 +19,9 @@ those belong to their respective skills. It covers how to observe
 whether those mechanisms are operating effectively.
 
 For the snapshot schema and field definitions, consult
-`references/snapshot-format.md`.
+`references/snapshot-format.md`. The snapshot includes a Diaboli panel
+(after Session Quality, before Operational Cadence) that surfaces
+advocatus-diaboli activity as descriptive stats across all objection records.
 
 ## The Four Layers
 

--- a/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
+++ b/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
@@ -134,6 +134,46 @@ guessing.
 | Signal distribution | Count of each signal type across all reflections (cumulative, not just since last snapshot) |
 | Quality trend | Compare "reflections with signal" percentage to previous snapshot. stable = ±2%, improving = >+2%, declining = <-2% |
 
+### Diaboli
+
+```text
+## Diaboli
+
+- In-scope specs: N (specs dated ≥ 2026-04-19)
+- Exempt specs (pre-feature): N
+- Objection records present: N
+- In-scope specs without a record: N
+- Fully-resolved record rate: P% (N of M records fully resolved)
+- Objections total: N (critical: A | high: B | medium: C | low: D)
+- Mean objections per spec: N.N
+- Disposition distribution: accepted: P% | deferred: P% | rejected: P%
+- Median days spec-to-disposition: N (or "insufficient data")
+```
+
+**Source:** `docs/superpowers/specs/` and `docs/superpowers/objections/`.
+
+A spec is **in-scope** if its filename date is on or after `2026-04-19`. A spec
+slug is the filename with the `YYYY-MM-DD-` prefix and `.md` extension stripped.
+A matching objection record is `docs/superpowers/objections/<slug>.md`.
+
+| Field | How to compute |
+| ------- | --------------- |
+| In-scope specs | Count `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19 |
+| Exempt specs (pre-feature) | Count specs with filename date < 2026-04-19 |
+| Objection records present | Count `docs/superpowers/objections/*.md`, excluding `.gitkeep` |
+| In-scope specs without a record | In-scope spec slugs with no matching file in `docs/superpowers/objections/` |
+| Fully-resolved record rate | Records where every `disposition` field is non-`pending` / total records (record-level ratio) |
+| Objections total | Sum of `objections` list lengths across all records |
+| Severity breakdown | Count critical/high/medium/low across all `objections` entries |
+| Mean objections per spec | Total objections / count of records, rounded to 1 decimal |
+| Disposition distribution | Among non-`pending` dispositions only: percentage accepted / deferred / rejected |
+| Median days spec-to-disposition | For each fully-resolved record: days between spec filename date and `git log --format=%as -1` date on the objection file. Median across all fully-resolved records. Report "insufficient data" if fewer than 3 fully-resolved records exist |
+
+**Error handling:** If a file at `docs/superpowers/objections/` fails YAML parse,
+report it by name as "parse error" and exclude it from all metrics.
+
+All fields are descriptive. No pass/fail status, no thresholds defined yet.
+
 ### Operational Cadence
 
 ```text

--- a/docs/explanation/adversarial-review.md
+++ b/docs/explanation/adversarial-review.md
@@ -117,6 +117,11 @@ makes the adversarial review load-bearing rather than advisory.
 ## Disposition patterns as a signal
 
 Over time, the distribution of dispositions across objection records becomes observable.
+These patterns are surfaced in `/superpowers-status` (Section 7: Diaboli Activity) and
+the harness-health snapshot (Diaboli panel), both of which report disposition distribution,
+mean objections per spec, and other descriptive stats across all records. No thresholds are
+set yet — the panel is diagnostic, not evaluative.
+
 Patterns carry information:
 
 **Clustering of `low` severity objections that are all deferred:** The agent is raising
@@ -150,6 +155,10 @@ Objection records accumulate in `docs/superpowers/objections/` and feed the othe
 - **Reflection loop**: Recurring patterns in objection types — `scope` objections
   appearing on every PR, for example — are candidates for HARNESS.md constraints or
   CLAUDE.md conventions. When a pattern repeats, it belongs in the harness.
+- **Observability loop**: Disposition distribution, mean objections per spec, and
+  median days to adjudication are surfaced in the Diaboli panel of `/superpowers-status`
+  and the harness-health snapshot. These accumulate across records and become visible on
+  the normal health cadence, without requiring a separate audit.
 
 ---
 

--- a/docs/how-to/review-a-spec-adversarially.md
+++ b/docs/how-to/review-a-spec-adversarially.md
@@ -106,6 +106,11 @@ The record lives at `docs/superpowers/objections/<slug>.md` and accumulates alon
 other objection records over time. A GC rule checks weekly whether any spec has been
 modified more recently than its objection record — if so, it flags the record as stale.
 
+As records accumulate, disposition patterns (distribution, mean objections per spec,
+median days to adjudication) become visible in `/superpowers-status` Section 7 and the
+harness-health snapshot Diaboli panel. These surfaces update on the normal health cadence
+without requiring a separate command.
+
 ---
 
 ## Next steps

--- a/docs/superpowers/objections/diaboli-observability.md
+++ b/docs/superpowers/objections/diaboli-observability.md
@@ -1,0 +1,258 @@
+---
+spec: docs/superpowers/specs/2026-04-19-diaboli-observability.md
+date: 2026-04-19
+diaboli_model: claude-sonnet-4-6
+objections:
+  - id: O1
+    category: implementation
+    severity: high
+    claim: "The median-days-spec-to-disposition metric uses git log on the objection file to find the resolution date, but objection files are overwritten on regeneration, making git log an unreliable proxy for disposition date."
+    evidence: "Spec Metrics table: 'Median days spec-to-disposition — Spec date from filename; resolution date from git log on objection file; median across fully-resolved records.' diaboli.md step 4: 'If a file already exists at that path, overwrite it. Warn the user that any prior dispositions are replaced and they will need to re-adjudicate.'"
+    disposition: leave
+    disposition_rationale: we are not trying to police dispositions.
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The 'Specs without a record' metric will immediately surface 27+ missing records because pre-diaboli specs are included in the count with no filtering mechanism defined, making the metric misleading from day one."
+    evidence: "Spec Metrics table: 'Specs without a record — Spec slugs with no matching objection file — slug comparison.' There are 28 files in docs/superpowers/specs/ and only 1 objection record, but at least 27 of those specs predate the advocatus-diaboli feature and were never intended to have objection records. The spec defines no start-date or exclusion mechanism."
+    disposition: fix
+    disposition_rationale: we must include an exclusion mechanism for existing specs.
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "harness-health.md step 7 hardcodes 'All 12 section headings' in its validation check, but inserting Diaboli as a new section would make 13 sections; the spec does not call out updating this count."
+    evidence: "harness-health.md step 7: 'All 12 section headings present in order: Enforcement, Enforcement Loop History, Garbage Collection, Mutation Testing, Compound Learning, Session Quality, Operational Cadence, Cost Indicators, Regression Indicators, Meta, Changes Since Last Snapshot, Trends.' Spec artefact #4 modifies harness-health.md to 'add Diaboli to required section list and section order' but does not mention updating the hardcoded '12' count or the enumerated list in the validation step."
+    disposition: fix
+    disposition_rationale: adjust this count.
+  - id: O4
+    category: risk
+    severity: medium
+    claim: "The Diaboli summary line in /superpowers-status uses a non-standard status format ([ACTIVE — N records] / [NO DATA]) that breaks the OK/WARNING/MISSING uniformity relied on by any consumer or CI check that parses the status dashboard."
+    evidence: "Spec: 'The summary line shows Diaboli [ACTIVE — N records] or [NO DATA] — explicitly not OK/WARNING/MISSING, since we have no threshold yet.' superpowers-status.md output format: all six existing sections emit exactly one of OK/WARNING/MISSING in square brackets."
+    disposition: fix
+    disposition_rationale: this needs to work well with CI
+  - id: O5
+    category: specification quality
+    severity: medium
+    claim: "The 'Disposition rate' metric definition is ambiguous: 'Records where all disposition fields are non-pending / total records' could mean fully-resolved records or records with at least one resolved disposition, and the field name does not disambiguate."
+    evidence: "Spec Metrics table: 'Disposition rate — Records where all disposition fields are non-pending / total records — YAML frontmatter.' The numerator clause describes records where every objection is resolved; the denominator 'total records' is record-level. But 'Disposition rate' more naturally reads as 'what fraction of dispositions are resolved' — a materially different number computed at the objection level."
+    disposition: fix
+    disposition_rationale: this should be made more clear.
+  - id: O6
+    category: premise
+    severity: medium
+    claim: "The observability layer is being built over a dataset with one objection record; most metrics will report 'insufficient data' or single-data-point values on launch day, making the dashboard uninformative at the moment it is most likely to be inspected."
+    evidence: "Spec Problem section describes wanting to see patterns (clustering, trends). Spec: 'Insufficient data is reported for median when fewer than 3 fully-resolved records exist.' At time of writing docs/superpowers/objections/ contains one file. Distribution and trend metrics require a meaningful sample the data does not yet contain."
+    disposition: accept
+    disposition_rationale: this is ok and expected. As more dispositions appear this problem will disappear.
+  - id: O7
+    category: scope
+    severity: medium
+    claim: "The 'Specs reviewed' denominator conflates 28 total specs (27 pre-dating the feature) with specs expected to have diaboli coverage, structurally inflating the 'Specs without a record' gap metric from the first snapshot with no resolution mechanism."
+    evidence: "Spec metrics table: 'Specs reviewed — Count of docs/superpowers/specs/*.md — filesystem.' The advocatus-diaboli feature was introduced on 2026-04-19; specs from 2026-04-06 onward predate it. No start-date filter, exclusion list, or legacy marker is defined."
+    disposition: fix
+    disposition_rationale: add a start date filter and/or a mechanism for specs prior to diaboli being introduced to exclude themselves.
+  - id: O8
+    category: alternatives
+    severity: low
+    claim: "The new observability.md reference file duplicates content that the ARCH_DECISION added to AGENTS.md in the same spec, creating two canonical locations for the observability-before-enforcement principle with no clear authority."
+    evidence: "Spec artefact #5 creates observability.md to document 'what each metric means, what it does NOT mean, and the watch-for patterns.' Spec artefact #7 adds an ARCH_DECISION to AGENTS.md capturing 'the observability-before-enforcement principle and the revisit conditions.' AGENTS.md is already the declared location for such decisions in this project."
+    disposition: fix
+    disposition_rationale: move arch enforcement to AGENTS.md
+  - id: O9
+    category: implementation
+    severity: low
+    claim: "The spec does not define error-handling behavior when a malformed or unparseable objection file YAML frontmatter is encountered during metric computation in /superpowers-status or /harness-health."
+    evidence: "Spec metrics table specifies 'YAML frontmatter' as the source for four metrics. The write-time validation checkpoint in diaboli.md step 5 validates at creation; the spec contains no instruction for what the status/health commands should do if a file is subsequently edited to an invalid YAML state."
+    disposition: fix
+    disposition_rationale: specify if the YAML is unparseable declare the spec as not being subject to diaboli
+  - id: O10
+    category: scope
+    severity: low
+    claim: "The taxonomy fix in diaboli.md validation checkpoint is a pre-existing bug independent of the observability work; bundling it risks the fix being dropped if the PR scope is narrowed."
+    evidence: "Spec: 'SKILL.md was updated to the new taxonomy in a prior PR. The command's checkpoint must be corrected.' This is described as a 'Side fix' within the Approach section. It does not depend on any new metric or section and could have been (and arguably should have been) a standalone patch PR."
+    disposition: accepted
+    disposition_rationale: acknowledged.
+---
+
+## O1 — implementation — high
+
+### Claim
+
+The median-days-spec-to-disposition metric uses `git log` on the objection file to determine the resolution date, but objection files are overwritten on every regeneration. This makes the git timestamp an unreliable proxy for when dispositions were actually filled.
+
+### Evidence
+
+The spec's metrics table specifies: "Median days spec-to-disposition — Spec date from filename; resolution date from git log on objection file; median across fully-resolved records."
+
+The `/diaboli` command (diaboli.md step 4) states: "If a file already exists at that path, overwrite it. Warn the user that any prior dispositions are replaced and they will need to re-adjudicate."
+
+### Why this matters
+
+If a spec is revised and `/diaboli` is re-run, the objection file is overwritten. The human then re-fills dispositions. The git log on that file now shows the regeneration date — possibly weeks later than the original resolution — or earlier if re-dispositioned quickly. The metric designed to signal whether "time-to-disposition is growing" would be computed on a timestamp that does not reflect the actual disposition timeline. A metric that is formally defined but epistemically ungrounded is worse than no metric: it creates false confidence in what is being measured.
+
+---
+
+## O2 — implementation — high
+
+### Claim
+
+The "Specs without a record" metric will immediately surface 27 or more missing records on launch day because the metric counts all files in `docs/superpowers/specs/` with no mechanism to distinguish pre-feature specs from specs that are expected to have objection coverage.
+
+### Evidence
+
+The spec's metrics table states: "Specs without a record — Spec slugs with no matching objection file — slug comparison — filesystem."
+
+As of 2026-04-19, `docs/superpowers/specs/` contains 28 files. The advocatus-diaboli feature was introduced on 2026-04-19. There is currently one objection record. The spec defines no start-date filter, no exclusion list, and no way to mark a spec as legacy or pre-feature.
+
+### Why this matters
+
+"Specs without a record: 27" is not a useful reading on the dashboard's first day. A developer seeing this number must manually verify whether the gap is a current problem or a historical artefact. The observability surface designed to surface patterns would itself require a post-hoc audit to interpret. A start-date or scope boundary is not an enhancement — it is required for the metric to be informative at all.
+
+---
+
+## O3 — specification quality — high
+
+### Claim
+
+`harness-health.md` step 7 hardcodes the string "All 12 section headings" and enumerates all 12 by name. Inserting the Diaboli section as a new mandatory section creates 13 sections, but the spec's artefact description for harness-health.md does not call out updating this count or the enumerated list.
+
+### Evidence
+
+`harness-health.md` step 7, structural check 1: "All 12 section headings present in order: Enforcement, Enforcement Loop History, Garbage Collection, Mutation Testing, Compound Learning, Session Quality, Operational Cadence, Cost Indicators, Regression Indicators, Meta, Changes Since Last Snapshot, Trends."
+
+Spec artefact #4: "`ai-literacy-superpowers/commands/harness-health.md` — add Diaboli to required section list and section order." The description mentions adding Diaboli to the list but does not mention updating the count "12" or the enumerated heading names in the same structural check.
+
+### Why this matters
+
+An implementer reading artefact #4 will add Diaboli to the section order. If they update the required section list but do not update the hardcoded "12" count or the enumerated heading names, the validation checkpoint will be internally inconsistent or will silently pass when a snapshot lacks a Diaboli section. The step 7 validation is described as "mandatory" — if its internal count is wrong, it cannot serve as the correctness gate the spec intends.
+
+---
+
+## O4 — risk — medium
+
+### Claim
+
+The Diaboli summary line in `/superpowers-status` uses `[ACTIVE — N records]` or `[NO DATA]`, which is structurally different from the `OK/WARNING/MISSING` format used by all other sections. Any parser or future consumer that reads the status dashboard for structured tokens will encounter an anomalous format in Section 7.
+
+### Evidence
+
+The spec states: "The summary line shows `Diaboli [ACTIVE — N records]` or `[NO DATA]` — explicitly not OK/WARNING/MISSING, since we have no threshold yet."
+
+The current `superpowers-status.md` output format template shows six sections each emitting exactly one of `[OK / WARNING / MISSING]`. The format is uniform and parseable by pattern.
+
+### Why this matters
+
+Explicitly choosing a non-standard format without auditing downstream consumers transfers the consistency debt to the future. The spec does not note whether such consumers exist. If a script or hook parses `/superpowers-status` output by looking for `[OK]`, `[WARNING]`, or `[MISSING]` tokens, Section 7 will be invisible to that consumer.
+
+---
+
+## O5 — specification quality — medium
+
+### Claim
+
+The "Disposition rate" metric definition is ambiguous. "Records where all `disposition` fields are non-`pending` / total records" could mean a record-level completion ratio or an objection-level completion ratio, and the field name "Disposition rate" does not resolve this.
+
+### Evidence
+
+Spec metrics table: "Disposition rate — Records where all `disposition` fields are non-`pending` / total records — YAML frontmatter."
+
+The numerator clause "Records where all disposition fields are non-`pending`" describes fully-resolved records. But "Disposition rate" more naturally reads as "what fraction of dispositions are resolved" — total non-pending dispositions / total dispositions — a materially different number when partial resolution exists.
+
+### Why this matters
+
+Two implementers reading this definition could produce different computations. Because the metric is the primary signal for whether objection review is completing, a computation ambiguity here produces a misleading headline number that cannot be detected without examining the implementation.
+
+---
+
+## O6 — premise — medium
+
+### Claim
+
+The observability layer is being built over a dataset with one objection record. The metrics designed to reveal patterns — mean objections per spec, disposition distribution, severity breakdown trends, median days to disposition — will report "insufficient data" or single-data-point values on launch day.
+
+### Evidence
+
+The spec's Problem section describes wanting to see patterns (clustering, trends). The spec notes: "'Insufficient data' is reported for median when fewer than 3 fully-resolved records exist." At time of writing, `docs/superpowers/objections/` contains one file.
+
+### Why this matters
+
+This is not fatal — the spec correctly frames the approach as "observability before enforcement" and the data will grow. But the Problem section implies the dashboard makes invisible patterns visible on day one. A dashboard that opens in `[NO DATA]` or single-point mode for most metrics defers the value. The spec would be strengthened by explicitly acknowledging the launch-day state and setting reader expectations.
+
+---
+
+## O7 — scope — medium
+
+### Claim
+
+The "Specs reviewed" denominator includes all 28 files in `docs/superpowers/specs/`, providing no mechanism to distinguish the 27 pre-feature specs (not intended to have diaboli coverage) from post-feature specs (which should). This structurally inflates the "Specs without a record" gap from the first snapshot.
+
+### Evidence
+
+Spec metrics table: "Specs reviewed — Count of `docs/superpowers/specs/*.md` — filesystem." The advocatus-diaboli feature was introduced on 2026-04-19; approximately 27 of the 28 specs predate it. No `since:` parameter, exclusion list, or legacy annotation is defined.
+
+### Why this matters
+
+"Specs without a record: 27" is indistinguishable from "27 current gaps" vs "27 historical specs" without contextual knowledge. A feature-activation date filter would make the metric immediately useful rather than requiring a separate audit to interpret.
+
+---
+
+## O8 — alternatives — low
+
+### Claim
+
+The new `observability.md` reference file duplicates content that the ARCH_DECISION added to AGENTS.md in the same spec, creating two canonical locations for the observability-before-enforcement design rationale with no clear authority.
+
+### Evidence
+
+Spec artefact #5 creates `observability.md` to document "what each metric means, what it does NOT mean, and the watch-for patterns worth a reflection entry." Spec artefact #7 adds an ARCH_DECISION to AGENTS.md capturing "the observability-before-enforcement principle and the revisit conditions." AGENTS.md is already the declared project location for architectural decisions with their rationale and revisit conditions.
+
+### Why this matters
+
+When the observability design is revisited at the 10-record trigger, a reader may find one document in AGENTS.md and a different or evolved version in `observability.md`, with no clear indication of which is authoritative.
+
+---
+
+## O9 — implementation — low
+
+### Claim
+
+The spec does not define error-handling behavior when `/superpowers-status` or `/harness-health` encounter a malformed or unparseable YAML frontmatter block in an objection file during metric computation.
+
+### Evidence
+
+The spec's metrics table specifies "YAML frontmatter" as the source for four metrics. The write-time validation checkpoint in diaboli.md step 5 validates at creation. The spec contains no instruction for what the status/health commands should do if a file is subsequently edited to an invalid YAML state.
+
+### Why this matters
+
+Without defined error handling, both commands would silently produce incorrect counts or surface a parsing error mid-health-check. A single sentence — "if a file fails YAML parse, report it as a named parse error in the Details section and exclude it from all metrics" — would close this gap.
+
+---
+
+## O10 — scope — low
+
+### Claim
+
+The taxonomy fix in `diaboli.md` validation checkpoint is a pre-existing bug independent of the observability work; bundling it risks the fix being dropped if the PR scope is narrowed.
+
+### Evidence
+
+The spec describes the diaboli.md taxonomy fix as a "Side fix" within the Approach section. It does not depend on any new metric or section. It would have been cleaner as a standalone patch PR.
+
+### Why this matters
+
+The taxonomy mismatch means the validation checkpoint currently accepts objection records with the old (wrong) category and severity values. If this PR is deferred for any reason, the taxonomy bug continues to silently accept malformed records. The fix is urgent relative to the observability additions.
+
+---
+
+## Explicitly not objecting to
+
+- **The observability-before-enforcement principle**: Choosing descriptive stats with no pass/fail thresholds before enforcement is correct sequencing. Enforcement without observable baselines produces arbitrary thresholds. The spec's reasoning is sound and aligns with the ARCH_DECISION pattern already in the project.
+
+- **The choice to surface metrics in existing surfaces rather than a new command**: Reusing `/superpowers-status` and `/harness-health` avoids command proliferation and keeps diaboli activity visible within the normal health cadence rather than requiring a separate invocation.
+
+- **The revisit trigger definition (10 fully-resolved records or 2026-07-19)**: A concrete, dual-condition revisit trigger is better than an open-ended deferral. The date-based backstop prevents indefinite delay; the data-based condition creates the right incentive to resolve dispositions promptly.
+
+- **Placement of the Diaboli section after Session Quality, before Operational Cadence**: This ordering places diaboli data in the quality/discipline cluster of the snapshot, contextually appropriate alongside measures of reflection and session quality.
+
+- **Not adding a GC rule or new constraint in this PR**: Adding enforcement before establishing a baseline would produce a threshold without evidence. The spec correctly defers this to the revisit evaluation.

--- a/docs/superpowers/specs/2026-04-19-diaboli-observability.md
+++ b/docs/superpowers/specs/2026-04-19-diaboli-observability.md
@@ -166,6 +166,8 @@ at 10 fully-resolved objection records or 2026-07-19, whichever comes first.
 
 ## Artefacts
 
+### Plugin files
+
 1. `ai-literacy-superpowers/commands/superpowers-status.md` — add Section 7; summary
    line uses `OK` / `MISSING` tokens; includes in-scope/exempt split and error handling
 2. `ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md`
@@ -179,12 +181,31 @@ at 10 fully-resolved objection records or 2026-07-19, whichever comes first.
    metric reference file (computation definitions and interpretive notes only; no arch
    decision content)
 6. `ai-literacy-superpowers/commands/diaboli.md` — fix validation checkpoint taxonomy
+
+### Project files
+
 7. `AGENTS.md` — add ARCH_DECISION (observability-before-enforcement principle,
    revisit conditions)
-8. `ai-literacy-superpowers/.claude-plugin/plugin.json` — 0.24.0 → 0.25.0
-9. `README.md` — badge bump
-10. `.claude-plugin/marketplace.json` — plugin_version bump
-11. `CHANGELOG.md` — new version entry
+
+### Docs site
+
+8. `docs/explanation/adversarial-review.md` — two updates:
+   - "Disposition patterns as a signal" section: add a sentence indicating where
+     these patterns are visible — the Diaboli panel in `/superpowers-status` and the
+     harness-health snapshot
+   - "How this fits the three loops" section: add the observability loop — disposition
+     patterns accumulate in the Diaboli panel and are surfaced by `/superpowers-status`
+     and `/harness-health` on their normal cadence
+9. `docs/how-to/review-a-spec-adversarially.md` — update "What you have now" to note
+   that disposition patterns accumulate across records and become visible in
+   `/superpowers-status` (Section 7: Diaboli Activity) and the harness-health snapshot
+
+### Version
+
+10. `ai-literacy-superpowers/.claude-plugin/plugin.json` — 0.24.0 → 0.25.0
+11. `README.md` — badge bump
+12. `.claude-plugin/marketplace.json` — plugin_version bump
+13. `CHANGELOG.md` — new version entry
 
 ## Exemptions
 

--- a/docs/superpowers/specs/2026-04-19-diaboli-observability.md
+++ b/docs/superpowers/specs/2026-04-19-diaboli-observability.md
@@ -2,10 +2,45 @@
 name: diaboli-observability
 description: Spec for surfacing advocatus-diaboli activity as descriptive stats in /superpowers-status and the harness-health snapshot — observability-before-enforcement, no new constraints or thresholds
 date: 2026-04-19
-status: draft
+status: approved
 ---
 
 # Diaboli Observability
+
+## Objection resolution notes
+
+*Applied after advocatus-diaboli review of this spec:*
+
+- **O2/O7 (implementation/scope/high+medium):** "Specs reviewed" and "Specs without a
+  record" must filter to post-feature specs only. A spec is in-scope for diaboli
+  coverage if its filename date is on or after 2026-04-19 (the date advocatus-diaboli
+  shipped). Pre-feature specs are counted separately as exempt. Metrics table updated;
+  artefact descriptions updated to specify the filter.
+- **O3 (specification quality/high):** `harness-health.md` step 7 hardcodes "12
+  section headings." The spec must explicitly call out updating this to "13" and adding
+  "Diaboli" to the enumerated list. Artefact #4 description updated.
+- **O4 (risk/medium):** `/superpowers-status` summary line must use `OK/WARNING/MISSING`
+  for CI compatibility. Since no threshold exists: `OK` when at least one in-scope
+  objection record exists, `MISSING` when none. Updated in Surfaces and metric
+  definitions.
+- **O5 (specification quality/medium):** "Disposition rate" renamed to
+  "Fully-resolved record rate" to remove ambiguity. Definition clarified to make
+  explicit it is a record-level ratio (all objections non-pending / total records).
+- **O8 (alternatives/low):** `observability.md` reference file scope narrowed to
+  metric computation definitions and interpretive notes only. The observability-before-
+  enforcement arch decision and revisit conditions belong exclusively in AGENTS.md.
+- **O9 (implementation/low):** Error handling added: if a file at
+  `docs/superpowers/objections/` fails YAML parse during metric computation, report
+  it by name in the Details section as "parse error" and exclude from all metrics.
+- **O1 (implementation/high): leave** — the median-days metric uses git log on the
+  objection file; the fact that regeneration resets this is acceptable. We are not
+  trying to police dispositions.
+- **O6 (premise/medium): accept** — launching with "insufficient data" for several
+  metrics is expected and fine; the data grows as the practice matures.
+- **O10 (scope/low): accepted** — taxonomy fix bundled in this PR is acknowledged
+  as a latent risk; proceeding with inclusion.
+
+---
 
 ## Problem
 
@@ -28,18 +63,30 @@ With visibility, patterns emerge across the normal observability cadence.
 Surface diaboli stats in two existing observability surfaces. No new GC rule,
 no new constraint, no new command.
 
+### Scope boundary
+
+A spec is **in-scope** for diaboli coverage if its filename date is on or after
+`2026-04-19` — the date the advocatus-diaboli feature shipped. Specs predating
+this date are **exempt** and are counted separately. All metrics that compare
+specs to objection records use only in-scope specs.
+
 ### Surfaces
 
 **`/superpowers-status`** gains a new Section 7: Diaboli Activity. It reads
-`docs/superpowers/specs/` and `docs/superpowers/objections/`, computes the
-metrics below, and reports them in the Details block. The summary line shows
-`Diaboli [ACTIVE — N records]` or `[NO DATA]` — explicitly not OK/WARNING/MISSING,
-since we have no threshold yet.
+in-scope specs from `docs/superpowers/specs/` and records from
+`docs/superpowers/objections/`, computes the metrics below, and reports them in
+the Details block. The summary line uses the standard token format:
+`Diaboli [OK]` when at least one in-scope objection record exists,
+`Diaboli [MISSING]` when none exist. No `WARNING` state yet — no threshold is
+defined.
 
 **`/harness-health` snapshot** gains a new Diaboli section after Session Quality
 and before Operational Cadence. The section follows the existing `- Field: Value`
 format used by all other sections. It is included in the mandatory section list
-so the validation checkpoint enforces its presence.
+so the validation checkpoint enforces its presence. `harness-health.md` step 7
+must be updated: change "All 12 section headings" to "All 13 section headings"
+and add "Diaboli" to the enumerated list between "Session Quality" and
+"Operational Cadence."
 
 **`skills/harness-observability/references/snapshot-format.md`** gets the
 canonical Diaboli section definition, including field-by-field computation
@@ -52,10 +99,11 @@ All metrics are descriptive. No pass/fail status, no thresholds.
 
 | Metric | Definition | Source |
 |---|---|---|
-| Specs reviewed | Count of `docs/superpowers/specs/*.md` | filesystem |
+| In-scope specs | Count of `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19 | filesystem |
+| Exempt specs (pre-feature) | Count of specs with filename date < 2026-04-19 | filesystem |
 | Objection records present | Count of `docs/superpowers/objections/*.md` (excluding `.gitkeep`) | filesystem |
-| Specs without a record | Spec slugs with no matching objection file | slug comparison |
-| Disposition rate | Records where all `disposition` fields are non-`pending` / total records | YAML frontmatter |
+| In-scope specs without a record | In-scope spec slugs with no matching objection file | slug comparison |
+| Fully-resolved record rate | Records where all `disposition` fields are non-`pending` / total records (record-level ratio: a record counts only when every objection within it is resolved) | YAML frontmatter |
 | Objections total | Sum of all `objections` list lengths across all records | YAML frontmatter |
 | Severity breakdown | Count of critical/high/medium/low across all objections | YAML frontmatter |
 | Mean objections per spec | Total objections / count of objection records (1 decimal) | derived |
@@ -68,6 +116,10 @@ records exist.
 A spec slug is derived from the spec filename by stripping the date prefix
 (`YYYY-MM-DD-`) and the `.md` extension. A matching objection record is a file
 at `docs/superpowers/objections/<slug>.md`.
+
+**Error handling:** If a file at `docs/superpowers/objections/` fails YAML parse
+during metric computation, report it by name in the Details section as a
+"parse error" and exclude it from all metrics.
 
 ### Side fix: diaboli.md validation checkpoint
 
@@ -82,8 +134,9 @@ in a prior PR. The command's checkpoint must be corrected to match:
 ### New reference file
 
 `ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md`
-documents what each metric means, what it does NOT mean, and the watch-for
-patterns worth a reflection entry.
+documents the metric computation definitions and interpretive notes: what each
+metric means, what it does NOT mean, and the watch-for patterns worth a reflection
+entry. Arch decisions and revisit conditions belong in AGENTS.md, not here.
 
 ### AGENTS.md
 
@@ -94,30 +147,40 @@ and the revisit conditions.
 
 After this change:
 
-- `/superpowers-status` shows a Diaboli Activity section with all metrics, no
-  pass/fail status
+- `/superpowers-status` shows a Diaboli Activity section with all metrics;
+  summary uses `OK` / `MISSING` (no `WARNING` — no threshold defined yet)
 - `/harness-health` generates a snapshot with a Diaboli panel in the correct
-  section order; the validation checkpoint enforces its presence
+  section order (after Session Quality, before Operational Cadence); step 7
+  validation enforces all 13 sections including Diaboli
 - `snapshot-format.md` defines the Diaboli section so future snapshots can be
   generated and validated against a reference
-- A reader who wants to understand what each metric means or does not mean can
-  consult `skills/advocatus-diaboli/references/observability.md`
+- A reader who wants the metric computation reference consults
+  `skills/advocatus-diaboli/references/observability.md`; a reader who wants the
+  design rationale and revisit conditions consults AGENTS.md
 - `commands/diaboli.md` validation checkpoint uses the correct taxonomy
 - An ARCH_DECISION in AGENTS.md records the observability-before-enforcement
-  decision and the revisit conditions
+  decision and the revisit conditions; observability.md is the metric reference only
 
 No new constraints or GC rules are added. The revisit evaluation is triggered
 at 10 fully-resolved objection records or 2026-07-19, whichever comes first.
 
 ## Artefacts
 
-1. `ai-literacy-superpowers/commands/superpowers-status.md` — add Section 7
-2. `ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md` — add Diaboli section
-3. `ai-literacy-superpowers/skills/harness-observability/SKILL.md` — add reference to Diaboli panel
-4. `ai-literacy-superpowers/commands/harness-health.md` — add Diaboli to required section list and section order
-5. `ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md` — new reference file
+1. `ai-literacy-superpowers/commands/superpowers-status.md` — add Section 7; summary
+   line uses `OK` / `MISSING` tokens; includes in-scope/exempt split and error handling
+2. `ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md`
+   — add Diaboli section definition with field computation table
+3. `ai-literacy-superpowers/skills/harness-observability/SKILL.md` — add reference to
+   Diaboli panel
+4. `ai-literacy-superpowers/commands/harness-health.md` — add Diaboli to required
+   section list; update step 7 from "12" to "13" and add "Diaboli" to the enumerated
+   heading list between "Session Quality" and "Operational Cadence"
+5. `ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md` — new
+   metric reference file (computation definitions and interpretive notes only; no arch
+   decision content)
 6. `ai-literacy-superpowers/commands/diaboli.md` — fix validation checkpoint taxonomy
-7. `AGENTS.md` — add ARCH_DECISION
+7. `AGENTS.md` — add ARCH_DECISION (observability-before-enforcement principle,
+   revisit conditions)
 8. `ai-literacy-superpowers/.claude-plugin/plugin.json` — 0.24.0 → 0.25.0
 9. `README.md` — badge bump
 10. `.claude-plugin/marketplace.json` — plugin_version bump

--- a/docs/superpowers/specs/2026-04-19-diaboli-observability.md
+++ b/docs/superpowers/specs/2026-04-19-diaboli-observability.md
@@ -1,0 +1,129 @@
+---
+name: diaboli-observability
+description: Spec for surfacing advocatus-diaboli activity as descriptive stats in /superpowers-status and the harness-health snapshot — observability-before-enforcement, no new constraints or thresholds
+date: 2026-04-19
+status: draft
+---
+
+# Diaboli Observability
+
+## Problem
+
+The advocatus-diaboli is live and running. Objection records are accumulating in
+`docs/superpowers/objections/`. But the patterns across specs are invisible: we
+cannot see whether dispositions cluster toward a single bucket, whether objection
+counts are trending toward zero (signal of rubber-stamping) or toward maximum
+(signal of charter over-firing), whether any spec slipped through without a
+record, or whether time-to-disposition is growing (signal of friction increasing).
+
+The existing observability surfaces — `/superpowers-status` and
+`/harness-health` — check whether the framework is wired correctly but say
+nothing about how the diaboli discipline is operating in practice.
+
+Without visibility, the only way to notice a problem is a post-hoc audit.
+With visibility, patterns emerge across the normal observability cadence.
+
+## Approach
+
+Surface diaboli stats in two existing observability surfaces. No new GC rule,
+no new constraint, no new command.
+
+### Surfaces
+
+**`/superpowers-status`** gains a new Section 7: Diaboli Activity. It reads
+`docs/superpowers/specs/` and `docs/superpowers/objections/`, computes the
+metrics below, and reports them in the Details block. The summary line shows
+`Diaboli [ACTIVE — N records]` or `[NO DATA]` — explicitly not OK/WARNING/MISSING,
+since we have no threshold yet.
+
+**`/harness-health` snapshot** gains a new Diaboli section after Session Quality
+and before Operational Cadence. The section follows the existing `- Field: Value`
+format used by all other sections. It is included in the mandatory section list
+so the validation checkpoint enforces its presence.
+
+**`skills/harness-observability/references/snapshot-format.md`** gets the
+canonical Diaboli section definition, including field-by-field computation
+instructions, so future snapshots can be generated and validated against a
+reference.
+
+### Metrics
+
+All metrics are descriptive. No pass/fail status, no thresholds.
+
+| Metric | Definition | Source |
+|---|---|---|
+| Specs reviewed | Count of `docs/superpowers/specs/*.md` | filesystem |
+| Objection records present | Count of `docs/superpowers/objections/*.md` (excluding `.gitkeep`) | filesystem |
+| Specs without a record | Spec slugs with no matching objection file | slug comparison |
+| Disposition rate | Records where all `disposition` fields are non-`pending` / total records | YAML frontmatter |
+| Objections total | Sum of all `objections` list lengths across all records | YAML frontmatter |
+| Severity breakdown | Count of critical/high/medium/low across all objections | YAML frontmatter |
+| Mean objections per spec | Total objections / count of objection records (1 decimal) | derived |
+| Disposition distribution | Among non-`pending` dispositions: accepted% / deferred% / rejected% | YAML frontmatter |
+| Median days spec-to-disposition | Spec date from filename; resolution date from git log on objection file; median across fully-resolved records | git log + filename |
+
+"Insufficient data" is reported for median when fewer than 3 fully-resolved
+records exist.
+
+A spec slug is derived from the spec filename by stripping the date prefix
+(`YYYY-MM-DD-`) and the `.md` extension. A matching objection record is a file
+at `docs/superpowers/objections/<slug>.md`.
+
+### Side fix: diaboli.md validation checkpoint
+
+`ai-literacy-superpowers/commands/diaboli.md` step 5 validation checkpoint still
+references the old category taxonomy (`premise|design|threat|failure|operational|cost`)
+and old severity values (`major|minor`). `SKILL.md` was updated to the new taxonomy
+in a prior PR. The command's checkpoint must be corrected to match:
+
+- Categories: `premise|scope|implementation|risk|alternatives|specification quality`
+- Severity: `critical|high|medium|low`
+
+### New reference file
+
+`ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md`
+documents what each metric means, what it does NOT mean, and the watch-for
+patterns worth a reflection entry.
+
+### AGENTS.md
+
+Add an ARCH_DECISION capturing the observability-before-enforcement principle
+and the revisit conditions.
+
+## Expected outcome
+
+After this change:
+
+- `/superpowers-status` shows a Diaboli Activity section with all metrics, no
+  pass/fail status
+- `/harness-health` generates a snapshot with a Diaboli panel in the correct
+  section order; the validation checkpoint enforces its presence
+- `snapshot-format.md` defines the Diaboli section so future snapshots can be
+  generated and validated against a reference
+- A reader who wants to understand what each metric means or does not mean can
+  consult `skills/advocatus-diaboli/references/observability.md`
+- `commands/diaboli.md` validation checkpoint uses the correct taxonomy
+- An ARCH_DECISION in AGENTS.md records the observability-before-enforcement
+  decision and the revisit conditions
+
+No new constraints or GC rules are added. The revisit evaluation is triggered
+at 10 fully-resolved objection records or 2026-07-19, whichever comes first.
+
+## Artefacts
+
+1. `ai-literacy-superpowers/commands/superpowers-status.md` — add Section 7
+2. `ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md` — add Diaboli section
+3. `ai-literacy-superpowers/skills/harness-observability/SKILL.md` — add reference to Diaboli panel
+4. `ai-literacy-superpowers/commands/harness-health.md` — add Diaboli to required section list and section order
+5. `ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md` — new reference file
+6. `ai-literacy-superpowers/commands/diaboli.md` — fix validation checkpoint taxonomy
+7. `AGENTS.md` — add ARCH_DECISION
+8. `ai-literacy-superpowers/.claude-plugin/plugin.json` — 0.24.0 → 0.25.0
+9. `README.md` — badge bump
+10. `.claude-plugin/marketplace.json` — plugin_version bump
+11. `CHANGELOG.md` — new version entry
+
+## Exemptions
+
+None. This is a plugin behavioral change (new output sections in two commands)
+warranting a minor version bump per CLAUDE.md semver rules.


### PR DESCRIPTION
## Summary

- `/superpowers-status` gains Section 7: Diaboli Activity — in-scope/exempt spec split, `OK`/`MISSING` summary tokens, error handling for malformed YAML
- `/harness-health` snapshot gains a Diaboli panel (after Session Quality, before Operational Cadence); step 7 validation updated from 12 to 13 required sections
- `snapshot-format.md` adds canonical Diaboli section definition with field computation table
- New `skills/advocatus-diaboli/references/observability.md` — metric reference file (computation, interpretive notes, watch-for patterns)
- `commands/diaboli.md` validation checkpoint taxonomy fixed (was still using old `major|minor` and `premise|design|threat|failure|operational|cost`)
- `AGENTS.md` ARCH_DECISION: observability-before-enforcement principle, revisit at 10 fully-resolved records or 2026-07-19
- `docs/explanation/adversarial-review.md` — disposition patterns section references Diaboli panel; three-loops section adds observability loop
- `docs/how-to/review-a-spec-adversarially.md` — "What you have now" notes patterns visible in status/health

Spec: `docs/superpowers/specs/2026-04-19-diaboli-observability.md`
Objections: `docs/superpowers/objections/diaboli-observability.md` (10 objections, 7 fixed, 1 accepted, 1 left, 1 accepted-acknowledged)

## Test plan

- [ ] `commands/superpowers-status.md` — Section 7 present with all fields; summary uses `OK`/`MISSING`; error handling documented
- [ ] `snapshot-format.md` — Diaboli section present after Session Quality, before Operational Cadence; field table complete
- [ ] `commands/harness-health.md` — Diaboli in section list; step 7 says "13" with "Diaboli" in enumerated list
- [ ] `commands/diaboli.md` — categories are `premise|scope|implementation|risk|alternatives|specification quality`; severity is `critical|high|medium|low`
- [ ] `AGENTS.md` — ARCH_DECISION present with revisit conditions
- [ ] `adversarial-review.md` — Diaboli panel referenced in disposition patterns section and observability loop added to three-loops section
- [ ] `review-a-spec-adversarially.md` — "What you have now" mentions status/health surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)