### PR TITLE
docs: add reflections as a signal source in HARNESS.md operation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@
   shape elided where amendments come from; the four-flow shape makes
   the reflection-driven ratchet (every preventable mistake becomes a
   rule) load-bearing in the prose.
+- Expanded the Signal capture flow from three pathways to seven to
+  cover the full set of plugin features that route into
+  `HARNESS.md` amendments: reflections, audit/GC findings,
+  convention extraction (`/extract-conventions`), assessment-driven
+  improvements (`/assess` + `literacy-improvements`), affordance
+  discovery and sibling-artefact promotion (`/harness-affordance
+  discover` and choice-story `disposition: promoted`), template
+  upgrades (`/harness-upgrade`), and direct human authoring. The
+  ordering goes from continuous observation through structured
+  elicitation to escape hatch.
 
 ### Docs — Choice Cartographer integration into docs site
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 - Cross-links added in `harness-engineering.md`, `self-improving-harness.md`,
   and the explanation `index.md` "Deep dives" section so the new page
   is discoverable from related entry points.
+- Restructured "How HARNESS.md is operated" section to add a Signal
+  capture flow that explicitly documents reflections as the primary
+  signal source feeding HARNESS.md amendments (alongside audit
+  findings and direct human authoring). The original three-flow
+  shape elided where amendments come from; the four-flow shape makes
+  the reflection-driven ratchet (every preventable mistake becomes a
+  rule) load-bearing in the prose.
 
 ### Docs — Choice Cartographer integration into docs site
 

--- a/docs/explanation/harness-md.md
+++ b/docs/explanation/harness-md.md
@@ -115,8 +115,10 @@ documented in the harness commands.
 
 ### 1. Signal capture
 
-Amendments enter the document from three pathways. The framework
-treats reflections as the primary one.
+Amendments enter the document from several pathways. The framework
+treats reflections as the primary one and arranges the others around
+it. The pathways below are ordered roughly from continuous
+observation to event-triggered elicitation to escape hatch.
 
 - **Reflections.** Every coding session ends with `/reflect`, which
   captures what was surprising, what failed, what should change, and
@@ -130,13 +132,53 @@ treats reflections as the primary one.
   than to `HARNESS.md`, but they are still proposed and adjudicated
   through the same reflection flow. `REFLECTION_LOG.md` is the
   durable trail.
-- **Audit and GC findings.** `/harness-audit` and the garbage-collection
-  sweeps surface drift between the declared state and the runtime
-  reality. A constraint listed as `deterministic` whose tool no
-  longer runs becomes a candidate for re-promotion or retirement. A
-  GC rule reporting recurring violations becomes a candidate for
-  hardening into a constraint. The harness-auditor and harness-gc
-  agents emit reports; the human routes findings into amendments.
+- **Audit and GC findings.** `/harness-audit`, `/governance-audit`,
+  and the garbage-collection sweeps surface drift between the
+  declared state and the runtime reality. A constraint listed as
+  `deterministic` whose tool no longer runs becomes a candidate for
+  re-promotion or retirement. A GC rule reporting recurring
+  violations becomes a candidate for hardening into a constraint.
+  The harness-auditor, governance-auditor, and harness-gc agents
+  emit reports; the human routes findings into amendments.
+- **Convention extraction.** `/extract-conventions` runs a guided
+  session that surfaces tacit team knowledge through structured
+  questions (naming, file structure, error handling, documentation
+  style, and similar) and proposes additions to the Context section
+  of `HARNESS.md` (and to `CLAUDE.md`). The pathway exists because
+  some conventions are real but never get written down — the team
+  follows them without articulating them, and the AI cannot follow
+  what it cannot read. Extraction is the framework asking the team
+  to articulate.
+- **Assessment-driven improvements.** `/assess` runs an AI literacy
+  assessment that scans the repo for evidence, asks clarifying
+  questions, produces a timestamped assessment document, and routes
+  identified gaps to specific plugin commands and skills via the
+  `literacy-improvements` skill. Several of those gaps map to
+  `HARNESS.md` amendments (e.g. a missing constraint that the
+  assessment level requires). The improvement plan is grouped by
+  target level; the human accepts or defers each item, and accepted
+  items invoke the relevant authoring command.
+- **Affordance discovery and sibling-artefact promotion.** Two
+  related pathways for promoting structured artefacts into `HARNESS.md`.
+  `/harness-affordance discover` scans `.claude/settings*.json` and
+  `.mcp.json` to produce a draft affordance inventory at
+  `.claude/affordance-discovery-<date>.md`; the how-to guide
+  describes the promote-to-`HARNESS.md` flow for affordances the
+  team wants to govern. Choice stories with `disposition: promoted`
+  (the third disposition value emitted by the choice-cartographer)
+  are an emerging pathway: the routing mechanism is tracked under
+  issue #211, but the disposition value is captured today so the
+  signal is preserved while the routing is built.
+- **Template upgrades.** `/harness-upgrade` discovers new
+  constraints, GC rules, sections, and optional blocks that have
+  been added to the plugin's `templates/HARNESS.md` since the user's
+  harness was last upgraded. Each new item is presented for review
+  and selectively adopted. The pathway exists because the plugin
+  evolves; new template content reflects framework-level signal
+  (failures, patterns, regulations) accumulated by the plugin's
+  community of users, and `/harness-upgrade` is how that signal
+  reaches an individual project. It is the only signal pathway
+  that originates outside the project's own running observation.
 - **Direct human authoring.** External requirements — a new
   governance obligation, a stack change, a team decision — can land
   in `HARNESS.md` at any time via `/harness-constrain`,
