### PR TITLE
Add diaboli code-time dispatch point (v0.26.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.25.0",
+  "plugin_version": "0.26.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.25.0"
+      "version": "0.26.0"
     }
   ]
 }

--- a/.github/prompts/diaboli.prompt.md
+++ b/.github/prompts/diaboli.prompt.md
@@ -1,33 +1,47 @@
 ---
 name: diaboli
-description: Run the adversarial spec reviewer on a spec file — produces or regenerates the objection record at docs/superpowers/objections/<spec-slug>.md; use after spec-writer completes or when a spec is substantively edited
+description: Run the adversarial reviewer on a spec or implementation — produces the objection record at docs/superpowers/objections/<slug>.md (spec mode) or <slug>-code.md (code mode); use after spec-writer completes or after the final code-reviewer PASS
 ---
 
 # Diaboli
 
-Run the advocatus-diaboli adversarial reviewer against a spec file.
+Run the advocatus-diaboli adversarial reviewer against a spec file (spec mode)
+or implementation (code mode).
 
 ## Usage
 
 ```
-/diaboli docs/superpowers/specs/<date>-<name>.md
+/diaboli docs/superpowers/specs/<date>-<name>.md [--mode spec|code]
 ```
+
+`--mode` defaults to `spec`. Pass `--mode code` after the final code-reviewer
+PASS, before integration-agent.
 
 ## Steps
 
 1. Confirm the spec file exists at the path provided
 2. Derive the slug: strip the date prefix and `.md` extension from the filename
-3. Read the spec file in full
-4. Read `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` for the
-   charter, six categories, severity definitions, and output format
-5. Generate objection record content following the skill's output format:
-   - YAML frontmatter with all objections (`disposition: pending`, `disposition_rationale: null`)
+3. Determine output path from mode:
+   - Spec mode: `docs/superpowers/objections/<slug>.md`
+   - Code mode: `docs/superpowers/objections/<slug>-code.md`
+4. Read the spec file in full; in code mode also read implementation files
+   changed on the current branch
+5. Read `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` for the
+   charter, six categories, severity definitions, dispatch mode weighting,
+   and output format
+6. Apply category weighting for the active mode (see Dispatch Modes section
+   in SKILL.md)
+7. Generate objection record content following the skill's output format:
+   - YAML frontmatter with `mode: spec|code`, all objections
+     (`disposition: pending`, `disposition_rationale: null`)
    - Prose sections per objection (`## O<N> — <category> — <severity>`)
    - Closing "Explicitly not objecting to" section (at least three entries)
-6. Write to `docs/superpowers/objections/<slug>.md` (overwrite if exists)
-7. Validate the written file: check frontmatter structure, field presence,
-   pending dispositions, category/severity enum values, objection count (1–12),
-   prose sections, closing section
-8. Fix any validation failures in place
-9. Report: output path, objection count (major/minor), category distribution
-10. Remind the user to fill in dispositions before the plan-approval gate
+8. Write to the mode-appropriate path (overwrite if exists)
+9. Validate the written file: check frontmatter structure including `mode:`
+   field, field presence, pending dispositions, category/severity enum values,
+   objection count (1–12), prose sections, closing section
+10. Fix any validation failures in place
+11. Report: output path, mode, objection count by severity, category distribution
+12. Remind the user to fill in dispositions before the appropriate gate:
+    - Spec mode: plan-approval gate
+    - Code mode: integration-approval gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,23 @@
   the constraint. Do not weaken the constraint at first friction — that builds
   ceremony, not a gate.
 
+- Decision: diaboli runs at two dispatch points (spec-time and code-time) using
+  a single agent with mode-based category weighting. One agent, two dispatches —
+  not two agents. Spec-time dispatch runs after spec-writer, before plan approval;
+  code-time dispatch runs once after the final code-reviewer PASS (or escalation),
+  before integration-agent. The integration-approval gate mirrors the plan-approval
+  gate: refuses while any code-mode disposition is `pending`. Alternatives
+  considered and rejected: (1) separate code-diaboli agent — rejected: duplicates
+  charter, fragments maintenance, creates divergent evolution risk; (2) running
+  diaboli inside the code-reviewer loop per cycle — rejected: burns tokens on draft
+  code, and adversarial review of drafts conflates the code-reviewer's constructive
+  role with diaboli's adversarial one; (3) running code-time diaboli only for PRs
+  above a size threshold — rejected: premature optimisation without
+  disposition-distribution data to justify it. Conditions for revisit: if code-time
+  disposition distribution diverges sharply from spec-time across a meaningful sample
+  (20+ PRs), consider whether the two modes need genuinely separate charters rather
+  than weighting.
+
 - Decision: diaboli activity is surfaced as descriptive stats in existing
   observability surfaces (`/superpowers-status` Section 7 and the harness-health
   snapshot Diaboli panel) without thresholds or new enforcement, pending a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.26.0 — 2026-04-19
+
+### Feature — diaboli code-time dispatch point
+
+- Add Dispatch Modes section to `skills/advocatus-diaboli/SKILL.md` documenting
+  spec-time weighting (premise, alternatives, scope, specification quality) and
+  code-time weighting (risk, implementation); six categories and trust boundary
+  unchanged across modes
+- Update `agents/advocatus-diaboli.agent.md` to accept `mode: spec|code` input
+  (default `spec`); apply mode-appropriate weighting; write to
+  `docs/superpowers/objections/<slug>.md` (spec mode) or
+  `docs/superpowers/objections/<slug>-code.md` (code mode); add `mode:` field to
+  frontmatter
+- Update `commands/diaboli.md` and `.github/prompts/diaboli.prompt.md` to accept
+  optional `--mode` flag; extend validation checkpoint to verify `mode:` field and
+  mode-appropriate required frontmatter fields explicitly
+- Update `agents/orchestrator.agent.md` — add code-time dispatch (step 4a) after
+  code-reviewer loop exits (PASS or escalation); add Integration Approval gate
+  that refuses while any code-mode disposition is `pending`; extend context object
+  with `code_diaboli_slug` field
+- Rename HARNESS.md constraint from "Spec has adjudicated objections" to "PRs have
+  adjudicated objections"; extend rule to require both spec-mode and code-mode
+  records; extend "Objection record freshness" GC rule to cover both record types
+- Extend `commands/superpowers-status.md` Section 7 Diaboli panel with mode-split
+  breakdown (spec-mode and code-mode separately) and overall totals for backward
+  compatibility
+- Extend `skills/harness-observability/references/snapshot-format.md` Diaboli
+  section with mode-split field definitions and computation table
+- Update `skills/advocatus-diaboli/references/observability.md` with mode-split
+  field definitions and cross-mode interpretation patterns (code-time counts
+  trending up/down, distribution divergence)
+- Update `MODEL_ROUTING.md` and `templates/MODEL_ROUTING.md` — note code-time
+  dispatch routes to most-capable tier; judgment load equivalent across modes
+- Update `templates/HARNESS.md` — extended constraint and GC rule for new projects
+- Add ARCH_DECISION to `AGENTS.md` — one agent, two dispatches; alternatives
+  considered and rejected; conditions for revisit at 20+ PRs
+- Update `README.md` — pipeline diagram shows both dispatch points and both gates;
+  Agents table row updated; agent count unchanged at 12
+- Update `docs/explanation/adversarial-review.md` — intro and three-loops section
+  describe both dispatch modes; disposition patterns section notes mode-split stats
+- Update `docs/how-to/review-a-spec-adversarially.md` — code mode documented with
+  `--mode code` flag, output path, and integration-approval gate
+
 ## 0.25.0 — 2026-04-19
 
 ### Feature — diaboli observability panel

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.23.0 -->
+<!-- template-version: 0.25.0 -->
 
 ## Context
 
@@ -194,16 +194,18 @@
 - **Tool**: harness-enforcer agent
 - **Scope**: pr
 
-### Spec has adjudicated objections
+### PRs have adjudicated objections
 
-- **Rule**: Every feature or behaviour-change spec must have a corresponding
+- **Rule**: Every feature or behaviour-change PR must have (a) a spec-mode
   objection record at `docs/superpowers/objections/<spec-slug>.md` with all
-  dispositions resolved (no `pending` values). Bug fixes, dependency updates,
-  and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or
-  branch-prefixed `fix/`, `chore/`) are exempt on the same terms as
-  spec-first-commit-ordering. Specs created before 2026-04-19 are exempt —
-  add `diaboli: exempt-pre-existing` to their frontmatter or rely on the
-  dated cutoff in the constraint text.
+  dispositions resolved (no `pending` values), and (b) a code-mode objection
+  record at `docs/superpowers/objections/<spec-slug>-code.md` with all
+  dispositions resolved. Bug fixes, dependency updates, and maintenance PRs
+  (labelled `bug`, `fix`, `chore`, `maintenance` or branch-prefixed `fix/`,
+  `chore/`) are exempt on the same terms as spec-first-commit-ordering. Specs
+  created before 2026-04-19 are exempt — add `diaboli: exempt-pre-existing`
+  to their frontmatter or rely on the dated cutoff. "Resolved" is a judgment
+  call on rationale quality, not a schema check.
 - **Enforcement**: agent
 - **Tool**: harness-enforcer
 - **Scope**: pr
