### PR TITLE
Spec: harness Affordances section (design only, revision pending)

### DIFF
--- a/docs/superpowers/objections/harness-affordances-design.md
+++ b/docs/superpowers/objections/harness-affordances-design.md
@@ -1,0 +1,509 @@
+---
+spec: docs/superpowers/specs/2026-04-26-harness-affordances-design.md
+date: 2026-04-26
+mode: spec
+diaboli_model: claude-opus-4-7
+objections:
+  - id: O1
+    category: premise
+    severity: high
+    claim: "The spec asserts that no existing location surfaces tool/identity/audit information, but does not show that practitioners actually fail the governance task today; the gap is asserted, not demonstrated."
+    evidence: "Spec lines 30-44: 'None of those locations are read by humans during governance review. None of them surface the questions a reviewer needs to ask...' and 'Today the answer to each of those is \"you'd have to grep several config files and reverse-engineer it.\" That is governance debt.'"
+    disposition: accept
+    disposition_rationale: "Spec will add a concrete contractor scenario as justification — a walkthrough of what a non-veteran reviewer (e.g. a contractor or new team member with limited project knowledge) faces when asked to answer the four reviewer questions today. This grounds the premise in a recognisable failure mode without requiring an actual logged incident."
+  - id: O2
+    category: alternatives
+    severity: high
+    claim: "A single garbage-collection rule that scans existing config files (settings.json, .mcp.json, hook scripts, agent frontmatter) and emits a generated read-only inventory would deliver the same governance visibility without introducing a hand-maintained fourth top-level section, a new command, a runtime tuple recorder, and a HARNESS-writing reconciler."
+    evidence: "Spec lines 73-77 explicitly defer 'Automated discovery' as a 'separate workstream', and lines 327-340 enumerate at least seven artefacts (template section, command, hook, reconciler, three docs pages, audit updates) the manual-first path commits to. The discovery alternative is acknowledged but not weighed against the manual-first cost."
+    disposition: accept
+    disposition_rationale: "Spec will be restructured to ship the discovery scanner first, producing a draft inventory generated from existing config (settings.json, .mcp.json, hook scripts, agent frontmatter). Humans then annotate that draft with the governance-only fields that configs do not supply (Identity, Audit Trail, Last Reviewed). This addresses the design inversion: the inventory is observed, not authored; only the governance metadata is authored. Sequencing in the spec flips accordingly — discovery becomes step 2, manual annotation step 3, command and chained constraints later. Non-Goals section will be updated to remove the 'discovery is a separate workstream' framing."
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "The 'Invoked by' auto-population mechanism violates a principle the spec itself names — 'humans own HARNESS.md' — and the proposed mitigation (the reconciler only edits one sub-line) is a convention, not a structural guarantee; nothing in markdown prevents a future refactor of the reconciler from over-writing more."
+    evidence: "Spec lines 231-236: 'The trade-off: the affordance section becomes partially machine-written, which conflicts with the harness principle of \"humans own HARNESS.md.\" Mitigation: the reconciler only updates the Invoked by sub-line of an existing affordance entry; it never adds, removes, or modifies any other field.'"
+    disposition: accept
+    disposition_rationale: "Spec restructured to enforce the invariant structurally: runtime data lives in observability/ (e.g. observability/affordance-invocations.json), declared inventory lives in HARNESS.md, and discovery scanning bridges the two. HARNESS.md remains 100% human-authored. The Invoked-by field is removed from the schema; instead, the section header references the runtime invocations file by path, and a chained constraint can join the two at audit time. Combined with O2, the architecture becomes: discovery scanner reads config + observability/ → produces draft inventory → humans annotate with governance metadata → HARNESS.md never written by a tool."
+  - id: O4
+    category: specification quality
+    severity: high
+    claim: "The schema does not define what counts as 'one' affordance, so two reviewers given the same tool surface will produce different entries. The hook-plus-CLI rule (lines 386-388) shows the spec is aware of the granularity problem but resolves it for one case only."
+    evidence: "Spec lines 175-178 say each hook is its own entry AND the CLI it invokes is its own entry. But the schema gives no rule for: a single CLI run under two identities (e.g. `gh` with PAT vs `gh` after `gh auth switch`); a wildcard MCP method set; an MCP server that fronts multiple remote APIs. The 'Resolved Design Decisions' section (lines 353-402) does not address granularity beyond the hook case."
+    disposition: accept
+    disposition_rationale: "Adopt rule (a): **one affordance per permission pattern**. `Bash(gh *)` is one affordance; `Bash(gh pr *)` is a separate (narrower) affordance. MCP server with N tools = one affordance per `mcp__server__*` pattern, not per method. The discovery scanner produces the inventory grouped by permission entries, which makes the chained constraint's 'matching' relation trivially deterministic — it becomes identity, not subset or wildcard reasoning. Same-CLI-different-identity (the `gh` with `$GITHUB_TOKEN` vs keychain case) is treated as one affordance entry with the runtime ambiguity flagged in Notes (and addressed structurally by O7's resolution)."
+  - id: O5
+    category: specification quality
+    severity: high
+    claim: "The 'Permission' field's matching rule is under-specified. A real settings.json contains overlapping wildcards (e.g. `Bash(*)`, `Bash(gh *)`, `Bash(gh pr *)`); the spec does not say which match the affordance entry should record, nor what the chained constraint should treat as 'matching'."
+    evidence: "Spec line 159 defines Permission as 'the matching pattern from settings.json / .claude/settings.local.json permissions allowlist that authorises this affordance at runtime' and lines 217-219 promise a constraint that 'every declared affordance has a matching permission, every granted permission has a matching affordance entry' — but 'matching' is not defined for overlapping or hierarchical patterns."
+    disposition: accept
+    disposition_rationale: "Resolved as a corollary of O4. Once 'one affordance per permission pattern' is the granularity rule, 'matching' becomes string equality on the permission pattern — no subset or wildcard reasoning needed. Broader patterns subsume narrower invocations rather than producing separate affordance entries; an action like `gh pr merge` authorised by a `Bash(gh *)` permission is recorded against the single broader-pattern affordance, not as a separate narrower one. The chained constraint becomes: 'For every entry in the Permission allowlist, there exists exactly one Affordance entry whose Permission field equals that pattern, and vice versa.' Trivially deterministic. Spec will state this matching algorithm explicitly."
+  - id: O6
+    category: scope
+    severity: high
+    claim: "Sequencing step 6 (runtime tuple recorder + reconciler with HARNESS write access) is the riskiest piece of work in the spec — it touches a session hook, a periodic GC writer, and the harness-edits-itself boundary — yet the spec defers its design to a future spec while still listing it as a Component (M effort) in the current one and using it to motivate the 'Invoked by' field's existence."
+    evidence: "Spec lines 222-230 outline the mechanism in two sentences and defer it to 'a separate spec'; the Components table (lines 336-337) lists 'Runtime tuple recorder (SessionEnd hook)' and 'Invoked by reconciler (GC rule with HARNESS.md write access)' as M effort; the Sequencing section (line 311) states step 6 'warrants its own spec PR before implementation.'"
+    disposition: accept
+    disposition_rationale: "Dissolves once O3 is accepted. With the Invoked-by field removed from the schema and runtime data relocated to observability/affordance-invocations.json, there is no required field with no source. The runtime tuple recorder becomes a clean follow-on spec producing an observability/ artefact — completely separable from this spec's scope. The chained constraint that previously depended on Invoked-by becomes 'is the observability/affordance-invocations.json file fresh?' — sourced from observability/, not from HARNESS.md. Components table entries for the runtime recorder and reconciler are removed from this spec."
+  - id: O7
+    category: premise
+    severity: medium
+    claim: "The 'Identity' framing assumes a sharp boundary between user-sso, service-account, current-user, and none, but in practice the boundary is often a runtime configuration choice (e.g. `gh` reads `GITHUB_TOKEN` if set, otherwise falls back to keychain). A static declaration in HARNESS.md will be wrong some non-trivial fraction of the time."
+    evidence: "Spec lines 180-196 enumerate four identity values as if they are mutually exclusive properties of the tool. The example entry for `gh-cli` (lines 103-106) hard-codes `user-sso (GitHub PAT in $GITHUB_TOKEN)` as if this is a tool property, not a session-environment property."
+    disposition: accept
+    disposition_rationale: "Add a fifth Identity value `runtime-resolved` meaning 'depends on session configuration; see Notes for the resolution order'. This matches the project's honesty-encouraged pattern (where 'Audit trail: none' is welcomed). For tools like `gh`, `aws`, and `kubectl` the entry will read `Identity: runtime-resolved` with Notes documenting the precedence chain (env var → profile → keychain → IAM role). Chained constraints that key on Identity treat `runtime-resolved` as a known unknown — they may flag it for human review rather than deterministically passing or failing. Five-value schema (user-sso, service-account, current-user, runtime-resolved, none) replaces the four-value schema in Field Schema and Resolved Design Decisions."
+  - id: O8
+    category: scope
+    severity: medium
+    claim: "The spec proposes that template projects adopt the affordance scaffold during /harness-init (line 416) but does not address backfill for existing harness adopters; without an opinionated backfill path, the section will exist in new projects and be empty in every project that adopted the harness before this version."
+    evidence: "Spec line 416: 'Template projects that adopt the plugin get an affordance scaffold during /harness-init and a guided way to populate it.' Sequencing steps 2-8 describe forward additions; no step describes how existing HARNESS.md files acquire the section, who owns the backfill, or what the chained constraint behaves like in projects that have not yet declared a single affordance."
+    disposition: accept
+    disposition_rationale: "Resolved by O2's flip to discovery-first. The discovery scanner IS the backfill path — any existing project gets a draft affordance inventory the moment the scanner runs against its existing config. The chained constraint ships as `unverified` until the first discovery + human-annotation pass completes, then graduates to `agent` or `deterministic`. This matches the existing harness pattern where new constraints start unverified and graduate via /harness-constrain. Spec will state this explicitly in the Sequencing section."
+  - id: O9
+    category: risk
+    severity: medium
+    claim: "The chained constraint 'every permission allowlist entry must have a matching affordance' (line 218) creates a one-way ratchet that punishes the safer state: if a project has a tightly scoped permission allowlist with twelve entries and only three declared affordances, the constraint fails even though the runtime grants are well-governed. The natural human response is to either delete permissions or fabricate affordance entries, both worse than the status quo."
+    evidence: "Spec lines 217-219: 'every declared affordance has a matching permission, every granted permission has a matching affordance entry. Affordances without permissions are dead inventory; permissions without affordances are ungoverned grants.' The framing treats both directions as symmetrically bad; this is asserted, not argued."
+    disposition: accept
+    disposition_rationale: "The two directions warrant different severities. **Affordance-without-permission** is a real safety concern (the agent has declared a tool it cannot actually invoke — likely indicates either the permission was removed without reviewing the affordance, or the affordance was added without authorising it) — this stays **blocking**. **Permission-without-affordance** is paperwork debt (the grant exists, the governance metadata is missing) — this becomes **advisory**, optionally with a 30-day deadline to either declare an affordance or revoke the permission. Spec will split the chained constraint into two named constraints with these distinct severities."
+  - id: O10
+    category: alternatives
+    severity: medium
+    claim: "The 'Identity is the load-bearing question' insight could be delivered as a single new field on the existing per-tool surface (a comment in `.claude/settings.local.json` next to each permission line, or a structured frontmatter block in agent files) rather than as a new top-level HARNESS.md section. The spec does not consider co-locating the metadata with the existing definitions."
+    evidence: "Spec lines 56-62 frame Identity and Audit as the load-bearing fields; the design (lines 89-150) places them in a brand-new section. No discussion of why the metadata should be denormalised into HARNESS.md rather than annotated on the source-of-truth files."
+    disposition: clarify
+    disposition_rationale: "Spec will add explicit rationale for the split rather than restructure. Two-part argument: (1) Tool surface metadata that machines own (the permission patterns, the MCP server names, the hook script paths) is already in source files and stays there — the discovery scanner reads it. (2) Governance metadata that humans own (Identity-as-narrative, Audit Trail prose, Last Reviewed dates, Notes) is review-facing and needs to live where reviewers already read, which is HARNESS.md. Splitting governance prose across N JSON config files would fragment the reviewer's attention. The 'humans own HARNESS.md' invariant (preserved by O3) is the load-bearing structural property; co-locating with source would violate it the same way the original Invoked-by reconciler did. Spec adds this rationale to a new 'Why a separate section' subsection in Design."
+  - id: O11
+    category: specification quality
+    severity: medium
+    claim: "The 'Last reviewed' field's semantics are imprecise: the spec says it dates 'when this affordance entry was last validated against reality' but does not define what 'validated' means concretely, who has authority to bump the date, or whether running /harness-affordance against an existing entry counts as a re-review."
+    evidence: "Spec line 161: 'YYYY-MM-DD; the date this affordance entry was last validated against reality (Identity correct, Audit trail still works, Permission still in settings).' Without a defined re-validation procedure, the date will be bumped whenever the entry is edited, eroding the staleness GC rule's value (line 259)."
+    disposition: accept
+    disposition_rationale: "Define re-validation concretely as three specific checks, all of which must pass before Last Reviewed is bumped: (1) the Identity claim still matches reality (the resolution chain has not changed for runtime-resolved entries; the named credential still exists for fixed entries), (2) the Audit Trail still produces a record where claimed (the log endpoint exists, retention matches what is stated, access scope holds), (3) the Permission entry is still present in settings.json with the recorded pattern. The date is bumped only by running `/harness-affordance review <name>`, which walks through the three checks interactively. Editing other fields (Notes, Constraint references) does not bump Last Reviewed. This separates re-validation from routine editing, which preserves the staleness GC rule's value and avoids the file-mtime degeneration."
+  - id: O12
+    category: implementation
+    severity: medium
+    claim: "Hook entries are declared first-class affordances, but Claude Code hooks are configured by event (PreToolUse, Stop, etc.) and a single script can be wired to multiple events; the schema has no field to capture the triggering event, so two hook entries with the same script-name field but different triggers cannot be distinguished and the chained constraint cannot detect a script wired into a wrong event."
+    evidence: "Spec lines 139-148 example shows `sync-to-global-cache-hook` with `Permission: configured in .claude/settings.local.json hooks.Stop` — encoding the event in the Permission field as freeform text rather than as a schema field. Resolved Decision 4 (lines 383-388) treats hooks as first-class but does not introduce a Trigger or Event field."
+    disposition: accept
+    disposition_rationale: "Add a `Trigger` field that is required for `Mode: hook` entries and not used for other modes. Values match Claude Code hook events: `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreCompact`, `Notification`. A single script wired to two events produces two distinct affordance entries differentiated by Trigger. The discovery scanner populates this directly from settings.json's hook structure, so no extra human work in the discovery-first flow. Future constraints can then key on Trigger (e.g. 'no PreToolUse hooks without an audit trail'). Permission field for hooks reverts to the actual permission pattern (e.g. the script path), with the trigger no longer encoded as freeform text."
+---
+
+# Adversarial Review — harness-affordances-design
+
+Spec: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+Mode: spec
+Reviewer: advocatus-diaboli (Claude Opus 4.7)
+
+## O1 — premise — high
+
+### Claim
+
+The spec asserts that no existing location surfaces tool, identity, and audit
+information, but it does not demonstrate that practitioners actually fail the
+governance task today. The gap is asserted, not evidenced.
+
+### Evidence
+
+> None of those locations are read by humans during governance review. None of
+> them surface the questions a reviewer needs to ask...
+>
+> Today the answer to each of those is "you'd have to grep several config
+> files and reverse-engineer it." That is governance debt.
+
+(Lines 30-44 of the spec.)
+
+### Why this matters
+
+The Problem section makes a strong empirical claim — "no one reads these
+files during governance review" — without citing a review that failed, an
+audit that produced wrong answers, or an incident that the proposed section
+would have prevented. The four bullet questions on lines 35-43 are framed as
+unanswerable today; in practice all four are answerable in 5-10 minutes by a
+reviewer who knows the project layout. If the real friction is "this takes
+10 minutes and we want it to take 30 seconds," the proposed cost (a new
+section, a new command, a runtime tuple recorder, a writing reconciler, and
+three docs pages) is large relative to the savings. Without one concrete
+example of a governance review that produced the wrong answer, the premise
+is plausible but unproven, and a less-invasive intervention may be sufficient.
+
+## O2 — alternatives — high
+
+### Claim
+
+A single garbage-collection rule that *reads* existing config (settings.json,
+.mcp.json, hook scripts, agent frontmatter) and emits a generated, read-only
+affordance inventory would deliver the same governance visibility without
+introducing a hand-maintained fourth section, a new command, a runtime
+tuple recorder, and a HARNESS-writing reconciler.
+
+### Evidence
+
+The spec defers automated discovery as "a separate workstream":
+
+> Automated discovery — scanning ~/.claude/settings.json, .mcp.json, and
+> shell env to populate the section. Discovery is valuable but is a
+> separate workstream; the format must prove itself with manual declaration
+> first.
+
+(Lines 73-77.)
+
+The Components table (lines 327-340) commits to seven new artefacts in the
+manual-first path: a template section, a new command, three command updates,
+a runtime hook, a reconciler, and three docs pages.
+
+### Why this matters
+
+The spec acknowledges the discovery alternative exists but does not justify
+why "prove the format manually first" is the right ordering. If the eventual
+end state is a generated inventory (because hand-maintenance is known to drift,
+which is why "Invoked by" is auto-populated), then the manual-first path
+incurs design cost twice: once for the manual schema and again when discovery
+forces schema changes to fit what real config files contain. The honest
+question is: does discovery first reveal the schema, or does the schema reveal
+what discovery should produce? The spec assumes the latter without argument.
+
+## O3 — implementation — high
+
+### Claim
+
+The "Invoked by" auto-population mechanism violates a principle the spec
+itself names — "humans own HARNESS.md" — and the proposed mitigation (the
+reconciler only edits one sub-line) is a convention, not a structural
+guarantee. Markdown has no schema enforcement; nothing prevents a future
+refactor of the reconciler from over-writing more.
+
+### Evidence
+
+> The trade-off: the affordance section becomes partially machine-written,
+> which conflicts with the harness principle of "humans own HARNESS.md."
+> Mitigation: the reconciler only updates the Invoked by sub-line of an
+> existing affordance entry; it never adds, removes, or modifies any other
+> field. Humans still control which affordances exist and how they are
+> described.
+
+(Lines 231-236.)
+
+### Why this matters
+
+The harness's value comes from being a high-trust, human-edited document.
+Once one tool is known to write into it, every subsequent agent that wants
+to write a "small, scoped" update will cite the same precedent. The
+mitigation is "the reconciler is well-behaved," which is a property of the
+current implementation, not a structural property of the design. A safer
+design would write tuples to a separate file (e.g. `observability/affordance-
+invocations.json`) and have HARNESS.md reference it by file path, preserving
+the "humans own HARNESS.md" invariant. The spec does not weigh this
+alternative.
+
+## O4 — specification quality — high
+
+### Claim
+
+The schema does not define what counts as "one" affordance, so two reviewers
+given the same tool surface will produce different entries. The hook-plus-CLI
+rule shows the spec is aware of the granularity problem but resolves it for
+one case only.
+
+### Evidence
+
+> Each hook is its own affordance entry; if a hook invokes a CLI internally,
+> the CLI is also an affordance entry — the hook is the surface the agent
+> triggers, the CLI is the underlying capability.
+
+(Lines 175-178.)
+
+But the schema gives no rule for:
+
+- A single CLI used under two identities in the same session (e.g. `gh`
+  with `$GITHUB_TOKEN` set vs after `gh auth switch`).
+- An MCP server that exposes many tools under one server name — is it one
+  affordance per server, or per method?
+- An MCP server that fronts multiple remote APIs (a wrapper MCP).
+- A `Bash(*)` permission entry — is that one affordance or many?
+
+### Why this matters
+
+The chained constraint that "every permission has a matching affordance"
+(line 218) is only meaningful if "matching" is well-defined. If two reviewers
+disagree on whether `gh pr merge` and `gh pr create` are one affordance or
+two, the constraint will fail or pass non-deterministically across projects
+and over time within a single project. Specification ambiguity at this layer
+poisons the enforcement layer downstream.
+
+## O5 — specification quality — high
+
+### Claim
+
+The "Permission" field's matching rule is under-specified. A real
+settings.json contains overlapping wildcards (e.g. `Bash(*)`, `Bash(gh *)`,
+`Bash(gh pr *)`); the spec does not say which the affordance entry should
+record, nor what "matching" means for the chained constraint.
+
+### Evidence
+
+> Permission | yes | declared | the matching pattern from settings.json /
+> .claude/settings.local.json permissions allowlist that authorises this
+> affordance at runtime
+
+(Line 159.) And:
+
+> A chained constraint can then verify the two are in sync — every declared
+> affordance has a matching permission, every granted permission has a
+> matching affordance entry.
+
+(Lines 217-219.)
+
+### Why this matters
+
+Permission allowlists are intentionally hierarchical — `Bash(gh *)`
+authorises `gh pr merge` and a thousand other invocations. If the affordance
+records the most-specific match, the most-general match, or any-overlapping
+match, the chained constraint produces three different verdicts. Without a
+defined matching algorithm, the "deterministic" enforcement loop is not
+deterministic, and the spec's most load-bearing design decision (Resolved
+Decision 2, lines 365-372) rests on a foundation it has not laid.
+
+## O6 — scope — high
+
+### Claim
+
+Sequencing step 6 — the runtime tuple recorder plus reconciler with
+HARNESS.md write access — is the riskiest piece of work in the spec. It
+touches a session hook, a periodic GC writer, and the harness-edits-itself
+boundary. The spec defers its design to a future spec while still listing
+it as a Component in the current one *and* using it to motivate the
+"Invoked by" field's inclusion in the schema.
+
+### Evidence
+
+> Implementation outline (deferred to a separate spec): a SessionEnd hook
+> records (tool_name, invoking_agent_or_command) tuples for the session;
+> a periodic reconciler (weekly GC) updates the Invoked by list in
+> HARNESS.md from the accumulated record.
+
+(Lines 224-229.)
+
+The Components table (lines 336-337) lists "Runtime tuple recorder
+(SessionEnd hook)" as M effort and "Invoked by reconciler (GC rule with
+HARNESS.md write access)" as M effort.
+
+### Why this matters
+
+The schema includes "Invoked by" as a required field. The field's value is
+asserted to come from a mechanism that does not yet exist and is acknowledged
+to need a separate spec. Until that mechanism exists, every affordance entry
+will have an empty or placeholder "Invoked by" line. The chained constraint
+"every affordance must show at least one auto-populated Invoked by consumer
+within 30 days of declaration" (line 256) will either fire universally
+(failing every entry) or be silently disabled. Either outcome erodes trust in
+the section. The honest sequencing would be: defer "Invoked by" until step 6
+ships, or remove the chained constraint that depends on it.
+
+## O7 — premise — medium
+
+### Claim
+
+The "Identity" framing assumes a sharp boundary between `user-sso`,
+`service-account`, `current-user`, and `none`, but in practice the boundary
+is often a runtime configuration choice. A static declaration in HARNESS.md
+will be wrong some non-trivial fraction of the time.
+
+### Evidence
+
+> Identity | yes | declared | user-sso / service-account / current-user /
+> none (with optional detail in parens)
+
+(Line 158.) And the gh-cli example:
+
+> Identity: user-sso (GitHub PAT in $GITHUB_TOKEN)
+
+(Line 105.)
+
+### Why this matters
+
+`gh` uses `$GITHUB_TOKEN` if set; otherwise it uses the keychain auth from
+`gh auth login`; otherwise it fails. Whether the action is `user-sso` or
+`service-account` depends on which token the human happened to export. The
+same applies to `aws` (profile vs env vars vs IAM role), `kubectl` (kubeconfig
+vs in-cluster service account), and many others. A declaration that pins a
+single identity per tool will mislead reviewers when the runtime reality
+differs. The schema needs a "depends on session config — see Notes" value or
+the field needs to be probed at runtime. Neither path is in the spec.
+
+## O8 — scope — medium
+
+### Claim
+
+The spec proposes that template projects adopt the affordance scaffold during
+/harness-init but does not address backfill for existing harness adopters.
+Without an opinionated backfill path, the section will exist in new projects
+and be empty in every project that adopted the harness before this version.
+
+### Evidence
+
+> Template projects that adopt the plugin get an affordance scaffold during
+> /harness-init and a guided way to populate it.
+
+(Line 416.)
+
+Sequencing steps 2-8 (lines 293-318) describe forward additions only.
+
+### Why this matters
+
+The chained constraint "every permission has a matching affordance" applies
+the day it ships. In a project that has been using the harness for months
+with a populated `.claude/settings.local.json` and an empty `## Affordances`
+section, every permission will fail the constraint. The graceful handling of
+this is unspecified — does the constraint default to advisory? Is there a
+template-version gate? Is there a `/harness-affordance backfill` step? Until
+this is decided, adopting the section in an existing project will produce a
+flood of failures or be silently ignored. Either outcome is poor.
+
+## O9 — risk — medium
+
+### Claim
+
+The chained constraint "every permission allowlist entry must have a matching
+affordance" creates a one-way ratchet that punishes the safer state. A project
+with a tightly scoped permission allowlist of twelve entries and only three
+declared affordances fails the constraint even though its runtime grants are
+well-governed. The natural human response is to either delete permissions or
+fabricate affordance entries, both worse than the status quo.
+
+### Evidence
+
+> every declared affordance has a matching permission, every granted
+> permission has a matching affordance entry. Affordances without permissions
+> are dead inventory; permissions without affordances are ungoverned grants.
+
+(Lines 217-219.)
+
+### Why this matters
+
+The spec frames both directions of mismatch as symmetrically problematic, but
+the consequences are not symmetric. A permission without an affordance is
+"undocumented" — a paperwork gap. Punishing it equally with a true safety
+violation creates pressure to either reduce permission specificity (replace
+twelve narrow rules with one `Bash(*)` rule that has one matching affordance)
+or to add token affordance entries to satisfy the check. Both are worse than
+the starting state. The spec should weigh whether the two directions warrant
+different severities, or whether the "permission without affordance" check
+should be advisory rather than blocking.
+
+## O10 — alternatives — medium
+
+### Claim
+
+The "Identity is the load-bearing question" insight could be delivered as a
+single new field on the existing per-tool surfaces (a comment in
+`.claude/settings.local.json` next to each permission line, or a structured
+frontmatter block in agent files) rather than as a brand-new top-level
+HARNESS.md section. The spec does not consider co-locating the metadata
+with its source-of-truth files.
+
+### Evidence
+
+The Problem section (lines 56-62) frames Identity and Audit as the load-
+bearing fields. The Design section (lines 89-150) places them in a new
+top-level section, denormalised from the configuration files that already
+list the tools.
+
+### Why this matters
+
+Denormalising metadata into HARNESS.md introduces drift between the harness
+declaration and the source-of-truth config. The spec acknowledges this drift
+risk for "Invoked by" (which is why that field is auto-populated) but does
+not acknowledge the same drift for Identity, Audit Trail, and Permission.
+A simpler intervention — a field convention attached to existing files,
+plus a /harness-affordance command that *generates* the HARNESS.md view from
+those files — would have one source of truth. The spec does not consider
+this shape.
+
+## O11 — specification quality — medium
+
+### Claim
+
+The "Last reviewed" field's semantics are imprecise. The spec says it dates
+"when this affordance entry was last validated against reality" but does not
+define what "validated" means, who has authority to bump the date, or whether
+running /harness-affordance against an existing entry counts as a re-review.
+
+### Evidence
+
+> Last reviewed | yes | declared | YYYY-MM-DD; the date this affordance
+> entry was last validated against reality (Identity correct, Audit trail
+> still works, Permission still in settings)
+
+(Line 161.)
+
+### Why this matters
+
+Without a defined re-validation procedure, the date will be bumped whenever
+the entry is edited (because the editor will tick the field as a matter of
+habit). The staleness GC rule (line 259) — "every affordance's Last reviewed
+date must be within the last 6 months" — then degrades to a "has anyone
+touched this file in six months" check, which the existing `git log` mtime
+check on the file already provides. Without procedural specification, the
+field collapses into noise.
+
+## O12 — implementation — medium
+
+### Claim
+
+Hook entries are declared first-class affordances, but Claude Code hooks are
+configured by event (PreToolUse, Stop, etc.) and a single script can be wired
+to multiple events. The schema has no field to capture the triggering event,
+so two hook entries with the same script name but different triggers cannot
+be distinguished, and the chained constraint cannot detect a script wired
+into a wrong event.
+
+### Evidence
+
+The example hook entry encodes the event in the Permission field as freeform
+text rather than as a schema field:
+
+> Permission: configured in .claude/settings.local.json hooks.Stop
+
+(Line 144.)
+
+Resolved Decision 4 (lines 383-388) treats hooks as first-class but does not
+introduce a Trigger or Event field.
+
+### Why this matters
+
+A hook fired on PostToolUse vs Stop has different governance properties (one
+runs after every tool invocation; one runs once per session). Conflating them
+because they share a script means the affordance entry under-describes the
+risk surface. A future chained constraint that wants to enforce "no hooks on
+PreToolUse without an audit trail" cannot be expressed against the current
+schema.
+
+## Explicitly not objecting to
+
+- **The choice of four Identity values** (`user-sso`, `service-account`,
+  `current-user`, `none`): the taxonomy is simple, defensible, and orthogonal;
+  whether the boundary is sharp at runtime is challenged in O7, but the
+  taxonomy itself is fine.
+- **The `/harness-affordance` command following the `/harness-constrain`
+  pattern**: this is correctly identified as the cheapest UX path and matches
+  prior project convention; no honest objection here.
+- **The "Audit trail: none is encouraged" framing**: explicitly inviting the
+  honest "no audit" answer is a strong design choice that resists fabrication
+  pressure; this is one of the spec's clearer ideas.
+- **The decision to keep Mode in the schema (Resolved Decision 1)**: the
+  reasoning ("cheap to maintain, helps reviewers categorise at a glance") is
+  pragmatic and correctly weighed against Identity being load-bearing; not
+  worth challenging.
+- **Naming the section "Affordances" rather than "Tools" or "Capabilities"**:
+  the term carries the right connotation (granted, not assumed) from
+  capability-based security; this is a deliberate and defensible naming
+  choice.
+- **The non-goal "this spec does not enumerate MCP method lists"**: keeping
+  the inventory at the *server* level rather than the *method* level is the
+  right scope for governance review — the contrary would produce unmanageable
+  surface.
+- **The Intellectual Foundations section's framing**: capability-based
+  security and identity-aware computing are correctly cited as the design
+  precedents; nothing rhetorically suspect there.

