### PR TITLE
docs: add determinacy calibration explanation and how-to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 0.29.0 — 2026-04-27
 
+### Docs — Determinacy Calibration explanation and how-to
+
+- Add `docs/explanation/determinacy-calibration.md` — explanation page
+  on calibration as a periodic review practice, covering bidirectional
+  movement (promotion, demotion, splitting, seam repair, leaving
+  unchanged), the four signal classes (change records, temporal
+  patterns, reflection-log patterns, seam integrity), recording
+  refusals as a first-class output, and the relationship to
+  `/harness-audit`, `/harness-gc`, and `/reflect`. Builds on Russ
+  Miles' [The Djinn's Determinacy Drift](https://www.softwareenchiridion.com/p/the-djinns-determinacy-drift)
+  for the bidirectional-drift framing and the harness-as-habitat
+  metaphor.
+- Add `docs/how-to/run-a-calibration-review.md` — practical guide
+  for running a periodic calibration review: cadence selection,
+  signal gathering, candidate movements, decision recording with
+  refusals, applying decisions through existing commands, and a
+  follow-up audit.
+- Cross-links added in `progressive-hardening.md` (the unidirectional
+  promotion framing's bidirectional companion) and the explanation
+  `index.md` "Deep dives" section.
+
 ### Docs — HARNESS.md overview page
 
 - Add `docs/explanation/harness-md.md` — explanation page covering what

--- a/docs/explanation/determinacy-calibration.md
+++ b/docs/explanation/determinacy-calibration.md
@@ -1,0 +1,293 @@
+---
+title: Determinacy Calibration
+layout: default
+parent: Explanation
+nav_order: 14
+---
+
+# Determinacy Calibration
+
+Progressive hardening describes the promotion ladder for constraints —
+unverified to agent to deterministic, with movement always upward. That
+framing is right as far as it goes, and the plugin's documentation
+treats it as the canonical path. But the real engineering practice is
+not unidirectional. Capabilities migrate up *and* down the determinacy
+spectrum. A script that started life as the right answer becomes the
+wrong answer when the team's understanding of the underlying problem
+sharpens. An agent-based check that catches a class of issue reliably
+becomes ready for promotion to a deterministic tool. A skill that has
+quietly accumulated flags and special cases is no longer a skill — it
+is an undeclared programming language nobody owns.
+
+**Determinacy calibration** is the periodic practice of looking at
+where each capability currently sits on the determinacy spectrum,
+gathering evidence about whether that placement is still correct, and
+moving capabilities deliberately — including not moving them at all.
+It is reflective, not reflexive. It runs on project cadence, not per
+execution. And the most important thing it does is make the invisible
+*choice not to move* a first-class output, on equal footing with
+promotion and demotion.
+
+This page sets out why bidirectional movement matters, what calibration
+is for, and how it relates to the audit, garbage-collection, and
+reflection mechanisms the plugin already provides.
+
+---
+
+## Two failure modes of drift
+
+Drift is asymmetric in attention. Teams notice when their AI agents
+behave inconsistently and reach for more scripting. Teams rarely
+notice when their scripting has metastasised, because metastasis
+*looks* like rigour.
+
+### Over-scripting drift
+
+Scripts accumulate flags, special cases, and accidental
+configuration languages. A bash script that started as ten lines
+becomes a hundred-line wrapper around three other scripts, two of
+which only the author understands. The team relocates indeterminacy
+from the agent to the script — but indeterminacy doesn't disappear,
+it just gets harder to see.
+
+This failure mode flatters itself. It looks responsible. It survives
+review because it produces visible artefacts. But it forces folklore
+and apprenticeship to maintain, and the team blames *agent
+unreliability* when the calibration that has actually drifted is the
+script's.
+
+### Under-scripting drift
+
+Capabilities remain looser than the team's understanding of them
+warrants. The same kind of failure recurs because the rule has not
+been promoted. Agents and humans both perform intelligence in places
+where structure could help. Output stays inconsistent — silently —
+even though the system continues to work.
+
+Under-scripting drift produces visible inconsistency only when the
+inconsistency is large enough to break something. Smaller drift
+accumulates without surfacing until the team tries to reason about
+the system as a whole and discovers that no two recent runs of the
+same nominal task look alike.
+
+---
+
+## Why movement is bidirectional
+
+Progressive hardening's "movement is always toward deterministic"
+framing is correct *for healthy promotions*. It is wrong as a
+description of legitimate calibration outputs. There are five honest
+moves at any given calibration cycle:
+
+1. **Promotion.** A capability has been agent-enforced reliably enough
+   that the underlying pattern is now expressible as a deterministic
+   tool. Move it up the ladder.
+
+2. **Demotion.** A deterministic tool has accumulated edge cases that
+   make its rule fragile, or the team's understanding of the problem
+   has shifted enough that the tool now misclassifies real cases.
+   Move it back to agent enforcement, where judgment can be applied,
+   while a better tool is designed (or accept that some constraints
+   live well at the agent layer).
+
+3. **Splitting.** A single capability is doing two jobs that have
+   different determinacy needs. Split it: one half stays at the
+   level where it was; the other half moves up or down to where it
+   belongs.
+
+4. **Seam repair.** A capability is in the right *layer* but the
+   surrounding seams have rotted — orphaned references, dead
+   pathways, scripts no skill invokes any more. Fix the seam without
+   moving the level.
+
+5. **Leaving unchanged.** The capability is at the right level for
+   the evidence the team currently has. The honest output is no
+   movement. This is the most under-recorded calibration outcome and
+   the most important one to surface — see "Recording refusals"
+   below.
+
+The article that motivated this page puts it sharply: *a calibrator
+that always proposes a move is optimising for visibility, not harness
+health*. Calibration's job is to interpret signal, not to manufacture
+activity.
+
+---
+
+## The four signal classes
+
+Calibration is not done by introspection alone. It is grounded in
+specific signal that the plugin's existing mechanisms already
+produce. Four classes of signal carry the most weight.
+
+- **Change records.** Variance in duration, token usage, and
+  artefact trails across nominally identical tasks. If running
+  `/harness-audit` takes 30 seconds one week and 5 minutes the next
+  with no change in scope, the variance is itself signal — something
+  about the audit's enforcement layer is shifting under the surface.
+  `/superpowers-status` and the harness-health snapshots are the
+  primary surfaces for this signal class.
+
+- **Temporal patterns.** The growth trajectory of scripts and the
+  invocation ratio of skills. A hooks directory that has grown 40%
+  this quarter is either responding to real demand or is in
+  over-scripting drift; the trajectory alone doesn't tell you which
+  — but it surfaces the question.
+
+- **Reflection-log patterns.** Where agents (or humans) noted
+  improvising around provided tooling. `REFLECTION_LOG.md` entries
+  with `Surprise:` text describing "I had to work around X" are
+  direct evidence that X is at the wrong level on the determinacy
+  spectrum. Recurring improvisation around the same capability
+  across multiple reflections is a strong promotion signal *or* a
+  splitting signal.
+
+- **Seam integrity.** Dead pathways, orphaned references, scripts no
+  skill invokes any more, constraints listed as `deterministic`
+  whose tool no longer runs, or skills that quote functions that
+  have been deleted. The plugin's GC rules and the harness-auditor
+  agent surface most of these directly. Seam rot is what makes a
+  capability look healthy from above while being effectively absent
+  underneath.
+
+These four classes are not exhaustive — calibration's whole point is
+that some signals will only become visible in the context of a
+specific project's evolution. But they are the load-bearing classes
+to gather every cycle.
+
+---
+
+## Calibration as a review activity
+
+Calibration runs on project rhythm, not on every execution. The
+plugin's enforcement mechanisms (hooks, CI gates, harness-enforcer)
+operate per-event — they fire when something happens. Calibration is
+the opposite shape: it is a deliberate review, scheduled, evidence-
+based, and slow.
+
+Cadences worth considering:
+
+- **End-of-iteration** (every sprint, fortnight, or release cycle)
+  for active projects. The volume of change is high enough that
+  drift can accumulate quickly; reviewing each iteration keeps the
+  determinacy distribution in calibration with the team's current
+  understanding.
+
+- **Monthly** for steady-state projects where the rate of change is
+  slower. The four signal classes accumulate over a month into a
+  meaningful sample.
+
+- **Quarterly** for portfolio-scale concerns — calibration patterns
+  visible only across multiple repositories, surfaced via
+  `/portfolio-assess`.
+
+The cadence choice itself is calibration: a team running calibration
+every iteration on a slow-moving project will produce mostly
+"leave-unchanged" outputs and learn to skip it; a team running it
+quarterly on a fast-moving project will accumulate drift faster than
+the cycle catches.
+
+---
+
+## Recording refusals
+
+Calibration's most under-recorded output is the decision *not* to
+move a capability. Refusals carry information:
+
+- A capability repeatedly proposed for promotion but always refused
+  is signal that the team has an unspoken constraint preventing
+  promotion — perhaps the deterministic version would impose a
+  workflow change the team isn't willing to make, or the cost of
+  the script is judged higher than the cost of the agent-time.
+  Surfacing the unspoken constraint is more valuable than promoting.
+
+- A capability repeatedly considered for demotion but kept at its
+  current level reveals genuine equilibrium. The team has tried to
+  destabilise the placement and failed — that is positive signal
+  about the placement, not absence of signal.
+
+- A capability that nobody proposes to move at all is a candidate
+  for *removal*. If no one is even debating its placement, it may
+  no longer be load-bearing.
+
+A good calibration record reads more like a meeting minutes than a
+patch series. It captures what was considered, what was moved, and
+what was deliberately left in place — with the rationale for each.
+The refusals make the record honest. A record showing only movements
+is a record optimised for visibility, not for the harness's health.
+
+---
+
+## How calibration relates to existing mechanisms
+
+Calibration sits *above* the per-event enforcement mechanisms and
+*alongside* the audit, GC, and reflection pathways. It consumes their
+output rather than replacing them.
+
+| Mechanism | Question it answers | Output |
+| --- | --- | --- |
+| `/harness-audit` | Does declared state match runtime reality? | Drift report; auto-updates Status block |
+| `/harness-gc` | Has entropy accumulated since the last sweep? | Findings against rule-bound checks |
+| `/reflect` | What surprised me or failed in this session? | Reflection entry, possibly auto-constraint proposal |
+| `/superpowers-status` | What's the current health of the habitat? | Dashboard with current metrics |
+| **Determinacy calibration** | Is the determinacy distribution across capabilities still right? | Promote / demote / split / repair / leave decisions, with rationale |
+
+Audit, GC, and reflection produce *raw* signal. Calibration
+*interprets* the signal across all four classes and decides, for each
+capability, whether the current placement is still correct.
+
+The relationship to progressive hardening is similar: progressive
+hardening describes the *shape* of the determinacy ladder; calibration
+is the practice that uses that shape over time. Promotions still
+follow the ladder; demotions follow the same ladder in reverse;
+splittings produce new ladder positions for the parts; refusals
+preserve the existing position. Progressive hardening is the
+geography. Calibration is the surveying.
+
+---
+
+## The harness-as-habitat framing
+
+The unifying metaphor is the one already present in the framework's
+[Habitat Engineering]({% link explanation/habitat-engineering.md %})
+explanation: a habitat has paths and wildness, and the right balance
+is contextual rather than absolute. Determinacy is the harness's
+paths-versus-wildness dial. Too many paths and the habitat
+suffocates: agents and humans alike must follow scripts that no
+longer reflect the territory, and improvisation gets blamed on
+unreliability rather than recognised as an honest response to over-
+constraint. Too few paths and the habitat becomes wilderness:
+output is inconsistent, the same problem gets re-solved every time
+it recurs, and structure that would help is missing.
+
+The calibration practice is what tunes the dial. Not toward more
+paths in general; not toward more wildness in general. Toward the
+right balance for the territory the team is currently working in,
+recalibrated as the territory itself shifts.
+
+---
+
+## See also
+
+- [Progressive Hardening]({% link explanation/progressive-hardening.md %}) —
+  the determinacy ladder calibration applies to; this page extends
+  that one with the bidirectional movement framing
+- [Self-Improving Harness]({% link explanation/self-improving-harness.md %}) —
+  the audit-and-amendment feedback loop that surfaces calibration
+  signal
+- [Compound Learning]({% link explanation/compound-learning.md %}) —
+  the broader frame for converting session-level signal into shared
+  infrastructure
+- [HARNESS.md, the Document]({% link explanation/harness-md.md %}) —
+  where calibration outputs land when they involve constraint
+  amendments
+- [Habitat Engineering]({% link explanation/habitat-engineering.md %}) —
+  the paths-versus-wildness framing from which calibration borrows
+  its underlying metaphor
+- [How to: Run a determinacy calibration review]({% link how-to/run-a-calibration-review.md %}) —
+  the practical procedure
+
+External: the article that motivated this page is Russ Miles'
+[The Djinn's Determinacy Drift](https://www.softwareenchiridion.com/p/the-djinns-determinacy-drift),
+which sets out the argument for calibration as a maintenance
+discipline and gives the harness-as-habitat framing its sharpest
+form.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -31,6 +31,7 @@ These pages go deeper into the mechanics of each component:
 - [Decision Archaeology]({% link explanation/decision-archaeology.md %}) -- the choice-cartographer's role; intent debt and cognitive debt; the soft gate / hard gate asymmetry
 - [Adversarial Review]({% link explanation/adversarial-review.md %}) -- the advocatus-diaboli's role and the human-cognition gate
 - [Progressive Hardening]({% link explanation/progressive-hardening.md %}) -- the promotion ladder from unverified to agent to deterministic
+- [Determinacy Calibration]({% link explanation/determinacy-calibration.md %}) -- the bidirectional review practice that uses the ladder over time; promotion, demotion, splitting, seam repair, and refusal as legitimate outputs
 - [The Three Enforcement Loops]({% link explanation/three-enforcement-loops.md %}) -- inner, middle, and outer loops operating at different timescales
 - [Garbage Collection]({% link explanation/garbage-collection.md %}) -- fighting entropy with periodic checks and scheduled agents
 - [Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %}) -- how constraints land in the harness and migrate from unverified to deterministic

--- a/docs/explanation/progressive-hardening.md
+++ b/docs/explanation/progressive-hardening.md
@@ -331,6 +331,7 @@ The rule text stays the same across all three promotions. The enforcement type a
 ## Further Reading
 
 - [Constraints and Enforcement]({% link explanation/constraints-and-enforcement.md %}) -- introductory concepts of constraint maturity and the promotion ladder
+- [Determinacy Calibration]({% link explanation/determinacy-calibration.md %}) -- the bidirectional companion to this page; calibration as a periodic review activity covering promotion, demotion, splitting, seam repair, and refusal as legitimate outputs
 - [Harness Engineering]({% link explanation/harness-engineering.md %}) -- the three components (context, constraints, garbage collection) and how they interact
 - [The Three Enforcement Loops]({% link explanation/three-enforcement-loops.md %}) -- inner, middle, and outer loop timing
 - [Context Engineering]({% link explanation/context-engineering.md %}) -- what context declares before constraints enforce

--- a/docs/how-to/run-a-calibration-review.md
+++ b/docs/how-to/run-a-calibration-review.md
@@ -1,0 +1,256 @@
+---
+title: Run a Determinacy Calibration Review
+layout: default
+parent: How-to Guides
+nav_order: 40
+---
+
+# Run a Determinacy Calibration Review
+
+Run a periodic calibration review to interpret the signal from
+`/harness-audit`, `/harness-gc`, and `REFLECTION_LOG.md` and decide,
+for each capability, whether its current placement on the determinacy
+spectrum is still correct.
+
+This is a deliberate, evidence-based review activity, not an automated
+loop. The plugin's existing commands surface raw signal; this guide
+describes the procedure for *interpreting* that signal and producing
+calibration decisions — including the decision to leave things alone.
+
+For the conceptual background, see
+[Determinacy Calibration]({% link explanation/determinacy-calibration.md %}).
+
+---
+
+## When to run it
+
+Cadence depends on the project's rate of change.
+
+- **End-of-iteration** (every sprint, fortnight, or release cycle)
+  for actively-changing projects.
+- **Monthly** for steady-state projects with slower change.
+- **Quarterly** for portfolio-scale calibration across multiple
+  repositories (use `/portfolio-assess` to gather cross-repo signal).
+
+Pick the longest cadence that still catches drift before it
+accumulates. A team running calibration every iteration on a slow
+project will mostly produce "leave unchanged" decisions and learn to
+skip the review. A team running it quarterly on a fast project will
+let drift accumulate beyond what the cycle can recover.
+
+The cadence is itself part of calibration. If reviews consistently
+produce mostly refusals, the cadence is too tight; if reviews
+consistently produce surprises that suggest unrecorded drift, the
+cadence is too loose.
+
+---
+
+## 1. Gather signal from the four classes
+
+Calibration is grounded in evidence, not introspection. Open four
+sources before starting the review:
+
+```text
+# Change records and current health
+/superpowers-status
+
+# Drift between declared and runtime state
+/harness-audit
+
+# Entropy and rule-bound checks
+/harness-gc
+```
+
+Then read by hand:
+
+- `REFLECTION_LOG.md` — recent entries (last cycle's worth). Look
+  for `Surprise:` text describing improvisation around tooling, and
+  for recurring patterns across multiple entries.
+- `observability/snapshots/` — recent harness-health snapshots.
+  Watch for variance in metrics across nominally identical periods,
+  and for trends in script count, hook count, or constraint
+  enforcement ratio.
+
+The four signal classes the explanation page describes —
+**change records**, **temporal patterns**, **reflection-log
+patterns**, and **seam integrity** — map directly to these sources.
+You're not reading them looking for problems to fix individually
+(audit and GC already do that). You're reading them looking for
+*shape*: where is the determinacy distribution shifting, and what
+does that shift suggest about which capabilities are now at the
+wrong level?
+
+---
+
+## 2. List candidate movements per capability
+
+For each capability surfaced by step 1, write a one-line proposal.
+Capabilities include constraints (in `HARNESS.md`), GC rules, hooks,
+skills, sub-agent prompts, and orchestrator pipeline stages.
+
+The legitimate proposal types are:
+
+| Type | When |
+| --- | --- |
+| **Promote** | Agent enforcement has caught the same class reliably; the rule is now expressible deterministically. |
+| **Demote** | The deterministic tool is producing false positives, or the team's understanding of the underlying rule has shifted enough that the tool now misclassifies real cases. Move back to agent enforcement. |
+| **Split** | One capability is doing two jobs with different determinacy needs. Separate them. |
+| **Repair seam** | The capability is at the right level but its surrounding integration has rotted (orphaned references, dead pathways, scripts no skill invokes). Fix the seam without moving the level. |
+| **Leave** | The capability is at the right level. The honest output. Surface the candidate even when the decision is to leave — refusals carry information. |
+
+It's normal — and healthy — for a calibration cycle to produce mostly
+"leave" decisions on capabilities. A cycle that always produces
+movement is optimising for visibility, not for harness health.
+
+---
+
+## 3. Decide and record
+
+For each candidate, decide and record. The format that works best in
+practice mirrors a meeting record: what was considered, what was
+moved, what was left in place, and the rationale for each.
+
+A simple template:
+
+```markdown
+# Calibration review — YYYY-MM-DD
+
+## Promotions
+
+- `<capability>`: agent → deterministic. Tool: `<command>`. Reason:
+  <one-sentence rationale grounded in cited signal>.
+
+## Demotions
+
+- `<capability>`: deterministic → agent. Reason: <signal showing the
+  tool is misclassifying or the rule has shifted>.
+
+## Splits
+
+- `<capability>` → `<part-A>` (level X) and `<part-B>` (level Y).
+  Reason: <evidence the two parts have different determinacy needs>.
+
+## Seam repairs
+
+- `<capability>`: <description of the rot fixed; level unchanged>.
+
+## Refusals (deliberately left in place)
+
+- `<capability>`: <considered for movement, not moved, reason>. This
+  section is load-bearing — it captures what the team chose *not*
+  to do, and why.
+
+## Removals
+
+- `<capability>`: removed because <reason>. Capabilities nobody
+  proposes to move at all are candidates for removal — if it isn't
+  worth debating, it may not be load-bearing.
+
+## Cadence note
+
+- Review took <duration>. Produced <N> movements and <M> refusals.
+  Suggested next cadence: <unchanged | tighter | looser>, because
+  <reason>.
+```
+
+Save the record under `observability/calibration/YYYY-MM-DD-review.md`
+(creating the directory if it doesn't exist). The records accumulate
+into a longitudinal trail of how the harness's determinacy
+distribution has evolved.
+
+---
+
+## 4. Apply the decisions through existing commands
+
+Calibration produces decisions; the plugin's existing commands apply
+them. Use:
+
+- `/harness-constrain` to write new or modified constraints into
+  `HARNESS.md`. Constraints whose `Enforcement:` field changes from
+  `agent` to `deterministic` (or vice versa) are applied through
+  the same command — calibration's promote and demote both route
+  here.
+- `/governance-constrain` for governance-flavoured constraints
+  (where the constraint references regulation, oversight, or
+  accountability language).
+- Direct edits to skill files, hook scripts, sub-agent prompts,
+  and CI workflows for capabilities that aren't expressed in
+  `HARNESS.md`.
+- `/convention-sync` after the underlying `HARNESS.md` is settled,
+  to propagate convention changes to other AI tools.
+
+Refusals are *not* applied through any command — they live in the
+calibration record and that's where they belong. Recording them in
+the review doc is the entire mechanism. The next cycle's review will
+read them when deciding whether the same refusal still holds.
+
+---
+
+## 5. Run a follow-up audit
+
+After applying the movements, run `/harness-audit` to confirm the
+declared state in `HARNESS.md` matches the runtime reality the
+calibration produced. Some movements will require a propagation
+cycle (a new CI workflow, an updated hook script, a regenerated
+convention file) — the audit catches anything that didn't land
+correctly.
+
+```text
+/harness-audit
+```
+
+The audit's output is also raw signal for the *next* calibration
+cycle. The loop continues.
+
+---
+
+## 6. What you have now
+
+A dated calibration record under `observability/calibration/`,
+movements applied to `HARNESS.md` and the surrounding harness
+artefacts, refusals captured for next cycle, and an audit
+confirming the harness reflects the decisions.
+
+The most useful artefact for future calibration cycles is often the
+refusals section — it tells the next reviewer what was already
+considered and consciously left in place, so the next cycle doesn't
+re-litigate the same questions without new evidence.
+
+---
+
+## Common patterns
+
+- **First calibration on a mature project.** Expect a long candidate
+  list and a high refusal rate. Most existing capabilities will be
+  at roughly the right level; the value of the first review is
+  surfacing the small handful that aren't, and establishing the
+  baseline of refusals for next cycle to read.
+- **A run that produces no movements.** Healthy if the refusal
+  rationales are substantive. Concerning if the review feels rushed
+  or the candidate list was thin — that suggests the signal-gather
+  step (step 1) was too shallow.
+- **A run that produces mostly demotions.** A signal worth taking
+  seriously. Either the team's previous calibration over-scripted
+  (chronic over-promotion drift), or the underlying problem domain
+  has shifted enough that previously-stable rules are now too
+  rigid. Either reading suggests the next cycle should look hard
+  at the script and hook directories specifically.
+- **A run that produces lots of seam repairs.** Indicates that
+  capabilities are at the right level but the surrounding
+  integration has rotted. Often a signal that GC rules need to be
+  added or sharpened so the rot surfaces continuously rather than
+  being discovered only at calibration time.
+
+---
+
+## See also
+
+- [Determinacy Calibration]({% link explanation/determinacy-calibration.md %}) —
+  the conceptual background: bidirectional movement, four signal
+  classes, refusals as outputs, the harness-as-habitat framing
+- [Progressive Hardening]({% link explanation/progressive-hardening.md %}) —
+  the determinacy ladder calibration applies to
+- [Run a Harness Audit]({% link how-to/run-a-harness-audit.md %}) —
+  the audit command that surfaces drift signal
+- [Add a Constraint]({% link how-to/add-a-constraint.md %}) —
+  applying calibration's promote/demote decisions


### PR DESCRIPTION
## Summary

- Closes #219
- New explanation page `docs/explanation/determinacy-calibration.md`: calibration as a periodic review practice with bidirectional movement (promotion / demotion / splitting / seam repair / leaving unchanged); four signal classes; recording refusals; relationship to `/harness-audit`, `/harness-gc`, `/reflect`, and progressive hardening
- New how-to `docs/how-to/run-a-calibration-review.md`: cadence selection, signal gathering, candidate movements, decision recording with refusal section, application through existing commands, follow-up audit
- Builds on Russ Miles' [The Djinn's Determinacy Drift](https://www.softwareenchiridion.com/p/the-djinns-determinacy-drift) for the bidirectional-drift framing and the harness-as-habitat metaphor
- Cross-links added in `progressive-hardening.md` and the explanation `index.md` "Deep dives" section
- Docs-only, no plugin version bump

## Why both pages, not all four

| Doc shape | Verdict | Reason |
|---|---|---|
| Explanation | Add | Bidirectional movement, harness-as-habitat metaphor, calibrator-as-proposer stance are genuinely additive to existing pages |
| How-to | Add | Calibration is a real procedure (cadence, signal classes, decision template, refusals) leaning on existing commands |
| Tutorial | Skip | Calibration is review-shaped, not build-shaped — would pad or reduce to "do the how-to once" |
| Reference | Defer | Signal catalogue / decision matrix is premature without lived calibration cycles |

## How calibration sits next to existing mechanisms

Audit / GC / reflection produce *raw* signal. Calibration *interprets* signal across all four classes and decides per-capability whether the current placement is still right — including the decision to leave it alone.

## Test plan

- [ ] markdownlint passes (verified locally — 0 errors across all 5 modified files)
- [ ] Other CI checks green