### PR TITLE
chore: bump HARNESS.md template marker to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.28.0 — 2026-04-27
 
+### Chore — harness marker bump
+
+- Bump `HARNESS.md` template-version marker from 0.26.0 to 0.28.0 after
+  running `/harness-upgrade` (issue #206). No new template content to
+  adopt — the plugin's `templates/HARNESS.md` carries internal marker
+  0.19.0, and the project HARNESS.md already contains every active rule
+  and commented block in the template plus many project-specific
+  additions. The bump records that v0.28.0 has been reviewed.
+
 ### Feature — `/harness-affordance discover` (sequencing step 2 of harness-affordances)
 
 - Add `commands/harness-affordance.md` — parent command for the

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.26.0 -->
+<!-- template-version: 0.28.0 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Closes #206
- Bumps `HARNESS.md` template-version marker from 0.26.0 → 0.28.0 after running `/harness-upgrade`
- Adds CHANGELOG entry under existing 0.28.0 heading (no plugin version bump — change is outside `ai-literacy-superpowers/`)

## Why no template content was adopted

The plugin's `templates/HARNESS.md` carries its own internal marker `0.19.0` — template content has not changed since the 0.19.0 release. The bumps from 0.19→0.28 added skills, commands, and agents but introduced no new template-shipped constraints or GC rules. Our project HARNESS.md already contains:

- Every active rule and commented block in the template
- Many project-specific additions (`Shell scripts pass syntax check`, `Plugin manifest currency`, `Release tag completeness`, `Marketplace plugin version sync`, `Spec captures intent`, `Reflections via PR workflow`, `Label PRs at creation time`, etc.)

So this PR is a marker-only chore, recording that v0.28.0 has been reviewed.

## CI gate exemptions

`chore` label exempts:
- `Spec-first commit ordering` (no spec required for chore PRs)
- `PRs have adjudicated objections` (chore exempt on the same terms)

## Test plan

- [ ] `Check version consistency` passes (HARNESS.md marker change is outside `ai-literacy-superpowers/`; expect no version-mismatch failure)
- [ ] `markdownlint` passes for HARNESS.md and CHANGELOG.md
- [ ] All other CI checks green