--- a/docs/superpowers/specs/2026-04-26-harness-affordances-design.md
+++ b/docs/superpowers/specs/2026-04-26-harness-affordances-design.md
@@ -1,11 +1,19 @@
 ---
 name: harness-affordances-design
-description: Design spec for an Affordances section in HARNESS.md that declares the agent's tool inventory (MCP / CLI), the identity each tool runs under, and the audit trail each tool produces — making implicit capability surface a first-class governance concern
+description: Design spec for a discovery-first Affordances section in HARNESS.md that declares the agent's tool inventory (CLI / MCP / hook), the identity each tool runs under, and the audit trail each tool produces — making implicit capability surface a first-class governance concern while preserving HARNESS.md as a 100% human-authored document
 date: 2026-04-26
 status: draft
 ---
 
 # Harness Affordances — Design Spec
+
+> **Adjudication trail.** This spec was reviewed via `/diaboli` in
+> spec mode; 12 objections raised, 11 accepted, 1 clarified. The full
+> objection record with dispositions and rationales is at
+> `docs/superpowers/objections/harness-affordances-design.md`. The
+> design below is the post-adjudication version. Where a section
+> derives directly from a disposition, the relevant objection ID is
+> noted.
 
 ## Problem
 
@@ -38,42 +46,78 @@ needs to ask:
 - If an audit asked "show me everything the agent did this quarter
   under my SSO," could we answer?
 
