### PR TITLE
Implement Unit A: discovery layer for assessor and harness-discoverer (v0.30.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.29.0",
+  "plugin_version": "0.30.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.29.0"
+      "version": "0.30.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.30.0 — 2026-04-28
+
+### Feature — Discovery layer for assessor and harness-discoverer (Unit A)
+
+Implements Unit A of the workflow signal captured in REFLECTION_LOG.md
+(2026-04-28 entry): the `/assess` discovery is no longer rigid about
+default paths and filenames. Items 1, 2, and 5 of the user-supplied
+feedback decomposed to a single structural fix; this release ships
+that fix.
+
+- Add `skills/ai-literacy-assessment/references/habitat-discovery.md`
+  — single source of truth for habitat document discovery covering
+  `HARNESS.md`, `AGENTS.md`, and `CLAUDE.md`. Documents alternative
+  paths to scan, content markers per document type, the discovery
+  report format with citations, and the two failure modes
+  (ambiguous discovery surfaces both candidates; genuine absence
+  lists every path checked).
+- Modify `agents/assessor.agent.md` Phase 1: split into 1a (habitat
+  document discovery using the new reference) and 1b (broader
+  signal scan). Discovery completes — with auditable absence claims
+  — before any maturity calculation.
+- Modify `agents/harness-discoverer.agent.md` step 5: convention
+  documentation discovery now applies the new reference rather than
+  defaulting to `CLAUDE.md` and `CONTRIBUTING.md` only.
+- Modify `commands/assess.md`: step 1 split into 1a (discovery
+  report as the first output) and 1b (broader scan). Ambiguous
+  discovery results halt the flow until the user resolves; silent
+  picks are forbidden.
+- Modify `skills/ai-literacy-assessment/SKILL.md`: Phase 1
+  (Observable Evidence) prefaced with the discovery methodology
+  note — habitat documents found at non-conventional paths count
+  as *present* for Level 3 indicators.
+
+The principle the discovery layer encodes: **every absence claim
+must come from a fully-completed search across known alternatives,
+not from "not at the default path"**. Discovery output is auditable
+— each finding cites the path matched and the marker confirmed.
+
+Unit B (evidence-base expansion — multi-tool config reading,
+content-shape analysis, literacy-improvements gap-to-amendment
+mapping update) is a separate follow-up. Issue #222 closes when
+Unit A merges; a new issue tracks Unit B.
+
 ## 0.29.0 — 2026-04-27
 
 ### Docs — Determinacy Calibration explanation and how-to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.29.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.30.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)
 [![Commands](https://img.shields.io/badge/Commands-24-2E8B57?style=flat-square)](#commands-24)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/assessor.agent.md
+++ b/ai-literacy-superpowers/agents/assessor.agent.md
@@ -39,7 +39,55 @@ Read the assessment template from `.claude/skills/ai-literacy-assessment/referen
 
 ### Phase 1: Scan the repository
 
-Search for observable evidence of each framework level. Check for:
+Phase 1 has two sub-phases. Run them in order — habitat document
+discovery must produce a complete, auditable report before any
+default-path-based scanning happens, because the habitat documents
+themselves are the foundation everything else is interpreted
+against.
+
+#### Phase 1a: Habitat document discovery
+
+Apply the discovery methodology defined in:
+
+```text
+ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md
+```
+
+That reference is the single source of truth for which paths to
+scan, which content markers confirm a match, and how to format the
+discovery report. Apply each rule and produce the discovery report
+section described there. Do not inline alternative paths or content
+markers here — edits to the discovery contract live in the
+reference file.
+
+The discovery report distinguishes:
+
+- `found at conventional path` — habitat document is at the
+  expected location with markers confirmed
+- `found at alternative path` — habitat document exists but lives
+  somewhere other than the conventional location; cite the path
+  and matched markers
+- `not found` — no path matched any markers across the full
+  alternatives list; cite every path checked
+
+Every absence claim made downstream (in Phase 1b, in the maturity
+calculation, in the assessment document) must come from
+`Phase 1a → not found` rather than from "the conventional path is
+empty". A document found at an alternative path is *present* and
+should be treated as such by the maturity calculation.
+
+If discovery returns `Ambiguities` (two or more candidates for the
+same habitat document type), STOP. Surface the ambiguities to the
+user, ask which file is the canonical record, and only continue
+once the user resolves. Silent picks produce confidently-wrong
+assessments.
+
+#### Phase 1b: Other observable signals
+
+After Phase 1a is complete, scan for the rest of the framework
+evidence. The habitat-document scan that used to live here has
+moved to Phase 1a — the searches below are for surrounding
+artefacts that don't need the same alternative-path discipline yet.
 
 **L2 signals** (verification):
 
@@ -50,13 +98,13 @@ grep -r "govulncheck\|owasp\|scout" .github/workflows/ 2>/dev/null  # Security s
 ls **/mutation* .github/workflows/mutation* 2>/dev/null  # Mutation testing
 ```
 
-**L3 signals** (habitat):
+**L3 signals beyond the habitat documents** (habitat support):
 
 ```bash
-ls CLAUDE.md HARNESS.md AGENTS.md MODEL_ROUTING.md REFLECTION_LOG.md 2>/dev/null
 ls .claude/skills/*/SKILL.md 2>/dev/null       # Custom skills
 ls .claude/agents/*.md 2>/dev/null             # Custom agents
 ls .claude/commands/*.md 2>/dev/null           # Custom commands
+ls MODEL_ROUTING.md REFLECTION_LOG.md 2>/dev/null  # Other habitat artefacts
 cat harness-engineering/hooks/hooks.json 2>/dev/null  # Hooks
 ```
 
@@ -75,7 +123,13 @@ ls harness-engineering/.claude-plugin/plugin.json 2>/dev/null  # Plugin
 grep -r "OTEL\|otel\|telemetry" . --include="*.yml" --include="*.json" 2>/dev/null
 ```
 
-Record every signal found with its file path. Also record signals NOT found.
+Record every signal found with its file path. Record signals NOT
+found *only after* a complete check — for the habitat documents
+covered in Phase 1a, follow the discovery report rather than
+inferring absence from the default-path scan above. The wider
+alternative-path methodology will extend to the other artefacts
+listed above in a follow-up iteration; until then, prefer reporting
+"not found at the conventional path" rather than claiming absence.
 
 ### Phase 2: Present findings and ask clarifying questions
 

--- a/ai-literacy-superpowers/agents/harness-discoverer.agent.md
+++ b/ai-literacy-superpowers/agents/harness-discoverer.agent.md
@@ -59,9 +59,27 @@ create anything — you only describe what exists.
    configuration files, coverage tool configs. Identify the test runner
    command.
 
-5. **Convention documentation**: Read CLAUDE.md, CONTRIBUTING.md,
-   .editorconfig, any docs/ directory. Note existing conventions that
-   could be migrated to HARNESS.md.
+5. **Convention documentation**: Apply the habitat document
+   discovery methodology defined in:
+
+   ```text
+   ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md
+   ```
+
+   That reference is the single source of truth for which paths to
+   scan and which content markers confirm a match for `HARNESS.md`,
+   `AGENTS.md`, and `CLAUDE.md` — including the case where a
+   project's habitat documents live at non-conventional paths or
+   are embedded inside other files. Produce the discovery report
+   section described there as part of your output, then continue
+   reading other convention sources (`CONTRIBUTING.md`,
+   `.editorconfig`, any `docs/` directory) for context that could
+   inform `HARNESS.md` once the canonical record is identified.
+
+   Do not infer "habitat document absent" from a missing default
+   path. Follow the discovery report — a document found at an
+   alternative path is *present* and should be reported with its
+   actual path.
 
 6. **Pre-commit hooks**: Check .husky/, .pre-commit-config.yaml,
    .git/hooks/. Identify what runs before commits.

--- a/ai-literacy-superpowers/commands/assess.md
+++ b/ai-literacy-superpowers/commands/assess.md
@@ -15,13 +15,44 @@ immediate adjustment and workflow recommendation phases.
 
 ### 1. Scan
 
-Scan the repository for observable evidence of each framework level.
-Check for CI workflows, test coverage, vulnerability scanning, mutation
-testing, CLAUDE.md, HARNESS.md, AGENTS.md, MODEL_ROUTING.md, custom
-skills, agents, commands, hooks, specifications, implementation plans,
-orchestrator safety gates, and platform-level tooling.
+The scan has two sub-phases — habitat document discovery first, then
+broader signal scanning.
 
-Record every signal found (with file path) and every signal not found.
+#### 1a. Habitat document discovery
+
+Apply the discovery methodology defined in
+`ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md`.
+That reference lists the alternative paths to scan and the content
+markers that confirm a match for `HARNESS.md`, `AGENTS.md`, and
+`CLAUDE.md` — including the case where a project's habitat
+documents live at non-conventional paths or are embedded inside
+other files.
+
+Produce the discovery report described in the reference as the
+**first output of `/assess`**, before any maturity claim. Each
+finding cites the path matched and the content markers confirmed,
+so the user can verify the discovery rather than trust it.
+
+If discovery returns ambiguities (two or more candidate files for
+the same habitat document type), STOP and ask the user to confirm
+which file is the canonical record before continuing. The
+discovery layer never silently picks one — silent picks produce
+confidently-wrong assessments.
+
+#### 1b. Broader signal scan
+
+Once the habitat documents are identified, scan the repository for
+the rest of the framework evidence: CI workflows, test coverage,
+vulnerability scanning, mutation testing, custom skills, agents,
+commands, hooks, specifications, implementation plans, orchestrator
+safety gates, and platform-level tooling. The detailed search list
+lives in the `assessor` agent's Phase 1b instructions.
+
+Record every signal found (with file path) and every signal not
+found. For habitat documents specifically, follow the Phase 1a
+discovery report — a document found at an alternative path is
+*present* and should be treated as such by the maturity
+calculation.
 
 ### 2. Present and Question
 

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -14,7 +14,19 @@ timestamped assessment document and a README badge.
 ### Phase 1: Observable Evidence
 
 Scan the repository for signals that indicate which framework level the
-team is operating at. Each signal maps to a specific level:
+team is operating at.
+
+**Habitat document discovery comes first.** Before scanning for any of
+the level indicators below, apply the methodology in
+`references/habitat-discovery.md` to find `HARNESS.md`, `AGENTS.md`,
+and `CLAUDE.md` — including their alternative paths and embedded
+forms. A habitat document found at a non-conventional path counts as
+*present* for the Level 3 indicators that reference it; "not at the
+default path" is not the same as "doesn't exist". Every absence claim
+must come from a fully-completed search across known alternatives,
+with the discovery report citing what was matched and where.
+
+Each signal below maps to a specific level:
 
 **Level 0-1 indicators (awareness + prompting)**:
 

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md
@@ -1,0 +1,247 @@
+# Habitat document discovery
+
+Reference for the discovery methodology used by `/assess`, the
+`assessor` agent, and the `harness-discoverer` agent before any
+maturity claim or absence finding.
+
+The methodology has one rule: **every absence claim must come from a
+fully-completed search across known alternatives, not from "not at the
+default path"**. Discovery output is auditable — each finding cites
+the path matched and the content marker that confirmed the match, so
+the user can verify rather than trust.
+
+This reference covers three habitat documents — `HARNESS.md`,
+`AGENTS.md`, and `CLAUDE.md`. Other artefacts (specs, objections,
+stories, snapshots, reflections) follow in a later iteration.
+
+## What's in scope (this iteration)
+
+The three core habitat documents:
+
+| Document | Role |
+| --- | --- |
+| `HARNESS.md` | Declared specification of the surrounding harness; constraints, GC rules, status |
+| `AGENTS.md` | Compound-learning memory the agent reads on every dispatch; STYLE, ARCH_DECISIONS, past gotchas |
+| `CLAUDE.md` | Project conventions in the agent's context window |
+
+Discovery answers, for each of the three: present at the conventional
+location, present at an alternative location, or genuinely absent
+across all the alternatives we checked.
+
+## Alternative paths to scan
+
+For each habitat document, scan the conventional location *and* the
+following alternatives. The list isn't exhaustive — it is the union
+of paths observed across real projects. New alternatives go here as
+they are discovered.
+
+### HARNESS.md alternatives
+
+```text
+HARNESS.md                          # Conventional
+docs/HARNESS.md
+.ai/HARNESS.md
+.agents/HARNESS.md
+conventions/HARNESS.md
+governance/HARNESS.md
+CONVENTIONS.md                      # Renamed equivalent
+STANDARDS.md                        # Renamed equivalent
+docs/conventions.md
+docs/standards.md
+```
+
+### AGENTS.md alternatives
+
+```text
+AGENTS.md                           # Conventional
+.agents/AGENTS.md
+docs/AGENTS.md
+.claude/AGENTS.md
+.cursor/AGENTS.md                   # Some projects place it under tool dirs
+```
+
+### CLAUDE.md alternatives
+
+```text
+CLAUDE.md                           # Conventional
+.claude/CLAUDE.md
+docs/CLAUDE.md
+.ai/CLAUDE.md
+```
+
+A path-only match is a *candidate*, not a *match*. Confirm with
+content markers below.
+
+## Content markers
+
+A habitat document at an alternative path is only a real match if its
+content contains the marker patterns associated with that document
+type. Path matching narrows the search; content-marker matching
+confirms the match.
+
+### HARNESS.md content markers
+
+Match if **at least two** of the following are present:
+
+- `^## Constraints` heading (with constraint blocks following)
+- `^### Status` or `^## Status` heading with last-audit-date or
+  enforcement-ratio fields
+- `^## Garbage Collection` heading
+- `^## Context` heading with stack/conventions sub-headings
+- A constraint block with the four-field shape:
+  `**Rule**:`, `**Enforcement**:`, `**Tool**:`, `**Scope**:`
+- The string `template-version:` in an HTML comment near the top
+- A YAML frontmatter `name:` field with a harness-shaped value
+
+The four-field constraint block is the strongest single marker — a
+file containing two or more such blocks is almost certainly a
+HARNESS.md equivalent regardless of filename or path.
+
+### AGENTS.md content markers
+
+Match if **at least two** of the following are present:
+
+- `ARCH_DECISION` headings or sections
+- `^## Style` heading with conventions-style content
+- A "past learnings" / "gotchas" / "patterns observed" section
+- References to `REFLECTION_LOG.md` or to specific past reflection
+  dates
+- Compound-learning vocabulary: "promotions from reflections", "what
+  agents should know"
+
+### CLAUDE.md content markers
+
+Match if **at least two** of the following are present:
+
+- Direct address to an AI: "You are…", "Do not…", "Always…", "Never…"
+- A conventions block with naming, file structure, error handling, or
+  documentation style sub-sections
+- References to specific agent commands (`/spec-writer`,
+  `/diaboli`, `/choice-cartograph`, etc.) as part of workflow
+  instructions
+- Workflow rules describing branching, commit messages, PR flow
+
+## Discovery report format
+
+The discovery report is the first artefact produced by `/assess` and
+the harness-discoverer, before any maturity claim. The format is
+auditable — every finding cites the path matched and the markers
+confirmed.
+
+```markdown
+## Habitat document discovery
+
+### HARNESS.md
+
+- **Status**: <found at conventional path | found at alternative path | not found>
+- **Path**: `<path>` (or `—` if not found)
+- **Markers matched**: <list of marker patterns, with line citations>
+  - `## Constraints` heading at line N
+  - 4-field constraint block at lines M–P
+  - `template-version: 0.29.0` in HTML comment at line K
+- **Notes**: <free text — e.g. "embedded inside CLAUDE.md as a
+  Constraints section rather than as a separate file" or "two
+  candidates found, see Ambiguities below">
+
+### AGENTS.md
+
+- **Status**: …
+- **Path**: …
+- **Markers matched**: …
+- **Notes**: …
+
+### CLAUDE.md
+
+- **Status**: …
+- **Path**: …
+- **Markers matched**: …
+- **Notes**: …
+
+### Ambiguities
+
+<empty if discovery was unambiguous; populated when multiple
+candidates were found for the same document type>
+
+- HARNESS.md: two candidates
+  - `HARNESS.md` (4-field constraint blocks at lines 50–80, no
+    Status block)
+  - `docs/STANDARDS.md` (Status block at line 200, no constraint
+    blocks)
+  - **Resolution**: ambiguous — user must confirm which is the
+    canonical record. Discovery does not pick silently.
+
+### Paths checked but not matched
+
+<every path scanned that did not match — even at conventional
+locations — so the user can verify the search was complete>
+
+- `HARNESS.md` — file does not exist
+- `docs/HARNESS.md` — file does not exist
+- `.ai/HARNESS.md` — file does not exist
+- `CONVENTIONS.md` — exists but does not contain any HARNESS markers
+- … (the full list of alternative paths from this reference)
+```
+
+The `Paths checked but not matched` section is what makes absence
+claims auditable. A user reading the report can see exactly which
+locations were scanned and which markers were checked. "Not found
+anywhere I checked" with the list of paths is a different claim
+than "not at the default path", and the report distinguishes them.
+
+## Failure modes
+
+Two cases the discovery layer must handle deliberately rather than
+silently.
+
+### Ambiguous discovery
+
+Two or more files match content markers for the same document type
+across the scanned paths. The discovery layer **fails loudly** — it
+lists every candidate with its path and matched markers, places them
+under an `Ambiguities` section, and asks the user to confirm which
+file is the canonical record. The discovery layer does not pick one
+silently; silent picks produce confidently-wrong assessments.
+
+Concrete example: a project has both `HARNESS.md` (with constraint
+blocks but no Status section) and `docs/CONVENTIONS.md` (with a
+Status section but no constraint blocks). Both partially match.
+Discovery reports both, the user resolves.
+
+### Genuine absence
+
+No path matches and no content marker is satisfied across any scanned
+path. The discovery layer reports `Status: not found`, lists every
+path checked under `Paths checked but not matched`, and continues to
+the next document. Downstream tooling (the assessor's maturity
+calculation, the harness-discoverer's report) treats genuine absence
+differently from "found at alternative path" — but both have to be
+distinguishable in the report.
+
+## Where this reference is consumed
+
+- `agents/assessor.agent.md` Phase 1 (Scan the repository) — consumes
+  this reference to perform habitat document discovery before the
+  rest of the scan.
+- `agents/harness-discoverer.agent.md` step 5 (Convention
+  documentation) — consumes this reference to find embedded habitat
+  patterns regardless of filename.
+- `commands/assess.md` — surfaces the discovery report as the first
+  output, before any maturity claim.
+- `skills/ai-literacy-assessment/SKILL.md` — references this file as
+  the methodology for habitat document discovery.
+
+Inline duplication of these paths or markers across the four
+consumers is forbidden. Edits to discovery contract live in this
+file so the consumers stay in sync.
+
+## What's deferred
+
+Out of scope for this iteration; tracked for follow-up:
+
+- Specs, objections, stories, snapshots, reflections paths
+- Reading parallel-tool configurations (`.cursor/rules/`,
+  `.github/copilot-instructions.md`, `.windsurf/rules/`) as
+  evidence sources — that's evidence-base expansion (Unit B), not
+  discovery
+- Content-shape analysis to distinguish state-based orchestration
+  from accumulated bash — also Unit B


### PR DESCRIPTION
## Summary

- Closes #222
- Plugin v0.29.0 → v0.30.0 (minor bump for behavioural change)
- Implements Unit A of the workflow signal captured in REFLECTION_LOG.md (2026-04-28 entry, PR #221)
- New shared reference `skills/ai-literacy-assessment/references/habitat-discovery.md` consumed by the assessor agent, harness-discoverer agent, `/assess` command, and the `ai-literacy-assessment` skill

## What changed

The `/assess` discovery and the harness-discoverer were rigid about default paths and filenames — items 1, 2, and 5 of the user-supplied feedback decomposed to a single structural fix. This PR ships that fix as an additive discovery layer that runs before any maturity calculation or absence claim.

| File | Change |
|---|---|
| `skills/ai-literacy-assessment/references/habitat-discovery.md` (new) | Single source of truth for habitat document discovery — alternative paths, content markers, discovery report format with citations, ambiguity handling, genuine-absence handling |
| `agents/assessor.agent.md` | Phase 1 split into 1a (habitat document discovery using the reference) and 1b (broader signal scan) |
| `agents/harness-discoverer.agent.md` | Convention documentation step applies the new reference |
| `commands/assess.md` | Step 1 split into 1a (discovery report as first output) and 1b (broader scan); ambiguity halts the flow |
| `skills/ai-literacy-assessment/SKILL.md` | Phase 1 prefaced with discovery methodology note |

## Encoded principle

> Every absence claim must come from a fully-completed search across known alternatives, not from "not at the default path". Discovery output is auditable — each finding cites the path matched and the marker confirmed.

## Why chore label

The work is reflection-driven and additive — Phase 1a is new; Phase 1b preserves existing behaviour. The reflection at #221 (workflow signal) and the issue at #222 (scope) together serve as the design record. Behaviour change is contained, auditable, and explicitly approved upstream.

## Out of scope (Unit B follow-up)

- Multi-tool config reading (`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`) as parallel evidence sources
- Content-shape analysis to distinguish state-based orchestration from accumulated bash
- Updates to `literacy-improvements` skill's gap-to-amendment mapping

## Test plan

- [ ] `Check spec-first commit ordering` passes (chore exempt)
- [ ] `Check version consistency` passes (0.30.0 in plugin.json + marketplace.json + README badge + CHANGELOG heading)
- [ ] `Enforce PR constraints` passes (chore exempt for choice-stories)
- [ ] `markdownlint` passes (verified locally — 0 errors across 7 modified files)