### PR TITLE
docs: integrate Choice Cartographer into docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## 0.29.0 — 2026-04-27
 
+### Docs — Choice Cartographer integration into docs site
+
+- `docs/reference/agents.md`: add `choice-cartographer` entry alongside
+  `advocatus-diaboli` with Routing Rule cross-reference; bump count from
+  12 to 13; expand pipeline-agents framing to seven agents with two
+  human gates (hard + soft); add row to the Tool Summary table.
+- `docs/reference/commands.md`: add `/choice-cartograph` entry under
+  Workflow with disposition values and merge-time gate context; bump
+  count from 23 to 24.
+- `docs/reference/skills.md`: add new "Spec-First Pipeline" section
+  containing both `advocatus-diaboli` and `choice-cartographer` skill
+  entries; bump count from 28 to 30 (advocatus-diaboli was missing too
+  and is now added under the new section).
+- `docs/explanation/agent-orchestration.md`: insert Choice Cartographer
+  step into the pipeline diagram; expand "Two things matter here" to
+  three to cover the soft-gate / hard-gate asymmetry; add cross-link to
+  `decision-archaeology.md`.
+- `docs/explanation/adversarial-review.md`: add Further Reading links
+  to `decision-archaeology.md` and `run-choice-cartograph.md` so the
+  paired agents are discoverable from each other.
+- `docs/index.md`: bump skills/agents/commands counts to 30/13/24 and
+  call out decision-archaeology in the value bullets.
+
 ### Feature — Choice Cartographer (decision-archaeology agent)
 
 - Add `agents/choice-cartographer.agent.md` — second chartered read-only

--- a/docs/explanation/adversarial-review.md
+++ b/docs/explanation/adversarial-review.md
@@ -172,6 +172,8 @@ Objection records accumulate in `docs/superpowers/objections/` and feed the othe
 ## Further reading
 
 - [How to: Review a Spec Adversarially]({% link how-to/review-a-spec-adversarially.md %}) — the practical steps for running `/diaboli` and adjudicating the record
+- [Decision Archaeology]({% link explanation/decision-archaeology.md %}) — the paired Choice Cartographer agent that runs after diaboli adjudication; the Routing Rule that partitions findings between the two
+- [How to: Run the Choice Cartographer]({% link how-to/run-choice-cartograph.md %}) — practical steps for `/choice-cartograph`
 - [Agent Orchestration]({% link explanation/agent-orchestration.md %}) — the full pipeline in which adversarial review sits
 - [Agents Reference]({% link reference/agents.md %}) — the advocatus-diaboli agent's tools and trust boundary
 - [Commands Reference: /diaboli]({% link reference/commands.md %}) — command invocation and output format

--- a/docs/explanation/agent-orchestration.md
+++ b/docs/explanation/agent-orchestration.md
@@ -101,7 +101,13 @@ Requirements
 [Advocatus Diaboli] --> Objection record
     |
     v
-*** HUMAN ADJUDICATES OBJECTIONS ***
+*** HUMAN ADJUDICATES OBJECTIONS (hard gate) ***
+    |
+    v
+[Choice Cartographer] --> Choice-story record
+    |
+    v
+*** HUMAN ADJUDICATES STORIES (soft gate) ***
     |
     v
 *** HUMAN REVIEWS AND APPROVES SPEC ***