-Today the answer to each of those is "you'd have to grep
-several config files and reverse-engineer it." That is governance
-debt.
+### The contractor scenario *(per O1)*
 
-The deeper failure mode this enables: **agents executing under shared
-or escalated identity without that fact being visible at governance
-review time**. A constraint like "all production-affecting actions
-require human review" is unenforceable if no one knows which actions
-are production-affecting — which depends on which identity executes
-them.
+To make the gap concrete: imagine a contractor is brought in for a
+two-week engagement to help review the project's AI governance
+posture. Their first task is to answer those four questions for the
+person who hired them.
+
+Today, here is what that contractor faces:
+
+1. They open `HARNESS.md`. The Constraints section talks about
+   `gh pr merge` and Honeycomb queries as actions, but does not say
+   what credentials those actions use. The Garbage Collection
+   section invokes scripts but does not say who owns them. The
+   Context section names the languages but not the tools.
+2. They open `~/.claude/settings.json`. They see permission
+   patterns like `Bash(gh *)` and `mcp__honeycomb__*`. The patterns
+   tell them *what is allowed* but not *under whose authority*.
+3. They open `.claude/settings.local.json`. They find hook scripts
+   referenced by path. To find out what the hooks actually do, they
+   open and read each script. To find out under what identity the
+   scripts run, they have to reason about the parent process and the
+   shell environment at session start.
+4. They open `.mcp.json`. They see server declarations. To find out
+   whether each MCP runs locally or hits a remote API under what
+   credential, they have to read the server's documentation.
+5. They open every `agents/*.agent.md` file and read the `tools:`
+   frontmatter to map agents to tools. None of these files mention
+   identity or audit trails.
+
+A diligent contractor can complete this exercise in two to four
+hours and produce a reasonable inventory. A less-diligent one
+produces a wrong inventory, or skips the exercise. *Neither outcome
+is the project's fault — the inventory simply does not exist as a
+review-facing artefact.* The project's governance review pace is
+gated on how thorough the contractor was on day one.
+
+The deeper failure mode this enables: **agents executing under
+shared or escalated identity without that fact being visible at
+governance review time**. A constraint like "all production-affecting
+actions require human review" is unenforceable if no one knows which
+actions are production-affecting — which depends on which identity
+executes them.
 
 ## Goals
 
 1. Make the agent's tool inventory **declarative and versioned** in
    `HARNESS.md` alongside Context, Constraints, and Garbage Collection.
-2. Surface **Identity** as a first-class field — *whose credentials does
-   this tool run under?* — because identity, not transport, is the load-
-   bearing governance question.
+2. Surface **Identity** as a first-class field — *whose credentials
+   does this tool run under?* — because identity, not transport, is
+   the load-bearing governance question.
 3. Surface **Audit Trail** as a first-class field — *where would you
-   find a record of what the agent did with this tool?* — including the
-   honest answer "nowhere" when that is the case.
+   find a record of what the agent did with this tool?* — including
+   the honest answer "nowhere" when that is the case.
 4. Enable **chained constraints** that reason about the affordance
