### PR TITLE
Adopt diaboli constraint and exempt pre-existing specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 0.22.0 — 2026-04-17
 
+### Harness — adopt diaboli constraint and exempt pre-existing specs
+
+- Bump `HARNESS.md` template-version marker from `0.22.0` to `0.26.0`
+  via `/harness-upgrade`
+- Adopt new constraint **"PRs have adjudicated objections"** (agent
+  enforcement, pr scope) — requires both spec-mode and code-mode
+  objection records under `docs/superpowers/objections/` for every
+  feature or behaviour-change PR, with the standard chore/fix
+  branch-prefix exemptions
+- Adopt new GC rule **"Objection record freshness"** (deterministic,
+  weekly) — flags specs edited after their objection record and
+  code-mode records older than the implementation commit that
+  introduced them
+- Add `diaboli: exempt-pre-existing` frontmatter to all 26 specs in
+  `docs/superpowers/specs/` so the new constraint does not retroactively
+  block PRs that re-touch lineage created before the constraint existed
+- No plugin version bump — `HARNESS.md`, `.claude/`, and
+  `docs/superpowers/specs/` are all outside `ai-literacy-superpowers/`
+  (0.22.0 retained)
+
 ### Docs — first-time tour tutorial
 
 - Add `docs/tutorials/first-time-tour.md` — a single route through

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.22.0 -->
+<!-- template-version: 0.26.0 -->
 
 ## Context
 
@@ -202,6 +202,22 @@
 - **Tool**: none yet
 - **Scope**: pr
 
+### PRs have adjudicated objections
+
+- **Rule**: Every feature or behaviour-change PR must have (a) a spec-mode
+  objection record at `docs/superpowers/objections/<spec-slug>.md` with all
+  dispositions resolved (no `pending` values), and (b) a code-mode objection
+  record at `docs/superpowers/objections/<spec-slug>-code.md` with all
+  dispositions resolved. Bug fixes, dependency updates, and maintenance PRs
+  (labelled `bug`, `fix`, `chore`, `maintenance` or branch-prefixed `fix/`,
+  `chore/`) are exempt on the same terms as spec-first-commit-ordering. Specs
+  created before the constraint was added are exempt — add
+  `diaboli: exempt-pre-existing` to their frontmatter. "Resolved" is a judgment
+  call on rationale quality, not a schema check.
+- **Enforcement**: agent
+- **Tool**: harness-enforcer
+- **Scope**: pr
+
 <!-- Uncomment if using spec-first development:
 
 ### Spec conformance
@@ -372,6 +388,18 @@ Use /governance-constrain for guided authoring of governance constraints.
 - **Frequency**: weekly
 - **Enforcement**: agent
 - **Tool**: harness-gc agent
+- **Auto-fix**: false
+
+### Objection record freshness
+
+- **What it checks**: (a) Whether any spec file in `docs/superpowers/specs/`
+  has been modified more recently than its corresponding spec-mode objection
+  record — a spec edited without re-running `/diaboli` produces a stale record.
+  (b) Whether any code-mode record (`<slug>-code.md`) is older than the most
+  recent implementation commit on the branch that introduced it.
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: file mtime comparison between spec and objection record
 - **Auto-fix**: false
 
 <!-- Uncomment if governance constraints are declared above:

--- a/docs/superpowers/specs/2026-04-06-secrets-detection-design.md
+++ b/docs/superpowers/specs/2026-04-06-secrets-detection-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Secrets Detection for the Harness — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-auto-constraint-from-reflections-design.md
+++ b/docs/superpowers/specs/2026-04-07-auto-constraint-from-reflections-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Auto-Constraint Generation from Reflections — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-auto-enforcer-action-design.md
+++ b/docs/superpowers/specs/2026-04-07-auto-enforcer-action-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Auto-Enforcer GitHub Action — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-convention-sync-design.md
+++ b/docs/superpowers/specs/2026-04-07-convention-sync-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Convention Sync Across AI Tools — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-fitness-functions-design.md
+++ b/docs/superpowers/specs/2026-04-07-fitness-functions-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Architectural Fitness Functions for GC — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-github-pages-docs-design.md
+++ b/docs/superpowers/specs/2026-04-07-github-pages-docs-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # GitHub Pages Documentation Site — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-learnings-in-agent-context-design.md
+++ b/docs/superpowers/specs/2026-04-07-learnings-in-agent-context-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Feed Learnings into Agent Context — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-regression-suite-gc-rule-design.md
+++ b/docs/superpowers/specs/2026-04-07-regression-suite-gc-rule-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Regression Suite GC Rule from Reflection Patterns — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-selective-harness-init-design.md
+++ b/docs/superpowers/specs/2026-04-07-selective-harness-init-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Selective Harness Init — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-tier2-complexity-hotspots-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-complexity-hotspots-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Complexity Hotspot Detection — Design Proposal (Tier 2)
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-tier2-dependency-age-budget-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-dependency-age-budget-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Dependency Age Budget (libyear) — Design Proposal (Tier 2)
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-07-tier2-executable-spec-integration-design.md
+++ b/docs/superpowers/specs/2026-04-07-tier2-executable-spec-integration-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Executable Spec Integration — Design Proposal (Tier 2)
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-08-feedback-flywheel-signals-design.md
+++ b/docs/superpowers/specs/2026-04-08-feedback-flywheel-signals-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Feedback Flywheel Signal Classification, Vocabulary Alignment, and Quality Metrics
 
 **Date:** 2026-04-08

