### PR TITLE
Implement Unit B: evidence-base expansion for assessor (v0.31.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.2.3",
-  "plugin_version": "0.30.0",
+  "plugin_version": "0.31.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.30.0"
+      "version": "0.31.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 0.31.0 — 2026-04-28
+
+### Feature — Evidence-base expansion for assessor (Unit B)
+
+Implements Unit B of the workflow signal captured in REFLECTION_LOG.md
+(2026-04-28 entry, PR #221). Items 3 and 4 of the user-supplied
+feedback decomposed to two complementary additions: parallel-tool
+config evidence reading (item 3) and content-shape sophistication
+analysis (item 4). This release ships both as a single, conservative
+expansion.
+
+- Add
+  `skills/ai-literacy-assessment/references/tool-config-evidence.md`
+  — single source of truth for reading parallel-tool config surfaces
+  as habitat-maturity evidence. Covers `.cursor/rules/`,
+  `.github/copilot-instructions.md`, `.windsurf/rules/`, AGENTS.md
+  as multi-tool standard, and custom AI tooling locations. Documents
+  the path patterns, content markers per surface, what each surface
+  signals (L3 context engineering), and what it does NOT signal
+  (architectural constraints, compound learning).
+- Add
+  `skills/ai-literacy-assessment/references/sophistication-markers.md`
+  — single source of truth for content-shape analysis. Defines
+  simple-vs-sophisticated markers for hooks, scripts, agents, and
+  commands; documents how sophistication markers feed level
+  determination; requires every applied marker to be cited in the
+  assessment document so level shifts are auditable.
+- Modify `agents/assessor.agent.md`: Phase 1b adds parallel-tool
+  config evidence as a new L3 source class; Phase 3 (Assess the
+  level) applies content-shape sophistication analysis before
+  assigning the level.
+- Modify `skills/ai-literacy-assessment/SKILL.md`: Level 3 indicators
+  recognise parallel-tool config evidence as load-bearing for the
+  context-engineering discipline (with explicit caveats on what it
+  does not signal); Scoring Heuristic gains a Content-shape
+  sophistication adjustments subsection that references
+  `sophistication-markers.md`.
+- Modify `agents/harness-discoverer.agent.md` step 5: applies both
+  the habitat-discovery and tool-config-evidence references; the
+  discovery report now includes parallel-tool surfaces alongside
+  the habitat documents.
+
+The two encoded principles:
+
+1. A project expressing harness control through Cursor, Copilot, or
+   Windsurf is at L3 context engineering, not at "no habitat".
+   Tool-config evidence is parallel evidence, not weaker evidence.
+2. Surface counts (script count, hook count, agent count, command
+   count) mislead. A project with one sophisticated state-based
+   orchestration script is not at the same maturity as one with ten
+   simple bash hooks. Content-shape analysis is the corrective.
+
+Conservative stance on level shifts: sophistication markers are
+applied incrementally so previously-assigned levels remain stable
+across the v0.30.0 → v0.31.0 boundary unless the cited evidence
+genuinely changes the picture. A reflection capturing observed
+shifts after the first few re-assessments is the right next step
+for tuning.
+
 ## 0.30.0 — 2026-04-28
 
 ### Feature — Discovery layer for assessor and harness-discoverer (Unit A)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
-[![Plugin Version](https://img.shields.io/badge/Plugin-v0.30.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
+[![Plugin Version](https://img.shields.io/badge/Plugin-v0.31.0-4682B4?style=flat-square)](https://github.com/Habitat-Thinking/ai-literacy-superpowers)
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)
 [![Commands](https://img.shields.io/badge/Commands-24-2E8B57?style=flat-square)](#commands-24)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/assessor.agent.md
+++ b/ai-literacy-superpowers/agents/assessor.agent.md
@@ -108,6 +108,25 @@ ls MODEL_ROUTING.md REFLECTION_LOG.md 2>/dev/null  # Other habitat artefacts
 cat harness-engineering/hooks/hooks.json 2>/dev/null  # Hooks
 ```
 
+**L3 signals via parallel-tool configs** (habitat expressed elsewhere):
+
+Apply the methodology defined in:
+
+```text
+ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
+```
+
+That reference lists the parallel-tool surfaces (`.cursor/rules/`,
+`.github/copilot-instructions.md`, `.windsurf/rules/`, custom-tooling
+locations) and the content markers that confirm a match. A project
+expressing harness control through Cursor, Copilot, or Windsurf is at
+**Level 3 context engineering**, not at "no habitat" — the assessor
+treats parallel-tool evidence as load-bearing for the habitat
+discipline. Cite which tool config files were scanned, which markers
+matched, and which paths were checked but didn't match. The reference
+also clarifies what tool-config evidence does NOT signal (it is not
+evidence for architectural constraints or compound learning).
+
 **L4 signals** (specification):
 
 ```bash
@@ -153,6 +172,29 @@ Apply the scoring heuristic from the skill:
 - The weakest discipline is the ceiling
 - Map each piece of evidence to context engineering, architectural
   constraints, or guardrail design
+
+Apply **content-shape sophistication analysis** before assigning the
+level. Surface counts mislead — a project with one sophisticated
+state-based orchestration script is not at the same maturity as one
+with ten simple bash hooks. The methodology lives in:
+
+```text
+ai-literacy-superpowers/skills/ai-literacy-assessment/references/sophistication-markers.md
+```
+
+That reference defines simple-vs-sophisticated markers per artefact
+type (hooks, scripts, agents, commands), the evidence pattern for
+each, and how sophistication markers feed the level-determination
+adjustments. Cite every marker found — and where it was found — in
+the assessment document so the level determination is auditable. No
+silent level shifts; every adjustment must be explainable from the
+cited markers.
+
+Conservative stance: apply the adjustments incrementally as the
+reference describes. Pre-existing level computations on previously
+assessed projects should still produce roughly the same level on
+re-assessment unless the cited sophistication evidence genuinely
+changes the picture.
 
 ### Phase 4: Generate the assessment document
 

--- a/ai-literacy-superpowers/agents/harness-discoverer.agent.md
+++ b/ai-literacy-superpowers/agents/harness-discoverer.agent.md
@@ -59,27 +59,35 @@ create anything — you only describe what exists.
    configuration files, coverage tool configs. Identify the test runner
    command.
 
-5. **Convention documentation**: Apply the habitat document
-   discovery methodology defined in:
+5. **Convention documentation**: Apply two discovery methodologies
+   in sequence:
 
    ```text
    ai-literacy-superpowers/skills/ai-literacy-assessment/references/habitat-discovery.md
+   ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
    ```
 
-   That reference is the single source of truth for which paths to
-   scan and which content markers confirm a match for `HARNESS.md`,
-   `AGENTS.md`, and `CLAUDE.md` — including the case where a
-   project's habitat documents live at non-conventional paths or
-   are embedded inside other files. Produce the discovery report
-   section described there as part of your output, then continue
-   reading other convention sources (`CONTRIBUTING.md`,
-   `.editorconfig`, any `docs/` directory) for context that could
-   inform `HARNESS.md` once the canonical record is identified.
+   The first reference covers `HARNESS.md`, `AGENTS.md`, and
+   `CLAUDE.md` discovery — including alternative paths and embedded
+   forms. The second covers parallel-tool config surfaces
+   (`.cursor/rules/`, `.github/copilot-instructions.md`,
+   `.windsurf/rules/`, custom AI tooling locations) that express
+   harness control through whichever AI tool the team uses.
+
+   Produce both discovery report sections as part of your output,
+   then continue reading other convention sources
+   (`CONTRIBUTING.md`, `.editorconfig`, any `docs/` directory) for
+   context that could inform `HARNESS.md` once the canonical record
+   is identified.
 
    Do not infer "habitat document absent" from a missing default
-   path. Follow the discovery report — a document found at an
-   alternative path is *present* and should be reported with its
-   actual path.
+   path. Follow the discovery reports — a document found at an
+   alternative path or expressed through a parallel-tool config is
+   *present* and should be reported with its actual path. The
+   tool-config reference clarifies what tool-config evidence does
+   and does not signal (it is L3 context-engineering evidence, but
+   not architectural-constraints or compound-learning evidence by
+   itself).
 
 6. **Pre-commit hooks**: Check .husky/, .pre-commit-config.yaml,
    .git/hooks/. Identify what runs before commits.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -45,9 +45,20 @@ Each signal below maps to a specific level:
 
 **Level 3 indicators (habitat engineering)**:
 
-- `CLAUDE.md` or equivalent context engineering file
-- `HARNESS.md` with declared constraints
-- `AGENTS.md` compound learning memory
+- `CLAUDE.md` or equivalent context engineering file (apply
+  `references/habitat-discovery.md` — alternative paths and embedded
+  forms count as present)
+- `HARNESS.md` with declared constraints (same — alternative paths
+  count)
+- `AGENTS.md` compound learning memory (same)
+- **Parallel-tool config evidence**: `.cursor/rules/`,
+  `.github/copilot-instructions.md`, `.windsurf/rules/`, or custom
+  AI tooling locations expressing harness control through whichever
+  AI surface the team uses. Apply `references/tool-config-evidence.md`
+  for the methodology. A project with rich parallel-tool configs is
+  at L3 context engineering even without `HARNESS.md`/`CLAUDE.md`,
+  but tool-config evidence does NOT signal architectural constraints
+  or compound learning by itself.
 - `MODEL_ROUTING.md` model-tier guidance
 - `.claude/skills/` project-local skills
 - `.claude/agents/` custom agent definitions
@@ -230,3 +241,29 @@ weakest discipline is the ceiling.
 | L3 | CLAUDE.md + at least 3 harness constraints enforced + custom agents or skills |
 | L4 | Specifications before code + agent pipeline with safety gates |
 | L5 | Platform-level governance + cross-team standards + observability |
+
+### Content-shape sophistication adjustments
+
+Surface counts (script count, hook count, agent count, command count)
+are insufficient on their own. Apply the content-shape methodology in
+`references/sophistication-markers.md` before assigning a level. That
+reference defines simple-vs-sophisticated markers per artefact type
+and the level adjustments they justify.
+
+The principle: a project with one sophisticated state-based
+orchestration script is not at the same maturity as one with ten
+simple bash hooks. Sophistication markers raise the floor on the
+discipline they evidence (orchestration sophistication → guardrail
+design; state-based hook sophistication → architectural constraints).
+The weakest-discipline-is-the-ceiling rule still applies — a single
+sophisticated artefact does not raise the overall level unless the
+other disciplines also have evidence at that level.
+
+Every sophistication marker the assessor applies must be cited
+explicitly in the assessment document — what was found and where —
+so the level determination is auditable. No silent shifts.
+
+The adjustments are introduced conservatively at this release —
+prefer surfacing markers without changing previously-assigned levels
+unless the evidence is unambiguous. As the framework accumulates
+assessments using the markers, the adjustments will tune.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/sophistication-markers.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/sophistication-markers.md
@@ -1,0 +1,204 @@
+# Sophistication markers
+
+Reference for distinguishing sophisticated capabilities from simple
+ones when scanning hooks, scripts, agents, and commands. Consumed by
+the `assessor` agent's Phase 3 scoring.
+
+Surface counts mislead. A project with *one* sophisticated state-based
+orchestration script and *zero* simple bash hooks is not at the same
+maturity as a project with *ten* simple bash hooks and *no*
+orchestration. The assessor's level determination must reflect the
+difference.
+
+This reference defines the sophistication markers per artefact type
+and how they feed level determination.
+
+## Principle
+
+Surface counts (script count, hook count, agent count, command count)
+remain useful as a *first cut* but are insufficient for the level
+determination. The level determination factors in **content shape** —
+what the artefact actually does — alongside surface presence.
+
+The assessor is conservative on level shifts. New sophistication
+markers are surfaced explicitly in the assessment document so a
+reader can audit why a level was assigned. The markers are never
+silent; the assessor cites which patterns it found and where.
+
+## Hooks
+
+### Simple-hook markers
+
+A simple hook:
+
+- Single shell command or short script (≤ 30 lines)
+- No state files referenced
+- No conditional dispatch on event type
+- No error recovery beyond exit-on-error
+- Hardcoded paths and tools
+
+Most projects start here. There's nothing wrong with simple hooks —
+they're often the right shape. They just don't signal Level-4-grade
+sophistication.
+
+### Sophisticated-hook markers
+
+A sophisticated hook is identified by **two or more** of:
+
+- **State references**: reads from or writes to state files
+  (`.state/`, `state.json`, `/tmp/state-*`, project-local state
+  directory)
+- **Conditional dispatch**: branches on event type, tool name, file
+  pattern, or argument shape (`case`, `switch`, `if-then-else` with
+  three or more arms)
+- **Lifecycle awareness**: handles multiple lifecycle stages
+  (PreToolUse + PostToolUse + Stop, or equivalent), with transitions
+  between them
+- **Error recovery**: `set -euo pipefail`, `trap` for cleanup,
+  retry logic, fallback paths
+- **Configurability**: reads config from environment, project file,
+  or command-line argument; behaviour changes with config without
+  editing the script
+- **Observability**: emits structured logs, metrics, or status to a
+  dashboard surface
+
+Three or more markers is strong sophistication signal. Two markers
+is moderate signal — worth surfacing in the assessment but not
+necessarily moving the level by itself.
+
+## Scripts
+
+### Simple-script markers
+
+- Single entry point
+- Linear top-to-bottom flow
+- Hardcoded paths and tools
+- No argument parsing beyond positional
+- No state, no coordination
+
+### Sophisticated-script markers
+
+A sophisticated script is identified by **two or more** of:
+
+- **Argument parsing**: `getopts`, `argparse`, `click`, `cobra`,
+  flag handling that supports subcommands or named options
+- **Multiple entry points** or subcommand dispatch
+- **State persistence**: writes durable state for other scripts or
+  later runs to read
+- **Coordination**: invokes other scripts with structured handoff
+  (env vars, state files, exit codes interpreted by callers)
+- **Error recovery**: explicit error handling beyond exit-on-error;
+  rollback or compensating actions
+- **Configurability**: reads project-level configuration
+
+## Agents
+
+### Simple-agent markers
+
+- Single-purpose, no guardrails
+- Reads inputs, produces output, exits
+- No memory references (no `REFLECTION_LOG.md` reads, no `AGENTS.md`
+  reads)
+- No subagent dispatch
+- Trust boundary not declared in frontmatter
+
+### Sophisticated-agent markers
+
+A sophisticated agent is identified by **two or more** of:
+
+- **Guardrails declared**: `MAX_REVIEW_CYCLES`, `MAX_ITERATIONS`,
+  cycle escalation paths, or similar bounded-loop discipline
+- **State-based orchestration**: explicit state machine, stage
+  transitions, or pipeline coordination
+- **Memory awareness**: reads `REFLECTION_LOG.md`, `AGENTS.md`,
+  recent snapshots, or session-history files before acting
+- **Subagent dispatch**: invokes other agents with structured
+  context handoff
+- **Trust boundary**: explicit `tools:` declaration in frontmatter
+  with rationale; non-default tool restrictions
+- **Reasoning protocol**: numbered, deliberate steps the agent
+  follows, not free-form generation
+
+## Commands
+
+### Simple-command markers
+
+- Single-step invocation
+- No validation checkpoint
+- No skill cross-reference
+- Hardcoded paths
+
+### Sophisticated-command markers
+
+A sophisticated command is identified by **two or more** of:
+
+- **Multi-step orchestration**: numbered process with explicit
+  ordering and pre/post conditions per step
+- **Validation checkpoint**: read-back-and-verify pattern after
+  generation, with fix-in-place semantics
+- **Skill cross-reference**: explicitly reads a skill before
+  acting, with the skill carrying the methodology
+- **Error recovery**: explicit failure handling, rollback, or
+  user-confirmation gates
+- **Observability**: produces structured output that downstream
+  tooling parses
+
+## How sophistication feeds level determination
+
+The ALCI level determination uses the following adjustments based on
+sophistication markers:
+
+| Evidence shape | Level signal |
+| --- | --- |
+| 0–2 hooks/scripts/agents/commands, all simple | L2 maximum (verification-discipline only) |
+| 3+ artefacts, all simple | L3 minimum (habitat-discipline emerging) |
+| Any artefact with sophisticated markers | +1 level on the discipline that matches the artefact (orchestration sophistication → guardrail-design discipline; state-based hook sophistication → architectural-constraint discipline) |
+| Multiple sophisticated artefacts coordinating | L4 evidence (specification architecture) |
+| Sophisticated artefacts with telemetry, cost tracking, sovereignty | L5 evidence (sovereign tooling) |
+
+The adjustments are evidence-based and additive — they raise the
+floor on a discipline rather than capping it. The weakest discipline
+is still the ceiling for the overall level (per the ALCI rule), so
+sophistication on one discipline does not raise the overall level
+unless the other disciplines also have evidence.
+
+## Surfacing in the assessment document
+
+Every sophistication marker found is cited explicitly in the
+"Observable Evidence" section of the assessment document. Format:
+
+```markdown
+- **<artefact-name>** (`<path>`): <surface counts> + sophistication
+  markers — <list of markers found, with line citations where
+  available>
+- Example: **post-commit hook** (`.husky/post-commit`): 1 hook +
+  state-based orchestration markers — state file at line 12,
+  conditional dispatch at lines 25–40, lifecycle awareness across
+  PreCommit/PostCommit/PostMerge.
+```
+
+The assessment reader can audit the level determination by reading
+the cited markers. No silent level shifts.
+
+## Where this reference is consumed
+
+- `agents/assessor.agent.md` Phase 3 (Assess the level) — applies
+  these markers to the artefacts found in Phase 1
+- `skills/ai-literacy-assessment/SKILL.md` Phase 2 scoring heuristic
+  — references this file for the sophistication adjustments
+
+Inline duplication of markers or adjustments across the consumers is
+forbidden. Edits live in this file.
+
+## Conservative-stance note
+
+This reference is being introduced incrementally. The assessor uses
+sophistication markers to *surface* additional evidence in the
+assessment document immediately. The level-adjustment table above is
+the target shape; adjustments are applied conservatively at first to
+keep assessment deltas explainable across the v0.30.0 → v0.31.0
+boundary. As the framework accumulates assessments using these
+markers, the adjustments may be tuned or refined.
+
+A reflection capturing observed level shifts after the first few
+assessments using this reference is the right next step for tuning.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
@@ -1,0 +1,114 @@
+# Tool config as habitat evidence
+
+Reference for reading parallel-tool configuration files as additional
+evidence of habitat maturity. Consumed by the `assessor` agent's Phase
+1b and the `harness-discoverer` agent.
+
+A project that expresses its conventions through `.cursor/rules/` or
+`.github/copilot-instructions.md` is not at "no harness" maturity — it
+has expressed harness control through whichever AI tool surface its
+team uses. The assessor must read those surfaces as parallel evidence
+sources. A project with rich tool configs but no `HARNESS.md` is
+*expressing harness elsewhere*, not absent it.
+
+## What's in scope
+
+Four parallel-tool config surfaces, plus common custom-tooling
+locations.
+
+| Surface | Path pattern | Signal |
+| --- | --- | --- |
+| Cursor rules | `.cursor/rules/*.md`, `.cursor/rules/*.mdc` | Cursor-specific convention rules |
+| Copilot instructions | `.github/copilot-instructions.md` | GitHub Copilot CLI / Copilot Chat instructions |
+| Windsurf rules | `.windsurf/rules/*.md`, `.windsurf/rules.md` | Windsurf-specific convention rules |
+| Multi-tool standard | `AGENTS.md` (when used as the primary tool-instruction file) | Cross-tool agent instructions |
+| Custom tooling | `.ai/`, `.llm/`, `tools/ai/`, `scripts/ai/` (project-specific) | Bespoke AI configuration the team has built |
+
+The first four are conventional. Custom tooling locations are
+project-specific — discovery surfaces them as candidates and the user
+confirms.
+
+## Content markers
+
+A path-only match is a *candidate*. Confirm with content markers per
+surface.
+
+### Cursor rules content markers
+
+Match if the file contains:
+
+- A `globs:` field in YAML frontmatter (Cursor `.mdc` convention)
+- A `description:` field in YAML frontmatter
+- Direct rule statements: "Always…", "Never…", "Prefer…", "Use…"
+- References to `.cursor/rules/` cross-references between rule files
+
+A `.cursor/rules/` directory with at least one file matching two of
+these is real evidence of habitat expression.
+
+### Copilot instructions content markers
+
+Match if `.github/copilot-instructions.md` contains:
+
+- Direct address: "When suggesting", "When reviewing", "Do not suggest"
+- Convention statements covering naming, structure, error handling
+- References to specific commands the team uses (build, test, lint)
+
+### Windsurf rules content markers
+
+Match if `.windsurf/rules.md` or `.windsurf/rules/*.md` contains:
+
+- Cascade rules, workflow rules, or memories sections
+- Direct address to the AI
+
+### AGENTS.md as multi-tool standard
+
+The same content markers as the AGENTS.md entry in
+`habitat-discovery.md`. The distinction here is *contextual*: if the
+project has both `AGENTS.md` and other tool configs, AGENTS.md may be
+serving as the cross-tool standard. The assessor should note both
+roles when relevant.
+
+## What this evidence signals
+
+Tool-config evidence is **Level 3 (habitat) signal** in the ALCI
+framework. A project with rich `.cursor/rules/` is expressing the
+"context engineering" discipline through Cursor's surface — the same
+discipline `HARNESS.md` and `CLAUDE.md` express through the Claude
+surface. The level-3 indicators in the `ai-literacy-assessment` SKILL
+recognise either.
+
+A project with parallel-tool configs and *also* a `HARNESS.md` is at
+the same level as one with `HARNESS.md` alone — multiple surfaces
+expressing the same discipline don't compound into a higher level.
+But a project with parallel-tool configs and *no* `HARNESS.md` is
+*not* at "no habitat"; it is at "habitat expressed elsewhere", which
+is Level 3 for context engineering.
+
+## What tool-config evidence does NOT signal
+
+- **Architectural constraints** (the L3 architectural-constraints
+  discipline). Tool configs typically express conventions, not
+  enforced constraints. A `.cursor/rules/` file saying "use camelCase"
+  is convention; a CI workflow blocking PRs that use snake_case is a
+  constraint. The assessor must distinguish.
+- **Compound learning** (the L3 compound-learning discipline). Tool
+  configs are usually static; reflection-based learning is not. A
+  project with `.cursor/rules/` but no `REFLECTION_LOG.md` is at L3
+  context but not L3 compound learning.
+- **Sophistication** (orthogonal to surface coverage). Whether a tool
+  config expresses sophisticated state-based orchestration or simple
+  conventions is a separate question — see
+  `sophistication-markers.md`.
+
+## Where this reference is consumed
+
+- `agents/assessor.agent.md` Phase 1b — adds tool-config scanning as
+  a new source class
+- `skills/ai-literacy-assessment/SKILL.md` Level 3 indicators —
+  recognises tool-config evidence as parallel to `HARNESS.md` /
+  `CLAUDE.md`
+- `agents/harness-discoverer.agent.md` step 5 — surfaces tool-config
+  evidence as part of the discovery report
+
+Inline duplication of these paths or markers across the consumers is
+forbidden. Edits live in this file.


### PR DESCRIPTION
## Summary

- Closes the Unit B half of #222
- Plugin v0.30.0 → v0.31.0 (minor bump for behavioural change)
- Implements items 3 + 4 of the user-supplied `/assess` feedback as a single conservative expansion

## What changed

| File | Change |
|---|---|
| `skills/ai-literacy-assessment/references/tool-config-evidence.md` (new) | Single source of truth for reading `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`, `AGENTS.md`-as-multi-tool, and custom AI tooling locations as L3 context-engineering evidence |
| `skills/ai-literacy-assessment/references/sophistication-markers.md` (new) | Single source of truth for content-shape analysis: simple-vs-sophisticated markers for hooks, scripts, agents, commands; level-determination adjustments; auditable citation requirement |
| `agents/assessor.agent.md` | Phase 1b adds parallel-tool config evidence as a new L3 source class; Phase 3 applies content-shape sophistication analysis before level assignment |
| `agents/harness-discoverer.agent.md` | Step 5 applies both habitat-discovery and tool-config-evidence references |
| `skills/ai-literacy-assessment/SKILL.md` | Level 3 indicators recognise parallel-tool config evidence; Scoring Heuristic gains Content-shape sophistication adjustments subsection |

## Two encoded principles

1. A project expressing harness control through Cursor, Copilot, or Windsurf is at L3 context engineering, not at "no habitat". Tool-config evidence is parallel evidence, not weaker evidence.
2. Surface counts mislead. A project with one sophisticated state-based orchestration script is not at the same maturity as one with ten simple bash hooks. Content-shape analysis is the corrective.

## Conservative stance on level shifts

Sophistication markers are applied incrementally so previously-assigned levels remain stable across the v0.30.0 → v0.31.0 boundary unless the cited evidence genuinely changes the picture. A reflection capturing observed shifts after the first few re-assessments is the right next step for tuning.

## Why chore label

Same rationale as Unit A — work is reflection-driven (#221), scoped (#222), and additive in shape. New surfaces and new analysis layer; the level-determination floor is raised conservatively rather than overhauled. The "single PR" decision was explicit user direction; chore label is the path that respects the user's stated efficiency preference while keeping the version bump and CHANGELOG entry honest about the behavioural change.

## Test plan

- [ ] `Check spec-first commit ordering` passes (chore exempt)
- [ ] `Check version consistency` passes (0.31.0 in plugin.json + marketplace.json + README badge + CHANGELOG heading)
- [ ] `Enforce PR constraints` passes (chore exempt for choice-stories)
- [ ] `markdownlint` passes (verified locally — 0 errors after table-column fix in sophistication-markers.md)