-   inventory ("every tool with `audit-trail: none` must have a
-   matching GC capture rule" / "tools running under shared service
-   accounts require an extra reviewer").
-5. Provide a **guided authoring command** (`/harness-affordance`) that
-   matches the existing `/harness-constrain` and `/governance-constrain`
-   pattern — interactive, no manual YAML editing required for routine
-   declarations.
+   inventory ("every affordance has a matching `Permission` allowlist
+   entry" / "tools running under shared service accounts require an
+   extra reviewer").
+5. Provide a **discovery scanner** that produces a draft inventory
+   from existing config files, so existing harness adopters get a
+   backfill path on day one and ongoing changes to config are
+   surfaced via diff.
+6. Provide a **guided annotation command** (`/harness-affordance`)
+   that walks humans through filling in the governance-only fields
+   the discovery scanner cannot infer — Identity narrative, Audit
+   Trail prose, Last Reviewed.
+7. Preserve the structural invariant that **HARNESS.md is 100%
+   human-authored**. Runtime data and machine-derivable inventory
+   live in `observability/` and config files; HARNESS.md is the
+   review-facing prose layer that humans own.
 
 ## Non-Goals
 
-- **Automated discovery** — scanning `~/.claude/settings.json`,
-  `.mcp.json`, and shell env to populate the section. Discovery is
-  valuable but is a separate workstream; the format must prove itself
-  with manual declaration first. (See "Sequencing" below.)
 - **Replacing or duplicating Cost Tracking or Model Routing.**
   Affordances declare the tool inventory; cost-tracking and model-
   routing reason about that inventory. Avoid restating per-tool cost
@@ -83,9 +127,45 @@ them.
   agent *can reach* it, under what identity, with what audit trail.
 - **Permission enforcement at runtime.** Existing Claude Code
   permission prompts and hooks already handle that. Affordances are
-  for governance review, not runtime gating.
+  for governance review, not runtime gating; the chained constraint
+  closes the *declaration vs enforcement* loop, not the runtime
+  enforcement itself.
+- **Writing into HARNESS.md from any automated tool.** Every other
+  harness section is human-authored; the affordance section will be
+  too. The discovery scanner produces drafts in a separate
+  scratch-file (or stdout); humans copy chosen entries into
+  HARNESS.md and add governance metadata. Runtime invocation data
+  lives in `observability/affordance-invocations.json`, referenced
+  by path from the affordance section header — never inlined.
 
 ## Design
+
+### Why a separate section *(per O10)*
+
+The most natural alternative — co-locate Identity and Audit metadata
+with the existing per-tool surface (comments next to permission
+lines in `settings.local.json`, structured frontmatter on agent
+files) — was considered and rejected. The split between machine-
+owned source files and human-owned governance metadata is
+intentional:
+
+- **Tool surface metadata that machines own** (the permission
+  patterns, the MCP server names, the hook script paths, the
+  trigger events) already lives in source files and stays there.
+  The discovery scanner reads it. There is no value in duplicating
+  it into HARNESS.md.
+- **Governance metadata that humans own** (Identity-as-narrative,
+  Audit Trail prose, Last Reviewed dates, Notes, links to
+  Constraints) is review-facing and needs to live where reviewers
+  already read, which is HARNESS.md. Splitting governance prose
+  across N JSON config files would fragment the reviewer's
+  attention — exactly the failure mode the contractor scenario
+  describes.
+
+The "humans own HARNESS.md" invariant is the load-bearing
+structural property of the harness; co-locating governance prose
+with source would violate it the same way an automated reconciler
+writing to HARNESS.md would. Both are rejected for the same reason.
 
 ### The Affordance Block in HARNESS.md
 
@@ -98,20 +178,37 @@ Collection`:
 <!-- Each entry declares one tool the agent can invoke. Identity is
      the load-bearing governance question — whose credentials authorise
      the action. Audit Trail's honest answer "none" is itself useful
-     governance signal. -->
+     governance signal.
+
+     Runtime invocation data (which agent invoked which tool, when,
+     how often) lives in observability/affordance-invocations.json
+     and is referenced — not inlined — here. HARNESS.md remains
+     entirely human-authored.
+
+     The discovery scanner (run via /harness-affordance discover)
+     produces a draft inventory from existing config files. Humans
+     paste chosen entries here and add the governance-only fields
+     (Identity narrative, Audit Trail prose, Last Reviewed). -->
+
+<!-- Runtime invocation data: observability/affordance-invocations.json -->
 
 ### gh-cli
 
 - **Mode**: cli
-- **Identity**: user-sso (GitHub PAT in $GITHUB_TOKEN)
+- **Identity**: runtime-resolved
 - **Audit trail**: github-audit (org audit log, 90-day retention,
-  admin-only access)
-- **Permission**: `Bash(gh *)` (allowlist in `.claude/settings.local.json`)
-- **Invoked by**: orchestrator, integration-agent, harness-enforcer
-  *(auto-populated)*
+  admin-only access) — assumes credentials resolve to a real GitHub
+  identity; if `$GITHUB_TOKEN` resolves to a service account the
+  audit trail will record that account, not the user
+- **Permission**: `Bash(gh *)` (allowlist in
+  `.claude/settings.local.json`)
 - **Last reviewed**: 2026-04-26
 - **Constraint references**: spec-first-commit-ordering,
   release-traceability
+- **Notes**: `gh` resolves credentials in this order:
+  `$GITHUB_TOKEN` → keychain (`gh auth login`) → fail. The
+  reviewer should confirm which path is active in the session
+  configuration before relying on this entry.
 
 ### honeycomb-mcp
 
@@ -119,29 +216,30 @@ Collection`:
 - **Identity**: service-account (HONEYCOMB_API_KEY shared across team)
 - **Audit trail**: honeycomb-query-log (per-team, 30-day retention,
   team-admin access)
-- **Permission**: `mcp__honeycomb__*` (allowlist in user `~/.claude/settings.json`)
-- **Invoked by**: honeycomb-investigator, instrumentation-advisor
-  *(auto-populated)*
+- **Permission**: `mcp__honeycomb__*` (allowlist in user
+  `~/.claude/settings.json`)
 - **Last reviewed**: 2026-04-26
 
 ### shell-write-to-tmp
 
 - **Mode**: cli
-- **Identity**: current-user (the human running the Claude Code session)
+- **Identity**: current-user (the human running the Claude Code
+  session)
 - **Audit trail**: none
 - **Permission**: `Bash(echo *)`, `Bash(touch *)` (allowlist)
-- **Invoked by**: harness-gc, observatory-verify *(auto-populated)*
 - **Last reviewed**: 2026-04-26
-- **Notes**: ephemeral session-local writes; if persistence is required,
-  promote to a tracked artefact
+- **Notes**: ephemeral session-local writes; if persistence is
+  required, promote to a tracked artefact
 
 ### sync-to-global-cache-hook
 
 - **Mode**: hook
+- **Trigger**: Stop
 - **Identity**: current-user
 - **Audit trail**: none (hook stderr, lost at session end)
-- **Permission**: configured in `.claude/settings.local.json` `hooks.Stop`
-- **Invoked by**: Claude Code runtime (Stop event) *(auto-populated)*
+- **Permission**: `hooks.Stop` entry in
+  `.claude/settings.local.json` invoking
+  `ai-literacy-superpowers/scripts/sync-to-global-cache.sh`
 - **Last reviewed**: 2026-04-26
 - **Notes**: invokes `rsync` under the current user; rsyncs plugin
   content into `~/.claude/plugins/cache/` after every session
@@ -153,14 +251,38 @@ Collection`:
 
 | Field | Required | Source | Values |
 | --- | --- | --- | --- |
-| `Mode` | yes | declared | `local-mcp` / `central-mcp` / `cli` / `hook` |
-| `Identity` | yes | declared | `user-sso` / `service-account` / `current-user` / `none` (with optional detail in parens) |
-| `Audit trail` | yes | declared | named log/store with retention + access scope, or `none` |
-| `Permission` | yes | declared | the matching pattern from `settings.json` / `.claude/settings.local.json` `permissions` allowlist that authorises this affordance at runtime |
-| `Invoked by` | yes | **auto-populated** | comma-separated list of agents or commands that invoked this tool, observed at runtime by Claude Code; declared affordances with no observed invocations are flagged by GC |
-| `Last reviewed` | yes | declared | YYYY-MM-DD; the date this affordance entry was last validated against reality (Identity correct, Audit trail still works, Permission still in settings) |
-| `Constraint references` | optional | declared | constraints in HARNESS.md that depend on this affordance |
-| `Notes` | optional | declared | freeform context the schema does not capture |
+| `Mode` | yes | declared (machine-derivable) | `local-mcp` / `central-mcp` / `cli` / `hook` |
+| `Trigger` | yes for `Mode: hook`; absent otherwise | declared (machine-derivable) | one of the Claude Code hook events: `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStop` / `SessionStart` / `SessionEnd` / `UserPromptSubmit` / `PreCompact` / `Notification` |
+| `Identity` | yes | declared (human-owned) | `user-sso` / `service-account` / `current-user` / `runtime-resolved` / `none` (with optional detail in parens) |
+| `Audit trail` | yes | declared (human-owned) | named log/store with retention + access scope, or `none` |
+| `Permission` | yes | declared (machine-derivable) | the permission pattern from `settings.json` / `.claude/settings.local.json` allowlist that authorises this affordance |
+| `Last reviewed` | yes | declared (procedure-controlled) | YYYY-MM-DD; bumped only by `/harness-affordance review <name>` after the three re-validation checks pass (see below) |
+| `Constraint references` | optional | declared (human-owned) | constraints in HARNESS.md that depend on this affordance |
+| `Notes` | optional | declared (human-owned) | freeform context the schema does not capture |
+
+**Granularity rule — one affordance per permission pattern** *(per O4)*:
+
+The unit of an affordance is one entry in the permissions allowlist.
+`Bash(gh *)` is one affordance. `Bash(gh pr *)` is a separate,
+narrower affordance. An MCP server with twenty methods exposed under
+`mcp__server__*` is one affordance, not twenty. Same CLI used under
+two different identities in different sessions is one entry with the
+runtime ambiguity flagged in Notes (or declared with
+`Identity: runtime-resolved`).
+
+This makes the chained-constraint matching relation trivially
+deterministic — no subset reasoning, no wildcard expansion.
+
+**Matching algorithm — string equality** *(per O5)*:
+
+When the chained constraint compares affordances against
+permissions, "matching" means string equality on the permission
+pattern. A permission entry `Bash(gh pr *)` matches the affordance
+entry whose `Permission` field is `Bash(gh pr *)` and no other.
+Broader patterns subsume narrower invocations rather than producing
+separate affordance entries — an action like `gh pr merge`
+authorised by a `Bash(gh *)` permission is recorded against the
+single broader-pattern affordance, not as a separate narrower one.
 
 **Mode values explained:**
 
@@ -170,13 +292,14 @@ Collection`:
   provider)
 - `cli` — shell command invoked by the agent (`gh`, `git`, `npx`,
   custom scripts)
-- `hook` — Claude Code hook script (PreToolUse, PostToolUse, Stop,
-  etc.) registered in `settings.json`. Each hook is its own
-  affordance entry; if a hook invokes a CLI internally, the CLI is
-  *also* an affordance entry — the hook is the surface the agent
-  triggers, the CLI is the underlying capability.
+- `hook` — Claude Code hook script registered in `settings.json`.
+  Each hook is its own affordance entry; if a hook invokes a CLI
+  internally, the CLI is *also* an affordance entry — the hook is
+  the surface the agent triggers, the CLI is the underlying
+  capability. The `Trigger` field disambiguates a script wired to
+  multiple events.
 
-**Identity values explained:**
+**Identity values explained** *(per O7)*:
 
 - `user-sso` — uses the human user's *external* SSO credentials
   (their GitHub PAT, their Slack token, their cloud SSO). Actions
@@ -188,174 +311,239 @@ Collection`:
   attribution is lost.
 - `current-user` — the human running the Claude Code session, with
   no special credentials and no boundary crossing. Filesystem reads
-  and writes, local network, `git status`, etc. This is the default
-  for most local CLI affordances and is distinct from `none`: a
-  `current-user` action is still attributable to a real principal,
-  even if there is no remote audit trail.
+  and writes, local network, `git status`, etc. Distinct from
+  `none`: a `current-user` action is still attributable to a real
+  principal, even if there is no remote audit trail.
+- `runtime-resolved` — identity depends on session configuration
+  (env vars, profile selection, IAM role assumption). The Notes
+  field MUST document the resolution chain. Chained constraints
+  treat `runtime-resolved` as a known unknown — they may flag it
+  for human review rather than deterministically pass or fail.
+  Examples: `gh` (env → keychain), `aws` (env → profile → IAM
+  role), `kubectl` (kubeconfig context → in-cluster service
+  account).
 - `none` — no authentication boundary crossed at all (pure local
   computation, no filesystem effects, no network).
 
 **Audit trail values:**
 
 Free-text but should follow the pattern `<source>: <retention>,
-<access scope>`. The honest answer `none` is encouraged and is itself
-governance signal — it tells reviewers where the gaps are without
-forcing fabrication.
+<access scope>`. The honest answer `none` is encouraged and is
+itself governance signal — it tells reviewers where the gaps are
+without forcing fabrication.
 
 **Permission and the enforcement loop:**
 
 The `Permission` field links each affordance to the corresponding
-entry in Claude Code's `permissions` allowlist (in `~/.claude/settings.json`
-or project `.claude/settings.local.json`). This pairing makes the
-governance loop explicit:
+entry in Claude Code's `permissions` allowlist. This pairing makes
+the governance loop explicit:
 
 - *Affordances declare what tools the agent should have access to.*
 - *Permissions enforce what tools the agent actually has access to.*
 
-A chained constraint can then verify the two are in sync — every
-declared affordance has a matching permission, every granted
-permission has a matching affordance entry. Affordances without
-permissions are dead inventory; permissions without affordances are
-ungoverned grants.
+Two chained constraints verify the pairing; see Chained Constraints
+below.
 
-**Invoked by — auto-populated, not hand-maintained:**
+**Re-validation procedure** *(per O11)*:
 