@@ -149,9 +191,13 @@ The reflection pathway is what makes Osmani's "every line in a good
 AGENTS.md should be traceable back to a specific thing that went
 wrong" actually work. Without reflections, the framework would
 depend on memory and discipline to surface failures; with
-reflections, the surfacing is part of the workflow. See
+reflections, the surfacing is part of the workflow. The other
+pathways extend the same logic: extraction surfaces what was tacit;
+assessment surfaces what was missing; affordance discovery surfaces
+what was implicit in configuration; template upgrades surface what
+the wider community has learned. See
 [Compound Learning]({% link explanation/compound-learning.md %}) for
-the broader treatment of how reflections become shared infrastructure.
+the broader treatment of how these signals become shared infrastructure.
 
 ### 2. Authoring and amendment
 

--- a/docs/explanation/harness-md.md
+++ b/docs/explanation/harness-md.md
@@ -110,40 +110,97 @@ audited.
 
 ## How HARNESS.md is operated
 
-`HARNESS.md` is operated through three flows, each of which is
-documented in the harness commands:
+`HARNESS.md` is operated through four flows, each of which is
+documented in the harness commands.
 
-1. **Authoring and amendment.** Constraints and garbage-collection
-   rules enter `HARNESS.md` via `/harness-init`,
-   `/harness-constrain`, `/governance-constrain`, and
-   `/harness-upgrade`. Each flow surfaces the implications and writes
-   the constraint with a declared enforcement state (`unverified`,
-   `agent`, or `deterministic`). See
-   [Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %}).
+### 1. Signal capture
 
-2. **Verification and propagation.** When a constraint reaches
-   `agent` or `deterministic` status, the corresponding artefact is
-   created or updated — a CI workflow, a hook script, a sub-agent
-   prompt, an entry in a convention file. The harness-enforcer agent
-   is the unified verification engine; it reads `HARNESS.md`,
-   identifies which constraints apply at the requested scope (commit,
-   pr, weekly, manual), and either executes the deterministic tool or
-   performs the agent-based review. Convention propagation to other
-   AI tools happens via `/convention-sync`.
+Amendments enter the document from three pathways. The framework
+treats reflections as the primary one.
 
-3. **Audit and self-correction.** `/harness-audit` runs the
-   meta-verification — it checks that `HARNESS.md`'s declared state
-   matches reality. The Status block in `HARNESS.md` is auto-updated
-   based on what the audit finds. Garbage-collection rules run
-   periodically via `/harness-gc` and detect entropy that neither
-   real-time hooks nor PR gates catch. The
-   [Self-Improving Harness]({% link explanation/self-improving-harness.md %})
-   page describes the feedback loop in detail.
+- **Reflections.** Every coding session ends with `/reflect`, which
+  captures what was surprising, what failed, what should change, and
+  classifies the signal type (`context`, `instruction`, `workflow`,
+  `failure`, or `none`). A `failure` classification triggers an
+  **auto-constraint proposal**: `/reflect` offers to draft a new
+  HARNESS constraint covering the failure mode, and if the human
+  accepts, it invokes `/harness-constrain` directly. This is the
+  ratchet — every preventable mistake becomes a rule. Workflow
+  signals route to `AGENTS.md` (compound learning memory) rather
+  than to `HARNESS.md`, but they are still proposed and adjudicated
+  through the same reflection flow. `REFLECTION_LOG.md` is the
+  durable trail.
+- **Audit and GC findings.** `/harness-audit` and the garbage-collection
+  sweeps surface drift between the declared state and the runtime
+  reality. A constraint listed as `deterministic` whose tool no
+  longer runs becomes a candidate for re-promotion or retirement. A
+  GC rule reporting recurring violations becomes a candidate for
+  hardening into a constraint. The harness-auditor and harness-gc
+  agents emit reports; the human routes findings into amendments.
+- **Direct human authoring.** External requirements — a new
+  governance obligation, a stack change, a team decision — can land
+  in `HARNESS.md` at any time via `/harness-constrain`,
+  `/governance-constrain`, or `/harness-init` re-runs. Direct
+  authoring is the smallest pathway in volume but the necessary
+  escape hatch when a constraint is required before the team has
+  experienced its absence as a failure.
 
