### PR TITLE
Add reflection: stale local main on harness-upgrade

### DIFF
--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -324,3 +324,19 @@
   - Model tiers used: flagship (main conversation, 100%; no subagents)
   - Pipeline stages completed: spec commit, diaboli spec-mode (dogfood), dispositions by user, implementation commit, version bump commit, PR #188, CI, merge; docs convention branch, commit, PR #190, CI, merge
   - Agent delegation: manual
+
+---
+
+- **Date**: 2026-04-26
+- **Agent**: claude-opus-4-7 (1M context) (main conversation, no subagents)
+- **Task**: Ran `/harness-upgrade` against plugin v0.26.0 (local marker was 0.22.0) and adopted two new template items (constraint + GC rule); then added `diaboli: exempt-pre-existing` frontmatter to all 26 pre-existing specs as a follow-up to keep the new "PRs have adjudicated objections" constraint from blocking future PRs that re-touch pre-existing spec lineage. PR #195.
+- **Surprise**: Local main was 12 commits behind origin/main (local plugin.json said `0.22.0`; origin/main was at `0.26.0`). The `/harness-upgrade` command correctly reads the plugin version from the *marketplace cache* (which auto-syncs from `origin/main` on every PR merge via the local PostToolUse hook), but compares it against the user's *local* HARNESS.md. So the upgrade target was right (0.26.0), but the "what does main already have" mental model was wrong by 12 commits. The mismatch only surfaced when `gh pr view` reported `mergeable: CONFLICTING` after push — at which point the constraint and GC rule I had just "adopted" turned out to already exist on main (added in #186 and #190 during the 0.23–0.25 work), making half the PR redundant and requiring substantial conflict resolution. The genuinely new contribution survived (frontmatter on the 26 specs); the rest got dropped during merge.
+- **Proposal**: WORKFLOW: Any harness-modifying command — `/harness-upgrade`, `/harness-constrain`, `/governance-constrain`, `/harness-init` re-runs — should perform a `git fetch origin main && git rev-list HEAD..origin/main --count` check up front and warn loudly if local main is behind. The marketplace cache reflects `origin/main` in near real time; local main can be arbitrarily stale. Reading the cache version *and* assuming local main matches it is a structural trap.
+- **Improvement**: Add a step 0 to `/harness-upgrade` (and similar harness-modifying commands): "Fetch origin/main and confirm local main is current. If `git rev-list HEAD..origin/main --count` is non-zero, warn the user and offer to pull before continuing." This catches the staleness *before* the comparison work begins, rather than after a push exposes it via merge conflict.
+- **Signal**: workflow
+- **Constraint**: none (the fix is a command-level pre-check, not a HARNESS.md rule)
+- **Session metadata**:
+  - Duration: ~2 hrs (interactive)
+  - Model tiers used: flagship (Opus 4.7, 1M context, main conversation; no subagents dispatched)
+  - Pipeline stages completed: harness-upgrade discovery, manual edits to HARNESS.md, branch chore/diaboli-exempt-existing-specs, frontmatter additions to 26 specs, lint fix, commit, push, PR #195, conflict surface, merge origin/main with conflict resolution (3 conflict blocks), CHANGELOG cleanup, push, CI green, squash-merge
+  - Agent delegation: manual (no orchestrator pipeline; user-driven step-by-step)


### PR DESCRIPTION
## Summary

Captures a reflection from the `/harness-upgrade` work in PR #195: the
local plugin clone was 12 commits behind `origin/main`, but
`/harness-upgrade` correctly read the upgrade target from the marketplace
cache (which auto-syncs from origin/main). The result: the upgrade
target was right (0.26.0) but the "what does main already have" mental
model was wrong by 12 commits, only surfacing when `gh pr view` reported
a merge conflict after push.

## Signal

- **Type**: workflow
- **Constraint**: none (the proposed fix is a command-level pre-check,
  not a HARNESS.md rule)
- **Proposed improvement**: Add a step 0 to `/harness-upgrade` (and
  similar harness-modifying commands) that runs
  `git fetch origin main && git rev-list HEAD..origin/main --count` and
  warns if local main is behind, before any comparison work begins.

## Test plan

- [x] Reflection entry has all 8 mandatory fields and 4 metadata subfields
- [x] Signal value (`workflow`) is in the enum
- [x] `npx markdownlint-cli2 REFLECTION_LOG.md` passes
- [ ] CI green