-The `Invoked by` field is populated by Claude Code at runtime, not
-edited by hand. Implementation outline (deferred to a separate spec):
-a SessionEnd hook records `(tool_name, invoking_agent_or_command)`
-tuples for the session; a periodic reconciler (weekly GC) updates the
-`Invoked by` list in `HARNESS.md` from the accumulated record. This
-keeps the field accurate as the agent ecosystem evolves and prevents
-the drift that hand-maintained lists always suffer from.
+`Last reviewed` is bumped only by `/harness-affordance review
+<name>`, which walks through three concrete checks interactively:
 
-The trade-off: the affordance section becomes partially machine-
-written, which conflicts with the harness principle of "humans own
-HARNESS.md." Mitigation: the reconciler only updates the `Invoked by`
-sub-line of an existing affordance entry; it never adds, removes, or
-modifies any other field. Humans still control which affordances
-exist and how they are described.
+1. **Identity check.** The Identity claim still matches reality.
+   For `runtime-resolved`, the resolution chain has not changed.
+   For fixed identity values, the named credential still exists
+   and still belongs to the named principal.
+2. **Audit Trail check.** The audit log endpoint exists, retention
+   matches what is stated, access scope holds. For `none`, confirm
+   no audit log has been added since last review.
+3. **Permission check.** The recorded permission pattern is still
+   present in `settings.json` (or the relevant settings layer).
+
+Editing other fields — Notes, Constraint references — does *not*
+bump Last Reviewed. This separates re-validation from routine
+editing and prevents the staleness GC rule from degenerating into
+a `git log` mtime check.
 
 ### Chained Constraints
 
-The new shape this introduces: constraints that reason about the
-affordance inventory rather than about code or process. Examples that
-become writable once affordances exist:
+The new shape this section introduces: constraints that reason about
+the affordance inventory rather than about code or process.
 
-- *"Every affordance must have a matching `Permission` entry in
-  `settings.json` / `.claude/settings.local.json`; every permission
-  allowlist entry must have a matching affordance."* — closes the
-  declaration-vs-enforcement loop. Deterministic.
-- *"Every affordance with `Audit trail: none` must have a matching
-  GC rule that captures usage in `observability/`."* — agent-enforced.
-- *"Affordances with `Identity: user-sso` may not be invoked by agents
-  that also have `Identity: service-account` affordances."* — prevents
-  privilege confusion. Deterministic.
-- *"Every affordance must show at least one auto-populated `Invoked
-  by` consumer within 30 days of declaration; an affordance with no
-  observed invocations is dead inventory and should be removed or
-  documented as latent."* — GC rule, monthly.
-- *"Every affordance's `Last reviewed` date must be within the last 6
-  months; stale entries flagged for re-validation."* — GC rule,
-  weekly.
+The two load-bearing constraints — different severities, asymmetric
+treatment per O9 — are:
+
+- **Affordance-without-permission (blocking).** Every affordance in
+  HARNESS.md must have a matching `Permission` entry in
+  `settings.json` or `.claude/settings.local.json`. An affordance
+  that lacks a permission means the agent has declared a tool it
+  cannot actually invoke — likely either the permission was removed
+  without reviewing the affordance, or the affordance was declared
+  without authorising it. Both are real safety concerns.
+  *Deterministic, blocking.*
+- **Permission-without-affordance (advisory).** Every entry in the
+  permissions allowlist should have a matching affordance. A
+  permission without an affordance is paperwork debt — the grant
+  exists, the governance metadata is missing. Optionally enforce a
+  30-day deadline to either declare an affordance or revoke the
+  permission. *Deterministic, advisory.*
+
+Other examples that become writable once affordances exist:
+
+- *"Every affordance with `Audit trail: none` must be declared in
+  the project's REFLECTION_LOG within 30 days, or be linked to a
+  GC rule that captures usage in `observability/`."* —
+  agent-enforced.
+- *"Affordances with `Identity: user-sso` may not be invoked by
+  agents that also have `Identity: service-account` affordances."*
+  — prevents privilege confusion. Deterministic.
+- *"No `Mode: hook` affordance with `Trigger: PreToolUse` may have
+  `Audit trail: none`."* — pre-tool hooks affect every tool
+  invocation; auditless ones are too dangerous to ship without
+  governance attention.
+- *"Every affordance's `Last reviewed` date must be within the last
+  6 months; stale entries flagged for re-validation via
+  `/harness-affordance review`."* — GC rule, weekly.
+- *"The runtime invocation file
+  `observability/affordance-invocations.json` must be no more than
+  N days stale."* — proxy for whether the runtime tuple recorder is
+  operational.
 
 These are not implemented in this spec; they are exemplars that
 motivate the section's existence.
 
-### The `/harness-affordance` Command
+### The `/harness-affordance` command
 
-Mirrors the `/harness-constrain` and `/governance-constrain` pattern:
+Mirrors the `/harness-constrain` and `/governance-constrain`
+pattern. Three subcommands: `discover`, `add`, `review`.
+
+**`/harness-affordance discover`** — produces a draft affordance
+inventory from existing config:
 
 ```text
-1. Detect or accept tool name (--name flag, or interactive prompt)
-2. Ask Mode (with definitions)
-3. Ask Identity (with definitions and load-bearing-question framing)
-4. Ask Audit Trail (with explicit "none is fine" guidance)
-5. Ask Permission — propose the matching pattern from settings.json
-   if one exists; warn if no permission entry covers the proposed
-   tool (the affordance would be ungranted at runtime)
-6. Set Last Reviewed to today's date automatically
-7. Skip Invoked By — leave it as a placeholder *(auto-populated by
-   runtime reconciler; never authored by hand)*
-8. Optional: Constraint References, Notes
-9. Validate: no duplicate name; required fields present; mode/identity
-   pairing makes sense (warn if `central-mcp` + `none` identity);
-   permission pattern actually exists in some settings.json file
-10. Append to HARNESS.md `## Affordances` section
-11. Suggest next:
-    - "Add a constraint that references this affordance?" →
-      `/harness-constrain` pre-filled with the affordance name
-    - If no Permission entry matched: "Add a permission allowlist
-      entry that authorises this affordance?" → guided edit of
-      settings.json
+1. Read all four sources: ~/.claude/settings.json,
+   .claude/settings.local.json, .mcp.json, agent frontmatter
+   (tools: lists), and hook scripts
+2. For each permission pattern, hook trigger entry, and MCP
+   server declaration: emit a draft affordance entry with Mode,
+   Trigger (where applicable), Permission, and a *placeholder*
+   for the human-owned fields (Identity, Audit Trail, Notes)
+3. Write the draft to a scratch file (e.g.
+   .claude/affordance-discovery-<date>.md), NOT to HARNESS.md
+4. Diff against the current ## Affordances section in HARNESS.md
+   if one exists; flag new permissions (would add an entry),
+   removed permissions (would remove an entry), and unchanged
+   ones
+5. Suggest: "Run /harness-affordance add <name> to copy a draft
+   entry into HARNESS.md and fill in governance metadata"
 ```
 
-### Sequencing
+**`/harness-affordance add <name>`** — guided annotation:
 
-1. **This spec.** Get the schema and the chained-constraint pattern
-   reviewed before any code lands.
-2. **Section + template.** Add `## Affordances` to `templates/HARNESS.md`
-   with 3-4 example entries and the schema in comments. Bumps minor.
-3. **`/harness-affordance` command.** Guided authoring with a
-   permission-pattern proposal step. Bumps minor.
-4. **First chained constraint: declaration vs enforcement.** Adopt
-   *"Every affordance has a matching `Permission` entry in some
-   `settings.json`; every permission allowlist entry has a matching
-   affordance entry."* This is the proof-of-concept for the chained-
-   constraint pattern and gives the section concrete enforcement
-   value from day one.
-5. **Last-reviewed staleness GC rule.** *"Every affordance's `Last
-   reviewed` date must be within 6 months."* Weekly check.
-6. **Auto-population of `Invoked by`.** Separate spec — adds a
-   SessionEnd hook that records `(tool, invoker)` tuples and a
-   reconciler GC that updates the `Invoked by` line in
-   `HARNESS.md`. Includes the human-control mitigation (reconciler
-   only touches the `Invoked by` sub-line, never any other field).
-7. **`/harness-affordance audit`.** GC rule that compares declared
-   affordances against actual settings (`.mcp.json`, hook scripts,
-   agent `tools:` frontmatter) and flags drift. Deferred.
-8. **Discovery automation.** `/harness-affordance discover` that
-   scans config and proposes entries. Deferred until manual format is
-   stable.
+```text
+1. If a draft entry exists in the discovery scratch file, use it
+   as the starting point; otherwise prompt for Mode, Trigger
+   (if Mode=hook), and Permission
+2. Ask Identity (with five-value definitions and load-bearing-
+   question framing); for runtime-resolved, prompt for the
+   resolution chain narrative
+3. Ask Audit Trail (with explicit "none is fine" guidance)
+4. Set Last Reviewed to today's date automatically
+5. Optional: Constraint References, Notes
+6. Validate: no duplicate name; required fields present; mode/
+   trigger pairing valid (Trigger only for Mode=hook); permission
+   pattern actually exists in some settings.json file
+7. Append to HARNESS.md ## Affordances section
+8. Suggest: "Add a constraint that references this affordance?"
+   → /harness-constrain pre-filled with the affordance name
+```
 
-Each step is a separate PR. Steps 2-5 could ship together as a single
-minor version (proposed `0.28.0` once this spec is approved). Step 6
-is a meaningful change in how `HARNESS.md` is maintained (machine-
-written sub-fields) and warrants its own spec PR before
-implementation.
+**`/harness-affordance review <name>`** — re-validation:
+
+```text
+1. Walk the user through the three re-validation checks
+   (Identity, Audit Trail, Permission); prompt for each:
+   "still correct?" → yes/no/needs-edit
+2. For any "needs-edit" answer, open the field for inline edit
+3. If all three pass, bump Last Reviewed to today's date
+4. If any check fails the user cannot fix in-session, leave
+   Last Reviewed unchanged and add a Notes line describing the
+   gap (so the staleness GC rule continues to fire)
+```
+
+### Sequencing *(restructured per O2 and O8)*
+
+1. **This spec.** Get the schema, the chained-constraint pattern,
+   and the discovery-first architecture reviewed before any code
+   lands.
+2. **Discovery scanner — `/harness-affordance discover`.** Reads
+   existing config, emits draft inventory to a scratch file. This
+   is also the **backfill path for existing harness adopters** — a
+   project with a populated `.claude/settings.local.json` runs the
+   scanner once and gets a draft for every existing permission.
+   Bumps minor.
+3. **Section + template + annotation command.** Add `## Affordances`
+   to `templates/HARNESS.md` with comments and the schema; ship
+   `/harness-affordance add` for guided annotation. Bumps minor.
+4. **First chained constraint: affordance-without-permission
+   (blocking).** Adopt the asymmetric pair (per O9). Ships
+   `unverified` until the project has run discovery + annotation
+   at least once; then graduates to `deterministic`. Bumps minor.
+5. **Second chained constraint: permission-without-affordance
+   (advisory).** Same pattern, advisory severity, optional 30-day
+   deadline.
+6. **Re-validation command — `/harness-affordance review`.** Plus
+   the staleness GC rule keying on Last Reviewed dates.
+7. **Runtime tuple recorder.** *Separate spec, separate PR.* Adds
+   a SessionEnd hook that writes
+   `observability/affordance-invocations.json`; HARNESS.md is
+   never written by this mechanism. The chained constraint that
+   keys on the file's freshness ships in the same PR.
+8. **Discovery automation in CI.** Adds a GC rule that runs
+   `/harness-affordance discover` and fails if any new draft
+   entries exist that have not been promoted to HARNESS.md.
+
+Steps 2-6 could ship together as a single minor version bump
+(proposed `0.28.0` once this spec is approved); steps 7 and 8 each
+warrant their own spec.
 
 ## Components
 
 | Component | Type | Effort | Sequencing step |
 | --- | --- | --- | --- |