@@ -413,10 +415,12 @@ Use /governance-constrain for guided authoring of governance constraints.
 
 ### Objection record freshness
 
-- **What it checks**: Whether any spec file in `docs/superpowers/specs/`
-  has been modified more recently than its corresponding objection record
-  in `docs/superpowers/objections/` — a spec edited without re-running
-  `/diaboli` produces a stale objection record
+- **What it checks**: (a) Whether any spec file in `docs/superpowers/specs/`
+  has been modified more recently than its corresponding spec-mode objection
+  record — a spec edited without re-running `/diaboli` produces a stale record.
+  (b) Whether any code-mode record (`<slug>-code.md`) is older than the most
+  recent implementation commit on the branch that introduced it — implementation
+  changes after code-time review produce a stale code-mode record.
 - **Frequency**: weekly
 - **Enforcement**: deterministic
 - **Tool**: find docs/superpowers/specs -name "*.md" -newer docs/superpowers/objections/$(basename "$f" .md | sed 's/^[0-9-]*-//').md 2>/dev/null | grep .

--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -9,7 +9,7 @@
 | --- | --- | --- |
 | orchestrator | Most capable | Coordination, judgment, decomposition |
 | spec-writer | Most capable | Design judgment, specification quality |
-| advocatus-diaboli | Most capable | Adversarial reasoning, evidence-grounded objection — judgment-heavy, not throughput-heavy |
+| advocatus-diaboli | Most capable | Adversarial reasoning, evidence-grounded objection — judgment-heavy, not throughput-heavy. Both spec-time and code-time dispatches use this tier; the judgment load is equivalent across modes. |
 | tdd-agent | Standard | Structured output from specs |
 | {{LANGUAGE}}-implementer | Standard / Capable | Depends on task complexity |
 | code-reviewer | Most capable | Nuance, quality judgment |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.25.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.26.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
 [![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)
@@ -191,7 +191,7 @@ A coordinated team that handles the full development lifecycle.
 | harness-auditor | Meta-agent — checks whether the harness matches reality | Write to Status only |
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
-| advocatus-diaboli | Adversarial spec reviewer — six-category objection record, read-only trust boundary, human-cognition gate on dispositions | Read only |
+| advocatus-diaboli | Adversarial reviewer — spec-time (premise/design focus, before plan approval) and code-time (risk/implementation focus, before integration); six-category objection record, read-only trust boundary, human-cognition gate on dispositions at both gates | Read only |
 
 ### Commands (22)
 
@@ -497,17 +497,19 @@ When you use the orchestrator agent, it runs this pipeline:
 ```text
 orchestrator
   → spec-writer
-  → advocatus-diaboli (adversarial review — read-only, produces objection record)
-  → GATE: objection adjudication (user writes dispositions; gate blocked while any is `pending`)
-  → GATE: plan approval (user reviews plan + adjudicated objection record)
+  → advocatus-diaboli (spec mode — read-only, produces spec objection record)
+  → GATE: objection adjudication — spec mode (user writes dispositions; gate blocked while any is `pending`)
+  → GATE: plan approval (user reviews plan + adjudicated spec objection record)
   → tdd-agent
   → implementer(s) (parallel, one per language — user-created per project)
   → code-reviewer
   → GUARDRAIL: MAX_REVIEW_CYCLES=3 (escalate after 3 loops)
+  → advocatus-diaboli (code mode — read-only, produces code objection record; runs once after loop exits)
+  → GATE: integration approval — code mode (user writes dispositions; gate blocked while any is `pending`)
   → integration-agent (includes reflection step)
 ```
 
-The objection adjudication gate raises premise-level challenges before any tests or code exist — the cheapest moment to change course. The plan approval gate catches bad plans before they become bad code. The loop guardrail prevents unbounded reviewer cycles.
+The spec objection adjudication gate raises premise-level challenges before any tests or code exist — the cheapest moment to change course. The plan approval gate catches bad plans before they become bad code. The loop guardrail prevents unbounded reviewer cycles. The code objection adjudication gate surfaces threat-model, failure-mode, and operational concerns visible in the implementation before merge.
 
 The plugin ships the orchestrator, spec-writer, tdd-agent, code-reviewer, and integration-agent. Language-specific implementers are not included — each project creates its own based on the stack. See [How to Extend](#how-to-extend) for instructions.
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
+++ b/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
@@ -1,6 +1,6 @@
 ---
 name: advocatus-diaboli
-description: Use after spec-writer completes and before plan approval — reads a spec file and produces a structured objection record at docs/superpowers/objections/<spec-slug>.md; read-only trust boundary enforces the human-cognition gate on dispositions
+description: Use after spec-writer completes (spec mode) or after the final code-reviewer PASS (code mode) — reads the spec or implementation and produces a structured objection record; read-only trust boundary enforces the human-cognition gate on dispositions at both gates
 tools: [Read, Glob, Grep]
 ---
 
@@ -25,10 +25,18 @@ exactly.
 
 ## Input
 
-You receive a spec file path. Read the spec in full before raising any objections.
-Also read any referenced files the spec explicitly points to (linked designs,
-existing constraints, related specs) — objections grounded only in the spec text
-may miss context the spec assumed the reader already had.
+You receive a spec file path and an optional mode: `spec` (default) or `code`.
+
+**Spec mode** (default): Read the spec in full before raising any objections.
+Also read any referenced files the spec explicitly points to — objections grounded
+only in the spec text may miss context the spec assumed the reader already had.
+
+**Code mode**: Read the spec to understand intent, then read all implementation
+files changed by the current branch (use Glob and Grep to find them). Your
+objections must be grounded in the implementation, not just the spec.
+
+Apply the category weighting for the active mode as defined in the Dispatch Modes
+section of the skill. Do not apply spec-time weighting in code mode or vice versa.
 
 ## Trust Boundary
 
@@ -65,8 +73,10 @@ the highest severity and strongest evidence.
 ## Output
 
 Return the full content of the objection record in your response to the
-orchestrator. The orchestrator writes it to
-`docs/superpowers/objections/<spec-slug>.md`.
+orchestrator. The orchestrator writes it to the mode-appropriate path:
+
+- **Spec mode**: `docs/superpowers/objections/<spec-slug>.md`
+- **Code mode**: `docs/superpowers/objections/<spec-slug>-code.md`
 
 The slug is derived from the spec filename: strip the date prefix and `.md`
 extension. Example:
@@ -74,8 +84,8 @@ extension. Example:
 
 Use the exact output format specified in the skill:
 
-- YAML frontmatter with all objections, each having `disposition: pending` and
-  `disposition_rationale: null`
+- YAML frontmatter with `mode: spec` or `mode: code` field, all objections
+  each having `disposition: pending` and `disposition_rationale: null`
 - One prose section per objection (`## O<N> — <category> — <severity>`)
 - A closing "Explicitly not objecting to" section with at least three entries
 
@@ -85,7 +95,8 @@ Return:
 
 1. The full objection record content (to be written to the objections file)
 2. A summary: number of objections by category and severity
-3. Whether any major objections were raised (yes/no)
+3. Whether any high or critical objections were raised (yes/no)
 4. The slug used for the output path
+5. The mode used (`spec` or `code`)
 
 The orchestrator writes the file; you provide the content.

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -61,6 +61,16 @@ message with multiple Agent tool calls.
            - Summarise what the implementer attempted in each cycle
            - Recommend: accept remaining findings as minor, or intervene manually
            Do NOT continue looping. Human judgment is needed.
+  4a. SEQUENTIAL — advocatus-diaboli  code mode — runs ONCE after the review
+           loop exits, whether by PASS or by escalation. Dispatch regardless of
+           how the loop exited; a PR that exhausted review cycles still requires
+           a code-mode objection record.
+     GATE: Integration Approval — surface the code-mode objection record to the
+           user. Refuse to dispatch integration-agent while any disposition is
+           `pending`. The user writes dispositions (`accepted`/`deferred`/
+           `rejected`) and rationales inline in
+           `docs/superpowers/objections/<spec-slug>-code.md`. Do NOT let any
+           agent write dispositions.
   5. SEQUENTIAL  — integration-agent  CHANGELOG, commit, PR, CI, merge, cleanup.
 
 ## Before dispatching spec-writer
@@ -72,12 +82,12 @@ message with multiple Agent tool calls.
    `gh issue create --title "TITLE" --body "DESCRIPTION"`
    Record the issue number — pass it to integration-agent at the end.
 
-## After spec-writer completes — Diaboli and Plan Approval Gate
+## After spec-writer completes — Diaboli (spec mode) and Plan Approval Gate
 
-### Step 1: Dispatch advocatus-diaboli
+### Step 1: Dispatch advocatus-diaboli in spec mode
 
-Dispatch the advocatus-diaboli agent with the spec file path as input. The agent
-returns the full objection record content. Write that content to
+Dispatch the advocatus-diaboli agent with the spec file path and `mode: spec`.
+The agent returns the full objection record content. Write that content to
 `docs/superpowers/objections/<spec-slug>.md`.
 
 The spec slug is derived from the spec filename: strip the date prefix and `.md`
@@ -133,6 +143,51 @@ Do NOT dispatch tdd-agent without user approval. This gate exists because it is
 far cheaper to fix a bad plan than to fix bad code — especially when the plan
 drives tests that drive implementation.
 
+## After code-reviewer exits — Diaboli (code mode) and Integration Approval Gate
+
+This runs once after the code-reviewer loop exits — whether by PASS or by
+MAX_REVIEW_CYCLES escalation. Do not run per cycle.
+
+### Step 1: Dispatch advocatus-diaboli in code mode
+
+Dispatch the advocatus-diaboli agent with the spec file path and `mode: code`.
+The agent reads the spec for intent and all implementation files changed on the
+branch. Write the returned content to
+`docs/superpowers/objections/<spec-slug>-code.md`.
+
+### Step 2: Validate the code-mode objection record
+
+Read back the written file and verify:
+
+1. YAML frontmatter present with `spec`, `date`, `mode: code`, `diaboli_model`,
+   `objections` fields
+2. Each objection has `id`, `category`, `severity`, `claim`, `evidence`,
+   `disposition: pending`, `disposition_rationale: null`
+3. Categories are one of: `premise`, `scope`, `implementation`, `risk`,
+   `alternatives`, `specification quality`
+4. Severities are one of: `critical`, `high`, `medium`, `low`
+5. Objection count is between 1 and 12 inclusive
+6. Prose sections present for each objection
+7. "Explicitly not objecting to" section present with at least three entries
+
+Fix any deviations in place. Do not re-dispatch the agent.
+
+### Step 3: Integration Approval Gate
+
+PAUSE and present the code-mode objection record to the user. Show:
+
+- Total objections (by severity)
+- Category distribution
+- Each objection's claim and evidence
+
+Tell the user: "Fill in `disposition` and `disposition_rationale` for each
+objection in `docs/superpowers/objections/<slug>-code.md` before proceeding."
+
+Do NOT dispatch integration-agent while any `disposition` is `pending`.
+
+Once the user confirms all code-mode dispositions are resolved, proceed to
+integration-agent.
+
 ## Context object
 
 Maintain a running context string that you update after each agent completes
@@ -144,6 +199,7 @@ and pass to the next. It should always contain:
   spec_changes: what changed in spec/plans (from spec-writer)
   failing_tests: test names confirmed red (from tdd-agent)
   review_result: PASS or findings summary (from code-reviewer)
+  code_diaboli_slug: slug used for the code-mode objection record
 
 ## Skipping stages
 

--- a/ai-literacy-superpowers/commands/diaboli.md
+++ b/ai-literacy-superpowers/commands/diaboli.md
@@ -1,18 +1,24 @@
 ---
 name: diaboli
-description: Run the adversarial spec reviewer on a spec file — produces or regenerates the objection record at docs/superpowers/objections/<spec-slug>.md; use after spec-writer completes or when a spec is substantively edited
+description: Run the adversarial reviewer on a spec or implementation — produces the objection record at docs/superpowers/objections/<slug>.md (spec mode) or <slug>-code.md (code mode); use after spec-writer completes or after the final code-reviewer PASS
 ---
 
-# /diaboli \<spec-path\>
+# /diaboli \<spec-path\> [--mode spec|code]
 
-Run the advocatus-diaboli agent against a spec file and write the objection record.
+Run the advocatus-diaboli agent against a spec file (spec mode) or implementation
+(code mode) and write the structured objection record.
+
+`--mode` defaults to `spec`. Pass `--mode code` after the final code-reviewer PASS,
+before integration-agent.
 
 ## When to use
 
-- Manually after `/spec-writer` completes, before presenting the plan
-- When a spec is substantively edited after an objection record already exists
-  (regenerates the record — old dispositions are lost; this is intentional)
-- When the orchestrator is not in use and you want adversarial review on demand
+- **Spec mode** (default): manually after `/spec-writer` completes, before presenting
+  the plan; when a spec is substantively edited after an objection record already exists
+  (regenerates the record — old dispositions are lost; this is intentional); when the
+  orchestrator is not in use and you want adversarial review on demand
+- **Code mode**: after the final code-reviewer PASS, before integration-agent; when
+  running outside the orchestrator and you want adversarial review of the implementation
 
 ## Process
 
@@ -30,13 +36,15 @@ Strip the date prefix and `.md` extension from the filename.
 
 Example: `docs/superpowers/specs/2026-04-19-advocatus-diaboli.md` → `advocatus-diaboli`
 
-The output path will be `docs/superpowers/objections/<slug>.md`.
+Output path:
+- Spec mode: `docs/superpowers/objections/<slug>.md`
+- Code mode: `docs/superpowers/objections/<slug>-code.md`
 
 ### 3. Dispatch the advocatus-diaboli agent
 
-Pass the spec file path. The agent reads the spec and returns the full objection
-record content. Do not pass any prior objection record — the agent reviews the
-spec fresh.
+Pass the spec file path and mode. The agent reads the spec (and implementation
+files in code mode) and returns the full objection record content. Do not pass
+any prior objection record — the agent reviews fresh.
 
 ### 4. Write the objection record
 
@@ -47,20 +55,22 @@ prior dispositions are replaced and they will need to re-adjudicate.
 
 ### 5. Validation checkpoint
 
-Read back `docs/superpowers/objections/<slug>.md` and verify:
+Read back the written file and verify:
 
 1. YAML frontmatter is present and parseable (opens with `---`)
-2. Required frontmatter fields present: `spec`, `date`, `diaboli_model`, `objections`
-3. Each objection entry has: `id`, `category`, `severity`, `claim`, `evidence`,
+2. Required frontmatter fields present for all modes: `spec`, `date`, `mode`,
+   `diaboli_model`, `objections`
+3. `mode` value is `spec` or `code` matching the flag passed
+4. Each objection entry has: `id`, `category`, `severity`, `claim`, `evidence`,
    `disposition`, `disposition_rationale`
-4. `disposition` value is `pending` for all entries (not pre-filled)
-5. `disposition_rationale` value is `null` for all entries (not pre-filled)
-6. Category values are one of: `premise`, `scope`, `implementation`, `risk`,
+5. `disposition` value is `pending` for all entries (not pre-filled)
+6. `disposition_rationale` value is `null` for all entries (not pre-filled)
+7. Category values are one of: `premise`, `scope`, `implementation`, `risk`,
    `alternatives`, `specification quality`
-7. Severity values are one of: `critical`, `high`, `medium`, `low`
-8. Objection count is between 1 and 12 inclusive
-9. Prose body contains one `## O<N>` section per objection
-10. File ends with an `## Explicitly not objecting to` section containing
+8. Severity values are one of: `critical`, `high`, `medium`, `low`
+9. Objection count is between 1 and 12 inclusive
+10. Prose body contains one `## O<N>` section per objection
+11. File ends with an `## Explicitly not objecting to` section containing
     at least three entries
 
 If any check fails, fix the deviation in place. Do not re-dispatch the agent.
@@ -69,16 +79,21 @@ If any check fails, fix the deviation in place. Do not re-dispatch the agent.
 
 Show:
 
-- Output path
-- Number of objections (major / minor split)
+- Output path and mode
+- Number of objections (by severity)
 - Category distribution
-- A reminder: "Fill in `disposition` and `disposition_rationale` for each
-  objection before proceeding. The plan-approval gate will not advance while
-  any disposition is `pending`."
+- A reminder:
+  - Spec mode: "Fill in `disposition` and `disposition_rationale` for each
+    objection before proceeding. The plan-approval gate will not advance while
+    any disposition is `pending`."
+  - Code mode: "Fill in `disposition` and `disposition_rationale` for each
+    objection before proceeding. The integration-approval gate will not advance
+    while any disposition is `pending`."
 
 ### 7. Suggest next steps
 
 If this was invoked manually (not via orchestrator):
 
-- Once all dispositions are filled, present the plan for approval
-- Proceed to tdd-agent only after plan approval
+- Spec mode: once all dispositions are filled, present the plan for approval;
+  proceed to tdd-agent only after plan approval
+- Code mode: once all dispositions are filled, proceed to integration-agent

--- a/ai-literacy-superpowers/commands/superpowers-status.md
+++ b/ai-literacy-superpowers/commands/superpowers-status.md
@@ -89,35 +89,50 @@ Check for CI configuration:
 
 Check `docs/superpowers/specs/` and `docs/superpowers/objections/`.
 
-A spec is **in-scope** if its filename date is on or after `2026-04-19` (the date
-advocatus-diaboli shipped). Specs with earlier dates are **exempt**. A spec slug is
-the filename with the `YYYY-MM-DD-` date prefix and `.md` extension stripped. A
-matching objection record is `docs/superpowers/objections/<slug>.md`.
+A spec is **in-scope** if its filename date is on or after `2026-04-19`. Specs with
+earlier dates are **exempt**. A spec slug is the filename with the `YYYY-MM-DD-` date
+prefix and `.md` extension stripped.
 
-Compute and report these fields. All are descriptive — no pass/fail status:
+- A **spec-mode record** matches `docs/superpowers/objections/<slug>.md`
+- A **code-mode record** matches `docs/superpowers/objections/<slug>-code.md`
+
+**Error handling**: if any file at `docs/superpowers/objections/` fails YAML parse,
+report it by name as "parse error" and exclude it from all metrics.
+
+#### Overall totals (all records, both modes)
 
 - **In-scope specs**: count of `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19
 - **Exempt specs (pre-feature)**: count of specs with filename date < 2026-04-19
-- **Objection records present**: count of `docs/superpowers/objections/*.md`,
+- **Objection records present**: count of all `docs/superpowers/objections/*.md`,
   excluding `.gitkeep`
-- **In-scope specs without a record**: in-scope spec slugs with no matching file in
-  `docs/superpowers/objections/`
-- **Fully-resolved record rate**: records where every `disposition` field is
-  non-`pending` / total records (record-level ratio)
+- **In-scope specs without any record**: in-scope spec slugs with no matching spec-mode
+  or code-mode file
 - **Objections total**: sum of `objections` list lengths across all records
-- **Severity breakdown**: count of critical / high / medium / low across all objections
-- **Mean objections per spec**: total objections / count of records (1 decimal)
-- **Disposition distribution**: among non-`pending` dispositions — accepted% / deferred% /
-  rejected%
-- **Median days spec-to-disposition**: spec date from filename; resolution date from
-  `git log` on the objection file; median across fully-resolved records. Report
-  "insufficient data" if fewer than 3 fully-resolved records exist.
+- **Mean objections per record**: total objections / count of records (1 decimal)
 
-**Error handling**: if a file at `docs/superpowers/objections/` fails YAML parse,
-report it by name in the Details section as "parse error" and exclude it from all
-metrics.
+#### Spec-mode breakdown
 
-Summary line: `Diaboli [OK]` when at least one in-scope objection record is present;
+- **Spec-mode records present**: count of `docs/superpowers/objections/<slug>.md` files
+  (no `-code` suffix), excluding `.gitkeep`
+- **Fully-resolved rate (spec-mode)**: records where every `disposition` is non-`pending`
+  / total spec-mode records (record-level ratio)
+- **Disposition distribution (spec-mode)**: among non-`pending` dispositions —
+  accepted% / deferred% / rejected%
+- **Mean objections per spec-mode record**: (1 decimal)
+
+#### Code-mode breakdown
+
+- **Code-mode records present**: count of `docs/superpowers/objections/<slug>-code.md`
+  files
+- **In-scope specs with spec-mode record but no code-mode record**: slugs where
+  `<slug>.md` exists but `<slug>-code.md` does not
+- **Fully-resolved rate (code-mode)**: records where every `disposition` is non-`pending`
+  / total code-mode records (record-level ratio)
+- **Disposition distribution (code-mode)**: among non-`pending` dispositions —
+  accepted% / deferred% / rejected%
+- **Mean objections per code-mode record**: (1 decimal)
+
+Summary line: `Diaboli [OK]` when at least one in-scope spec-mode record is present;
 `Diaboli [MISSING]` when none exist. No `WARNING` state — no threshold is defined yet.
 
 ## Output format

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md
@@ -136,9 +136,63 @@ it chose not to challenge, it did not engage with the spec at the depth
 required. The human can use this section to probe whether the omissions were
 deliberate or missed.
 
+## Dispatch Modes
+
+The charter, six categories, evidence requirements, 12-objection cap, and
+"Explicitly not objecting to" discipline are identical across modes. Only
+category weighting differs. The mode is set by the dispatcher; do not infer
+it from the input.
+
+### Spec-time (default)
+
+Emphasise **premise**, **alternatives**, **scope**, and **specification quality**.
+
+- `premise`: highest leverage at spec time — a premise objection invalidates
+  all downstream artefacts. Challenge the "why" hard before any tests or
+  code exist.
+- `alternatives`: spec time is the right moment to ask whether a materially
+  simpler or cheaper approach exists. Once implementation begins, alternatives
+  are largely academic.
+- `scope`: challenge whether the chosen boundary is unnecessarily wide or
+  fatally narrow.
+- `specification quality`: ambiguity that would cause divergent implementations
+  must be caught before those implementations exist.
+
+**Deprioritise at spec time:** `risk` objections that require examining
+concrete code or runtime behaviour to ground. Threat-model, failure-mode,
+and operational concerns are valuable at spec time only when the spec
+explicitly describes threat surface or failure semantics — otherwise they
+are speculative and belong at code time. An ungrounded risk objection at
+spec time wastes adjudication time.
+
+### Code-time
+
+Emphasise **risk** and **implementation**.
+
+- `risk`: code time is when threat-model, failure-mode, and operational
+  concerns become groundable with specific evidence from the implementation —
+  API surface exposures, error path gaps, resource-management failures, and
+  operational blind spots.
+- `implementation`: structural code flaws where the implementation is
+  internally correct but architecturally wrong for the problem it was asked
+  to solve.
+
+**Deprioritise at code time:** `premise`. The premise was adjudicated at
+the plan-approval gate. If a premise objection fires at code time, it signals
+that the spec or spec-time dispositions were incomplete — note it in the
+record and cite the spec-time objection record (`<spec-slug>.md`) for context.
+Do not re-litigate adjudicated dispositions.
+
+`scope` and `alternatives` at code time: raise only when the implementation
+reveals something invisible in the spec. Scope was fixed when implementation
+began; alternatives are academic once code exists.
+
 ## Output Format
 
-Produce the output at `docs/superpowers/objections/<spec-slug>.md`.
+Produce the output at the mode-appropriate path:
+
+- **Spec mode**: `docs/superpowers/objections/<spec-slug>.md`
+- **Code mode**: `docs/superpowers/objections/<spec-slug>-code.md`
 
 The spec slug is derived from the spec filename: strip the date prefix and
 the `.md` extension. For example:
@@ -150,6 +204,7 @@ the `.md` extension. For example:
 ---
 spec: <path to spec file>
 date: <ISO date>
+mode: spec|code
 diaboli_model: <model-id used>
 objections:
   - id: O1

--- a/ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md
+++ b/ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md
@@ -1,6 +1,6 @@
 ---
 name: diaboli-observability-reference
-description: Metric computation definitions and interpretive notes for the Diaboli panel in /superpowers-status and the harness-health snapshot — what each field means, what it does NOT mean, and watch-for patterns
+description: Metric computation definitions and interpretive notes for the Diaboli panel in /superpowers-status and the harness-health snapshot — what each field means, what it does NOT mean, watch-for patterns, and mode-split interpretation
 ---
 
 # Diaboli Observability Reference
@@ -10,7 +10,7 @@ The Diaboli panel surfaces advocatus-diaboli activity as descriptive stats in
 documents how each metric is computed, how to interpret it, and what it does not tell you.
 
 For the arch decision behind this approach (observability-before-enforcement, revisit
-conditions), see `AGENTS.md` → ARCH_DECISIONS.
+conditions, and the one-agent two-dispatch design), see `AGENTS.md` → ARCH_DECISIONS.
 
 ---
 
@@ -18,16 +18,21 @@ conditions), see `AGENTS.md` → ARCH_DECISIONS.
 
 A spec is **in-scope** for diaboli coverage if its filename date is on or after
 `2026-04-19` — the date the advocatus-diaboli feature shipped. Specs predating this
-date are **exempt** and counted separately. All metrics that compare specs to objection
-records use only in-scope specs.
+date are **exempt** and counted separately.
 
 A **spec slug** is the filename with the `YYYY-MM-DD-` date prefix and `.md` extension
-stripped. A matching **objection record** is the file at
-`docs/superpowers/objections/<slug>.md`.
+stripped.
+
+- A **spec-mode record** is at `docs/superpowers/objections/<slug>.md`
+- A **code-mode record** is at `docs/superpowers/objections/<slug>-code.md`
 
 ---
 
 ## Field definitions
+
+The panel reports **overall totals** (all records, both modes) and **per-mode
+breakdowns** (spec-mode and code-mode separately). The overall totals preserve
+backward comparability with snapshots generated before code-mode existed.
 
 ### In-scope specs
 
@@ -122,6 +127,45 @@ is overwritten. The git date then reflects the post-revision fill date, not the 
 one. This makes the metric an approximation of disposition speed rather than a precise
 measurement. It is useful as an order-of-magnitude indicator of friction, not as a precise
 SLA metric.
+
+---
+
+## Mode-split interpretation
+
+The panel reports per-mode breakdowns for objection records present, disposition
+distribution, and mean objections per record. These cross-mode comparisons carry
+interpretive signal that the per-mode numbers alone do not.
+
+### Code-time objection counts trending up
+
+May indicate spec-time charter is too loose — premise and design issues are not being
+caught at spec time and are slipping through to the implementation. Check whether
+spec-time objection counts are stable or declining at the same time.
+
+**Does not mean:** code-time is working incorrectly. It may also mean specs are arriving
+with genuine ambiguity that only code reveals, or that implementations have broader risk
+surface. Read recent code-mode records to distinguish.
+
+### Code-time objection counts trending down
+
+May indicate spec-time charter is working (fewer issues reaching code), OR may indicate
+code-time charter is too narrow (risk and implementation concerns not being raised). The
+direction alone cannot distinguish these. Check code-mode disposition distribution: a
+high `rejected` rate suggests the agent is raising concerns but humans find them
+unconvincing. A low count with high `accepted` rate may mean the agent is under-challenging.
+
+**Does not mean:** fewer code-time objections is better. The target is raising the
+objections that matter, not minimising objections.
+
+### Disposition distribution diverging sharply between modes
+
+If spec-mode clusters on `rejected` while code-mode clusters on `accepted` (or vice
+versa), the weighting difference is producing qualitatively different objection quality.
+This is a candidate for a reflection — the charter may need mode-specific tuning beyond
+weighting adjustment.
+
+No thresholds are defined. These patterns are candidates for reflection entries, not
+automatic actions.
 
 ---
 

--- a/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
+++ b/ai-literacy-superpowers/skills/harness-observability/references/snapshot-format.md
@@ -139,35 +139,54 @@ guessing.
 ```text
 ## Diaboli
 
+Overall:
 - In-scope specs: N (specs dated ≥ 2026-04-19)
 - Exempt specs (pre-feature): N
-- Objection records present: N
-- In-scope specs without a record: N
-- Fully-resolved record rate: P% (N of M records fully resolved)
+- Objection records present: N (spec-mode: A | code-mode: B)
+- In-scope specs without any record: N
 - Objections total: N (critical: A | high: B | medium: C | low: D)
-- Mean objections per spec: N.N
+- Mean objections per record: N.N
+
+Spec-mode:
+- Records present: N
+- Fully-resolved rate: P% (N of M records fully resolved)
 - Disposition distribution: accepted: P% | deferred: P% | rejected: P%
-- Median days spec-to-disposition: N (or "insufficient data")
+- Mean objections per record: N.N
+
+Code-mode:
+- Records present: N
+- In-scope specs with spec-mode but no code-mode record: N
+- Fully-resolved rate: P% (N of M records fully resolved)
+- Disposition distribution: accepted: P% | deferred: P% | rejected: P%
+- Mean objections per record: N.N
 ```
 
 **Source:** `docs/superpowers/specs/` and `docs/superpowers/objections/`.
 
 A spec is **in-scope** if its filename date is on or after `2026-04-19`. A spec
 slug is the filename with the `YYYY-MM-DD-` prefix and `.md` extension stripped.
-A matching objection record is `docs/superpowers/objections/<slug>.md`.
+
+- A **spec-mode record** matches `docs/superpowers/objections/<slug>.md`
+- A **code-mode record** matches `docs/superpowers/objections/<slug>-code.md`
 
 | Field | How to compute |
 | ------- | --------------- |
 | In-scope specs | Count `docs/superpowers/specs/*.md` with filename date ≥ 2026-04-19 |
 | Exempt specs (pre-feature) | Count specs with filename date < 2026-04-19 |
-| Objection records present | Count `docs/superpowers/objections/*.md`, excluding `.gitkeep` |
-| In-scope specs without a record | In-scope spec slugs with no matching file in `docs/superpowers/objections/` |
-| Fully-resolved record rate | Records where every `disposition` field is non-`pending` / total records (record-level ratio) |
+| Objection records present | Count all `docs/superpowers/objections/*.md`, excluding `.gitkeep` |
+| In-scope specs without any record | In-scope slugs with no matching spec-mode or code-mode file |
 | Objections total | Sum of `objections` list lengths across all records |
 | Severity breakdown | Count critical/high/medium/low across all `objections` entries |
-| Mean objections per spec | Total objections / count of records, rounded to 1 decimal |
-| Disposition distribution | Among non-`pending` dispositions only: percentage accepted / deferred / rejected |
-| Median days spec-to-disposition | For each fully-resolved record: days between spec filename date and `git log --format=%as -1` date on the objection file. Median across all fully-resolved records. Report "insufficient data" if fewer than 3 fully-resolved records exist |
+| Mean objections per record | Total objections / count of all records, rounded to 1 decimal |
+| Spec-mode records present | Count `docs/superpowers/objections/<slug>.md` files (no `-code` suffix), excluding `.gitkeep` |
+| Fully-resolved rate (spec-mode) | Spec-mode records where every `disposition` is non-`pending` / total spec-mode records |
+| Disposition distribution (spec-mode) | Among non-`pending` dispositions in spec-mode records: accepted% / deferred% / rejected% |
+| Mean objections per spec-mode record | Sum of spec-mode objection counts / count of spec-mode records, 1 decimal |
+| Code-mode records present | Count `docs/superpowers/objections/<slug>-code.md` files |
+| Specs with spec-mode but no code-mode | In-scope slugs where `<slug>.md` exists but `<slug>-code.md` does not |
+| Fully-resolved rate (code-mode) | Code-mode records where every `disposition` is non-`pending` / total code-mode records |
+| Disposition distribution (code-mode) | Among non-`pending` dispositions in code-mode records: accepted% / deferred% / rejected% |
+| Mean objections per code-mode record | Sum of code-mode objection counts / count of code-mode records, 1 decimal |
 
 **Error handling:** If a file at `docs/superpowers/objections/` fails YAML parse,
 report it by name as "parse error" and exclude it from all metrics.

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -60,15 +60,18 @@
 - **Tool**: gitleaks detect --source . --no-banner --exit-code 1
 - **Scope**: commit
 
-### Spec has adjudicated objections
+### PRs have adjudicated objections
 
-- **Rule**: Every feature or behaviour-change spec must have a corresponding
+- **Rule**: Every feature or behaviour-change PR must have (a) a spec-mode
   objection record at `docs/superpowers/objections/<spec-slug>.md` with all
-  dispositions resolved (no `pending` values). Bug fixes, dependency updates,
-  and maintenance PRs (labelled `bug`, `fix`, `chore`, `maintenance` or
-  branch-prefixed `fix/`, `chore/`) are exempt on the same terms as
-  spec-first-commit-ordering. Specs created before the constraint was added
-  are exempt — add `diaboli: exempt-pre-existing` to their frontmatter.
+  dispositions resolved (no `pending` values), and (b) a code-mode objection
+  record at `docs/superpowers/objections/<spec-slug>-code.md` with all
+  dispositions resolved. Bug fixes, dependency updates, and maintenance PRs
+  (labelled `bug`, `fix`, `chore`, `maintenance` or branch-prefixed `fix/`,
+  `chore/`) are exempt on the same terms as spec-first-commit-ordering. Specs
+  created before the constraint was added are exempt — add
+  `diaboli: exempt-pre-existing` to their frontmatter. "Resolved" is a judgment
+  call on rationale quality, not a schema check.
 - **Enforcement**: agent
 - **Tool**: harness-enforcer
 - **Scope**: pr
@@ -196,10 +199,11 @@ Use /governance-constrain for guided authoring of governance constraints.
 
 ### Objection record freshness
 
-- **What it checks**: Whether any spec file in `docs/superpowers/specs/`
-  has been modified more recently than its corresponding objection record
-  in `docs/superpowers/objections/` — a spec edited without re-running
-  `/diaboli` produces a stale objection record
+- **What it checks**: (a) Whether any spec file in `docs/superpowers/specs/`
+  has been modified more recently than its corresponding spec-mode objection
+  record — a spec edited without re-running `/diaboli` produces a stale record.
+  (b) Whether any code-mode record (`<slug>-code.md`) is older than the most
+  recent implementation commit on the branch that introduced it.
 - **Frequency**: weekly
 - **Enforcement**: deterministic
 - **Tool**: file mtime comparison between spec and objection record

--- a/ai-literacy-superpowers/templates/MODEL_ROUTING.md
+++ b/ai-literacy-superpowers/templates/MODEL_ROUTING.md
@@ -14,6 +14,7 @@
 | ----- | ---- | --------- |
 | orchestrator | Flagship | Coordinates the full pipeline, makes judgment calls about plan approval, review escalation, and skipping stages — requires strong reasoning |
 | spec-writer | Flagship | Producing precise acceptance scenarios and functional requirements that drive tests and implementation demands careful thinking |
+| advocatus-diaboli | Flagship | Adversarial reasoning, evidence-grounded objection — judgment-heavy, not throughput-heavy. Both spec-time and code-time dispatches use this tier; the judgment load is equivalent across modes. |
 | tdd-agent | Balanced | Translating well-specified scenarios into test code is a structured task; a mid-tier model handles it well |
 | code-reviewer | Balanced | Applying CUPID and literate programming lenses is systematic; a mid-tier model can work through the checklist reliably |
 | integration-agent | Efficient | CHANGELOG updates, commit messages, and PR descriptions are templated tasks; a fast, cheap model is sufficient |

--- a/docs/explanation/adversarial-review.md
+++ b/docs/explanation/adversarial-review.md
@@ -7,10 +7,12 @@ nav_order: 19
 
 # Adversarial Review
 
-The advocatus-diaboli agent raises objections to a spec before any implementation
-artefacts exist. This page explains why the mechanism is designed the way it is —
-the structural sycophancy problem it addresses, its historical and philosophical roots,
-and what the human-cognition gate actually does.
+The advocatus-diaboli agent runs at two points in the pipeline: once before plan
+approval (spec mode — challenging the premise and design before any code exists) and
+once before integration (code mode — challenging the implementation for threat-model,
+failure-mode, and operational concerns). This page explains why the mechanism is
+designed the way it is — the structural sycophancy problem it addresses, its historical
+and philosophical roots, and what the human-cognition gate actually does.
 
 ---
 
@@ -118,9 +120,14 @@ makes the adversarial review load-bearing rather than advisory.
 
 Over time, the distribution of dispositions across objection records becomes observable.
 These patterns are surfaced in `/superpowers-status` (Section 7: Diaboli Activity) and
-the harness-health snapshot (Diaboli panel), both of which report disposition distribution,
-mean objections per spec, and other descriptive stats across all records. No thresholds are
-set yet — the panel is diagnostic, not evaluative.
+the harness-health snapshot (Diaboli panel), both of which report disposition distribution
+and mean objections split by mode (spec-mode and code-mode) alongside overall totals.
+No thresholds are set yet — the panel is diagnostic, not evaluative.
+
+Cross-mode patterns carry additional signal: code-time objection counts trending up may
+indicate spec-time charter is too loose; code-time counts trending down may indicate
+spec-time is working OR code-time charter is too narrow. See the observability reference
+for interpretation guidance.
 
 Patterns carry information:
 
@@ -145,8 +152,8 @@ against them with reasons. This is the healthy pattern.
 
 ## How this fits the three loops
 
-Adversarial review operates in the commit-time loop — it fires once per feature spec,
-before implementation begins.
+Adversarial review operates in the commit-time loop — it fires twice per feature PR:
+once before implementation begins (spec mode) and once before merge (code mode).
 
 Objection records accumulate in `docs/superpowers/objections/` and feed the other loops:
 

--- a/docs/how-to/review-a-spec-adversarially.md
+++ b/docs/how-to/review-a-spec-adversarially.md
@@ -7,14 +7,23 @@ nav_order: 38
 
 # Review a Spec Adversarially
 
-Run `/diaboli` to get an adversarial review of a spec file before approving the implementation plan.
+Run `/diaboli` to get an adversarial review of a spec (before plan approval) or an
+implementation (before integration). The same command, same agent, same output format —
+only the category weighting and output path differ by mode.
 
 ## When to use this
+
+**Spec mode (default):**
 
 - After `/spec-writer` completes and before you approve the plan
 - When a spec is substantially edited after an objection record already exists
   (the command regenerates the record; prior dispositions are lost — this is intentional)
 - When working outside the full orchestrator pipeline and you want adversarial review on demand
+
+**Code mode (`--mode code`):**
+
+- After the final code-reviewer PASS (or MAX_REVIEW_CYCLES escalation), before integration-agent
+- When working outside the orchestrator pipeline and you want adversarial review of the implementation
 
 Do not use this as a quality check on your own reasoning. The point of the agent is that it
 disagrees with you from a clean context. Running it after you have already decided to proceed
@@ -22,19 +31,24 @@ removes the gate it is meant to enforce.
 
 ---
 
-## 1. Run `/diaboli <spec-path>`
+## 1. Run `/diaboli <spec-path> [--mode spec|code]`
 
-Pass the path to a spec file under `docs/superpowers/specs/`:
+Pass the path to the spec file and an optional mode flag:
 
 ```text
+# Spec mode (default — before plan approval)
 /diaboli docs/superpowers/specs/2026-04-19-my-feature.md
-```
 
-The command dispatches the advocatus-diaboli agent, which reads the spec and produces a
-structured objection record at `docs/superpowers/objections/<spec-slug>.md`.
+# Code mode (after final code-reviewer PASS, before integration)
+/diaboli docs/superpowers/specs/2026-04-19-my-feature.md --mode code
+```
 
 The slug is derived from the spec filename by stripping the date prefix and `.md` extension.
 For example, `2026-04-19-my-feature.md` → `my-feature`.
+
+Output paths:
+- Spec mode: `docs/superpowers/objections/my-feature.md`
+- Code mode: `docs/superpowers/objections/my-feature-code.md`
 
 ---
 
@@ -100,23 +114,27 @@ new thing and deserves a fresh adversarial review.
 ## 5. What you have now
 
 An adjudicated objection record with all dispositions filled and all rationales written.
-The plan-approval gate will not advance while any disposition is `pending`.
 
-The record lives at `docs/superpowers/objections/<slug>.md` and accumulates alongside
-other objection records over time. A GC rule checks weekly whether any spec has been
-modified more recently than its objection record — if so, it flags the record as stale.
+- **Spec mode**: the plan-approval gate will not advance while any disposition is `pending`.
+  The record lives at `docs/superpowers/objections/<slug>.md`.
+- **Code mode**: the integration-approval gate will not advance while any disposition is
+  `pending`. The record lives at `docs/superpowers/objections/<slug>-code.md`.
 
-As records accumulate, disposition patterns (distribution, mean objections per spec,
-median days to adjudication) become visible in `/superpowers-status` Section 7 and the
-harness-health snapshot Diaboli panel. These surfaces update on the normal health cadence
-without requiring a separate command.
+A GC rule checks weekly whether specs or implementations have been modified more recently
+than their corresponding records — if so, the record is flagged as stale.
+
+As records accumulate, disposition patterns (distribution, mean objections per record,
+split by mode) become visible in `/superpowers-status` Section 7 and the harness-health
+snapshot Diaboli panel. These surfaces update on the normal health cadence without
+requiring a separate command. Cross-mode patterns (spec-time vs code-time objection rates)
+carry interpretive signal about whether the spec-time charter is catching issues early.
 
 ---
 
 ## Next steps
 
-- Present the plan for approval — once all dispositions are filled, return to the
-  orchestrator pipeline and approve the spec
-- Proceed to tdd-agent only after plan approval
+- **Spec mode**: once all dispositions are filled, return to the orchestrator pipeline and
+  present the plan for approval; proceed to tdd-agent only after plan approval
+- **Code mode**: once all dispositions are filled, proceed to integration-agent
 - See [Adversarial Review]({% link explanation/adversarial-review.md %}) for the
   conceptual background on why this gate exists and what the agent is not allowed to do

--- a/docs/superpowers/objections/diaboli-code-time.md
+++ b/docs/superpowers/objections/diaboli-code-time.md
@@ -1,0 +1,249 @@
+---
+spec: docs/superpowers/specs/2026-04-19-diaboli-code-time.md
+date: 2026-04-19
+mode: spec
+diaboli_model: claude-sonnet-4-6
+objections:
+  - id: O1
+    category: implementation
+    severity: high
+    claim: "Code-time diaboli has no defined behaviour when the review loop exits via escalation (MAX_REVIEW_CYCLES=3) rather than PASS, leaving PRs that exhaust review cycles without a code-time objection record while the renamed constraint requires one."
+    evidence: "Approach section: 'Dispatch timing: once, after the final code-reviewer PASS, before integration-agent.' Orchestrator artefact (#5): 'add code-time dispatch after final code-reviewer PASS.' The escalation path (MAX_REVIEW_CYCLES exceeded → human intervenes → human may approve proceeding) is not mentioned. The renamed HARNESS constraint requires a code-mode record for all feature PRs with no escalation exemption."
+    disposition: fix
+    disposition_rationale: Define as existing thr process.
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The `pr_ref:` field in code-mode frontmatter cannot be filled by the agent at write time — the PR does not exist until integration-agent runs, which is after the integration-approval gate the record must pass."
+    evidence: "Approach section: 'Frontmatter additions: mode: code and pr_ref: fields in code-mode records.' Artefact #2: 'include pr_ref: pointing to the PR under review.' The agent's trust boundary is read-only (Read, Glob, Grep only — it cannot write files). The PR number is unknown at code-time diaboli dispatch because integration-agent creates the PR after the gate. A human would need to fill pr_ref: manually, or the field should be filled later, or the field should be removed."
+    disposition: fix
+    disposition_rationale: remove.
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "The spec does not specify what the harness-health.md step 7 section count becomes after the Diaboli panel is extended, leaving the validation checkpoint underspecified and likely to produce a broken check."
+    evidence: "Artefact #7: 'extend Diaboli panel to split stats by mode; apply validation-checkpoint discipline.' The current harness-health.md step 7 validates 'All 13 section headings.' The diaboli-observability spec required updating this from 12 to 13 (PR #186). If the Diaboli section is extended in place (not split into new sections), the count stays at 13. If new sections are added, the count increases. The spec does not specify which."
+    disposition: fix
+    disposition_rationale: increase count.
+  - id: O4
+    category: specification quality
+    severity: medium
+    claim: "The observability artefact says 'retain overall totals for backward comparison' but does not define which fields are 'overall' versus 'per-mode', leaving implementers to choose incompatible field sets."
+    evidence: "Step 9 of the task scope: 'Keep the overall totals for backward comparison with prior snapshots.' Artefact #6 and #7: extend panels to split stats by mode with 'objection records present, disposition distribution, mean objections per PR.' The existing fields (In-scope specs, Objections total, Severity breakdown, Mean objections per spec, Disposition distribution, Median days spec-to-disposition) are not labelled 'overall' or 'per-mode' in the spec. An implementer must guess the partition."
+    disposition: fix
+    disposition_rationale: label appropriately
+  - id: O5
+    category: risk
+    severity: medium
+    claim: "The integration-approval gate is enforced only when the orchestrator is in use; manual pipelines have no gate and could arrive at integration-agent without running code-time diaboli, failing the renamed HARNESS constraint silently."
+    evidence: "Approach section: 'New gate: Integration Approval — mirrors the plan-approval gate. Refuses to proceed while any code-mode disposition is pending.' Artefact #5: 'add Integration Approval gate' in orchestrator.agent.md. The harness-enforcer constraint check happens at PR time (scope: pr) and is agent-based, not a hard block. A developer running integration-agent directly bypasses the gate and the constraint check runs only when harness-enforcer is dispatched. The existing plan-approval gate has the same structural gap — this objection applies to both gates equally, which may be a reason to accept it as a known limitation."
+    disposition: accept
+    disposition_rationale: this is accepted behaviour at this point.
+  - id: O6
+    category: implementation
+    severity: low
+    claim: "The validation checkpoint extension for --mode is described as 'extend the validation checkpoint to verify mode-appropriate frontmatter fields' without specifying which fields are required for each mode, making the checkpoint implementation underspecified."
+    evidence: "Artefact #3: 'add optional --mode flag (default: spec); extend validation checkpoint to verify mode-appropriate frontmatter fields.' The spec defines the frontmatter schema (mode: field; pr_ref: in code mode) but the validation checkpoint step in commands/diaboli.md is not updated in the artefact description to name the new required fields explicitly."
+    disposition: fix
+    disposition_rationale: specify fields explicitly.
+---
+
+## O1 — implementation — high
+
+### Claim
+
+Code-time diaboli has no defined behaviour when the review loop exits via
+escalation rather than PASS. When MAX_REVIEW_CYCLES is exhausted and the
+orchestrator escalates to the human, the loop does not exit via PASS. The
+spec says code-time diaboli runs "after the final code-reviewer PASS" — which
+does not happen in the escalation path. Feature PRs that exhaust review cycles
+would arrive at integration without a code-mode record while the renamed
+HARNESS constraint requires one.
+
+### Evidence
+
+> "Dispatch timing: once, after the final code-reviewer PASS, before
+> integration-agent. Not per review cycle — only after the loop exits."
+
+> "GUARDRAIL: MAX_REVIEW_CYCLES = 3. If the reviewer has not returned PASS
+> after 3 reviewer→implementer cycles, STOP the loop and escalate."
+> (orchestrator.agent.md)
+
+The renamed constraint (artefact #10) requires a code-mode record for all
+feature PRs with no escalation exemption stated.
+
+### Why this matters
+
+A PR that exhausts review cycles is already in a degraded state. Arriving at
+integration without a code-mode objection record means it also fails the HARNESS
+constraint — compounding the problem. The human making the escalation decision
+needs clear instructions: does code-time diaboli still run, and if so, when?
+
+---
+
+## O2 — implementation — high
+
+### Claim
+
+The `pr_ref:` field in code-mode frontmatter cannot be filled by the agent at
+write time. The PR does not exist when code-time diaboli runs — integration-agent
+creates the PR after the integration-approval gate the record must pass.
+
+### Evidence
+
+> "Frontmatter additions: `mode: code` and `pr_ref:` fields in code-mode records"
+
+> "In code mode, include an additional frontmatter field `pr_ref:` pointing to
+> the PR under review." (step 4 of task scope)
+
+The agent's trust boundary: `tools: [Read, Glob, Grep]` — write capability is
+structurally absent. The PR number is not known until integration-agent creates
+it. The field as specified cannot be populated by any agent without breaking
+either the read-only boundary or the sequencing.
+
+### Why this matters
+
+If `pr_ref:` is listed as a required frontmatter field and the validation
+checkpoint enforces it, every code-mode record will fail validation. If it is
+optional or filled later (by integration-agent after PR creation), that must
+be stated explicitly in the spec and reflected in the validation checkpoint.
+
+---
+
+## O3 — specification quality — high
+
+### Claim
+
+The spec does not state what the harness-health.md step 7 section count becomes
+after the Diaboli panel is extended, leaving the validation checkpoint broken or
+underspecified.
+
+### Evidence
+
+> "Artefact #7: extend Diaboli panel to split stats by mode; apply
+> validation-checkpoint discipline."
+
+The current harness-health.md step 7 explicitly validates: "All 13 section
+headings present in order." The diaboli-observability spec required a specific
+update from 12 to 13. If this change extends the Diaboli section in place
+(no new top-level sections), the count stays 13. If new sections are added,
+it increases. The spec does not say.
+
+### Why this matters
+
+The validation checkpoint is what makes the structured output trustworthy. An
+underspecified checkpoint will either miss the new fields (too loose) or fail
+on the new structure (too strict). The diaboli-observability PR had to make
+this explicit — the same clarity is needed here.
+
+---
+
+## O4 — specification quality — medium
+
+### Claim
+
+"Retain overall totals for backward comparison" is not actionable without a
+definition of which existing fields are "overall" and which new fields are
+"per-mode." Implementers will produce incompatible field sets.
+
+### Evidence
+
+> "Keep the overall totals for backward comparison with prior snapshots."
+> (step 9 of task scope)
+
+The existing Diaboli panel fields include: In-scope specs, Exempt specs,
+Objection records present, In-scope specs without a record, Fully-resolved
+record rate, Objections total, Severity breakdown, Mean objections per spec,
+Disposition distribution, Median days spec-to-disposition. None are labelled
+"overall" in the spec. The new per-mode fields (objection records present,
+disposition distribution, mean objections per PR) overlap in name with
+existing fields, creating further ambiguity.
+
+### Why this matters
+
+The observability reference (artefact #8) and both commands must agree on field
+names and partitioning. Without explicit definitions, the snapshot-format
+reference and the commands will diverge, and the validation checkpoint cannot
+enforce structure.
+
+---
+
+## O5 — risk — medium
+
+### Claim
+
+The integration-approval gate is only enforced when the orchestrator is in use.
+Manual pipelines can bypass it silently, arriving at integration without a
+code-mode record while the HARNESS constraint requires one.
+
+### Evidence
+
+> "New gate: Integration Approval — mirrors the plan-approval gate. Refuses to
+> proceed while any code-mode disposition is `pending`."
+
+The gate lives in orchestrator.agent.md. A developer running integration-agent
+directly bypasses the orchestrator entirely. The harness-enforcer constraint
+check is agent-based (scope: pr) — it fires at PR review time, not at
+integration-agent dispatch time.
+
+### Why this matters
+
+The plan-approval gate has the identical structural gap. If that gap is
+accepted as a known limitation of the orchestrator-optional architecture, this
+objection has the same answer and can be noted as such. The objection is raised
+to surface the decision explicitly rather than assume the answer.
+
+---
+
+## O6 — implementation — low
+
+### Claim
+
+The validation checkpoint extension for `--mode` is described without specifying
+which fields are required per mode, leaving the checkpoint implementation
+underspecified.
+
+### Evidence
+
+> "Artefact #3: add optional --mode flag (default: spec); extend validation
+> checkpoint to verify mode-appropriate frontmatter fields."
+
+The frontmatter schema is shown in the approved plan but not reproduced in the
+spec. The validation checkpoint step in commands/diaboli.md currently checks for
+`spec`, `date`, `diaboli_model`, `objections`. The new fields (`mode`,
+`pr_ref`) need explicit inclusion in the checkpoint field list.
+
+### Why this matters
+
+Low — the schema is clear from the plan. This is a spec-completeness note rather
+than a blocking concern.
+
+---
+
+## Explicitly not objecting to
+
+- **Read-only trust boundary for code-time dispatch**: The same boundary that
+  enforces the human-cognition gate at spec time is equally correct at code time.
+  The disposition fields require human engagement; the read-only boundary is the
+  mechanism. No objection.
+
+- **Running code-time diaboli once after the final review cycle rather than per
+  cycle**: The spec gives the correct rationale (burns tokens on drafts; conflates
+  roles). Running it per cycle would produce objections on intermediate states that
+  implementers are actively fixing. Once after PASS is the right timing. No
+  objection.
+
+- **Reusing the same agent rather than creating a new code-diaboli agent**: The
+  charter, categories, evidence requirements, and output format are identical
+  across modes. A separate agent would duplicate the charter and fragment
+  maintenance. Mode-based weighting within one agent is the correct design. No
+  objection.
+
+- **Not including hook changes**: Code-time diaboli is an orchestrator-wired
+  dispatch, not a stop-hook concern. Hooks are for advisory nudges at session end;
+  gates are for blocking progression. The division is correct. No objection.
+
+- **The six-category output taxonomy staying identical across modes**: The
+  weighting changes; the categories do not. This is the right level of
+  abstraction — the output format stays machine-readable and comparable across
+  modes without introducing a new schema. No objection.

--- a/docs/superpowers/specs/2026-04-19-diaboli-code-time.md
+++ b/docs/superpowers/specs/2026-04-19-diaboli-code-time.md
@@ -1,0 +1,142 @@
+---
+name: diaboli-code-time
+description: Extend advocatus-diaboli to a second dispatch point — post-code-review,
+             before integration-agent — reusing the same agent with mode-based
+             category weighting
+date: 2026-04-19
+status: draft
+---
+
+# Diaboli Code-Time Dispatch
+
+## Problem
+
+### 1. Spec-time diaboli cannot see the implementation
+
+Spec-time diaboli catches premise and design flaws before code is written.
+But threat-model, failure-mode, and operational objections require concrete
+implementation evidence to ground them. At spec time, those categories are
+speculative unless the spec itself describes threat surface or failure
+semantics. The speculative objection wastes adjudication time and will be
+re-raised — with better evidence — once code exists. There is currently
+nowhere for that re-raising to happen.
+
+### 2. Code-reviewer is constructive by charter
+
+The code-reviewer evaluates code through CUPID and literate programming
+lenses. Its charter is to find what to improve and return findings for the
+implementer. Constructive review and adversarial review are different
+epistemic stances — the same agent cannot hold both simultaneously without
+compromising both roles. The code-reviewer should not be asked to raise
+steel-manned objections to the approach; that is a different kind of work.
+
+### 3. No adversarial gate before integration
+
+Between the final code-reviewer PASS and integration-agent, there is
+currently no gate that asks: "Is there a structural risk in this
+implementation that a constructive reviewer would not raise?" API surface
+exposures, error path gaps, resource-management failures, and operational
+blind spots are all visible in finished code and invisible in spec text.
+They currently have no structured mechanism to surface before merge.
+
+## Approach
+
+Second dispatch of the same advocatus-diaboli agent, with the same read-only
+trust boundary and the same output format, using a mode parameter to apply
+category weighting appropriate to code time.
+
+- **Mode input**: `spec` (existing default) | `code` (new)
+- **Dispatch timing**: once, after the final code-reviewer PASS, before
+  integration-agent. Not per review cycle — only after the loop exits.
+  Running adversarial review on draft code conflates the code-reviewer's
+  constructive role with diaboli's adversarial one and burns tokens on
+  intermediate states.
+- **Output path**: `docs/superpowers/objections/<spec-slug>-code.md`
+  (spec-mode path unchanged: `docs/superpowers/objections/<spec-slug>.md`)
+- **Frontmatter additions**: `mode: code` and `pr_ref:` fields in code-mode
+  records
+- **New gate**: Integration Approval — mirrors the plan-approval gate.
+  Refuses to proceed while any code-mode disposition is `pending`. Human
+  writes dispositions inline before integration-agent is dispatched.
+- **Category weighting**: documented in SKILL.md Dispatch Modes section.
+  Spec-time emphasises premise, design (implementation), and cost
+  (alternatives). Code-time emphasises threat model, failure mode, and
+  operational (all mapping to `risk`) and implementation-level structural
+  flaws.
+
+## Expected Outcome
+
+Every feature PR arrives at integration-agent with two adjudicated objection
+records: a spec-mode record (premise/design focus, adjudicated before plan
+approval) and a code-mode record (risk/implementation focus, adjudicated
+after final code review). The pipeline has two diaboli-backed gates — one
+before code is written, one before it is merged.
+
+The HARNESS.md constraint "Spec has adjudicated objections" is renamed to
+"PRs have adjudicated objections" and extended to require both records.
+Observability panels split descriptive stats by mode while retaining overall
+totals for backward comparison.
+
+## Artefacts
+
+### Plugin files
+
+1. `ai-literacy-superpowers/skills/advocatus-diaboli/SKILL.md` — add
+   Dispatch Modes section documenting spec-time and code-time weighting
+2. `ai-literacy-superpowers/agents/advocatus-diaboli.agent.md` — accept
+   mode input (`spec|code`, default `spec`); apply mode-appropriate
+   weighting; output to mode-appropriate path; include `mode:` in
+   frontmatter; include `pr_ref:` in code-mode frontmatter
+3. `ai-literacy-superpowers/commands/diaboli.md` — add optional `--mode`
+   flag (default: `spec`); extend validation checkpoint to verify
+   mode-appropriate frontmatter fields
+4. `.github/prompts/diaboli.prompt.md` — match commands/diaboli.md
+5. `ai-literacy-superpowers/agents/orchestrator.agent.md` — add code-time
+   dispatch after final code-reviewer PASS; add Integration Approval gate
+   that refuses while any code-mode disposition is `pending`
+6. `ai-literacy-superpowers/commands/superpowers-status.md` — extend
+   Diaboli panel to split stats by mode (objection records present,
+   disposition distribution, mean objections per PR per mode; retain overall
+   totals)
+7. `ai-literacy-superpowers/commands/harness-health.md` — extend Diaboli
+   panel to split stats by mode; apply validation-checkpoint discipline
+8. `ai-literacy-superpowers/skills/advocatus-diaboli/references/observability.md`
+   — add mode-split field definitions and interpretation notes; document
+   cross-mode patterns (code-time counts up = spec-time charter too loose;
+   code-time counts down = spec-time working OR code-time charter too narrow)
+9. `ai-literacy-superpowers/templates/MODEL_ROUTING.md` — note code-time
+   routes to most-capable tier same as spec-time
+
+### Project files
+
+10. `HARNESS.md` — rename "Spec has adjudicated objections" to "PRs have
+    adjudicated objections"; extend rule to require both spec-mode and
+    code-mode records; extend "Objection record freshness" GC rule to cover
+    both record types
+11. `MODEL_ROUTING.md` — note code-time routes to most-capable tier
+12. `AGENTS.md` — add ARCH_DECISION: one agent, two dispatches, mode-based
+    weighting; alternatives considered and rejected; conditions for revisit
+13. `ai-literacy-superpowers/templates/HARNESS.md` — update constraint and
+    GC rule to match project HARNESS.md
+
+### Docs
+
+14. `README.md` — update pipeline diagram to show both dispatch points and
+    both gates; update Agents table row for advocatus-diaboli to mention both
+    modes; agent count unchanged at 12
+
+### Version
+
+15. `ai-literacy-superpowers/.claude-plugin/plugin.json` — 0.25.0 → 0.26.0
+16. `README.md` — badge bump (combined with item 14)
+17. `.claude-plugin/marketplace.json` — plugin_version bump
+18. `CHANGELOG.md` — new version entry
+
+## Exemptions
+
+This change adds new required records for future PRs only. Existing
+spec-mode objection records without a `mode:` field are valid — the field
+is new and backward-compatible. The pre-existing exempt clause (specs before
+2026-04-19) carries forward unchanged. Bug fixes, dependency updates, and
+maintenance PRs remain exempt from both records on the same terms as
+spec-first-commit-ordering.


### PR DESCRIPTION
Closes #187

## Summary

Second dispatch point for advocatus-diaboli — post-code-review, before integration-agent — reusing the same agent with mode-based category weighting. One agent, two dispatches, not two agents.

- **Spec mode** (existing, unchanged): runs after spec-writer, catches premise/design flaws, gates plan approval
- **Code mode** (new): runs once after code-reviewer loop exits, catches threat-model/failure-mode/operational concerns, gates integration

## What changed

- `SKILL.md`: Dispatch Modes section — spec-time and code-time category weighting
- `advocatus-diaboli.agent.md`: `mode` input, mode-appropriate output path (`<slug>-code.md`), `mode:` frontmatter field
- `diaboli.md` + `diaboli.prompt.md`: `--mode` flag, per-mode validation checkpoint
- `orchestrator.agent.md`: step 4a code-time dispatch + Integration Approval gate (mirrors plan-approval gate)
- `HARNESS.md`: constraint renamed "PRs have adjudicated objections" (requires both records); GC rule extended to cover both record types
- `superpowers-status.md` + `snapshot-format.md`: Diaboli panel split by mode with overall totals for backward compatibility
- `observability.md`: mode-split field definitions and cross-mode interpretation patterns
- `MODEL_ROUTING.md` (project + template): code-time routes to most-capable tier
- `templates/HARNESS.md`: extended constraint + GC rule for new projects
- `AGENTS.md`: ARCH_DECISION (one agent, two dispatches; alternatives rejected)
- `README.md`: pipeline diagram updated (two diaboli-backed gates); Agents table row updated
- `docs/explanation/adversarial-review.md` + `docs/how-to/review-a-spec-adversarially.md`: both modes documented

## Objection records

- Spec-mode: `docs/superpowers/objections/diaboli-code-time.md` — 6 objections, all resolved
- Code-mode: not applicable (this PR is the feature introducing code-time dispatch)

## Disposition summary

| O | Severity | Disposition | Effect |
|---|----------|-------------|--------|
| O1 | high | fix | Code-time dispatch runs after loop exit regardless of path (PASS or escalation) |
| O2 | high | fix | `pr_ref:` field removed — cannot be filled by the read-only agent before PR exists |
| O3 | high | fix | Diaboli section extended in-place; section count stays 13 |
| O4 | medium | fix | Overall totals and per-mode breakdowns explicitly labelled |
| O5 | medium | accept | Gate enforced in orchestrator path; harness-enforcer is the backstop (same as plan-approval gate) |
| O6 | low | fix | Validation checkpoint names `mode:` field explicitly |

## Commit structure

1. `Add spec: diaboli code-time dispatch point` — spec only
2. `Add diaboli code-time dispatch point (v0.26.0)` — all 16 implementation files + adjudicated objection record
3. `Bump version to 0.26.0` — plugin.json, marketplace.json, README badge, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)