@@ -131,9 +137,9 @@ Requirements
 [Integrator] --> Changelog, commit, PR, CI
 ```
 
-Two things matter here.
+Three things matter here.
 
-**The human gates.** There are now two. First, the advocatus-diaboli reviews the spec and produces an objection record — you adjudicate each objection, writing your disposition and rationale inline. The agent cannot do this for you: its trust boundary is read-only. Second, you review and approve the *spec* itself. Not line 47 of a 200-line diff — the plan. "Is this what I actually want? Does this approach make sense? Are we building the right thing?" That is the highest-leverage decision in the process. Once you approve the spec, the pipeline can run without you.
+**The human gates.** There are now three. First, the advocatus-diaboli reviews the spec and produces an objection record — you adjudicate each objection, writing your disposition and rationale inline. The agent cannot do this for you: its trust boundary is read-only. The diaboli's gate is **hard** — the pipeline refuses to advance while any disposition is `pending`. Second, the choice-cartographer maps the implicit decisions the spec has made and produces a choice-story record — you write dispositions for each story (the same trust-boundary mechanism applies). The cartographer's gate is **soft** — `cartograph_pending_count` is surfaced as observability and the pipeline continues; the merge-time HARNESS constraint blocks the PR until dispositions are written. Third, you review and approve the *spec* itself. Not line 47 of a 200-line diff — the plan. "Is this what I actually want? Does this approach make sense? Are we building the right thing?" That is the highest-leverage decision in the process. Once you approve the spec, the pipeline can run without you. See [Decision Archaeology]({% link explanation/decision-archaeology.md %}) for why the cartographer's gate is soft and the diaboli's is hard.
 
 **The cycle limit.** When the reviewer rejects and the implementer fixes, there is a maximum of three cycles. Without a limit, you get agent ping-pong: the reviewer keeps finding issues, the implementer keeps introducing new ones, and the token cost keeps climbing. Three cycles is enough for genuine iteration. If it is not resolved in three, a human needs to look — and the problem is usually in the spec, not the code.
 
@@ -206,6 +212,7 @@ That is the review process working. The reviewer can reject, and the implementer
 
 - [Agents Reference]({% link reference/agents.md %}) — detailed catalogue of all agents in this plugin
 - [Adversarial Review]({% link explanation/adversarial-review.md %}) — the concepts behind the advocatus-diaboli and the human-cognition gate
+- [Decision Archaeology]({% link explanation/decision-archaeology.md %}) — the choice-cartographer's role; intent debt and cognitive debt; the soft gate / hard gate asymmetry
 - [Compound Learning]({% link explanation/compound-learning.md %}) — how agent output feeds the learning loop
 - [Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %}) — the constraints agents enforce
 - [Harness Engineering]({% link explanation/harness-engineering.md %}) — the broader framework that agent orchestration fits within

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,14 +55,15 @@ stays trustworthy at scale.
 
 It gives you:
 
-- **29 skills** — domain knowledge for security auditing, constraint
-  design, context engineering, fitness functions, model sovereignty, and more
-- **12 agents** — autonomous workers for orchestration, enforcement,
+- **30 skills** — domain knowledge for security auditing, constraint
+  design, context engineering, fitness functions, model sovereignty,
+  decision archaeology, and more
+- **13 agents** — autonomous workers for orchestration, enforcement,
   garbage collection, code review, governance auditing, adversarial
-  spec/code review, and TDD
-- **23 commands** — slash commands for harness lifecycle, assessment,
+  spec/code review, decision archaeology, and TDD
+- **24 commands** — slash commands for harness lifecycle, assessment,
   portfolio assessment, reflection, governance, onboarding, affordance
-  inventory, and convention management
+  inventory, decision-archaeology mapping, and convention management
 - **3 enforcement loops** — advisory at edit time, strict at merge
   time, investigative on schedule
 

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Agents
 
-The plugin ships 12 agents organised into four groups: the
+The plugin ships 13 agents organised into three groups: the
 **spec-first pipeline** that coordinates feature work end to end,
 the **harness agents** that verify and maintain infrastructure
 conventions, and the **assessor** that measures AI literacy.
@@ -21,11 +21,12 @@ makes this explicit.
 
 ## Pipeline Agents
 
-These six agents form the spec-first development pipeline. After
+These seven agents form the spec-first development pipeline. After
 spec-writer produces the spec, the advocatus-diaboli reviews it
-adversarially and a human adjudicates the objections before plan
-approval; only then do tdd-agent, code-reviewer, and
-integration-agent run.
+adversarially and a human adjudicates the objections (hard gate);
+the choice-cartographer then maps the implicit decisions and a human
+adjudicates the choice-stories (soft gate); only then is the plan
+approved and tdd-agent, code-reviewer, and integration-agent run.
 
 ### orchestrator
 
@@ -70,6 +71,43 @@ alter the problem statement, and the absence of a disposition-writing tool
 forces a human to open the record and adjudicate before the pipeline
 proceeds. This human-cognition gate is the primary purpose of the agent —
 not finding objections, but ensuring a human engages with them.
+
+Applies the **Routing Rule** before emitting any candidate: a finding
+belongs in the diaboli's record iff removing it would leave a class of
+failures undetected. Findings shaped "this chose X over Y" without a
+failure implication belong in the choice-cartographer's record (see
+below). The two agents form a complete partition of findings worth
+surfacing about a spec.
+
+### choice-cartographer
+
+- **Tools**: Read, Glob, Grep
+- **Dispatched by**: orchestrator (after spec-mode advocatus-diaboli
+  dispositions are resolved, before plan approval)
+- **Trust boundary**: Read-only
+
+Decision-archaeology agent. Reads the spec and the matching adjudicated
+diaboli record, then maps the implicit decisions the spec has committed
+to — defaults inherited, alternatives unspoken, patterns unnamed,
+consequences accepted. Emits each material choice as a *choice story*
+(Henney-style pattern story, POSA Vol. 5) for human disposition.
+Produces a structured choice-story record at
+`docs/superpowers/stories/<spec-slug>.md`.
+
+Six lenses: forces, alternatives, defaults, patterns, consequences,
+coherence. Selectivity is enforced inside the agent's reasoning protocol
+(bias toward 5–8 stories per spec, hard cap of 15). Mirrors the diaboli's
+read-only mechanism: cannot modify the spec, cannot write dispositions.
+
+Applies the **Routing Rule** as the partition with the diaboli: a finding
+belongs in the cartographer's record iff removing it would leave a
+decision unrecorded but no failure undetected. The plan-approval gate is
+**soft** — `cartograph_pending_count` is surfaced as observability but
+does not block progression. The merge-time HARNESS constraint
+**PRs have adjudicated choice stories** is the forcing function.
+
+This release is spec-mode only. Code-mode behaviour is tracked under
+[issue #209](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/209).
 
 ### tdd-agent
 
@@ -227,6 +265,7 @@ governance analysis requires nuanced judgement about meaning.
 | orchestrator | x | x | x | x | x | x | x | x | read-write |
 | spec-writer | x | x | x | x | x | | | | read-write |
 | advocatus-diaboli | x | | | x | x | | | | read-only |
+| choice-cartographer | x | | | x | x | | | | read-only |
 | tdd-agent | x | x | x | x | x | x | | | read-write |
 | code-reviewer | x | | | x | x | x | | | read-only |
 | integration-agent | x | x | x | | | x | | | read-write |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # Commands
 
-All 23 slash commands registered in `commands/`. Each command is
+All 24 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -327,6 +327,48 @@ begins.
 
 Run `/diaboli <spec-path>` after spec-writer completes and before approving
 the plan. Re-run it if the spec is substantively edited after initial review.
+
+### /choice-cartograph
+
+- **Skills read**: choice-cartographer
+- **Agents dispatched**: choice-cartographer
+
+Run the Choice Cartographer (decision-archaeology agent) on a spec file.
+Takes a path to a spec file under `docs/superpowers/specs/` and produces
+a structured choice-story record at
+`docs/superpowers/stories/<spec-slug>.md`.
+
+The record contains up to 15 stories across six lenses — forces,
+alternatives unspoken, defaults inherited, patterns unnamed, consequences
+accepted, and story coherence. Each story names a choice the spec made
+implicitly: a force resolved silently, a default inherited, a pattern
+not named. The agent biases toward 5–8 stories per spec; selectivity is
+the value, and pedantic enumeration is dropped in the agent's reasoning
+protocol.
+
+The agent applies the **Routing Rule** with the diaboli before emitting
+any candidate: a finding belongs in the cartographer's record iff
+removing it would leave a decision unrecorded but no failure undetected.
+Findings shaped "this could fail" belong in the diaboli's record
+instead.
+
+Story dispositions must be written by a human, but the plan-approval
+gate is **soft** — `cartograph_pending_count` is surfaced as
+observability and progression is allowed even with pending stories.
+The merge-time HARNESS constraint
+**"PRs have adjudicated choice stories"** is the forcing function:
+PR merge is blocked while any story is `pending`.
+
+Disposition values: `accepted`, `revisit` (deferred), `promoted`. All
+three are passing values at the merge gate — `revisit` carries the
+"captured-but-deferred" semantic, not "spec needs to change."
+
+Run `/choice-cartograph <spec-path>` after spec-mode `/diaboli`
+dispositions are resolved. Re-run it if the spec is substantively
+edited after initial mapping.
+
+This release is spec-mode only. Code-mode behaviour is tracked under
+[issue #209](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/209).
 
 ### /worktree
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Skills
 
-The plugin ships 28 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 30 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -144,3 +144,36 @@ Governance audit methodology. Covers the seven-step audit process, the five-stag
 ### governance-observability
 
 Governance metrics and dashboard specification. Covers the seven governance metrics (constraint count, falsifiability ratio, drift score, debt inventory size, frame alignment score, last audit date, drift velocity), the snapshot format extension, staleness thresholds, audit report format, HTML dashboard section specifications, and portfolio integration. Referenced by the governance-auditor agent and `/governance-health`.
+
+---
+
+## Spec-First Pipeline
+
+Two paired read-only agents that run between spec-writer and plan
+approval. The diaboli challenges; the cartographer maps. Both have
+read-only trust boundaries that enforce a human-cognition gate on
+dispositions. They share a deterministic Routing Rule that partitions
+findings between them.
+
+### advocatus-diaboli
+
+Adversarial spec review. Covers the six objection categories
+(premise, scope, implementation, risk, alternatives, specification
+quality), severity levels (critical, high, medium, low), evidence
+requirements grounded in the spec text, the 12-objection cap, the
+"Explicitly not objecting to" discipline, dispatch-mode category
+weighting (spec-time vs. code-time), and the Routing Rule that
+partitions findings with the choice-cartographer. Referenced by
+`/diaboli` and the advocatus-diaboli agent.
+
+### choice-cartographer
+
+Decision archaeology. Covers the six lenses (forces, alternatives,
+unspoken, defaults inherited, patterns unnamed, consequences accepted,
+story coherence), the Routing Rule (failure-vs-decision test that
+partitions findings with the diaboli), the selectivity protocol
+(5–8 stories per spec target with a self-imposed 15-cap inside the
+agent's reasoning), the cross-reference protocol (deterministic
+resolution of `O\d+` and `#N` tokens in `Refs` fields), and the
+output format. Referenced by `/choice-cartograph` and the
+choice-cartographer agent.