-| `templates/HARNESS.md` `## Affordances` section + comments | template | XS | 2 |
-| `commands/harness-affordance.md` | command | S | 3 |
-| Update `commands/harness-init.md` to surface affordances during init | command | XS | 2 |
-| Update `commands/harness-status.md` to count affordances | command | XS | 2 |
-| Update `commands/harness-audit.md` to report affordance count + drift | command | S | 7 |
-| Two chained constraints in `templates/HARNESS.md` (declaration-vs-enforcement + last-reviewed staleness) | template | XS | 4-5 |
-| Runtime tuple recorder (SessionEnd hook) | hook | M | 6 |
-| `Invoked by` reconciler (GC rule with HARNESS.md write access) | hook + GC | M | 6 |
-| `docs/explanation/harness-affordances.md` (why this exists) | docs | S | 2 |
-| `docs/how-to/declare-an-affordance.md` (using the command) | docs | XS | 3 |
-| `docs/reference/affordance-schema.md` (field-by-field reference) | docs | S | 2 |
+| `templates/HARNESS.md` `## Affordances` section + comments | template | XS | 3 |
+| `commands/harness-affordance.md` (`discover` / `add` / `review` subcommands) | command | M | 2-6 |
+| Discovery scanner script (reads settings.json, .mcp.json, agent frontmatter, hook configs) | bash | M | 2 |
+| Update `commands/harness-init.md` to surface affordances during init | command | XS | 3 |
+| Update `commands/harness-status.md` to count affordances | command | XS | 3 |
+| Update `commands/harness-audit.md` to report affordance count + drift via discovery diff | command | S | 8 |
+| Two chained constraints in `templates/HARNESS.md` (asymmetric: blocking + advisory) | template | XS | 4-5 |
+| One staleness GC rule in `templates/HARNESS.md` (keyed on Last Reviewed) | template | XS | 6 |
+| `docs/explanation/harness-affordances.md` (why this exists, the contractor scenario, the source-of-truth split) | docs | S | 3 |
+| `docs/how-to/declare-an-affordance.md` (using the three subcommands) | docs | XS | 3 |
+| `docs/reference/affordance-schema.md` (field-by-field reference) | docs | S | 3 |
+
+Notably absent from this spec's components (deferred to step 7's
+separate spec): the runtime tuple recorder hook, any reconciler that
+writes into HARNESS.md, and the `Invoked by` field that previously
+required them.
 
 ## Dependencies
 
 - **CLAUDE.md "Docs Site Review" convention** (already in place):
   every plugin behaviour change must come with docs updates in the
   same PR.
-- **`/harness-constrain` pattern** (already in place): the new command
-  follows the same interaction shape so users do not have to learn a
-  new mental model.
-- **No new external libraries.** Pure markdown + bash, like the rest
-  of the plugin.
+- **`/harness-constrain` pattern** (already in place): the new
+  command follows the same interaction shape so users do not have
+  to learn a new mental model.
+- **No new external libraries.** Pure markdown + bash, like the
+  rest of the plugin.
 
 ## Resolved Design Decisions
 
-The following questions were raised during initial design and resolved
-before this spec went to PR. Captured here as a record of *why* the
-schema looks the way it does, so future readers do not re-litigate
-without context.
+The following were resolved during initial design discussion or via
+the `/diaboli` adjudication trail. Captured here as a record of
+*why* the schema looks the way it does, so future readers do not
+re-litigate without context.
 
 1. **Mode retained.** Identity is load-bearing for governance, but
    Mode helps onboarding reviewers categorise the inventory at a
@@ -363,48 +551,87 @@ without context.
 
 2. **Permissions are the enforcement layer; affordances are the
    declaration layer.** Each affordance has a `Permission` field
-   linking to the matching pattern in `settings.json` /
-   `.claude/settings.local.json`. A chained constraint verifies
-   declaration and enforcement match: every affordance has a
-   permission, every permission has an affordance. This is the most
-   load-bearing design decision in the spec — it gives the section
-   a concrete enforcement loop instead of leaving it as documentation
-   only.
+   linking to the matching pattern in settings.json. Two chained
+   constraints verify declaration and enforcement match — the
+   asymmetric pair per Decision 11 below.
 
-3. **`Invoked by` is auto-populated, never hand-maintained.** Claude
-   Code records `(tool, invoking_agent_or_command)` tuples at runtime
-   (likely via a SessionEnd hook) and a periodic reconciler updates
-   the `Invoked by` line in HARNESS.md. The reconciler only touches
-   the `Invoked by` sub-line of an existing affordance; it never adds,
-   removes, or modifies any other field. Humans still own which
-   affordances exist; runtime owns which agents actually use them.
-   Implementation outline deferred to a follow-up spec.
+3. **Hook scripts are first-class affordance entries, with
+   `Trigger`** *(per O12)*. Each hook gets its own entry with
+   `Mode: hook` and a required `Trigger` field naming the Claude
+   Code event. A single script wired to two events is two
+   affordance entries differentiated by Trigger. If a hook invokes
+   a CLI internally, the CLI is *also* a separate affordance.
 
-4. **Hook scripts are first-class affordance entries.** Each hook
-   gets its own entry with `Mode: hook`. If a hook invokes a CLI
-   internally (e.g. an `rsync` call from a Stop hook), the CLI is
-   *also* a separate affordance entry. The hook is the surface the
-   agent triggers; the CLI is the underlying capability. Both deserve
-   independent governance attention.
+4. **`current-user` covers ephemeral local actions.** No `intrinsic`
+   value is needed; the current user IS the intrinsic identity for
+   filesystem reads, `git status`, local network calls, etc.
 
-5. **`current-user` covers ephemeral local actions; no `intrinsic`
-   value needed.** The current user IS the intrinsic identity for
-   filesystem reads, `git status`, local network calls, etc. The
-   schema uses `current-user` as the value (clearer than the original
-   `process-owner` proposal) and leaves `none` for true zero-boundary
-   actions like pure local computation.
+5. **`Last reviewed` field added per affordance, with a defined
+   re-validation procedure** *(per O11)*. Three checks (Identity,
+   Audit Trail, Permission) all pass before Last Reviewed bumps;
+   only `/harness-affordance review` bumps the date.
 
-6. **`Last reviewed` field added per affordance.** Date-stamp every
-   entry. Pairs with a GC rule: "all affordances must be re-validated
-   within the last 6 months." This catches the failure mode where an
-   audit log changes (Honeycomb adds one, GitHub deprecates one) and
-   the affordance description silently goes stale.
+6. **A contractor scenario grounds the Problem** *(per O1)*. The
+   gap is concrete enough for a reader who has never run a
+   governance review on this codebase.
+
+7. **Discovery-first sequencing** *(per O2)*. Affordances are
+   observed artefacts, not authored ones — the inventory should
+   come from a scanner reading existing config; humans annotate
+   the draft with governance-only fields. Manual-first would have
+   incurred design cost twice (once for the manual schema, again
+   when discovery forced changes).
+
+8. **Runtime data lives in `observability/`, not in HARNESS.md**
+   *(per O3)*. The `Invoked by` field is removed from the schema;
+   runtime invocation tuples live in
+   `observability/affordance-invocations.json`, referenced by path
+   from the affordance section header. HARNESS.md remains 100%
+   human-authored as a structural invariant, not a behavioural
+   convention.
+
+9. **Granularity rule: one affordance per permission pattern**
+   *(per O4)*. `Bash(gh *)` is one affordance, `Bash(gh pr *)` is
+   another. Same-CLI-different-identity is one entry with
+   `Identity: runtime-resolved` and a Notes field explaining the
+   resolution chain.
+
+10. **Matching algorithm: string equality on permission pattern**
+    *(per O5)*. Broader patterns subsume narrower invocations
+    rather than producing separate entries. No subset reasoning,
+    no wildcard expansion.
+
+11. **Chained constraints are split asymmetrically** *(per O9)*.
+    Affordance-without-permission is blocking (real safety
+    concern); permission-without-affordance is advisory (paperwork
+    debt). Two constraints, two severities.
+
+12. **Five Identity values** *(per O7)*. `user-sso` /
+    `service-account` / `current-user` / `runtime-resolved` /
+    `none`. The `runtime-resolved` value handles tools whose
+    identity depends on session config (gh, aws, kubectl).
+
+13. **Discovery scanner is the backfill path** *(per O8)*.
+    Existing harness adopters get a draft inventory the moment
+    they run `/harness-affordance discover`. The chained
+    constraints ship `unverified` until the first review pass
+    completes.
+
+14. **The split between machine-owned source files and
+    human-owned governance metadata is intentional** *(per O10)*.
+    Tool surface metadata stays in source files (the discovery
+    scanner reads it); governance metadata lives in HARNESS.md
+    where reviewers already look. Co-locating governance prose
+    with source would fragment reviewer attention.
 
 ## Expected Outcome
 
 - A `HARNESS.md` reviewer can answer, in under 30 seconds: "What
   tools does the agent have, whose credentials run them, and where
   would I find an audit trail?"
+- The contractor scenario from the Problem section becomes a 30-
+  minute exercise instead of a four-hour one — the contractor reads
+  one section instead of grepping six file types.
 - A new constraint that says "production-affecting actions require
   human review" becomes meaningfully enforceable, because
   "production-affecting" can be defined as "any affordance with
@@ -412,44 +639,56 @@ without context.
   `release-traceability`."
 - Governance debt around "no audit trail" becomes visible and
   countable rather than buried in config files.
-- Template projects that adopt the plugin get an affordance scaffold
-  during `/harness-init` and a guided way to populate it.
+- Existing harness adopters get a backfill path on day one
+  (`/harness-affordance discover` produces a draft from current
+  config); new adopters get the same scaffold via `/harness-init`.
 
 ## Version Impact
 
-If this spec is approved and Sequencing steps 2-4 ship together:
+If this spec is approved and Sequencing steps 2-6 ship together:
 
 - Minor bump (proposed `0.28.0`)
 - New section in `templates/HARNESS.md`
-- New command `commands/harness-affordance.md`
-- Updates to `commands/harness-init.md`, `commands/harness-status.md`,
-  `commands/harness-audit.md`
+- New command `commands/harness-affordance.md` with three
+  subcommands
+- New discovery scanner bash script under `scripts/`
+- Updates to `commands/harness-init.md`, `commands/harness-status.md`
+- Two new chained constraints + one staleness GC rule in
+  `templates/HARNESS.md`
 - New docs pages under `docs/explanation/`, `docs/how-to/`,
   `docs/reference/`
 - CHANGELOG entry under new heading
 
-Discovery automation (Sequencing step 6) would be a separate later
-minor bump.
+Steps 7 (runtime tuple recorder) and 8 (discovery-in-CI) each
+warrant their own spec PR with their own version bumps.
 
 ## Exemptions
 
-None requested. This is a normal feature spec; the implementation PR(s)
-will need spec-mode and code-mode objection records per the standard
-adjudicated-objections constraint.
+None requested. This is a normal feature spec; the implementation
+PR(s) will need spec-mode and code-mode objection records per the
+standard adjudicated-objections constraint.
 
 ## Intellectual Foundations
 
 - **Capability-based security.** Treating tool affordances as
-  declared capabilities — not ambient grants — makes the principle of
-  least privilege legible at the governance layer rather than only at
-  the runtime layer.
+  declared capabilities — not ambient grants — makes the principle
+  of least privilege legible at the governance layer rather than
+  only at the runtime layer.
 - **Identity-aware computing.** Audit and accountability collapse
   when actions cannot be attributed back to a real principal. The
   `Identity` field forces that question to be answered, not assumed.
-- **Honest debt accounting.** Per the harness-engineering tradition,
-  the section is most valuable when it lets people record `none` for
-  audit trail without flinching. The visibility is the point.
-- **Declarative inventory + chained constraints** is the same pattern
-  as governance-constraint design (declare the requirement, attach
-  enforcement, periodic re-review). The harness already has the
-  scaffolding; affordances reuse it rather than invent something new.
+- **Source-of-truth normalisation.** Each piece of data has one
+  authoritative location. Tool surface metadata lives in source
+  files (the discovery scanner reads it from there); governance
+  metadata lives in HARNESS.md (humans write it there). The two
+  layers compose via the discovery scanner; neither duplicates the
+  other.
+- **Honest debt accounting.** Per the harness-engineering
+  tradition, the section is most valuable when it lets people
+  record `none` for audit trail without flinching. The visibility
+  is the point.
+- **Declarative inventory + chained constraints** is the same
+  pattern as governance-constraint design (declare the requirement,
+  attach enforcement, periodic re-review). The harness already has
+  the scaffolding; affordances reuse it rather than invent
+  something new.

