### PR TITLE
Implement /harness-affordance discover (v0.28.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.27.0",
+  "plugin_version": "0.28.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.27.0"
+      "version": "0.28.0"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Harness upgrade dismissal marker — local session state, not committed
 .claude/.harness-upgrade-dismissed
+
+# Discovery scanner output — per-session drafts that are reviewed and
+# (if approved) copied into HARNESS.md by hand. Never committed.
+.claude/affordance-discovery-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.28.0 — 2026-04-27
+
+### Feature — `/harness-affordance discover` (sequencing step 2 of harness-affordances)
+
+- Add `commands/harness-affordance.md` — parent command for the
+  affordance inventory workflow with three subcommands: `discover`
+  (implemented), `add` (planned, sequencing step 3), `review`
+  (planned, sequencing step 6). `add` and `review` print a clear
+  "not yet implemented" message pointing at the design spec.
+- Add `scripts/harness-affordance-discover.sh` — bash discovery
+  scanner that reads `.claude/settings.json`,
+  `.claude/settings.local.json`, and `.mcp.json`, deriving one draft
+  affordance per permission pattern, hook entry, and MCP server.
+  Output goes to `<project>/.claude/affordance-discovery-<date>.md`,
+  never to `HARNESS.md`. Idempotent — re-running on the same input
+  produces the same output modulo the date in the heading.
+- Output entries fill machine-derivable fields (Mode, Trigger for
+  hooks, Permission) and leave human-owned governance fields
+  (Identity, Audit trail, Notes) as `TODO` placeholders.
+- Disambiguates colliding derived names by appending numeric
+  suffixes (`awk-cli`, `awk-cli-2`, ...).
+- Cross-checks `.mcp.json` against permission allowlists and
+  warns when an MCP server is declared without a matching
+  `mcp__<server>__*` permission entry.
+- Add `docs/how-to/discover-affordances.md` — one-page guide
+  covering prerequisites (jq), invocation, output structure, and
+  the promote-to-HARNESS.md flow.
+- Update `.gitignore` to exclude `.claude/affordance-discovery-*.md`
+  so drafts never accidentally land in version control.
+- Update README Commands count badge from 22 to 23 and Commands
+  table to include `/harness-affordance`.
+- This is the **backfill path** for existing harness adopters
+  promised by sequencing step 2 of the affordances design — running
+  the scanner once produces a draft for every existing permission,
+  hook, and MCP server in any project that already declared them.
+
 ## 0.27.0 — 2026-04-26
 
 ### Commands — sync check on /harness-upgrade and PR workflow on /reflect

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.27.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.28.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-29-2E8B57?style=flat-square)](#skills-29)
 [![Agents](https://img.shields.io/badge/Agents-12-2E8B57?style=flat-square)](#agents-12)
-[![Commands](https://img.shields.io/badge/Commands-22-2E8B57?style=flat-square)](#commands-22)
+[![Commands](https://img.shields.io/badge/Commands-23-2E8B57?style=flat-square)](#commands-23)
 [![Harness](https://img.shields.io/badge/Harness-13%2F14_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -193,7 +193,7 @@ A coordinated team that handles the full development lifecycle.
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 | advocatus-diaboli | Adversarial reviewer — spec-time (premise/design focus, before plan approval) and code-time (risk/implementation focus, before integration); six-category objection record, read-only trust boundary, human-cognition gate on dispositions at both gates | Read only |
 
-### Commands (22)
+### Commands (23)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -219,6 +219,7 @@ A coordinated team that handles the full development lifecycle.
 | `/harness-onboarding` | Generate a human-readable onboarding guide from harness state |
 | `/observatory-verify` | Verify all Observatory signal contracts against latest output files |
 | `/diaboli` | Run the adversarial spec reviewer — produces objection record at `docs/superpowers/objections/<slug>.md` |
+| `/harness-affordance` | Manage the project's affordance inventory — `discover` scans config to produce a draft inventory; `add` and `review` planned |
 
 ### Templates (11)
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-affordance.md
+++ b/ai-literacy-superpowers/commands/harness-affordance.md
@@ -1,0 +1,86 @@
+---
+name: harness-affordance
+description: Manage the project's affordance inventory — declared tools the agent can invoke, the identity each tool runs under, and the audit trail each tool produces. Subcommands - discover (scan config to produce a draft inventory), add (planned), review (planned). See docs/superpowers/specs/2026-04-26-harness-affordances-design.md for the design.
+---
+
+# /harness-affordance \<subcommand\> [args...]
+
+Manage the project's affordance inventory — the declared tools the
+agent can invoke, with their identity, audit trail, and permission
+allowlist links.
+
+## Subcommands
+
+### `discover`
+
+Scan the project's config (`.claude/settings.json`,
+`.claude/settings.local.json`, `.mcp.json`) and emit a draft
+affordance inventory to a scratch file at
+`.claude/affordance-discovery-<date>.md`.
+
+The scanner does not touch `HARNESS.md`. After review, the human
+copies approved entries into the `## Affordances` section by hand
+(or, in a future release, via `/harness-affordance add <name>`),
+filling in the human-owned governance fields (Identity, Audit
+trail, Notes).
+
+This is the **backfill path** for projects that adopted the harness
+before the affordances section shipped — running `discover` once
+produces a draft for every existing permission, hook, and MCP
+server.
+
+### Process
+
+1. **Verify prerequisites.** `jq` must be installed. If missing,
+   the script aborts with a clear install hint. Verify the project
+   directory contains at least one of `.claude/settings.json`,
+   `.claude/settings.local.json`, or `.mcp.json`. If none exist,
+   tell the user: "No project config found to scan — nothing to
+   discover."
+2. **Invoke the scanner.** Run
+   `bash ${CLAUDE_PLUGIN_ROOT}/scripts/harness-affordance-discover.sh`
+   from the project root. The script is responsible for reading
+   sources, deriving entries, and writing the output file.
+3. **Report.** Print to the user:
+   - Output file path
+   - Count of draft entries by Mode (`cli` / `local-mcp` /
+     `central-mcp` / `hook`)
+   - Any warnings the scanner emitted (e.g. MCP server declared
+     without a matching permission entry)
+   - Suggested next step: "Review the draft, then copy approved
+     entries to HARNESS.md under `## Affordances`. Each entry needs
+     **Identity** and **Audit trail** filled in (the scanner only
+     supplies the machine-derivable fields)."
+
+### `add` *(not yet implemented)*
+
+Planned for sequencing step 3. Will guide annotation of a draft
+entry — prompts for Identity, Audit trail, optional Notes, then
+appends the completed entry to `HARNESS.md`.
+
+If invoked today, tell the user: "`/harness-affordance add` is not
+yet implemented (sequencing step 3 of the affordances design). For
+now, copy entries from the discovery output to HARNESS.md by hand
+and fill in Identity and Audit trail. See
+`docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+for the design."
+
+### `review` *(not yet implemented)*
+
+Planned for sequencing step 6. Will walk through the three
+re-validation checks (Identity, Audit trail, Permission) and bump
+`Last reviewed` if all pass.
+
+If invoked today, tell the user: "`/harness-affordance review` is
+not yet implemented (sequencing step 6 of the affordances design).
+For now, hand-edit `Last reviewed` after manually re-validating
+the three checks listed in the design spec."
+
+## Routing
+
+If invoked without a subcommand, print the list of available
+subcommands and a one-line summary of each. Do not assume a
+default.
+
+If invoked with an unknown subcommand, list the supported
+subcommands and exit. Do not silently proceed.

--- a/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Discovery scanner for /harness-affordance discover.
+#
+# Reads project-level config (.claude/settings.json,
+# .claude/settings.local.json, .mcp.json) and emits a draft
+# affordance inventory to .claude/affordance-discovery-<date>.md.
+#
+# The scanner emits machine-derivable fields only (Mode, Trigger
+# for hooks, Permission). Human-owned governance fields (Identity,
+# Audit trail, Notes) are left as TODO placeholders for the human
+# to fill in via /harness-affordance add or by hand.
+#
+# Output file is gitignored (.claude/ is in .gitignore by project
+# convention) so drafts never accidentally land in version control.
+#
+# Idempotent: running twice produces the same output modulo the
+# date in the heading. Entries are sorted alphabetically by
+# derived name. No timestamps inside entries.
+#
+# Requires: jq (for JSON parsing)
+#
+# Usage: bash harness-affordance-discover.sh [project-dir]
+#        Default project-dir is $CLAUDE_PROJECT_DIR or "."
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${1:-.}}"
+PROJECT_DIR="${PROJECT_DIR%/}"  # Strip trailing slash
+
+# Prerequisite: jq
+if ! command -v jq >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+ERROR: jq is required for /harness-affordance discover.
+Install via:
+  macOS:  brew install jq
+  Linux:  apt install jq   (Debian/Ubuntu)
+          dnf install jq   (Fedora/RHEL)
+EOF
+  exit 1
+fi
+
+SETTINGS_BASE="${PROJECT_DIR}/.claude/settings.json"
+SETTINGS_LOCAL="${PROJECT_DIR}/.claude/settings.local.json"
+MCP_JSON="${PROJECT_DIR}/.mcp.json"
+
+# Guard: at least one source must exist
+if [ ! -f "$SETTINGS_BASE" ] && [ ! -f "$SETTINGS_LOCAL" ] && [ ! -f "$MCP_JSON" ]; then
+  echo "No project config found at ${PROJECT_DIR}/.claude/ or ${PROJECT_DIR}/.mcp.json — nothing to discover." >&2
+  exit 0
+fi
+
+DATE=$(date +%Y-%m-%d)
+OUT_DIR="${PROJECT_DIR}/.claude"
+OUT_FILE="${OUT_DIR}/affordance-discovery-${DATE}.md"
+
+mkdir -p "$OUT_DIR"
+
+# Temp working files for accumulating entries before sorting.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+ENTRIES_FILE="${WORK}/entries.txt"  # Lines: <name>\t<markdown-block-base64>
+WARN_FILE="${WORK}/warnings.txt"
+: > "$ENTRIES_FILE"
+: > "$WARN_FILE"
+
+# Counters
+COUNT_CLI=0
+COUNT_LOCAL_MCP=0
+COUNT_CENTRAL_MCP=0
+COUNT_HOOK=0
+COUNT_SETTINGS_BASE=0
+COUNT_SETTINGS_LOCAL=0
+COUNT_MCP_SERVERS=0
+
+# --- Helpers ----------------------------------------------------------------
+
+# Validate JSON; emit parse error on stderr and return 1 on failure.
+validate_json() {
+  local file="$1"
+  if ! jq -e . "$file" >/dev/null 2>&1; then
+    echo "ERROR: malformed JSON at ${file}" >&2
+    jq . "$file" 2>&1 | head -5 >&2 || true
+    return 1
+  fi
+  return 0
+}
+
+# Derive an affordance name from a permission pattern.
+# Examples:
+#   Bash(gh *)            -> gh-cli
+#   Bash(git *)           -> git-cli
+#   Bash(npx *)           -> npx-cli
+#   Bash(echo)            -> echo-cli
+#   Bash(echo *)          -> echo-cli
+#   mcp__honeycomb__*     -> honeycomb-mcp
+#   mcp__honeycomb__query -> honeycomb-mcp-query
+#   WebFetch(*)           -> webfetch-cli
+derive_name() {
+  local pattern="$1"
+  # Bash(...)
+  if [[ "$pattern" =~ ^Bash\((.+)\)$ ]]; then
+    local inner="${BASH_REMATCH[1]}"
+    # Skip leading env-var assignments (KEY=value or KEY="value")
+    while [[ "$inner" =~ ^[A-Z_][A-Z0-9_]*=[^[:space:]]*[[:space:]]+(.*)$ ]]; do
+      inner="${BASH_REMATCH[1]}"
+    done
+    # Take first whitespace-delimited token
+    local cmd="${inner%% *}"
+    # Strip trailing wildcards, colons, and slashes
+    cmd="${cmd%\*}"
+    cmd="${cmd%:}"
+    cmd="${cmd%/}"
+    # Pull out the basename (handles paths like /usr/bin/foo or $HOME/bin/foo)
+    cmd=$(basename "$cmd")
+    # Final scrub: strip remaining colons and lowercase
+    cmd="${cmd//:/}"
+    echo "${cmd}-cli" | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+  # mcp__server__method or mcp__server__*
+  if [[ "$pattern" =~ ^mcp__([A-Za-z0-9_-]+)__(.+)$ ]]; then
+    local server="${BASH_REMATCH[1]}"
+    local method="${BASH_REMATCH[2]}"
+    if [ "$method" = "*" ]; then
+      echo "${server}-mcp" | tr '[:upper:]' '[:lower:]' | tr '_' '-'
+    else
+      echo "${server}-mcp-${method}" | tr '[:upper:]' '[:lower:]' | tr '_' '-'
+    fi
+    return
+  fi
+  # Other tool patterns like WebFetch(*), Read, Edit, etc.
+  if [[ "$pattern" =~ ^([A-Za-z][A-Za-z0-9]*)(\(.*\))?$ ]]; then
+    local tool="${BASH_REMATCH[1]}"
+    echo "${tool}-cli" | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+  # Fallback: lowercase, replace non-alphanumeric with hyphen, collapse
+  echo "$pattern" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g'
+}
+
+# Infer Mode from a permission pattern and the MCP servers list.
+# $1 = pattern, $2 = comma-separated list of central-mcp server names.
+infer_mode() {
+  local pattern="$1"
+  local central_servers="$2"
+  if [[ "$pattern" =~ ^mcp__([A-Za-z0-9_-]+)__ ]]; then
+    local server="${BASH_REMATCH[1]}"
+    if [[ ",${central_servers}," == *",${server},"* ]]; then
+      echo "central-mcp"
+    else
+      echo "local-mcp"
+    fi
+    return
+  fi
+  echo "cli"
+}
+
+# Resolve a candidate name to a unique one by appending a numeric
+# suffix if needed. Echoes the resolved name. Reads ENTRIES_FILE
+# (does not modify).
+unique_name() {
+  local candidate="$1"
+  local final="$candidate"
+  local suffix=1
+  while grep -q -F "${final}"$'\t' "$ENTRIES_FILE" 2>/dev/null; do
+    suffix=$((suffix + 1))
+    final="${candidate}-${suffix}"
+  done
+  echo "$final"
+}
+
+# Add an entry to the working file. The block must already use the
+# final (disambiguated) name in its heading — pass it through
+# unique_name() before building the block.
+# $1 = final name, $2 = markdown block.
+add_entry() {
+  local name="$1"
+  local block="$2"
+  printf '%s\t%s\n' "$name" "$(printf '%s' "$block" | base64 | tr -d '\n')" >> "$ENTRIES_FILE"
+}
+
+# Emit one cli/mcp affordance from a permission pattern.
+# $1 = pattern, $2 = source-file label, $3 = central servers list.
+emit_permission_affordance() {
+  local pattern="$1"
+  local source_label="$2"
+  local central_servers="$3"
+
+  local candidate mode name
+  candidate=$(derive_name "$pattern")
+  name=$(unique_name "$candidate")
+  mode=$(infer_mode "$pattern" "$central_servers")
+
+  case "$mode" in
+    cli)         COUNT_CLI=$((COUNT_CLI + 1)) ;;
+    local-mcp)   COUNT_LOCAL_MCP=$((COUNT_LOCAL_MCP + 1)) ;;
+    central-mcp) COUNT_CENTRAL_MCP=$((COUNT_CENTRAL_MCP + 1)) ;;
+  esac
+
+  local block
+  block=$(cat <<EOF
+### ${name}
+
+- **Mode**: ${mode}
+- **Identity**: TODO
+- **Audit trail**: TODO
+- **Permission**: \`${pattern}\` (declared in ${source_label})
+- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)
+EOF
+)
+  add_entry "$name" "$block"
+}
+
+# Emit one hook affordance.
+# $1 = trigger event, $2 = matcher (or empty), $3 = command, $4 = source label.
+emit_hook_affordance() {
+  local trigger="$1"
+  local matcher="$2"
+  local hook_command="$3"
+  local source_label="$4"
+
+  # Derive a candidate name from the script basename + trigger.
+  local script_basename
+  script_basename=$(basename "${hook_command%% *}")
+  script_basename="${script_basename%.sh}"
+  script_basename="${script_basename%.py}"
+  local trigger_lower
+  trigger_lower=$(echo "$trigger" | tr '[:upper:]' '[:lower:]')
+  local candidate="${script_basename}-${trigger_lower}"
+  candidate=$(echo "$candidate" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+  local name
+  name=$(unique_name "$candidate")
+
+  COUNT_HOOK=$((COUNT_HOOK + 1))
+
+  local matcher_clause=""
+  if [ -n "$matcher" ] && [ "$matcher" != "null" ]; then
+    matcher_clause=" matching \`${matcher}\`"
+  fi
+
+  local block
+  block=$(cat <<EOF
+### ${name}
+
+- **Mode**: hook
+- **Trigger**: ${trigger}
+- **Identity**: TODO
+- **Audit trail**: TODO
+- **Permission**: \`hooks.${trigger}\`${matcher_clause} entry in ${source_label} invoking \`${hook_command}\`
+- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)
+EOF
+)
+  add_entry "$name" "$block"
+}
+
+# --- Read MCP servers (used to infer central-mcp vs local-mcp) -------------
+
+CENTRAL_SERVERS=""
+if [ -f "$MCP_JSON" ]; then
+  if validate_json "$MCP_JSON"; then
+    # Servers with a `url` field (typically https://) are central; others local.
+    while IFS= read -r server; do
+      [ -z "$server" ] && continue
+      COUNT_MCP_SERVERS=$((COUNT_MCP_SERVERS + 1))
+      has_url=$(jq -r --arg s "$server" '.mcpServers[$s].url // empty' "$MCP_JSON")
+      if [ -n "$has_url" ]; then
+        CENTRAL_SERVERS="${CENTRAL_SERVERS},${server}"
+      fi
+    done < <(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON")
+    CENTRAL_SERVERS="${CENTRAL_SERVERS#,}"
+  fi
+fi
+
+# --- Read permission entries from settings files ----------------------------
+
+# Reads permissions and emits affordances. Updates global counters
+# directly. Must NOT be invoked via $(...) — that runs the function in a
+# subshell and the global updates are lost.
+# $1 = file, $2 = label, $3 = name of global var to set with entry count.
+read_permissions_from() {
+  local file="$1"
+  local label="$2"
+  local count_var="$3"
+  [ -f "$file" ] || return 0
+  validate_json "$file" || return 1
+  local count=0
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+    emit_permission_affordance "$pattern" "$label" "$CENTRAL_SERVERS"
+    count=$((count + 1))
+  done < <(jq -r '.permissions.allow[]? // empty' "$file")
+  printf -v "$count_var" '%d' "$count"
+}
+
+if [ -f "$SETTINGS_BASE" ]; then
+  read_permissions_from "$SETTINGS_BASE" ".claude/settings.json" COUNT_SETTINGS_BASE
+fi
+
+if [ -f "$SETTINGS_LOCAL" ]; then
+  read_permissions_from "$SETTINGS_LOCAL" ".claude/settings.local.json" COUNT_SETTINGS_LOCAL
+fi
+
+# --- Read hook entries from settings files ----------------------------------
+
+read_hooks_from() {
+  local file="$1"
+  local label="$2"
+  [ -f "$file" ] || return 0
+  validate_json "$file" || return 1
+  # hooks.<event>[].matcher  hooks.<event>[].hooks[].command
+  while IFS=$'\t' read -r event matcher hook_command; do
+    [ -z "$event" ] && continue
+    [ -z "$hook_command" ] && continue
+    emit_hook_affordance "$event" "$matcher" "$hook_command" "$label"
+  done < <(jq -r '
+    .hooks // {} | to_entries[] |
+    .key as $event |
+    .value[]? |
+    (.matcher // "") as $matcher |
+    (.hooks // [])[]? |
+    [$event, $matcher, .command // ""] | @tsv
+  ' "$file")
+}
+
+if [ -f "$SETTINGS_BASE" ]; then
+  read_hooks_from "$SETTINGS_BASE" ".claude/settings.json"
+fi
+
+if [ -f "$SETTINGS_LOCAL" ]; then
+  read_hooks_from "$SETTINGS_LOCAL" ".claude/settings.local.json"
+fi
+
+# --- Cross-check: MCP servers with no matching permission allowlist entry ---
+
+if [ -f "$MCP_JSON" ] && validate_json "$MCP_JSON"; then
+  while IFS= read -r server; do
+    [ -z "$server" ] && continue
+    # Have we emitted any affordance whose permission matches mcp__<server>__*?
+    pattern_prefix="mcp__${server}__"
+    if ! grep -q -F "${pattern_prefix}" "$ENTRIES_FILE"; then
+      echo "WARN: MCP server '${server}' is declared in .mcp.json but has no matching permission entry (mcp__${server}__*) in any settings file." >> "$WARN_FILE"
+    fi
+  done < <(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON")
+fi
+
+# --- Compose the output file ------------------------------------------------
+
+{
+  echo "# Affordance Discovery — ${DATE}"
+  echo ""
+  echo "Draft affordance inventory generated from project config."
+  echo "Review each entry, fill in the human-owned fields"
+  echo "(**Identity**, **Audit trail**, optional **Notes**), then"
+  echo "copy approved entries into \`HARNESS.md\` under \`## Affordances\`."
+  echo ""
+  echo "Source files scanned:"
+  if [ -f "$SETTINGS_BASE" ]; then
+    echo "- \`.claude/settings.json\` (${COUNT_SETTINGS_BASE} permission entries)"
+  fi
+  if [ -f "$SETTINGS_LOCAL" ]; then
+    echo "- \`.claude/settings.local.json\` (${COUNT_SETTINGS_LOCAL} permission entries)"
+  fi
+  if [ -f "$MCP_JSON" ]; then
+    echo "- \`.mcp.json\` (${COUNT_MCP_SERVERS} MCP servers)"
+  fi
+  echo ""
+  echo "Counts by mode: cli=${COUNT_CLI}, local-mcp=${COUNT_LOCAL_MCP}, central-mcp=${COUNT_CENTRAL_MCP}, hook=${COUNT_HOOK}"
+  echo ""
+
+  if [ -s "$WARN_FILE" ]; then
+    echo "## Warnings"
+    echo ""
+    while IFS= read -r warn; do
+      echo "- ${warn}"
+    done < "$WARN_FILE"
+    echo ""
+  fi
+
+  echo "---"
+  echo ""
+
+  # Emit entries sorted alphabetically by derived name.
+  if [ -s "$ENTRIES_FILE" ]; then
+    sort -t$'\t' -k1,1 "$ENTRIES_FILE" | while IFS=$'\t' read -r name encoded; do
+      printf '%s' "$encoded" | base64 -d
+      echo ""
+      echo ""
+    done
+  else
+    echo "_No affordances discovered. Either no permission, hook, or MCP server is declared in the scanned files, or the files are empty._"
+  fi
+} > "$OUT_FILE"
+
+# --- Report -----------------------------------------------------------------
+
+echo "Wrote draft affordance inventory to: ${OUT_FILE}"
+echo "  cli:         ${COUNT_CLI}"
+echo "  local-mcp:   ${COUNT_LOCAL_MCP}"
+echo "  central-mcp: ${COUNT_CENTRAL_MCP}"
+echo "  hook:        ${COUNT_HOOK}"
+if [ -s "$WARN_FILE" ]; then
+  echo ""
+  echo "Warnings:"
+  while IFS= read -r warn; do
+    echo "  ${warn}"
+  done < "$WARN_FILE"
+fi

--- a/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
@@ -6,16 +6,32 @@
 # affordance inventory to .claude/affordance-discovery-<date>.md.
 #
 # The scanner emits machine-derivable fields only (Mode, Trigger
-# for hooks, Permission). Human-owned governance fields (Identity,
-# Audit trail, Notes) are left as TODO placeholders for the human
-# to fill in via /harness-affordance add or by hand.
+# for hooks, Permission, Notes). Human-owned governance fields
+# (Identity, Audit trail) are left as TODO placeholders for the
+# human to fill in via /harness-affordance add or by hand.
 #
-# Output file is gitignored (.claude/ is in .gitignore by project
-# convention) so drafts never accidentally land in version control.
+# Output file is gitignored (.claude/affordance-discovery-*.md is
+# in the project .gitignore) so drafts never accidentally land in
+# version control.
 #
-# Idempotent: running twice produces the same output modulo the
-# date in the heading. Entries are sorted alphabetically by
-# derived name. No timestamps inside entries.
+# Idempotency: running twice on identical input produces output that
+# differs only in the date in the heading. Permission patterns are
+# sorted lex-ascending before processing so disambiguation suffixes
+# do not depend on JSON allow-array order. Final entries are
+# concatenated in `LC_ALL=C ls -1` order from a temp directory of
+# per-entry files (no base64 encoding round-trip).
+#
+# Error handling: a malformed source file aborts the scanner via
+# `set -e` before subsequent sources are processed. This is
+# documented in the spec's Error Handling section as deliberate —
+# loud failure beats partial output of dubious provenance.
+#
+# Limitation: hook commands that use shell wrappers (`bash -c '...'`,
+# `python -m foo`, etc.) currently derive to wrapper-named entries
+# (`bash-stop`, `python-stop`). Configure hooks to invoke scripts
+# directly when affordance-readability matters. A future
+# improvement will recognise common wrappers and parse their
+# arguments.
 #
 # Requires: jq (for JSON parsing)
 #
@@ -55,13 +71,12 @@ OUT_FILE="${OUT_DIR}/affordance-discovery-${DATE}.md"
 
 mkdir -p "$OUT_DIR"
 
-# Temp working files for accumulating entries before sorting.
+# Working directory: one file per entry, named "<derived-name>.md".
+# Final output concatenates these in `LC_ALL=C ls -1` order.
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
-ENTRIES_FILE="${WORK}/entries.txt"  # Lines: <name>\t<markdown-block-base64>
-WARN_FILE="${WORK}/warnings.txt"
-: > "$ENTRIES_FILE"
-: > "$WARN_FILE"
+ENTRIES_DIR="${WORK}/entries"
+mkdir -p "$ENTRIES_DIR"
 
 # Counters
 COUNT_CLI=0
@@ -71,6 +86,7 @@ COUNT_HOOK=0
 COUNT_SETTINGS_BASE=0
 COUNT_SETTINGS_LOCAL=0
 COUNT_MCP_SERVERS=0
+COUNT_ORPHAN_MCP=0
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -85,16 +101,20 @@ validate_json() {
   return 0
 }
 
+# Strip known script extensions. Used by both Bash-pattern and
+# hook-script name derivation so a `Bash(./scripts/foo.sh)` permission
+# and a hook invoking `foo.sh` derive to the same root name.
+strip_known_extensions() {
+  local name="$1"
+  name="${name%.sh}"
+  name="${name%.py}"
+  name="${name%.js}"
+  name="${name%.rb}"
+  name="${name%.ts}"
+  echo "$name"
+}
+
 # Derive an affordance name from a permission pattern.
-# Examples:
-#   Bash(gh *)            -> gh-cli
-#   Bash(git *)           -> git-cli
-#   Bash(npx *)           -> npx-cli
-#   Bash(echo)            -> echo-cli
-#   Bash(echo *)          -> echo-cli
-#   mcp__honeycomb__*     -> honeycomb-mcp
-#   mcp__honeycomb__query -> honeycomb-mcp-query
-#   WebFetch(*)           -> webfetch-cli
 derive_name() {
   local pattern="$1"
   # Bash(...)
@@ -112,6 +132,8 @@ derive_name() {
     cmd="${cmd%/}"
     # Pull out the basename (handles paths like /usr/bin/foo or $HOME/bin/foo)
     cmd=$(basename "$cmd")
+    # Strip known script extensions for symmetry with hook entries
+    cmd=$(strip_known_extensions "$cmd")
     # Final scrub: strip remaining colons and lowercase
     cmd="${cmd//:/}"
     echo "${cmd}-cli" | tr '[:upper:]' '[:lower:]'
@@ -138,45 +160,40 @@ derive_name() {
   echo "$pattern" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g'
 }
 
-# Infer Mode from a permission pattern and the MCP servers list.
+# Infer Mode from a permission pattern.
 # $1 = pattern, $2 = comma-separated list of central-mcp server names.
+# Echoes the mode AND a "needs-notes" flag (1 if mode was guessed; 0 if known).
 infer_mode() {
   local pattern="$1"
   local central_servers="$2"
+  if [[ "$pattern" =~ ^Bash\( ]]; then
+    echo "cli 0"
+    return
+  fi
   if [[ "$pattern" =~ ^mcp__([A-Za-z0-9_-]+)__ ]]; then
     local server="${BASH_REMATCH[1]}"
     if [[ ",${central_servers}," == *",${server},"* ]]; then
-      echo "central-mcp"
+      echo "central-mcp 0"
     else
-      echo "local-mcp"
+      echo "local-mcp 0"
     fi
     return
   fi
-  echo "cli"
+  # `other` case per spec: Mode: cli with a Notes flag.
+  echo "cli 1"
 }
 
 # Resolve a candidate name to a unique one by appending a numeric
-# suffix if needed. Echoes the resolved name. Reads ENTRIES_FILE
-# (does not modify).
+# suffix if needed. Reads the entries dir for existing files.
 unique_name() {
   local candidate="$1"
   local final="$candidate"
   local suffix=1
-  while grep -q -F "${final}"$'\t' "$ENTRIES_FILE" 2>/dev/null; do
+  while [ -e "${ENTRIES_DIR}/${final}" ]; do
     suffix=$((suffix + 1))
     final="${candidate}-${suffix}"
   done
   echo "$final"
-}
-
-# Add an entry to the working file. The block must already use the
-# final (disambiguated) name in its heading — pass it through
-# unique_name() before building the block.
-# $1 = final name, $2 = markdown block.
-add_entry() {
-  local name="$1"
-  local block="$2"
-  printf '%s\t%s\n' "$name" "$(printf '%s' "$block" | base64 | tr -d '\n')" >> "$ENTRIES_FILE"
 }
 
 # Emit one cli/mcp affordance from a permission pattern.
@@ -186,10 +203,12 @@ emit_permission_affordance() {
   local source_label="$2"
   local central_servers="$3"
 
-  local candidate mode name
+  local candidate name mode_with_flag mode needs_notes
   candidate=$(derive_name "$pattern")
   name=$(unique_name "$candidate")
-  mode=$(infer_mode "$pattern" "$central_servers")
+  mode_with_flag=$(infer_mode "$pattern" "$central_servers")
+  mode="${mode_with_flag% *}"
+  needs_notes="${mode_with_flag##* }"
 
   case "$mode" in
     cli)         COUNT_CLI=$((COUNT_CLI + 1)) ;;
@@ -197,22 +216,53 @@ emit_permission_affordance() {
     central-mcp) COUNT_CENTRAL_MCP=$((COUNT_CENTRAL_MCP + 1)) ;;
   esac
 
-  local block
-  block=$(cat <<EOF
-### ${name}
+  {
+    echo "### ${name}"
+    echo ""
+    echo "- **Mode**: ${mode}"
+    echo "- **Identity**: TODO"
+    echo "- **Audit trail**: TODO"
+    echo "- **Permission**: \`${pattern}\` (declared in ${source_label})"
+    echo "- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)"
+    if [ "$needs_notes" = "1" ]; then
+      echo "- **Notes**: Mode \`cli\` was inferred for an unrecognised pattern shape; reviewer should verify the actual transport before promoting"
+    fi
+  } > "${ENTRIES_DIR}/${name}"
+}
 
-- **Mode**: ${mode}
-- **Identity**: TODO
-- **Audit trail**: TODO
-- **Permission**: \`${pattern}\` (declared in ${source_label})
-- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)
-EOF
-)
-  add_entry "$name" "$block"
+# Emit an MCP-orphan affordance — for an MCP server declared in
+# .mcp.json with no matching mcp__<server>__* permission entry.
+# Per spec: emit a draft affordance with a WARN Notes flag.
+emit_mcp_orphan_affordance() {
+  local server="$1"
+  local central_servers="$2"
+
+  local candidate name mode
+  candidate=$(echo "${server}-mcp" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+  name=$(unique_name "$candidate")
+  if [[ ",${central_servers}," == *",${server},"* ]]; then
+    mode="central-mcp"
+    COUNT_CENTRAL_MCP=$((COUNT_CENTRAL_MCP + 1))
+  else
+    mode="local-mcp"
+    COUNT_LOCAL_MCP=$((COUNT_LOCAL_MCP + 1))
+  fi
+  COUNT_ORPHAN_MCP=$((COUNT_ORPHAN_MCP + 1))
+
+  {
+    echo "### ${name}"
+    echo ""
+    echo "- **Mode**: ${mode}"
+    echo "- **Identity**: TODO"
+    echo "- **Audit trail**: TODO"
+    echo "- **Permission**: _none — the agent cannot actually invoke this MCP server until a permission allowlist entry is added_"
+    echo "- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity, Audit trail, and Permission are addressed)"
+    echo "- **Notes**: WARN: MCP server \`${server}\` declared in .mcp.json but no \`mcp__${server}__*\` permission entry in any settings.json. Either add a permission to grant the agent access, or remove the server declaration."
+  } > "${ENTRIES_DIR}/${name}"
 }
 
 # Emit one hook affordance.
-# $1 = trigger event, $2 = matcher (or empty), $3 = command, $4 = source label.
+# $1 = trigger, $2 = matcher, $3 = command, $4 = source label.
 emit_hook_affordance() {
   local trigger="$1"
   local matcher="$2"
@@ -220,10 +270,11 @@ emit_hook_affordance() {
   local source_label="$4"
 
   # Derive a candidate name from the script basename + trigger.
+  # Note: shell wrappers (bash -c '...', python -m foo) produce
+  # wrapper-named entries (bash-<event>, python-<event>); see header.
   local script_basename
   script_basename=$(basename "${hook_command%% *}")
-  script_basename="${script_basename%.sh}"
-  script_basename="${script_basename%.py}"
+  script_basename=$(strip_known_extensions "$script_basename")
   local trigger_lower
   trigger_lower=$(echo "$trigger" | tr '[:upper:]' '[:lower:]')
   local candidate="${script_basename}-${trigger_lower}"
@@ -238,27 +289,26 @@ emit_hook_affordance() {
     matcher_clause=" matching \`${matcher}\`"
   fi
 
-  local block
-  block=$(cat <<EOF
-### ${name}
-
-- **Mode**: hook
-- **Trigger**: ${trigger}
-- **Identity**: TODO
-- **Audit trail**: TODO
-- **Permission**: \`hooks.${trigger}\`${matcher_clause} entry in ${source_label} invoking \`${hook_command}\`
-- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)
-EOF
-)
-  add_entry "$name" "$block"
+  {
+    echo "### ${name}"
+    echo ""
+    echo "- **Mode**: hook"
+    echo "- **Trigger**: ${trigger}"
+    echo "- **Identity**: TODO"
+    echo "- **Audit trail**: TODO"
+    echo "- **Permission**: \`hooks.${trigger}\`${matcher_clause} entry in ${source_label} invoking \`${hook_command}\`"
+    echo "- **Last reviewed**: TODO (run \`/harness-affordance review\` once Identity and Audit trail are filled in)"
+  } > "${ENTRIES_DIR}/${name}"
 }
 
 # --- Read MCP servers (used to infer central-mcp vs local-mcp) -------------
+# Cache the parsed MCP_JSON content so we only validate/parse it once.
 
 CENTRAL_SERVERS=""
+MCP_SERVERS=""  # newline-separated server names
 if [ -f "$MCP_JSON" ]; then
   if validate_json "$MCP_JSON"; then
-    # Servers with a `url` field (typically https://) are central; others local.
+    MCP_SERVERS=$(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON")
     while IFS= read -r server; do
       [ -z "$server" ] && continue
       COUNT_MCP_SERVERS=$((COUNT_MCP_SERVERS + 1))
@@ -266,18 +316,19 @@ if [ -f "$MCP_JSON" ]; then
       if [ -n "$has_url" ]; then
         CENTRAL_SERVERS="${CENTRAL_SERVERS},${server}"
       fi
-    done < <(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON")
+    done <<< "$MCP_SERVERS"
     CENTRAL_SERVERS="${CENTRAL_SERVERS#,}"
   fi
 fi
 
 # --- Read permission entries from settings files ----------------------------
+# Patterns are accumulated in a tempfile, then sorted lex-ascending so
+# disambiguation does not depend on source-array order.
 
-# Reads permissions and emits affordances. Updates global counters
-# directly. Must NOT be invoked via $(...) — that runs the function in a
-# subshell and the global updates are lost.
-# $1 = file, $2 = label, $3 = name of global var to set with entry count.
-read_permissions_from() {
+PATTERNS_FILE="${WORK}/patterns.tsv"
+: > "$PATTERNS_FILE"
+
+read_permissions_into_file() {
   local file="$1"
   local label="$2"
   local count_var="$3"
@@ -286,18 +337,26 @@ read_permissions_from() {
   local count=0
   while IFS= read -r pattern; do
     [ -z "$pattern" ] && continue
-    emit_permission_affordance "$pattern" "$label" "$CENTRAL_SERVERS"
+    printf '%s\t%s\n' "$pattern" "$label" >> "$PATTERNS_FILE"
     count=$((count + 1))
   done < <(jq -r '.permissions.allow[]? // empty' "$file")
   printf -v "$count_var" '%d' "$count"
 }
 
 if [ -f "$SETTINGS_BASE" ]; then
-  read_permissions_from "$SETTINGS_BASE" ".claude/settings.json" COUNT_SETTINGS_BASE
+  read_permissions_into_file "$SETTINGS_BASE" ".claude/settings.json" COUNT_SETTINGS_BASE
+fi
+if [ -f "$SETTINGS_LOCAL" ]; then
+  read_permissions_into_file "$SETTINGS_LOCAL" ".claude/settings.local.json" COUNT_SETTINGS_LOCAL
 fi
 
-if [ -f "$SETTINGS_LOCAL" ]; then
-  read_permissions_from "$SETTINGS_LOCAL" ".claude/settings.local.json" COUNT_SETTINGS_LOCAL
+# Sort patterns lex-ascending so disambiguation suffixes are
+# independent of source-array order.
+if [ -s "$PATTERNS_FILE" ]; then
+  LC_ALL=C sort -t$'\t' -k1,1 "$PATTERNS_FILE" -o "$PATTERNS_FILE"
+  while IFS=$'\t' read -r pattern label; do
+    emit_permission_affordance "$pattern" "$label" "$CENTRAL_SERVERS"
+  done < "$PATTERNS_FILE"
 fi
 
 # --- Read hook entries from settings files ----------------------------------
@@ -307,7 +366,6 @@ read_hooks_from() {
   local label="$2"
   [ -f "$file" ] || return 0
   validate_json "$file" || return 1
-  # hooks.<event>[].matcher  hooks.<event>[].hooks[].command
   while IFS=$'\t' read -r event matcher hook_command; do
     [ -z "$event" ] && continue
     [ -z "$hook_command" ] && continue
@@ -325,22 +383,21 @@ read_hooks_from() {
 if [ -f "$SETTINGS_BASE" ]; then
   read_hooks_from "$SETTINGS_BASE" ".claude/settings.json"
 fi
-
 if [ -f "$SETTINGS_LOCAL" ]; then
   read_hooks_from "$SETTINGS_LOCAL" ".claude/settings.local.json"
 fi
 
 # --- Cross-check: MCP servers with no matching permission allowlist entry ---
+# Operates on plaintext PATTERNS_FILE rather than encoded entry blocks.
 
-if [ -f "$MCP_JSON" ] && validate_json "$MCP_JSON"; then
+if [ -n "$MCP_SERVERS" ]; then
   while IFS= read -r server; do
     [ -z "$server" ] && continue
-    # Have we emitted any affordance whose permission matches mcp__<server>__*?
     pattern_prefix="mcp__${server}__"
-    if ! grep -q -F "${pattern_prefix}" "$ENTRIES_FILE"; then
-      echo "WARN: MCP server '${server}' is declared in .mcp.json but has no matching permission entry (mcp__${server}__*) in any settings file." >> "$WARN_FILE"
+    if ! grep -q -F "${pattern_prefix}" "$PATTERNS_FILE" 2>/dev/null; then
+      emit_mcp_orphan_affordance "$server" "$CENTRAL_SERVERS"
     fi
-  done < <(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON")
+  done <<< "$MCP_SERVERS"
 fi
 
 # --- Compose the output file ------------------------------------------------
@@ -361,29 +418,30 @@ fi
     echo "- \`.claude/settings.local.json\` (${COUNT_SETTINGS_LOCAL} permission entries)"
   fi
   if [ -f "$MCP_JSON" ]; then
-    echo "- \`.mcp.json\` (${COUNT_MCP_SERVERS} MCP servers)"
+    echo "- \`.mcp.json\` (${COUNT_MCP_SERVERS} MCP servers"
+    if [ "$COUNT_ORPHAN_MCP" -gt 0 ]; then
+      echo -n "  "
+      echo "; ${COUNT_ORPHAN_MCP} without matching permission entries — see entries flagged WARN below)"
+    else
+      echo "  )"
+    fi
   fi
   echo ""
   echo "Counts by mode: cli=${COUNT_CLI}, local-mcp=${COUNT_LOCAL_MCP}, central-mcp=${COUNT_CENTRAL_MCP}, hook=${COUNT_HOOK}"
   echo ""
-
-  if [ -s "$WARN_FILE" ]; then
-    echo "## Warnings"
-    echo ""
-    while IFS= read -r warn; do
-      echo "- ${warn}"
-    done < "$WARN_FILE"
-    echo ""
-  fi
-
   echo "---"
   echo ""
 
-  # Emit entries sorted alphabetically by derived name.
-  if [ -s "$ENTRIES_FILE" ]; then
-    sort -t$'\t' -k1,1 "$ENTRIES_FILE" | while IFS=$'\t' read -r name encoded; do
-      printf '%s' "$encoded" | base64 -d
-      echo ""
+  # Emit entries in LC_ALL=C-sorted basename order. Sorting by basename
+  # (not full path) ensures `awk-cli` precedes `awk-cli-2` — full-path
+  # sort would put `awk-cli-2.md` before `awk-cli.md` because `-` < `.`
+  # in ASCII. Names are constrained by derive_name to lowercase
+  # alphanumeric + hyphens, so `ls -1` is safe here.
+  # shellcheck disable=SC2012
+  if [ -n "$(LC_ALL=C ls -1 "$ENTRIES_DIR" 2>/dev/null)" ]; then
+    # shellcheck disable=SC2012
+    LC_ALL=C ls -1 "$ENTRIES_DIR" | while IFS= read -r entry_file; do
+      cat "${ENTRIES_DIR}/${entry_file}"
       echo ""
     done
   else
@@ -398,10 +456,7 @@ echo "  cli:         ${COUNT_CLI}"
 echo "  local-mcp:   ${COUNT_LOCAL_MCP}"
 echo "  central-mcp: ${COUNT_CENTRAL_MCP}"
 echo "  hook:        ${COUNT_HOOK}"
-if [ -s "$WARN_FILE" ]; then
+if [ "$COUNT_ORPHAN_MCP" -gt 0 ]; then
   echo ""
-  echo "Warnings:"
-  while IFS= read -r warn; do
-    echo "  ${warn}"
-  done < "$WARN_FILE"
+  echo "Note: ${COUNT_ORPHAN_MCP} MCP server(s) declared in .mcp.json have no matching permission entry; see WARN-flagged entries in the output."
 fi

--- a/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-discover.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # Discovery scanner for /harness-affordance discover.
 #
 # Reads project-level config (.claude/settings.json,
@@ -37,8 +39,6 @@
 #
 # Usage: bash harness-affordance-discover.sh [project-dir]
 #        Default project-dir is $CLAUDE_PROJECT_DIR or "."
-
-set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${1:-.}}"
 PROJECT_DIR="${PROJECT_DIR%/}"  # Strip trailing slash

--- a/docs/how-to/discover-affordances.md
+++ b/docs/how-to/discover-affordances.md
@@ -1,3 +1,10 @@
+---
+title: Discover Affordances
+layout: default
+parent: How-to Guides
+nav_order: 39
+---
+
 # Discover Affordances
 
 Run the affordance discovery scanner against your project's existing
@@ -36,16 +43,16 @@ From a Claude Code session:
 /harness-affordance discover
 ```
 
-Or from a terminal directly:
+Or from a terminal directly (assumes the plugin is installed via
+the `ai-literacy-superpowers` marketplace):
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/harness-affordance-discover.sh
+bash ~/.claude/plugins/cache/ai-literacy-superpowers/ai-literacy-superpowers/<version>/scripts/harness-affordance-discover.sh
 ```
 
-(`${CLAUDE_PLUGIN_ROOT}` resolves to the plugin's installed cache
-path; the script reads from the current working directory by
-default. Pass an explicit project directory as the first argument
-if you want to scan a different project.)
+The script reads from the current working directory by default. Pass
+an explicit project directory as the first argument if you want to
+scan a different project.
 
 ## Read the output
 
@@ -82,10 +89,14 @@ in the **machine-derivable fields** (`Mode`, `Trigger` for hooks,
 ```
 
 If the scanner finds an MCP server declared in `.mcp.json` but no
-matching `mcp__<server>__*` permission entry, it emits a warning at
-the top of the file. That is the *affordance-without-permission*
-case from the harness-affordances design — worth resolving before
-the corresponding constraint goes live.
+matching `mcp__<server>__*` permission entry, it emits a draft
+affordance entry for that server with a `WARN:` note in the `Notes`
+field explaining the missing permission. The header summary also
+reports the count of orphan MCP servers. This is the
+*affordance-without-permission* case from the harness-affordances
+design — the entry surfaces in the inventory itself rather than as a
+separate warning paragraph, so it is impossible to miss when scanning
+the entries.
 
 ## Promote entries to HARNESS.md
 
@@ -110,16 +121,21 @@ this annotation interactively. For now it is hand-edited.
 If two permission patterns derive to the same name (e.g. eight
 different `Bash(awk ...)` patterns all derive to `awk-cli`), the
 scanner appends a numeric suffix: `awk-cli`, `awk-cli-2`,
-`awk-cli-3`, etc. This is deterministic — re-running the scanner
-produces the same suffixes for the same patterns in the same input
-order.
+`awk-cli-3`, etc. This is deterministic and **independent of the
+order patterns appear in your `permissions.allow` array** — the
+scanner sorts patterns lex-ascending before assigning suffixes, so
+re-ordering the array (e.g. alphabetising it) does not silently
+re-name entries you have already promoted to `HARNESS.md`.
 
 ## Idempotency
 
 Running the scanner twice on identical input produces output that
 differs only in the date in the heading. Entry order is alphabetical
-by derived name; no timestamps appear inside entries. This makes it
-safe to `diff` successive runs to find what changed.
+by derived name (basename, not full path); no timestamps appear
+inside entries. Sort and listing are pinned to the `C` locale so
+output is byte-identical across machines with different default
+locales. This makes it safe to `diff` successive runs to find what
+changed.
 
 ## What the scanner does NOT do
 

--- a/docs/how-to/discover-affordances.md
+++ b/docs/how-to/discover-affordances.md
@@ -1,0 +1,138 @@
+# Discover Affordances
+
+Run the affordance discovery scanner against your project's existing
+config to produce a draft inventory of every tool the agent can
+invoke.
+
+## When to use this
+
+- **First time setting up the affordances section.** Existing harness
+  adopters can backfill the `## Affordances` section in `HARNESS.md`
+  by running `discover` once and then promoting the entries.
+- **After changing project permissions.** Add a new permission entry,
+  hook, or MCP server? Re-run `discover` to see the diff against the
+  previous draft and find what is new.
+- **As part of a governance review.** A reviewer can run `discover`
+  to confirm that the declared affordances in `HARNESS.md` still
+  match what the project's config actually grants.
+
+## Prerequisites
+
+- **`jq`** must be installed. The scanner uses it to parse JSON
+  config files robustly.
+  - macOS: `brew install jq`
+  - Debian/Ubuntu: `apt install jq`
+  - Fedora/RHEL: `dnf install jq`
+- The plugin must be installed and at version `0.28.0` or later.
+- At least one of the following must exist in your project root:
+  `.claude/settings.json`, `.claude/settings.local.json`,
+  `.mcp.json`. If none exist there is nothing to discover.
+
+## Run it
+
+From a Claude Code session:
+
+```text
+/harness-affordance discover
+```
+
+Or from a terminal directly:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/harness-affordance-discover.sh
+```
+
+(`${CLAUDE_PLUGIN_ROOT}` resolves to the plugin's installed cache
+path; the script reads from the current working directory by
+default. Pass an explicit project directory as the first argument
+if you want to scan a different project.)
+
+## Read the output
+
+The scanner writes to `<project>/.claude/affordance-discovery-<YYYY-MM-DD>.md`.
+The file is gitignored — drafts never accidentally land in version
+control.
+
+The output starts with a header summarising what was scanned:
+
+```text
+# Affordance Discovery — 2026-04-27
+
+Source files scanned:
+- `.claude/settings.local.json` (72 permission entries)
+- `.mcp.json` (3 MCP servers)
+
+Counts by mode: cli=72, local-mcp=2, central-mcp=1, hook=2
+```
+
+Followed by one entry per discovered affordance. The scanner fills
+in the **machine-derivable fields** (`Mode`, `Trigger` for hooks,
+`Permission`); the **human-owned governance fields** (`Identity`,
+`Audit trail`, optional `Notes`) start as `TODO`:
+
+```markdown
+### gh-cli
+
+- **Mode**: cli
+- **Identity**: TODO
+- **Audit trail**: TODO
+- **Permission**: `Bash(gh *)` (declared in .claude/settings.local.json)
+- **Last reviewed**: TODO (run `/harness-affordance review` once
+  Identity and Audit trail are filled in)
+```
+
+If the scanner finds an MCP server declared in `.mcp.json` but no
+matching `mcp__<server>__*` permission entry, it emits a warning at
+the top of the file. That is the *affordance-without-permission*
+case from the harness-affordances design — worth resolving before
+the corresponding constraint goes live.
+
+## Promote entries to HARNESS.md
+
+For each draft entry you want to keep:
+
+1. **Fill in `Identity`** — whose credentials does this tool run
+   under? Use one of: `user-sso`, `service-account`, `current-user`,
+   `runtime-resolved`, `none`. See the
+   [affordances design spec](../superpowers/specs/2026-04-26-harness-affordances-design.md)
+   for the full definitions.
+2. **Fill in `Audit trail`** — where would you find a record of what
+   the agent did? `none` is encouraged when there genuinely is no
+   audit trail; the visibility is the point.
+3. **Set `Last reviewed`** to today's date.
+4. **Copy the entry** into `HARNESS.md` under `## Affordances`.
+
+In a future release `/harness-affordance add <name>` will guide
+this annotation interactively. For now it is hand-edited.
+
+## Disambiguation
+
+If two permission patterns derive to the same name (e.g. eight
+different `Bash(awk ...)` patterns all derive to `awk-cli`), the
+scanner appends a numeric suffix: `awk-cli`, `awk-cli-2`,
+`awk-cli-3`, etc. This is deterministic — re-running the scanner
+produces the same suffixes for the same patterns in the same input
+order.
+
+## Idempotency
+
+Running the scanner twice on identical input produces output that
+differs only in the date in the heading. Entry order is alphabetical
+by derived name; no timestamps appear inside entries. This makes it
+safe to `diff` successive runs to find what changed.
+
+## What the scanner does NOT do
+
+- It never writes to `HARNESS.md`. Promotion is always a human
+  action.
+- It does not read `~/.claude/settings.json` (user-level settings
+  are out of scope for project-level governance).
+- It does not infer `Identity`, `Audit trail`, or `Last reviewed` —
+  these are governance judgments that humans must make.
+- It does not ship `add` or `review` subcommands — those land in
+  later sequencing steps of the affordances design.
+
+## Related
+
+- [Harness Affordances — Design Spec](../superpowers/specs/2026-04-26-harness-affordances-design.md)
+- [`/harness-affordance discover` — Implementation Spec](../superpowers/specs/2026-04-27-harness-affordance-discover.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,13 +55,14 @@ stays trustworthy at scale.
 
 It gives you:
 
-- **27 skills** — domain knowledge for security auditing, constraint
+- **29 skills** — domain knowledge for security auditing, constraint
   design, context engineering, fitness functions, model sovereignty, and more
-- **11 agents** — autonomous workers for orchestration, enforcement,
-  garbage collection, code review, governance auditing, and TDD
-- **21 commands** — slash commands for harness lifecycle, assessment,
-  portfolio assessment, reflection, governance, onboarding, and
-  convention management
+- **12 agents** — autonomous workers for orchestration, enforcement,
+  garbage collection, code review, governance auditing, adversarial
+  spec/code review, and TDD
+- **23 commands** — slash commands for harness lifecycle, assessment,
+  portfolio assessment, reflection, governance, onboarding, affordance
+  inventory, and convention management
 - **3 enforcement loops** — advisory at edit time, strict at merge
   time, investigative on schedule
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Commands
 
-All 22 slash commands registered in `commands/`. Each command is
+All 23 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -135,6 +135,42 @@ template not in your HARNESS.md), Updated (changed items), and Removed
 accepted or dismissed individually. Dismissing writes a
 `.claude/.harness-upgrade-dismissed` marker so the SessionStart hook
 does not re-prompt until the next plugin update.
+
+### /harness-affordance
+
+- **Skills read**: none
+- **Agents dispatched**: none
+- **Subcommands**: `discover` (implemented), `add` and `review`
+  (planned)
+
+Manage the project's affordance inventory — the declared tools the
+agent can invoke, with the identity each tool runs under, the audit
+trail each tool produces, and the permission allowlist that
+authorises it. See the
+[harness-affordances design spec](../superpowers/specs/2026-04-26-harness-affordances-design.md)
+for the full schema.
+
+`/harness-affordance discover` reads `.claude/settings.json`,
+`.claude/settings.local.json`, and `.mcp.json`, and writes a draft
+affordance inventory to `<project>/.claude/affordance-discovery-<date>.md`
+(gitignored). One draft entry per permission pattern, hook entry, and
+MCP server. Machine-derivable fields (`Mode`, `Trigger` for hooks,
+`Permission`, `Notes` when needed) are filled in; human-owned
+governance fields (`Identity`, `Audit trail`, `Last reviewed`) are
+left as `TODO` placeholders. The scanner is the **backfill path** for
+existing harness adopters: running it once produces a draft for every
+existing permission. See
+[Discover Affordances](../how-to/discover-affordances.md) for the
+full how-to.
+
+`/harness-affordance add <name>` (planned, sequencing step 3 of the
+affordances design) will guide annotation of a draft entry —
+prompts for Identity, Audit trail, optional Notes, then appends the
+completed entry to `HARNESS.md`.
+
+`/harness-affordance review <name>` (planned, sequencing step 6)
+will walk through the three re-validation checks (Identity, Audit
+trail, Permission) and bump `Last reviewed` if all pass.
 
 ---
 

--- a/docs/superpowers/objections/harness-affordance-discover-code.md
+++ b/docs/superpowers/objections/harness-affordance-discover-code.md
@@ -1,0 +1,236 @@
+---
+spec: docs/superpowers/specs/2026-04-27-harness-affordance-discover.md
+date: 2026-04-27
+mode: code
+diaboli_model: claude-opus-4-7
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "The MCP-without-permission cross-check searches base64-encoded entry blocks for plaintext permission prefixes, so the grep can never match a real permission and the warning logic is effectively broken."
+    evidence: "scripts/harness-affordance-discover.sh stores entries as `<name>\\t<base64-of-block>`; the cross-check then runs `grep -q -F \"${pattern_prefix}\" \"$ENTRIES_FILE\"` looking for `mcp__<server>__` against a file whose body column is base64."
+    disposition: accept
+    disposition_rationale: "Critical bug confirmed. Fix by eliminating base64 encoding entirely: write one entry per file to a temp directory (named by the affordance name), and maintain a parallel plaintext permissions.txt for the cross-check. The grep then operates on real content. Also resolves O3, O4, O6 by removing the encoding round-trip and giving each entry a stable on-disk presence."
+  - id: O2
+    category: specification quality
+    severity: high
+    claim: "The implementation omits the `Notes` field from every emitted block, but the spec's output template defines `Notes` and the `Sources read` section explicitly requires a Notes flag for the `other → cli` case."
+    evidence: "Spec output template defines `- **Notes**: <any warnings emitted by the scanner; otherwise omit>` and the mode-inference rules say `other → Mode: cli with a Notes flag`. The `emit_permission_affordance` block has no `Notes` line."
+    disposition: accept
+    disposition_rationale: "Spec deviation. Add a `Notes` field to the block as an optional line — emitted only when the scanner has something to say (the `other → cli` case, the WARN flag for MCP orphans, etc.). Block schema gains one conditional line; the `add` and `review` subcommands later can rely on a stable shape."
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "The spec mandates that an MCP server with no matching permission entry produces a draft affordance (with a Notes flag); the implementation only writes a top-of-file warning line and never emits an affordance entry for that server."
+    evidence: "Spec says the cross-check should emit a draft affordance with a `WARN: no permission allowlist entry` Notes flag. The script writes to WARN_FILE only and never calls add_entry for the orphan server."
+    disposition: accept
+    disposition_rationale: "Spec deviation. After the refactor for O1, the orphan-MCP-server case calls `add_entry` like any other affordance, with `Notes: WARN: no permission allowlist entry in any settings.json`. The reviewer then sees the orphan as a row in the entry stream rather than as a separate warning paragraph."
+  - id: O4
+    category: implementation
+    severity: high
+    claim: "Disambiguation suffixes depend on the insertion order into ENTRIES_FILE, which mirrors the order of `permissions.allow` in the JSON source — reordering the allow-array silently swaps which collision-victim wins the unsuffixed name."
+    evidence: "`unique_name` walks suffixes against entries already present in `ENTRIES_FILE`; entries enter in source-array order via `jq -r '.permissions.allow[]?'`. Spec claims re-runs produce stable identifiers without qualifying source-order dependency."
+    disposition: accept
+    disposition_rationale: "Sort the permission patterns lex-ascending before iteration so disambiguation is independent of source-array order. A user who reorders the allow array still gets the same suffix assignments. Combined with O1's one-file-per-entry refactor, the disambiguation logic becomes filename-based instead of grep-based, which is also faster and more obvious."
+  - id: O5
+    category: implementation
+    severity: high
+    claim: "The output sort is locale-dependent — `sort -t$'\\t' -k1,1` without `LC_ALL=C` produces different orderings on systems with different default locales, defeating the spec's cross-machine idempotency claim."
+    evidence: "The script uses `sort -t$'\\t' -k1,1 \"$ENTRIES_FILE\"`. Spec promises diffable, idempotent runs; the script does not pin the collation locale."
+    disposition: accept
+    disposition_rationale: "One-line fix: use `LC_ALL=C sort` (and `LC_ALL=C ls -1` after the refactor) so collation is byte-ordered and identical across machines. Defends the cross-machine idempotency claim."
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "The base64 encode/decode round-trip uses `base64 -d` for decoding, which is GNU coreutils convention; older or stripped-down BSD `base64` builds use `-D`, with no probe or fallback. On a system where `-d` is unsupported the decode silently produces no output and entries disappear."
+    evidence: "Script invokes `printf '%s' \"$encoded\" | base64 -d`. The script header documents macOS and Linux as supported; no probe selects between `-d` and `-D`."
+    disposition: accept
+    disposition_rationale: "Resolved by O1's refactor: removing base64 entirely eliminates the portability concern. No probe needed, no fallback needed."
+  - id: O7
+    category: implementation
+    severity: medium
+    claim: "Hook script-name derivation strips `.sh` and `.py` extensions, but Bash-pattern derivation strips no extensions, so `Bash(./scripts/foo.sh)` becomes `foo.sh-cli` while a hook invoking the same script becomes `foo-stop` — inconsistent."
+    evidence: "Hook path strips `.sh`/`.py` only; `derive_name` for Bash calls `basename` but never strips a suffix."
+    disposition: accept
+    disposition_rationale: "Extract a shared `strip_known_extensions` helper that both `derive_name` (for Bash patterns) and `emit_hook_affordance` (for hook script paths) call. Strip `.sh`, `.py`, `.js`, `.rb`, `.ts` — the common script extensions. A Bash permission for `Bash(./scripts/foo.sh)` and a hook invoking `foo.sh` will then both derive to `foo`."
+  - id: O8
+    category: implementation
+    severity: medium
+    claim: "Hook command parsing takes the first whitespace-delimited token as the script path. Shell wrappers (`bash -c '...'`, `python -m foo`) collapse to wrapper-named entries (`bash-stop`, `python-stop`) that convey nothing about what the hook does."
+    evidence: "Script uses `script_basename=$(basename \"${hook_command%% *}\")`. The spec's example assumes script-style hook commands but does not constrain the input form."
+    disposition: clarify
+    disposition_rationale: "Real concern but the fix is non-trivial (parse `-c` arguments, recognise known wrappers like `bash`, `sh`, `python`, `node`). Defer to a follow-on improvement; for v0.28.0, accept the limitation. Spec will be updated to document that hook commands using shell wrappers produce wrapper-named affordances and recommend that hook configs invoke scripts directly when affordance-readability matters."
+  - id: O9
+    category: risk
+    severity: medium
+    claim: "`validate_json` runs against `.mcp.json` twice; if the file is edited between those calls and becomes malformed, the second call aborts the script via `set -e` after entries are accumulated but before the output file is written — silent data loss."
+    evidence: "Script invokes `validate_json \"$MCP_JSON\"` at MCP server enumeration and again at the cross-check step. Output is written in a heredoc block that only runs after both checks complete."
+    disposition: accept
+    disposition_rationale: "Read `.mcp.json` once into a variable at the start of the script and use the cached parse for both the server enumeration and the cross-check. Eliminates the race window."
+  - id: O10
+    category: specification quality
+    severity: low
+    claim: "Behaviour on a malformed first source file is undocumented — the script aborts under `set -e` before other source files are processed, but the spec only specifies non-zero exit on malformed JSON without saying whether other sources should still be scanned."
+    evidence: "Spec's Error Handling section says `exit non-zero so CI can catch` without addressing partial progress. Script aborts via `set -e` on first malformed source."
+    disposition: accept
+    disposition_rationale: "Document the all-or-nothing behaviour explicitly in the spec's Error Handling section: a malformed source file aborts the scanner before subsequent sources are processed. The implementation choice is reasonable (loud failure beats partial output of dubious provenance), but it should not be implicit."
+---
+
+# Adversarial Review — harness-affordance-discover (code mode)
+
+Spec: `docs/superpowers/specs/2026-04-27-harness-affordance-discover.md`
+Mode: code
+Reviewer: advocatus-diaboli (Claude Opus 4.7)
+
+## O1 — implementation — critical
+
+### Claim
+
+The MCP-without-permission cross-check is broken. It searches base64-encoded entry blocks for plaintext permission prefixes, which can never match.
+
+### Evidence
+
+`emit_permission_affordance` and `add_entry` store each entry as `<name>\t<base64-of-block>`. The cross-check then does `grep -q -F "${pattern_prefix}" "$ENTRIES_FILE"` looking for `mcp__<server>__`. Only the derived name (e.g. `honeycomb-mcp`) is plaintext on each line. The literal string `mcp__honeycomb__` is base64-encoded and so is invisible to a literal grep.
+
+### Why this matters
+
+The cross-check is the design's "asymmetric blocking case": permission-without-affordance is advisory, but affordance-without-permission is a governance hole that must be surfaced. Shipping a check that cannot actually detect this case — while the how-to claims it can — is worse than not shipping the check, because reviewers will trust the absence of warnings as evidence of correctness.
+
+A correct check should grep against the original permission patterns held in plaintext (write a parallel `${WORK}/permissions.txt` capturing every raw pattern as it is read from settings, or invert the test by enumerating every `mcp__<server>__*` permission and confirming each derived server name is in the `.mcp.json` server list).
+
+## O2 — specification quality — high
+
+### Claim
+
+The implementation does not emit a `Notes` field on any block, but the spec's output template defines `Notes` and the mode-inference rules require a Notes flag for the `other → cli` case.
+
+### Evidence
+
+Spec template has `- **Notes**: <any warnings emitted by the scanner; otherwise omit>`. Spec rules: "other → `Mode: cli` with a Notes flag". The `emit_permission_affordance` block has no Notes line and no path that emits one.
+
+### Why this matters
+
+(1) The "other" case (e.g. `WebFetch(*)`, `Read`, `Edit`) is silently mis-classified as ordinary `cli` with no flag — the human reviewer has no signal that the derivation guessed at `Mode: cli`. (2) Any caller relying on the spec's stated entry shape will have to handle two block shapes — one with Notes, one without — or be retrofitted later.
+
+## O3 — specification quality — high
+
+### Claim
+
+For the MCP-server-without-permission case, the spec requires the scanner to emit a draft *affordance* with a Notes flag. The implementation emits only a top-of-file warning line and produces no affordance entry for the orphan server.
+
+### Evidence
+
+Spec: cross-check should "emit a draft affordance with a `WARN: no permission allowlist entry` Notes flag". The script only writes to `WARN_FILE` and never calls `add_entry` for the orphan.
+
+### Why this matters
+
+A reviewer scanning the affordance entries gets no row for the orphan server, so the natural promotion workflow never produces an affordance entry for the unauthorised server. The spec's design was to make the affordance entry itself the artefact reviewers act on. (Compounds with O1: even if the cross-check grep is fixed, the architectural choice to write to `WARN_FILE` instead of `add_entry` remains a deviation.)
+
+## O4 — implementation — high
+
+### Claim
+
+Disambiguation suffixes depend on insertion order into `ENTRIES_FILE`, which mirrors the order of `permissions.allow` in the JSON source. Reordering the allow-array silently swaps which collision-victim wins the unsuffixed name; HARNESS.md entries already promoted under the previous order silently dangle.
+
+### Evidence
+
+`unique_name` walks suffixes only against entries already present in `ENTRIES_FILE`. Entries enter in source-array order via `jq -r '.permissions.allow[]?'`. Spec claims "re-runs produce stable identifiers" without qualifying that stability depends on source-array order being stable.
+
+### Why this matters
+
+A user who promotes `awk-cli` to HARNESS.md and later re-orders the allow array gets a HARNESS.md entry that now describes a different permission. There is no diff signal at the affordance-name level. A more robust derivation would suffix by content hash, by lexical order of the colliding pattern strings, or warn loudly when collisions occur.
+
+## O5 — implementation — high
+
+### Claim
+
+The output sort is locale-dependent. `sort -t$'\t' -k1,1` without `LC_ALL=C` produces different orderings on systems whose default locales differ, defeating the spec's cross-machine idempotency claim.
+
+### Evidence
+
+`sort -t$'\t' -k1,1 "$ENTRIES_FILE"`. Spec promises "safe to diff successive runs"; the script does not pin the collation locale.
+
+### Why this matters
+
+CI runs the scanner in one locale; developers in another. Diffing CI output against local output produces spurious noise. The fix is one line — `LC_ALL=C sort ...`.
+
+## O6 — risk — medium
+
+### Claim
+
+The base64 encode/decode round-trip uses `base64 -d` (GNU convention). BSD `base64` historically requires `-D`. On a system where the on-PATH `base64` does not accept `-d`, the decode silently produces empty output and entries disappear with no error.
+
+### Evidence
+
+`printf '%s' "$encoded" | base64 -d`. No probe selects between flags; `set -e` does not catch a `base64` that exits 0 with empty output.
+
+### Why this matters
+
+Modern macOS does accept `-d` (since circa 2014), but older or trimmed-down systems fail silently — counts in the heading would not match the entries below. An alternative that avoids the encoding entirely (one entry per file in a sorted directory, then `cat` in `ls -1` order) eliminates the portability concern.
+
+## O7 — implementation — medium
+
+### Claim
+
+Hook script-name derivation strips `.sh` and `.py` extensions; Bash-pattern derivation strips no extensions. `Bash(./scripts/foo.sh)` becomes `foo.sh-cli` while a hook invoking the same script becomes `foo-stop` — inconsistent.
+
+### Evidence
+
+Hook path strips `.sh`/`.py` only; `derive_name` for Bash calls `basename` but never strips a suffix.
+
+### Why this matters
+
+Affordance entries are meant to be human-readable handles. Two entries describing the same underlying script under inconsistent names invites the reviewer to treat them as separate concerns. Fix is a one-line addition in `derive_name`.
+
+## O8 — implementation — medium
+
+### Claim
+
+Hook command parsing takes the first whitespace-delimited token as the script path. Shell wrappers (`bash -c '...'`, `python -m foo`) collapse to wrapper-named entries (`bash-stop`, `python-stop`) that convey nothing about what the hook does.
+
+### Evidence
+
+`script_basename=$(basename "${hook_command%% *}")`. Spec's example assumes script-style hook commands but does not constrain the input form.
+
+### Why this matters
+
+`bash-stop` and `bash-stop-2` are not useful identifiers for governance. A more informative derivation would inspect the `-c` argument or the next non-flag token after a known wrapper, or fall back to a content hash.
+
+## O9 — risk — medium
+
+### Claim
+
+`validate_json` runs against `.mcp.json` twice — once during MCP-server enumeration, again at the cross-check. If the file is edited between calls and becomes malformed, the second call aborts the script via `set -e` after entries are accumulated but before the output file is written. The user gets no output and no signal that work was lost.
+
+### Evidence
+
+Script invokes `validate_json "$MCP_JSON"` at MCP server enumeration and again at the cross-check step. Output is written in a heredoc block that only runs after the cross-check completes.
+
+### Why this matters
+
+Concurrent edits to `.mcp.json` are not exotic. The narrow window does occur, and "scan succeeded silently then failed silently" is poor UX for a tool positioned as safe to run on a schedule. Reading and validating each file once into a variable, or writing partial output to a `.partial` path that is moved into place at the end, would harden this.
+
+## O10 — specification quality — low
+
+### Claim
+
+Behaviour on a malformed first source file is undocumented — the script aborts under `set -e` before other source files are processed, but the spec only specifies non-zero exit on malformed JSON without saying whether other sources should still be scanned.
+
+### Evidence
+
+Spec's Error Handling: "Malformed JSON → emit the file path and parse error to stderr, exit non-zero so CI can catch." Nothing about partial progress. Script aborts via `set -e` on first malformed source.
+
+### Why this matters
+
+The user's mental model from the spec is "exit non-zero on malformed JSON"; the implementation also implicitly enforces "and process nothing further." Either pin the choice in the spec, or relax the implementation to continue and accumulate parse errors.
+
+## Explicitly not objecting to
+
+- **`set -euo pipefail` choice**: strict mode is correct for this kind of scanner.
+- **Use of `jq` as a hard dependency**: jq is widely available; the install-hint failure path is clean.
+- **Tempdir cleanup via `trap 'rm -rf "$WORK"' EXIT`**: standard idiom; behaves correctly under exit and SIGINT/SIGTERM.
+- **`derive_name` env-var-prefix handling**: the leading `KEY=value` strip handles real-world patterns and the regex is well-anchored.
+- **Subshell-counter fix via `printf -v "$count_var"`**: the iteration-1 bug was fixed correctly.
+- **Stub messages for `add` and `review` subcommands**: pointing the user at the design spec is the right interim contract.
+- **`.claude/` gitignored output path**: aligns with project convention.
+- **Splitting the parent command from the scanner script**: the decomposition matches the design spec's command-routing pattern and gives `add`/`review` clean addition paths later.

--- a/docs/superpowers/specs/2026-04-27-harness-affordance-discover.md
+++ b/docs/superpowers/specs/2026-04-27-harness-affordance-discover.md
@@ -1,0 +1,218 @@
+---
+name: harness-affordance-discover
+description: Implementation spec for /harness-affordance discover — the discovery scanner that reads project config (settings.json, .mcp.json, hook entries) and emits a draft affordance inventory to a scratch file. First implementation step of the harness-affordances design (sequencing step 2).
+date: 2026-04-27
+status: draft
+---
+
+# /harness-affordance discover — Implementation Spec
+
+> Implements **sequencing step 2** of
+> `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`.
+> The design spec is the source of truth for *why* this exists, the
+> schema, and the full command surface. This spec covers *what to
+> build first*: the discovery scanner only.
+
+## Problem
+
+The harness-affordances design (PR #198) is approved on main, but
+no implementation has shipped. The first step is the discovery
+scanner — without it, populating the new `## Affordances` section
+requires hand-typing every entry, which collides with the
+"discovery-first sequencing" decision (Resolved Decision 7) and
+gives existing harness adopters no backfill path (Resolved
+Decision 13).
+
+## Goals
+
+1. Ship `/harness-affordance discover` as a working command that
+   produces a draft affordance inventory from the current project's
+   config.
+2. The output is a standalone scratch file (not appended to
+   HARNESS.md), preserving the "humans own HARNESS.md" structural
+   invariant (Resolved Decision 8).
+3. Existing harness adopters gain the backfill path immediately on
+   v0.28.0 — they run the command once and get a draft for every
+   permission, hook, and MCP server already declared in config.
+4. The scanner is idempotent — running it twice produces the same
+   output (modulo timestamps), so it can be safely run on a
+   schedule or in CI.
+
+## Non-Goals
+
+- **`add` and `review` subcommands.** Out of scope; sequencing
+  steps 3 and 6 respectively. The command file is structured so
+  both can be wired up later without rewrites.
+- **Diff against existing HARNESS.md `## Affordances` section.**
+  Out of scope for this PR; will be added when the section itself
+  ships in step 3 (no point diffing against a section that does not
+  yet exist on any project).
+- **Reading `~/.claude/settings.json`.** User-level settings are
+  out of scope for project-level governance review. Project
+  affordances come from project-level config only.
+- **Inferring Identity, Audit Trail, or Last Reviewed.** These are
+  the human-owned governance fields; the scanner emits empty
+  placeholders for the human to fill in via the `add` subcommand
+  (or by hand) in a later step.
+- **Writing to HARNESS.md.** The scanner only ever writes to
+  `.claude/affordance-discovery-<date>.md`.
+
+## Design
+
+### Sources read
+
+In order of precedence (later sources override earlier when the same
+permission pattern appears in both):
+
+1. `<project>/.claude/settings.json`
+2. `<project>/.claude/settings.local.json`
+3. `<project>/.mcp.json`
+
+For each source, the scanner extracts:
+
+- **`permissions.allow` entries** → one draft affordance per
+  pattern, with `Mode` inferred from the pattern shape:
+  - `Bash(...)` → `Mode: cli`
+  - `mcp__<server>__...` → `Mode: local-mcp` *or* `central-mcp`
+    depending on whether the matching MCP server in `.mcp.json` has
+    a remote URL (default `local-mcp` if cannot determine)
+  - other → `Mode: cli` with a Notes flag
+- **`hooks.<event>` entries** → one draft affordance per hook,
+  with `Mode: hook` and `Trigger: <event>` (matching the nine
+  Claude Code hook event names per the design spec)
+- **MCP servers in `.mcp.json` not already covered by a
+  `mcp__<server>__*` permission entry** → emit a draft affordance
+  with a `WARN: no permission allowlist entry` Notes flag (this is
+  the asymmetric case from O9 — permission-without-affordance is
+  advisory, but affordance-without-permission is blocking, so an
+  MCP declared without authorisation is worth surfacing).
+
+### Output format
+
+A markdown file at `<project>/.claude/affordance-discovery-<date>.md`.
+The `.claude/` directory is gitignored, so drafts do not pollute
+git. Filename includes the date so re-running creates a new draft
+side-by-side with prior drafts.
+
+Output structure:
+
+```markdown
+# Affordance Discovery — <YYYY-MM-DD>
+
+Draft affordance inventory generated from project config.
+Review each entry, fill in the human-owned fields (**Identity**,
+**Audit trail**, optional **Notes**), then copy approved entries
+into `HARNESS.md` under `## Affordances`.
+
+Source files scanned:
+- .claude/settings.json (N entries)
+- .claude/settings.local.json (M entries)
+- .mcp.json (P servers)
+
+---
+
+### <derived-name>
+
+- **Mode**: cli
+- **Identity**: TODO
+- **Audit trail**: TODO
+- **Permission**: `Bash(gh *)`
+- **Last reviewed**: TODO (run `/harness-affordance review` once
+  Identity and Audit trail are filled in)
+- **Notes**: <any warnings emitted by the scanner; otherwise omit>
+
+### <derived-name-2>
+...
+```
+
+### Derived names
+
+The affordance name is derived deterministically from the
+permission pattern, so re-runs produce stable identifiers:
+
+- `Bash(gh *)` → `gh-cli`
+- `Bash(git *)` → `git-cli`
+- `Bash(npx *)` → `npx-cli`
+- `Bash(<single-token>)` → `<single-token>-cli`
+- `mcp__honeycomb__*` → `honeycomb-mcp`
+- `mcp__honeycomb__query` → `honeycomb-mcp-query` (rare; the
+  granularity rule prefers per-pattern, so per-method permissions
+  produce per-method affordances)
+- Hook entry → `<script-basename>-<trigger-lowercase>` (e.g.
+  `sync-to-global-cache-stop`)
+
+If two derived names collide (e.g. two unrelated permissions hash
+to the same name), the second appends a numeric suffix.
+
+### Idempotency
+
+Running the scanner twice on the same input produces output that
+differs only in the date in the heading. Entry order is alphabetical
+by derived name. No timestamps inside entries. This makes it safe to
+diff successive runs.
+
+### Error handling
+
+- Missing source file → skip silently (not all projects have all
+  three).
+- Malformed JSON → emit the file path and parse error to stderr,
+  exit non-zero so CI can catch.
+- `jq` not installed → fail with a clear message: "jq is required
+  for /harness-affordance discover. Install via `brew install jq`
+  or `apt install jq`."
+
+## Components
+
+| Component | Type | Effort |
+| --- | --- | --- |
+| `ai-literacy-superpowers/commands/harness-affordance.md` (parent command with subcommand routing; `add` and `review` produce "not yet implemented" pointing at the design spec) | command | XS |
+| `ai-literacy-superpowers/scripts/harness-affordance-discover.sh` (the scanner) | bash | M |
+| `docs/how-to/discover-affordances.md` (one-page how-to: prerequisites, invocation, reading the output) | docs | XS |
+| `CHANGELOG.md` entry under new `## 0.28.0` heading | docs | XS |
+| Plugin version bump to `0.28.0` in three locations | meta | XS |
+
+## Dependencies
+
+- **`jq`** — required at runtime for JSON parsing. Documented in
+  the how-to and in the script's failure message.
+- **CLAUDE.md "Docs Site Review" convention** (already in place):
+  the how-to lands in this PR, not as a follow-up.
+- **Affordances design spec** (PR #198, on main): defines the
+  schema and the discovery-first sequencing this implements.
+
+## Test plan
+
+The scanner is verifiable end-to-end by running it against this
+project's own config. Expected output: at minimum, draft entries
+for the existing permission patterns in
+`.claude/settings.local.json` (gitignored, but present on the
+maintainer's machine), the hooks declared there, and any MCP
+servers declared in `.mcp.json`.
+
+CI cannot run the scanner against `.claude/settings.local.json`
+(the file is gitignored), but the script's `bash -n` syntax check,
+`shellcheck` clean run, and dry-run against a fixture file (added
+under `tests/fixtures/affordance-discover/` if needed) cover the
+core paths.
+
+## Version Impact
+
+- Plugin minor bump: `0.27.0` → `0.28.0`
+- Files updated:
+  - `ai-literacy-superpowers/.claude-plugin/plugin.json`
+  - `.claude-plugin/marketplace.json` (`plugin_version` and
+    per-plugin `version`)
+  - `README.md` Plugin Version badge
+  - `CHANGELOG.md` new heading
+
+## Exemptions
+
+None. Standard feature PR; spec-first satisfied by this file as the
+first commit; `/diaboli` code-mode review will run on the
+implementation before merge.
+
+## Open Questions
+
+None at spec time — the design decisions were already locked in
+PR #198. The `/diaboli` code-mode review will surface any
+implementation-level objections that need adjudication.

--- a/docs/superpowers/specs/2026-04-27-harness-affordance-discover.md
+++ b/docs/superpowers/specs/2026-04-27-harness-affordance-discover.md
@@ -156,7 +156,12 @@ diff successive runs.
 - Missing source file → skip silently (not all projects have all
   three).
 - Malformed JSON → emit the file path and parse error to stderr,
-  exit non-zero so CI can catch.
+  exit non-zero so CI can catch. **Behaviour is all-or-nothing**: a
+  malformed source file aborts the scanner before subsequent sources
+  are processed, and no output file is written. This is deliberate —
+  loud failure beats partial output of dubious provenance, and a
+  partial write would mislead downstream tools that compare counts in
+  the heading against entries below. Per O10 of the code-mode review.
 - `jq` not installed → fail with a clear message: "jq is required
   for /harness-affordance discover. Install via `brew install jq`
   or `apt install jq`."


### PR DESCRIPTION
## Summary

First implementation step of the harness-affordances design (PR #198,
on main as of v0.27.0). Ships the discovery scanner that produces a
draft affordance inventory from project config; the parent
\`/harness-affordance\` command is structured for the \`add\` and
\`review\` subcommands to slot in later (sequencing steps 3 and 6).

## Spec-first discipline

- **Commit 1**: implementation spec at
  \`docs/superpowers/specs/2026-04-27-harness-affordance-discover.md\`
- **Commit 2**: implementation
- **Commit 3**: \`/diaboli\` code-mode objection record at
  \`docs/superpowers/objections/harness-affordance-discover-code.md\`
  with all 10 dispositions resolved (9 accept, 1 clarify, 0 pending),
  plus the scanner refactor that the dispositions drove

## What ships

- \`commands/harness-affordance.md\` — parent command with three
  subcommand routes: \`discover\` (implemented), \`add\` and
  \`review\` (print 'not yet implemented' with pointers to the
  design spec)
- \`scripts/harness-affordance-discover.sh\` — bash discovery
  scanner. Reads \`.claude/settings.json\`,
  \`.claude/settings.local.json\`, and \`.mcp.json\`. One affordance
  per permission pattern; one per hook entry (with \`Trigger\`); MCP
  servers without matching permissions emit affordance entries with
  WARN in Notes. Output goes to
  \`<project>/.claude/affordance-discovery-<date>.md\`, never to
  HARNESS.md
- Idempotent. Sort and disambiguation pinned to \`LC_ALL=C\` for
  cross-machine reproducibility. One file per entry (no base64
  packing, no portability concerns)
- \`docs/how-to/discover-affordances.md\` — one-page guide
- \`.gitignore\` — exclude
  \`.claude/affordance-discovery-*.md\` so drafts never accidentally
  land in version control

## Adjudication highlights

The \`/diaboli\` code-mode review found a critical bug (O1) and three
related architectural issues (O3, O4, O6) all rooted in the original
base64-pack-into-single-tempfile design. The accepted refactor — one
file per entry in a temp directory, with a parallel plaintext
permissions file for the cross-check — dissolves all four. Other
accepted dispositions add a Notes field for inferred-mode entries
(O2), pin sort locale (O5), share an extension-stripping helper
between Bash-pattern and hook-script name derivation (O7), cache
\`.mcp.json\` to eliminate a TOCTOU race (O9), and document the
all-or-nothing behaviour on malformed JSON (O10). O8 (shell-wrapper
hook commands derive to wrapper-named entries) is documented as a
known limitation; the fix is non-trivial and deferred to a future
improvement.

## Verified by running against this project's own config

- 72 \`cli\` affordances + 2 \`hook\` affordances discovered
- All entry names unique (disambiguation working)
- \`awk-cli\` precedes \`awk-cli-2\` in sort order (basename sort,
  not full-path)
- Idempotent (\`md5\` matches across re-runs)

## Version bump

Plugin minor: \`0.27.0\` → \`0.28.0\` (new behaviour). Updated:
\`plugin.json\`, \`marketplace.json\` (\`plugin_version\` and
per-plugin \`version\`), README badge + Commands count badge (22 →
23) + Commands table, CHANGELOG.

## Test plan

- [x] \`shellcheck scripts/harness-affordance-discover.sh\` clean
- [x] \`bash -n\` syntax check passes
- [x] \`npx markdownlint-cli2\` passes for all modified files
- [x] Scanner produces expected output against this project
  (74 affordances total)
- [x] All version pins match across plugin.json, marketplace.json
  (both fields), README badge, CHANGELOG top heading
- [x] \`/diaboli\` code-mode objection record present with 0
  \`pending\` dispositions
- [ ] CI green