-The pattern is: **declarative document → runtime artefacts → audit →
-amendment → declarative document**. The document is the only stable
-node in the loop. Every other node is generated, audited, or
-regenerated against it.
+The reflection pathway is what makes Osmani's "every line in a good
+AGENTS.md should be traceable back to a specific thing that went
+wrong" actually work. Without reflections, the framework would
+depend on memory and discipline to surface failures; with
+reflections, the surfacing is part of the workflow. See
+[Compound Learning]({% link explanation/compound-learning.md %}) for
+the broader treatment of how reflections become shared infrastructure.
+
+### 2. Authoring and amendment
+
+Once a signal has produced a candidate amendment, the constraint
+or GC rule is written into `HARNESS.md` via `/harness-init`,
+`/harness-constrain`, `/governance-constrain`, or
+`/harness-upgrade`. Each flow surfaces the implications and writes
+the constraint with a declared enforcement state (`unverified`,
+`agent`, or `deterministic`). See
+[Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %})
+for the field-level shape.
+
+### 3. Verification and propagation
+
+When a constraint reaches `agent` or `deterministic` status, the
+corresponding runtime artefact is created or updated — a CI
+workflow, a hook script, a sub-agent prompt, an entry in a
+convention file. The harness-enforcer agent is the unified
+verification engine; it reads `HARNESS.md`, identifies which
+constraints apply at the requested scope (commit, pr, weekly,
+manual), and either executes the deterministic tool or performs
+the agent-based review. Convention propagation to other AI tools
+happens via `/convention-sync`.
+
+### 4. Audit and self-correction
+
+`/harness-audit` runs the meta-verification — it checks that
+`HARNESS.md`'s declared state matches reality. The Status block in
+`HARNESS.md` is auto-updated based on what the audit finds.
+Garbage-collection rules run periodically via `/harness-gc` and
+detect entropy that neither real-time hooks nor PR gates catch.
+Audit findings feed back into flow 1 as fresh signals — the loop
+closes. The
+[Self-Improving Harness]({% link explanation/self-improving-harness.md %})
+page describes the feedback loop in detail.
+
+### The shape of the loop
+
+The pattern is:
+
+> **reflection / audit → signal → amendment → declarative document
+> → runtime artefacts → reality → reflection / audit → …**
+
+The document is the only stable node in the loop. Every runtime
+artefact is generated, audited, or regenerated against it; every
+amendment originates in observed signal rather than aspiration.
+Reflections are what keep the loop turning between audits — they
+catch failure modes the audit has not yet been built to detect, and
+they propose the constraint that the next audit will check for.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes #217
- Fix gap in `docs/explanation/harness-md.md` (added in #216)
- Restructures "How HARNESS.md is operated" from three flows to four, with a new **Signal capture** flow at the start that explicitly documents reflections as the primary signal source feeding amendments

## What was missing

The original three-flow shape (authoring → verification → audit) skipped where amendments come from. Reflections are the primary signal source — `/reflect` has an auto-constraint-proposal step that routes failure signals via `/harness-constrain`, turning every preventable mistake into a candidate rule. Without that documented, the page misrepresented how the harness actually evolves.

## The new flow shape

1. **Signal capture** (NEW) — reflections, audit findings, direct human authoring
2. Authoring and amendment (was 1)
3. Verification and propagation (was 2)
4. Audit and self-correction (was 3)

The closing "shape of the loop" diagram now reads:

> reflection / audit → signal → amendment → declarative document → runtime artefacts → reality → reflection / audit → …

## Test plan

- [ ] markdownlint passes (verified locally — 0 errors)
- [ ] Other CI checks green