--- a/docs/superpowers/specs/2026-04-26-harness-affordances-design.md
+++ b/docs/superpowers/specs/2026-04-26-harness-affordances-design.md
@@ -1,0 +1,455 @@
+---
+name: harness-affordances-design
+description: Design spec for an Affordances section in HARNESS.md that declares the agent's tool inventory (MCP / CLI), the identity each tool runs under, and the audit trail each tool produces — making implicit capability surface a first-class governance concern
+date: 2026-04-26
+status: draft
+---
+
+# Harness Affordances — Design Spec
+
+## Problem
+
+`HARNESS.md` today tells agents three things: what conventions exist
+(Context), what must be true (Constraints), and what periodic checks
+fight entropy (Garbage Collection). It does not tell anyone — human
+or agent — *what tools the agent has been granted, under whose
+authority each tool executes, and what record (if any) is left behind
+when the agent uses one*.
+
+That information exists somewhere. It is spread across:
+
+- `~/.claude/settings.json` (user-level MCP servers, permissions)
+- Project `.claude/settings.local.json` (project-level allowlists,
+  hooks)
+- Project `.mcp.json` (MCP server declarations)
+- Shell environment (`GITHUB_TOKEN`, `HONEYCOMB_API_KEY`, etc.)
+- Hook scripts in `ai-literacy-superpowers/hooks/scripts/`
+- Agent definitions (`agents/*.agent.md` `tools:` frontmatter)
+
+It is *implicit*. None of those locations are read by humans during
+governance review. None of them surface the questions a reviewer
+needs to ask:
+
+- When the agent runs `gh pr merge`, whose credentials authorise it?
+- When the agent queries Honeycomb via MCP, who owns the API key?
+  Where is the query logged?
+- When the agent invokes a local MCP that wraps a remote service, is
+  the boundary between local execution and remote API call observable?
+- If an audit asked "show me everything the agent did this quarter
+  under my SSO," could we answer?
+
+Today the answer to each of those is "you'd have to grep
+several config files and reverse-engineer it." That is governance
+debt.
+
+The deeper failure mode this enables: **agents executing under shared
+or escalated identity without that fact being visible at governance
+review time**. A constraint like "all production-affecting actions
+require human review" is unenforceable if no one knows which actions
+are production-affecting — which depends on which identity executes
+them.
+
+## Goals
+
+1. Make the agent's tool inventory **declarative and versioned** in
+   `HARNESS.md` alongside Context, Constraints, and Garbage Collection.
+2. Surface **Identity** as a first-class field — *whose credentials does
+   this tool run under?* — because identity, not transport, is the load-
+   bearing governance question.
+3. Surface **Audit Trail** as a first-class field — *where would you
+   find a record of what the agent did with this tool?* — including the
+   honest answer "nowhere" when that is the case.
+4. Enable **chained constraints** that reason about the affordance
+   inventory ("every tool with `audit-trail: none` must have a
+   matching GC capture rule" / "tools running under shared service
+   accounts require an extra reviewer").
+5. Provide a **guided authoring command** (`/harness-affordance`) that
+   matches the existing `/harness-constrain` and `/governance-constrain`
+   pattern — interactive, no manual YAML editing required for routine
+   declarations.
+
+## Non-Goals
+
+- **Automated discovery** — scanning `~/.claude/settings.json`,
+  `.mcp.json`, and shell env to populate the section. Discovery is
+  valuable but is a separate workstream; the format must prove itself
+  with manual declaration first. (See "Sequencing" below.)
+- **Replacing or duplicating Cost Tracking or Model Routing.**
+  Affordances declare the tool inventory; cost-tracking and model-
+  routing reason about that inventory. Avoid restating per-tool cost
+  or model assignments in the affordance entry.
+- **Tool capability discovery.** This spec does not catalogue what
+  each MCP server *can do* (its method list). It catalogues that the
+  agent *can reach* it, under what identity, with what audit trail.
+- **Permission enforcement at runtime.** Existing Claude Code
+  permission prompts and hooks already handle that. Affordances are
+  for governance review, not runtime gating.
+
+## Design
+
+### The Affordance Block in HARNESS.md
+
+A new top-level section, sibling to `## Constraints` and `## Garbage
+Collection`:
+
+```markdown
+## Affordances
+
+<!-- Each entry declares one tool the agent can invoke. Identity is
+     the load-bearing governance question — whose credentials authorise
+     the action. Audit Trail's honest answer "none" is itself useful
+     governance signal. -->
+
+### gh-cli
+
+- **Mode**: cli
+- **Identity**: user-sso (GitHub PAT in $GITHUB_TOKEN)
+- **Audit trail**: github-audit (org audit log, 90-day retention,
+  admin-only access)
+- **Permission**: `Bash(gh *)` (allowlist in `.claude/settings.local.json`)
+- **Invoked by**: orchestrator, integration-agent, harness-enforcer
+  *(auto-populated)*
+- **Last reviewed**: 2026-04-26
+- **Constraint references**: spec-first-commit-ordering,
+  release-traceability
+
+### honeycomb-mcp
+
+- **Mode**: central-mcp (api.honeycomb.io)
+- **Identity**: service-account (HONEYCOMB_API_KEY shared across team)
+- **Audit trail**: honeycomb-query-log (per-team, 30-day retention,
+  team-admin access)
+- **Permission**: `mcp__honeycomb__*` (allowlist in user `~/.claude/settings.json`)
+- **Invoked by**: honeycomb-investigator, instrumentation-advisor
+  *(auto-populated)*
+- **Last reviewed**: 2026-04-26
+
+### shell-write-to-tmp
+
+- **Mode**: cli
+- **Identity**: current-user (the human running the Claude Code session)
+- **Audit trail**: none
+- **Permission**: `Bash(echo *)`, `Bash(touch *)` (allowlist)
+- **Invoked by**: harness-gc, observatory-verify *(auto-populated)*
+- **Last reviewed**: 2026-04-26
+- **Notes**: ephemeral session-local writes; if persistence is required,
+  promote to a tracked artefact
+
+### sync-to-global-cache-hook
+
+- **Mode**: hook
+- **Identity**: current-user
+- **Audit trail**: none (hook stderr, lost at session end)
+- **Permission**: configured in `.claude/settings.local.json` `hooks.Stop`
+- **Invoked by**: Claude Code runtime (Stop event) *(auto-populated)*
+- **Last reviewed**: 2026-04-26
+- **Notes**: invokes `rsync` under the current user; rsyncs plugin
+  content into `~/.claude/plugins/cache/` after every session
+
+---
+```
+
+### Field Schema
+
+| Field | Required | Source | Values |
+| --- | --- | --- | --- |
+| `Mode` | yes | declared | `local-mcp` / `central-mcp` / `cli` / `hook` |
+| `Identity` | yes | declared | `user-sso` / `service-account` / `current-user` / `none` (with optional detail in parens) |
+| `Audit trail` | yes | declared | named log/store with retention + access scope, or `none` |
+| `Permission` | yes | declared | the matching pattern from `settings.json` / `.claude/settings.local.json` `permissions` allowlist that authorises this affordance at runtime |
+| `Invoked by` | yes | **auto-populated** | comma-separated list of agents or commands that invoked this tool, observed at runtime by Claude Code; declared affordances with no observed invocations are flagged by GC |
+| `Last reviewed` | yes | declared | YYYY-MM-DD; the date this affordance entry was last validated against reality (Identity correct, Audit trail still works, Permission still in settings) |
+| `Constraint references` | optional | declared | constraints in HARNESS.md that depend on this affordance |
+| `Notes` | optional | declared | freeform context the schema does not capture |
+
+**Mode values explained:**
+
+- `local-mcp` — MCP server running on the user's machine (local
+  process, may call out to remote APIs)
+- `central-mcp` — MCP server hosted remotely (e.g. by the tool
+  provider)
+- `cli` — shell command invoked by the agent (`gh`, `git`, `npx`,
+  custom scripts)
+- `hook` — Claude Code hook script (PreToolUse, PostToolUse, Stop,
+  etc.) registered in `settings.json`. Each hook is its own
+  affordance entry; if a hook invokes a CLI internally, the CLI is
+  *also* an affordance entry — the hook is the surface the agent
+  triggers, the CLI is the underlying capability.
+
+**Identity values explained:**
+
+- `user-sso` — uses the human user's *external* SSO credentials
+  (their GitHub PAT, their Slack token, their cloud SSO). Actions
+  appear in remote audit logs as if the user did them. **Highest-
+  attribution failure mode.**
+- `service-account` — uses dedicated bot credentials shared across
+  the team or pinned to the project (CI tokens, shared API keys).
+  Actions appear in audit logs as the service account; per-user
+  attribution is lost.
+- `current-user` — the human running the Claude Code session, with
+  no special credentials and no boundary crossing. Filesystem reads
+  and writes, local network, `git status`, etc. This is the default
+  for most local CLI affordances and is distinct from `none`: a
+  `current-user` action is still attributable to a real principal,
+  even if there is no remote audit trail.
+- `none` — no authentication boundary crossed at all (pure local
+  computation, no filesystem effects, no network).
+
+**Audit trail values:**
+
+Free-text but should follow the pattern `<source>: <retention>,
+<access scope>`. The honest answer `none` is encouraged and is itself
+governance signal — it tells reviewers where the gaps are without
+forcing fabrication.
+
+**Permission and the enforcement loop:**
+
+The `Permission` field links each affordance to the corresponding
+entry in Claude Code's `permissions` allowlist (in `~/.claude/settings.json`
+or project `.claude/settings.local.json`). This pairing makes the
+governance loop explicit:
+
+- *Affordances declare what tools the agent should have access to.*
+- *Permissions enforce what tools the agent actually has access to.*
+
+A chained constraint can then verify the two are in sync — every
+declared affordance has a matching permission, every granted
+permission has a matching affordance entry. Affordances without
+permissions are dead inventory; permissions without affordances are
+ungoverned grants.
+
+**Invoked by — auto-populated, not hand-maintained:**
+
+The `Invoked by` field is populated by Claude Code at runtime, not
+edited by hand. Implementation outline (deferred to a separate spec):
+a SessionEnd hook records `(tool_name, invoking_agent_or_command)`
+tuples for the session; a periodic reconciler (weekly GC) updates the
+`Invoked by` list in `HARNESS.md` from the accumulated record. This
+keeps the field accurate as the agent ecosystem evolves and prevents
+the drift that hand-maintained lists always suffer from.
+
+The trade-off: the affordance section becomes partially machine-
+written, which conflicts with the harness principle of "humans own
+HARNESS.md." Mitigation: the reconciler only updates the `Invoked by`
+sub-line of an existing affordance entry; it never adds, removes, or
+modifies any other field. Humans still control which affordances
+exist and how they are described.
+
+### Chained Constraints
+
+The new shape this introduces: constraints that reason about the
+affordance inventory rather than about code or process. Examples that
+become writable once affordances exist:
+
+- *"Every affordance must have a matching `Permission` entry in
+  `settings.json` / `.claude/settings.local.json`; every permission
+  allowlist entry must have a matching affordance."* — closes the
+  declaration-vs-enforcement loop. Deterministic.
+- *"Every affordance with `Audit trail: none` must have a matching
+  GC rule that captures usage in `observability/`."* — agent-enforced.
+- *"Affordances with `Identity: user-sso` may not be invoked by agents
+  that also have `Identity: service-account` affordances."* — prevents
+  privilege confusion. Deterministic.
+- *"Every affordance must show at least one auto-populated `Invoked
+  by` consumer within 30 days of declaration; an affordance with no
+  observed invocations is dead inventory and should be removed or
+  documented as latent."* — GC rule, monthly.
+- *"Every affordance's `Last reviewed` date must be within the last 6
+  months; stale entries flagged for re-validation."* — GC rule,
+  weekly.
+
+These are not implemented in this spec; they are exemplars that
+motivate the section's existence.
+
+### The `/harness-affordance` Command
+
+Mirrors the `/harness-constrain` and `/governance-constrain` pattern:
+
+```text
+1. Detect or accept tool name (--name flag, or interactive prompt)
+2. Ask Mode (with definitions)
+3. Ask Identity (with definitions and load-bearing-question framing)
+4. Ask Audit Trail (with explicit "none is fine" guidance)
+5. Ask Permission — propose the matching pattern from settings.json
+   if one exists; warn if no permission entry covers the proposed
+   tool (the affordance would be ungranted at runtime)
+6. Set Last Reviewed to today's date automatically
+7. Skip Invoked By — leave it as a placeholder *(auto-populated by
+   runtime reconciler; never authored by hand)*
+8. Optional: Constraint References, Notes
+9. Validate: no duplicate name; required fields present; mode/identity
+   pairing makes sense (warn if `central-mcp` + `none` identity);
+   permission pattern actually exists in some settings.json file
+10. Append to HARNESS.md `## Affordances` section
+11. Suggest next:
+    - "Add a constraint that references this affordance?" →
+      `/harness-constrain` pre-filled with the affordance name
+    - If no Permission entry matched: "Add a permission allowlist
+      entry that authorises this affordance?" → guided edit of
+      settings.json
+```
+
+### Sequencing
+
+1. **This spec.** Get the schema and the chained-constraint pattern
+   reviewed before any code lands.
+2. **Section + template.** Add `## Affordances` to `templates/HARNESS.md`
+   with 3-4 example entries and the schema in comments. Bumps minor.
+3. **`/harness-affordance` command.** Guided authoring with a
+   permission-pattern proposal step. Bumps minor.
+4. **First chained constraint: declaration vs enforcement.** Adopt
+   *"Every affordance has a matching `Permission` entry in some
+   `settings.json`; every permission allowlist entry has a matching
+   affordance entry."* This is the proof-of-concept for the chained-
+   constraint pattern and gives the section concrete enforcement
+   value from day one.
+5. **Last-reviewed staleness GC rule.** *"Every affordance's `Last
+   reviewed` date must be within 6 months."* Weekly check.
+6. **Auto-population of `Invoked by`.** Separate spec — adds a
+   SessionEnd hook that records `(tool, invoker)` tuples and a
+   reconciler GC that updates the `Invoked by` line in
+   `HARNESS.md`. Includes the human-control mitigation (reconciler
+   only touches the `Invoked by` sub-line, never any other field).
+7. **`/harness-affordance audit`.** GC rule that compares declared
+   affordances against actual settings (`.mcp.json`, hook scripts,
+   agent `tools:` frontmatter) and flags drift. Deferred.
+8. **Discovery automation.** `/harness-affordance discover` that
+   scans config and proposes entries. Deferred until manual format is
+   stable.
+
+Each step is a separate PR. Steps 2-5 could ship together as a single
+minor version (proposed `0.28.0` once this spec is approved). Step 6
+is a meaningful change in how `HARNESS.md` is maintained (machine-
+written sub-fields) and warrants its own spec PR before
+implementation.
+
+## Components
+
+| Component | Type | Effort | Sequencing step |
+| --- | --- | --- | --- |
+| `templates/HARNESS.md` `## Affordances` section + comments | template | XS | 2 |
+| `commands/harness-affordance.md` | command | S | 3 |
+| Update `commands/harness-init.md` to surface affordances during init | command | XS | 2 |
+| Update `commands/harness-status.md` to count affordances | command | XS | 2 |
+| Update `commands/harness-audit.md` to report affordance count + drift | command | S | 7 |
+| Two chained constraints in `templates/HARNESS.md` (declaration-vs-enforcement + last-reviewed staleness) | template | XS | 4-5 |
+| Runtime tuple recorder (SessionEnd hook) | hook | M | 6 |
+| `Invoked by` reconciler (GC rule with HARNESS.md write access) | hook + GC | M | 6 |
+| `docs/explanation/harness-affordances.md` (why this exists) | docs | S | 2 |
+| `docs/how-to/declare-an-affordance.md` (using the command) | docs | XS | 3 |
+| `docs/reference/affordance-schema.md` (field-by-field reference) | docs | S | 2 |
+
+## Dependencies
+
+- **CLAUDE.md "Docs Site Review" convention** (already in place):
+  every plugin behaviour change must come with docs updates in the
+  same PR.
+- **`/harness-constrain` pattern** (already in place): the new command
+  follows the same interaction shape so users do not have to learn a
+  new mental model.
+- **No new external libraries.** Pure markdown + bash, like the rest
+  of the plugin.
+
+## Resolved Design Decisions
+
+The following questions were raised during initial design and resolved
+before this spec went to PR. Captured here as a record of *why* the
+schema looks the way it does, so future readers do not re-litigate
+without context.
+
+1. **Mode retained.** Identity is load-bearing for governance, but
+   Mode helps onboarding reviewers categorise the inventory at a
+   glance and is cheap to maintain. Both stay in the schema.
+
+2. **Permissions are the enforcement layer; affordances are the
+   declaration layer.** Each affordance has a `Permission` field
+   linking to the matching pattern in `settings.json` /
+   `.claude/settings.local.json`. A chained constraint verifies
+   declaration and enforcement match: every affordance has a
+   permission, every permission has an affordance. This is the most
+   load-bearing design decision in the spec — it gives the section
+   a concrete enforcement loop instead of leaving it as documentation
+   only.
+
+3. **`Invoked by` is auto-populated, never hand-maintained.** Claude
+   Code records `(tool, invoking_agent_or_command)` tuples at runtime
+   (likely via a SessionEnd hook) and a periodic reconciler updates
+   the `Invoked by` line in HARNESS.md. The reconciler only touches
+   the `Invoked by` sub-line of an existing affordance; it never adds,
+   removes, or modifies any other field. Humans still own which
+   affordances exist; runtime owns which agents actually use them.
+   Implementation outline deferred to a follow-up spec.
+
+4. **Hook scripts are first-class affordance entries.** Each hook
+   gets its own entry with `Mode: hook`. If a hook invokes a CLI
+   internally (e.g. an `rsync` call from a Stop hook), the CLI is
+   *also* a separate affordance entry. The hook is the surface the
+   agent triggers; the CLI is the underlying capability. Both deserve
+   independent governance attention.
+
+5. **`current-user` covers ephemeral local actions; no `intrinsic`
+   value needed.** The current user IS the intrinsic identity for
+   filesystem reads, `git status`, local network calls, etc. The
+   schema uses `current-user` as the value (clearer than the original
+   `process-owner` proposal) and leaves `none` for true zero-boundary
+   actions like pure local computation.
+
+6. **`Last reviewed` field added per affordance.** Date-stamp every
+   entry. Pairs with a GC rule: "all affordances must be re-validated
+   within the last 6 months." This catches the failure mode where an
+   audit log changes (Honeycomb adds one, GitHub deprecates one) and
+   the affordance description silently goes stale.
+
+## Expected Outcome
+
+- A `HARNESS.md` reviewer can answer, in under 30 seconds: "What
+  tools does the agent have, whose credentials run them, and where
+  would I find an audit trail?"
+- A new constraint that says "production-affecting actions require
+  human review" becomes meaningfully enforceable, because
+  "production-affecting" can be defined as "any affordance with
+  `Identity: user-sso` plus a `Constraint references` value of
+  `release-traceability`."
+- Governance debt around "no audit trail" becomes visible and
+  countable rather than buried in config files.
+- Template projects that adopt the plugin get an affordance scaffold
+  during `/harness-init` and a guided way to populate it.
+
+## Version Impact
+
+If this spec is approved and Sequencing steps 2-4 ship together:
+
+- Minor bump (proposed `0.28.0`)
+- New section in `templates/HARNESS.md`
+- New command `commands/harness-affordance.md`
+- Updates to `commands/harness-init.md`, `commands/harness-status.md`,
+  `commands/harness-audit.md`
+- New docs pages under `docs/explanation/`, `docs/how-to/`,
+  `docs/reference/`
+- CHANGELOG entry under new heading
+
+Discovery automation (Sequencing step 6) would be a separate later
+minor bump.
+
+## Exemptions
+
+None requested. This is a normal feature spec; the implementation PR(s)
+will need spec-mode and code-mode objection records per the standard
+adjudicated-objections constraint.
+
+## Intellectual Foundations
+
+- **Capability-based security.** Treating tool affordances as
+  declared capabilities — not ambient grants — makes the principle of
+  least privilege legible at the governance layer rather than only at
+  the runtime layer.
+- **Identity-aware computing.** Audit and accountability collapse
+  when actions cannot be attributed back to a real principal. The
+  `Identity` field forces that question to be answered, not assumed.
+- **Honest debt accounting.** Per the harness-engineering tradition,
+  the section is most valuable when it lets people record `none` for
+  audit trail without flinching. The visibility is the point.
+- **Declarative inventory + chained constraints** is the same pattern
+  as governance-constraint design (declare the requirement, attach
+  enforcement, periodic re-review). The harness already has the
+  scaffolding; affordances reuse it rather than invent something new.


