### PR TITLE
Add docs site review convention and harness constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,28 @@ When adding a new command that writes structured markdown, add a
 validation step following this pattern. Reference the format spec
 rather than inlining field definitions.
 
+## Docs Site Review
+
+The `docs/` directory is the project's documentation site. When presenting a
+plan or opening a PR, always check whether any docs pages need to be created
+or updated:
+
+- `docs/how-to/` — task-oriented guides (one guide per command or workflow)
+- `docs/explanation/` — conceptual background (why things work the way they do)
+- `docs/reference/` — API/schema reference material
+- `docs/tutorials/` — end-to-end walkthroughs
+
+**When a feature adds a new command, skill, or agent**: check for an existing
+how-to guide and create one if missing.
+
+**When a feature changes behaviour**: check whether explanation pages reference
+the old behaviour and update them.
+
+**When a feature changes a format or schema**: check whether reference pages
+are current.
+
+Include docs changes in the same PR as the implementation, not as a follow-up.
+
 ## Sync from Source
 
 This plugin's reusable components originate from the

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -194,6 +194,17 @@
 - **Tool**: harness-enforcer agent
 - **Scope**: pr
 
+### Docs site kept current
+
+- **Rule**: When a PR adds, removes, or substantially changes a skill, agent,
+  or command, the corresponding docs pages in `docs/` (how-to guides,
+  explanation pages, reference material) must be reviewed and updated in the
+  same PR. A PR that changes plugin behaviour without a docs review note in the
+  PR description is incomplete.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer agent
+- **Scope**: pr
+
 ### PRs have adjudicated objections
 
 - **Rule**: Every feature or behaviour-change PR must have (a) a spec-mode


### PR DESCRIPTION
## Summary

- `CLAUDE.md` — new **Docs Site Review** section: standing instruction to check `docs/how-to/`, `docs/explanation/`, `docs/reference/`, and `docs/tutorials/` at plan time, covering the four trigger cases (new command/skill/agent, behaviour change, format/schema change)
- `HARNESS.md` — new **Docs site kept current** constraint: agent-enforced PR gate requiring docs review alongside any skill, agent, or command change

No plugin files changed — no version bump required.

## Test plan

- [ ] Verify markdownlint passes on both files
- [ ] Confirm the new HARNESS.md constraint appears in the next `/harness-audit` run

Closes #189