--- a/docs/superpowers/specs/2026-04-09-assessment-practice-article-design.md
+++ b/docs/superpowers/specs/2026-04-09-assessment-practice-article-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # The Assessment Practice — Article Design
 
 **Date:** 2026-04-09

--- a/docs/superpowers/specs/2026-04-09-literacy-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-09-literacy-improvements-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Literacy Improvements Skill — Design
 
 **Date:** 2026-04-09

--- a/docs/superpowers/specs/2026-04-09-portfolio-assessment-design.md
+++ b/docs/superpowers/specs/2026-04-09-portfolio-assessment-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Portfolio Assessment — Design
 
 **Date:** 2026-04-09

--- a/docs/superpowers/specs/2026-04-09-portfolio-dashboard-howto-design.md
+++ b/docs/superpowers/specs/2026-04-09-portfolio-dashboard-howto-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Build an AI Literacy Portfolio Dashboard — How-To Design
 
 **Date:** 2026-04-09

--- a/docs/superpowers/specs/2026-04-11-marketplace-listing-versioning-design.md
+++ b/docs/superpowers/specs/2026-04-11-marketplace-listing-versioning-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Marketplace Listing Versioning — Design
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-12-spec-first-discipline-gate-design.md
+++ b/docs/superpowers/specs/2026-04-12-spec-first-discipline-gate-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Spec-First Discipline Gate
 
 **Date**: 2026-04-12

--- a/docs/superpowers/specs/2026-04-13-governance-documentation-design.md
+++ b/docs/superpowers/specs/2026-04-13-governance-documentation-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Design: Governance Dimension Documentation
 
 **Date:** 2026-04-13

--- a/docs/superpowers/specs/2026-04-15-harness-onboarding-design.md
+++ b/docs/superpowers/specs/2026-04-15-harness-onboarding-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Harness Onboarding Documentation Generator
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-15-harness-upgrade-design.md
+++ b/docs/superpowers/specs/2026-04-15-harness-upgrade-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Harness Upgrade — Design Spec
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-15-observatory-verify-design.md
+++ b/docs/superpowers/specs/2026-04-15-observatory-verify-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Observatory Signal Verification Command
 
 ## Problem
@@ -100,6 +104,7 @@ Summary: N PRESENT, N PARTIAL, N MISSING out of N total signals
 ```
 
 Status values:
+
 - **PRESENT** — signal documented in format spec and present in latest output
 - **PARTIAL** — signal exists but incomplete (e.g. section present, field missing)
 - **MISSING** — signal not found in latest output

--- a/docs/superpowers/specs/2026-04-15-output-validation-checkpoints-design.md
+++ b/docs/superpowers/specs/2026-04-15-output-validation-checkpoints-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Output Validation Checkpoints
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-15-release-governance-constraint-design.md
+++ b/docs/superpowers/specs/2026-04-15-release-governance-constraint-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Release Governance Constraint
 
 ## Problem

--- a/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
+++ b/docs/superpowers/specs/2026-04-16-marketplace-cache-auto-sync-design.md
@@ -1,3 +1,7 @@
+---
+diaboli: exempt-pre-existing
+---
+
 # Marketplace Cache Auto-Sync — Design Spec
 
 ## Problem


### PR DESCRIPTION
## Summary

Two coordinated changes triggered by `/harness-upgrade` discovering new
template content in plugin v0.26.0:

- **`HARNESS.md`** — bump template-version marker `0.22.0` → `0.26.0`
  and adopt two new template items:
  - **Constraint** "PRs have adjudicated objections" (agent enforcement,
    pr scope) — requires both spec-mode and code-mode objection records
    under `docs/superpowers/objections/` for every feature/behaviour-change PR
  - **GC rule** "Objection record freshness" (deterministic, weekly) —
    flags specs edited after their objection record and code-mode records
    older than the implementation commit that introduced them
- **`docs/superpowers/specs/`** — add `diaboli: exempt-pre-existing`
  frontmatter to all 26 existing specs so the new constraint does not
  retroactively block PRs that re-touch lineage created before it existed
- **Drive-by**: fix one pre-existing MD032 lint finding in
  `2026-04-15-observatory-verify-design.md` that surfaced once frontmatter
  shifted line numbers (one blank line before a list)

No plugin version bump — `HARNESS.md`, `.claude/`, and
`docs/superpowers/specs/` are all outside `ai-literacy-superpowers/`.
0.22.0 retained.

## Why a `chore/` branch

This PR exists *because* of the new constraint; needing a spec-then-code
ordering and an objection record for the change that introduces the
exemption mechanism would be circular. The `chore/` prefix opts into the
existing exemption built into both `Spec-first commit ordering` and the
new `PRs have adjudicated objections` constraint.

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` passes (0 errors across 238 files)
- [x] All 26 specs now contain `diaboli: exempt-pre-existing` frontmatter
- [x] HARNESS.md template-version marker reads `0.26.0`
- [ ] CI green