### PR TITLE
Add sync check on /harness-upgrade and PR workflow on /reflect (v0.27.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.26.0",
+  "plugin_version": "0.27.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.26.0"
+      "version": "0.27.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.27.0 — 2026-04-26
+
+### Commands — sync check on /harness-upgrade and PR workflow on /reflect
+
+- Update `commands/harness-upgrade.md` step 1 — fetch `origin/main` and
+  warn when the local clone is behind. The marketplace cache reflects
+  `origin/main` in near real time, so a stale local clone produces an
+  upgrade comparison that suggests content already on main and yields a
+  conflicting PR at push time. Best-effort: skipped silently if no
+  remote main, detached HEAD, or fetch failure
+- Update `commands/reflect.md` step 7 — replace the unconditional
+  `git commit` with a branch + labelled-PR workflow when the project
+  declares a "Reflections via PR workflow" constraint, and keep direct
+  commit as the fallback when no such constraint is declared. The PR
+  variant uses `--label chore` on `gh pr create` directly so the
+  spec-first and adjudicated-objections gates exempt the reflection
+- Both updates trace to a reflection in PR #196 captured during the
+  /harness-upgrade run that produced PRs #195 and #196
+
 ## 0.26.0 — 2026-04-19
 
 ### Harness — bump local template marker and exempt pre-existing specs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.26.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.27.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
 [![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-upgrade.md
+++ b/ai-literacy-superpowers/commands/harness-upgrade.md
@@ -17,6 +17,29 @@ selectively adopt what you want.
 Verify HARNESS.md exists at the project root. If not, tell the user:
 "No HARNESS.md found. Run /harness-init to create one."
 
+**Verify local main is in sync with origin.** The marketplace cache
+auto-syncs from `origin/main` on every PR merge, so this command
+compares the user's local HARNESS.md against a near-real-time view of
+main. If the local clone is stale, the upgrade will suggest content
+that has already merged, and the resulting PR will conflict at push
+time. Run:
+
+```bash
+git fetch origin main 2>/dev/null && \
+  git rev-list HEAD..origin/main --count 2>/dev/null
+```
+
+If the count is non-zero, warn the user: "Your local clone is N
+commits behind origin/main. The upgrade comparison may suggest content
+that has already merged. Recommend `git pull` (if on main) or rebasing
+your branch before continuing."
+
+Offer to abort so the user can sync, or continue if the divergence is
+known to be safe. Default: prompt the user. If `git fetch` or
+`git rev-list` fails (no remote `main`, detached HEAD), skip this
+check and continue silently — the staleness guard is best-effort, not
+a hard block.
+
 Read the plugin version from
 `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`.
 

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -119,9 +119,35 @@ Capture a post-task reflection and append it to REFLECTION_LOG.md.
 1. Do NOT modify `AGENTS.md` — only humans edit that file. If the
    reflection contains a proposal, note it and let the human decide.
 
-1. Commit the updated REFLECTION_LOG.md:
+1. Commit the updated REFLECTION_LOG.md.
+
+   Check whether the project declares a "Reflections via PR workflow"
+   constraint (or equivalent) in `HARNESS.md`. If yes, use a branch and
+   a labelled PR; if not, commit directly to the current branch.
+
+   **PR workflow (when the constraint is declared):**
+
+   ```bash
+   slug="<short-slug-derived-from-task>"
+   git checkout -b "add-reflection-${slug}"
+   git add REFLECTION_LOG.md
+   git commit -m "Add reflection: <one-line summary of the task>"
+   git push -u origin "add-reflection-${slug}"
+   gh pr create --label chore \
+     --title "Add reflection: <one-line summary of the task>" \
+     --body "<short body summarising the surprise + signal classification>"
+   ```
+
+   Pass `--label chore` directly on `gh pr create` (per the "Label PRs
+   at creation time" constraint, where present) so the PR is exempt
+   from spec-first-commit-ordering and adjudicated-objections gates
+   that would otherwise block a docs-only reflection PR. Wait for CI
+   to pass, then merge with
+   `gh pr merge <n> --squash --delete-branch` and `git pull` on main.
+
+   **Direct commit (when the constraint is not declared):**
 
    ```bash
    git add REFLECTION_LOG.md
-   git commit -m "Add reflection: [one-line summary of the task]"
+   git commit -m "Add reflection: <one-line summary of the task>"
    ```


### PR DESCRIPTION
## Summary

Two command refinements traced to the reflection captured in PR #196.

- **`/harness-upgrade` step 1**: fetch `origin/main` and warn when the
  local clone is behind. The marketplace cache reflects `origin/main`
  in near real time, so a stale local clone produces an upgrade
  comparison that suggests content already on main and yields a
  conflicting PR at push time (exactly what happened in PR #195,
  consuming substantial conflict-resolution effort). Best-effort: the
  check skips silently on no remote main, detached HEAD, or fetch
  failure.
- **`/reflect` step 7**: replace the unconditional `git commit` with a
  branch + labelled-PR workflow when the project declares a
  "Reflections via PR workflow" constraint (or equivalent). Keeps the
  direct-commit fallback for projects without that constraint. The PR
  variant uses `--label chore` on `gh pr create` directly so the
  spec-first and adjudicated-objections gates exempt the reflection
  PR — both constraints active in this project.

## Version bump

Plugin behaviour changes in two commands → minor bump per CLAUDE.md
semver rules. Updated:

- `ai-literacy-superpowers/.claude-plugin/plugin.json` → `0.27.0`
- `.claude-plugin/marketplace.json` → `plugin_version` and per-plugin
  `version` both → `0.27.0` (listing `version` `0.2.3` retained — no
  contract change)
- `README.md` Plugin Version badge → `v0.27.0`
- `CHANGELOG.md` new top heading `## 0.27.0 — 2026-04-26`

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` finds no errors in modified
  files (the 3 pre-existing MD040 errors in
  `2026-04-19-docs-advocatus-diaboli-and-harness-upgrade.md` are not
  touched by this PR)
- [x] All version pins match (plugin.json, marketplace.json
  plugin_version, marketplace.json per-plugin version, README badge,
  CHANGELOG top heading)
- [x] `chore/` branch prefix + `chore` label = exempt from spec-first
  and adjudicated-objections gates (this PR has no spec, no objection
  records)
- [ ] CI green