### PR DESCRIPTION
## Summary

- Closes #212
- Completes the docs-site integration for the Choice Cartographer agent that landed in v0.29.0 (#208 / merged in #210)
- All changes outside `ai-literacy-superpowers/` — no plugin version bump

## What changed

| File | Update |
|---|---|
| `docs/reference/agents.md` | +`choice-cartographer` entry, +Routing Rule on `advocatus-diaboli`, count 12→13, pipeline-agents framing extended to seven with hard+soft gates, Tool Summary row added |
| `docs/reference/commands.md` | +`/choice-cartograph` entry, count 23→24 |
| `docs/reference/skills.md` | +"Spec-First Pipeline" section with both `advocatus-diaboli` and `choice-cartographer` skills, count 28→30 (diaboli was also missing) |
| `docs/explanation/agent-orchestration.md` | Pipeline diagram expanded with Cartographer step + soft gate; "Two things matter here" expanded to three; cross-link to `decision-archaeology.md` |
| `docs/explanation/adversarial-review.md` | Further Reading: link to `decision-archaeology.md` and `run-choice-cartograph.md` |
| `docs/index.md` | Counts updated; decision-archaeology surfaced in value bullets |
| `CHANGELOG.md` | Docs entry appended under existing 0.29.0 heading |

## Constraint exemptions

- `chore` label — exempts this PR from `Spec-first commit ordering` and `PRs have adjudicated choice stories` (docs-only chore)

## Test plan

- [ ] `Check spec-first commit ordering` passes (chore exempt)
- [ ] `Check version consistency` passes (no plugin file changes)
- [ ] `Enforce PR constraints` passes (chore exempt for choice-stories; lint passes)
- [ ] `markdownlint` passes (verified locally — 0 errors across all 6 modified docs files)