### PR DESCRIPTION
## Summary

Spec-only PR for design review. Proposes adding a fourth top-level
section to \`HARNESS.md\` — \`## Affordances\` — that declares the
agent's tool inventory (CLI / local-MCP / central-MCP / hook), the
identity each tool runs under, the audit trail it produces, and the
permission allowlist that authorises it. Goal: make implicit
capability surface a first-class governance concern.

This PR contains:

- The original spec at \`docs/superpowers/specs/2026-04-26-harness-affordances-design.md\`
- A \`/diaboli\` spec-mode objection record at
  \`docs/superpowers/objections/harness-affordances-design.md\` with
  all 12 objections adjudicated (11 \`accept\`, 1 \`clarify\`, 0
  \`pending\`)

The spec-on-disk reflects the **original** design. The objection
record reflects the **agreed revisions**. A follow-up commit on
this branch will reconcile the two before merge.

## Three load-bearing structural changes (per accepted dispositions)

| ID | Change |
|---|---|
| O2 | **Flip sequencing to discovery-first.** Discovery scanner ships first (reads existing config — settings.json, .mcp.json, hook scripts, agent frontmatter — and produces a draft inventory); humans then annotate the draft with governance-only fields (Identity, Audit Trail, Last Reviewed). The original 'manual-first' framing was a design inversion: affordances are observed artefacts, not authored ones. |
| O3 | **Move runtime data out of HARNESS.md.** Runtime invocation tuples live in \`observability/affordance-invocations.json\`; the affordance section header references the file by path. HARNESS.md remains 100% human-authored — the 'humans own HARNESS.md' invariant becomes structural, not behavioural. The \`Invoked by\` field is removed from the schema. |
| O4 | **Granularity rule: one affordance per permission pattern.** \`Bash(gh *)\` is one affordance; \`Bash(gh pr *)\` is a separate, narrower affordance. MCP server with N tools = one affordance per \`mcp__server__*\` pattern. Makes the chained-constraint matching relation trivially deterministic (string equality, no subset reasoning). |

## Smaller revisions (also accepted)

| ID | Change |
|---|---|
| O1 | Add a contractor-onboarding scenario to the Problem section as concrete justification |
| O5 | State the matching algorithm explicitly (string equality on permission pattern) |
| O7 | Add a fifth Identity value \`runtime-resolved\` for tools whose identity depends on session config (\`gh\`, \`aws\`, \`kubectl\`) |
| O8 | Note that the discovery scanner IS the backfill path; constraint ships as \`unverified\` until first review pass |
| O9 | Split the symmetric chained constraint into two: affordance-without-permission (blocking) and permission-without-affordance (advisory) |
| O10 | Add a 'Why a separate section' subsection arguing the split between machine-owned source files and human-owned governance metadata |
| O11 | Define re-validation as three concrete checks (Identity, Audit Trail, Permission); date bumped only by \`/harness-affordance review\` subcommand |
| O12 | Add \`Trigger\` field for \`Mode: hook\` entries (PreToolUse / PostToolUse / Stop / etc.) |

## What does not change

The seven 'Explicitly not objecting to' items in the objection record
remain as-is: the four-then-five Identity values, the
\`/harness-affordance\` command following \`/harness-constrain\`
pattern, the 'audit-trail: none is encouraged' framing, retaining
Mode in the schema, naming the section 'Affordances', the per-server
(not per-method) MCP granularity, and the Intellectual Foundations.

## Why this PR is spec-only and not exempt

- Branch is \`spec/...\` not \`chore/...\` — this is feature work
- \`/diaboli\` spec-mode review has been run and adjudicated, so the
  spec-mode half of the 'PRs have adjudicated objections' constraint
  is satisfied
- Code-mode review will happen on the implementation PRs (one per
  Sequencing step) once this spec is approved and revised
- No plugin file changes — no version bump

## Test plan

- [x] Spec-first commit ordering: commit 1 contains only the spec file
- [x] \`/diaboli\` objection record present with 0 \`pending\`
  dispositions
- [x] \`npx markdownlint-cli2\` passes for both new files
- [ ] Spec revision commit lands before merge
- [ ] CI green