### PR TITLE
model-cards: new sister plugin (v0.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Russ Miles"
   },
-  "version": "0.2.3",
+  "version": "0.3.0",
   "plugin_version": "0.31.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
@@ -16,6 +16,12 @@
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
       "version": "0.31.1"
+    },
+    {
+      "name": "model-cards",
+      "source": "./model-cards",
+      "description": "Researches and authors Mitchell-extended model cards from a model name.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -26,9 +26,30 @@ jobs:
       - name: Extract versions from all locations
         id: versions
         run: |
-          # plugin.json version
+          # ai-literacy-superpowers plugin.json version (canonical plugin)
           PLUGIN_VERSION=$(grep '"version"' ai-literacy-superpowers/.claude-plugin/plugin.json | sed 's/.*"version": "\(.*\)".*/\1/')
           echo "plugin=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
+
+          # All plugins enumerated from marketplace.json plugins[]
+          # Each entry's source path + .claude-plugin/plugin.json version is verified
+          # against its marketplace.json plugins[] entry's version (per-plugin sync).
+          PLUGIN_NAMES=$(jq -r '.plugins[].name' .claude-plugin/marketplace.json)
+          PLUGIN_MISMATCHES=""
+          for name in $PLUGIN_NAMES; do
+            source=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source' .claude-plugin/marketplace.json)
+            mp_version=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .version' .claude-plugin/marketplace.json)
+            pj_version=$(jq -r '.version' "${source}/.claude-plugin/plugin.json" 2>/dev/null || echo "MISSING")
+            echo "  $name: marketplace=$mp_version, plugin.json=$pj_version"
+            if [ "$mp_version" != "$pj_version" ]; then
+              PLUGIN_MISMATCHES="$PLUGIN_MISMATCHES $name(mp=$mp_version,pj=$pj_version)"
+            fi
+          done
+          if [ -n "$PLUGIN_MISMATCHES" ]; then
+            echo "::error::Plugin version mismatches:$PLUGIN_MISMATCHES"
+            echo "Each plugin's plugin.json version must match its marketplace.json plugins[] entry's version."
+            exit 1
+          fi
+          echo "All per-plugin versions in sync"
 
           # README badge version
           README_VERSION=$(grep -o 'Plugin-v[0-9.]*' README.md | head -1 | sed 's/Plugin-v//')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,23 @@
 <!-- Key architectural decisions and the reasoning behind them.
      Each entry: what was decided, why, and what the alternatives were. -->
 
+- Decision: content-emitting agents in this codebase use a three-part trust
+  architecture — **agent-emit + dispatcher-persist + human-disposes**. The
+  agent's tool boundary is research-and-author only (no Edit, no Bash); the
+  agent returns content as a string; the dispatching command writes the file
+  after a structured human review (accept / edit / re-run / abort). This
+  pattern is in production across three agents: `advocatus-diaboli`,
+  `choice-cartographer`, and `model-card-researcher`. Three repetitions
+  promote it from convention to named architecture (Hunt/Thomas's Rule of
+  Three). Future research-and-author agents in this codebase should default
+  to this shape unless an explicit reason argues otherwise. The two halves
+  are: (1) tool-boundary — minimum-trust-surface, no shell, no edit; (2)
+  human-gate — structured review summary, named dispositions, command
+  refuses to persist when the agent emits a refusal string (e.g.
+  model-card-researcher's REFUSED: line for unconfirmed model existence).
+  Source: `docs/superpowers/stories/model-cards-plugin-design.md` stories
+  #7 and #8 (promoted disposition).
+
 - Decision: hook scripts never block, only warn. Reason: this is a
   plugin used across diverse projects — blocking hooks could break
   workflows the plugin authors cannot predict. Advisory messages let

--- a/docs/superpowers/objections/model-cards-plugin-design.md
+++ b/docs/superpowers/objections/model-cards-plugin-design.md
@@ -1,0 +1,270 @@
+---
+spec: docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
+date: 2026-04-29
+mode: spec
+diaboli_model: claude-opus-4-7[1m]
+objections:
+  - id: O1
+    category: premise
+    severity: high
+    claim: "The 'driver satisfied' claim conflates 'I am the user' with 'a downstream consumer asked with a concrete use case', which were the conditions yesterday's reflection set for revisit — meaning the spec may be answering its own door."
+    evidence: "Cross-references mention satisfaction of Driver 2 from yesterday's Conditions for Revisit list — but Driver 2 was 'a downstream consumer of the plugin asks for it with a concrete use case', and the author named themselves as the user."
+    disposition: rejected
+    disposition_rationale: "The objection's substance is acknowledged: 'the user is the user' is a weak satisfaction of yesterday's gate as written. Author exercises author's judgment to proceed anyway. The work is being undertaken because the author wants the artefact and finds the marketplace-shipped form acceptable; this stance is recorded honestly here rather than rationalised through the gate. Future similar judgments will be calibrated against this precedent — and against whether real users emerge to use the resulting plugin."
+  - id: O2
+    category: premise
+    severity: high
+    claim: "The audience-asymmetry pivot does not actually solve the dilution risk that killed Option A-E yesterday — it relocates it. Marketplace consumers see the new plugin in the listing whether they want evaluator tooling or not."
+    evidence: "Marketplace integration adds a second plugins[] entry and bumps the listing version. The spec does not articulate why marketplace consumers want a sister plugin shipped, only why the author does."
+    disposition: rejected
+    disposition_rationale: "Author accepts that adding a sister plugin imposes a marketplace-listing cost on consumers and judges that cost acceptable. Marketplace consumers can ignore plugins they don't want; listing growth is the explicit cost of operating a marketplace. The asymmetry the objection identifies (one-sided ledger) is real but the missing side is small: cost-of-an-extra-listing-line per consumer is genuinely low."
+  - id: O3
+    category: alternatives
+    severity: high
+    claim: "A simpler shape — a personal scratch repo, a CLI tool, or a single skill — is not weighed against a sister plugin. Plugin-with-marketplace-listing is the most expensive shape on offer."
+    evidence: "The Decisions table lists six clarifying questions but none ask 'should this be a plugin at all'. Q6a only debates the name suffix."
+    disposition: rejected
+    disposition_rationale: "Author chose plugin shape deliberately. Claude Code marketplace integration IS the value-add over CLI/personal-repo/skill alternatives — the plugin is invoked from inside the same tool the author is already using when evaluating models, with hybrid review-before-commit gating. CLI lacks Claude-Code coupling; personal repo lacks discoverability; single-skill lacks coherent invocation surface; doc-page is not actionable. The 'plugin or not' fork was implicit in the user's initial framing ('I'd like this plugin to be runnable when new models are released') — not absent from consideration, but not formally tabulated. Recording here as adjudicated rejection."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "Hallucination-and-staleness risk treated as documentation problem (last_researched date, citations) rather than structural one. Authoritative-looking cards are exactly what users trust without re-verifying."
+    evidence: "Risks section mentions citations make verification cheap; no expiry, no banner, no agent-side refusal when tier-1 is unreachable, no honesty-rule for tier-4-only sections."
+    disposition: rejected
+    disposition_rationale: "Rejected for v0.1.0. Author accepts hallucination/staleness risk as inherent to AI-generated cards; per-claim citation + last_researched date provide the verification surface; users opting into AI-generated cards implicitly accept the limitation. The hybrid review-before-commit gate (Q4) is the structural mitigation. Will revisit if real cards in the wild surface specific authoritative-looking-but-wrong examples — the cards will be exposed to scrutiny via the library; failures will be visible."
+  - id: O5
+    category: risk
+    severity: high
+    claim: "Agent training cutoff bounds knowledge of model identity. Several seed-list models may not exist or be misnamed; agent has no way to distinguish 'doesn't exist' from 'I don't know yet'. Honesty rule applies per-claim, not per-card."
+    evidence: "Seed list includes gpt-5, o4, o4-mini, llama-4, grok-4, qwen3-coder etc. Honesty rules cover claim-level fabrication; no rule says 'refuse to create a card when tier-1+tier-2 silent on the model itself'."
+    disposition: rejected
+    disposition_rationale: "Rejected for v0.1.0. The failure mode (card full of 'Not publicly available' for a possibly-non-existent model) is acceptable for personal evaluation use — users will notice when a card has no real content and move on. The implementation plan may add a card-level honesty rule ('refuse if tier-1+tier-2 both silent on model existence') as a small enhancement; this rationale records the door open for that without making it a v0.1.0 blocker."
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "Agent has WebFetch + global file write to ~/.claude/model-cards/. No provenance-hygiene rule: no prohibition on excerpting from authenticated URLs, no scrubbing of session-specific tokens, no flagging of 401-redirected pages."
+    evidence: "Tools list includes WebFetch + Write. Default path is global per-user. Honesty rules cover fabrication and conflict resolution but not content-class safety."
+    disposition: rejected
+    disposition_rationale: "WebFetch's behaviour with authenticated URLs is a tool-implementation concern, not a spec concern. If WebFetch leaks authenticated content into research outputs, that is a Claude Code framework issue affecting many tools, not a model-cards plugin issue. The plugin will not specifically prohibit excerpting from authenticated URLs because doing so requires the agent to reliably detect 'this URL was authenticated' — which is exactly what the framework would need to do globally. Out of scope for v0.1.0."
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "Seed flow underspecified for failure: 14 sequential web operations over 30-60 minutes will hit rate limits, transient failures, 4xx/5xx in real conditions. Spec describes happy path with one-line failed counter."
+    evidence: "Seed flow steps describe iteration and final summary; no resume semantics, no idempotency for partial cards, no rate-limit backoff."
+    disposition: rejected
+    disposition_rationale: "Rejected for v0.1.0. Seed flow happy-path is sufficient for the use case (one-time bulk populate by the author). If failures are common in practice, --resume / --retry-failed flags can be added in v0.1.x as small enhancements without spec rework. The 'skip if card exists' check provides natural resumability for the most common case (re-run after partial success). Adding full failure-mode treatment now is premature."
+  - id: O8
+    category: scope
+    severity: medium
+    claim: "Embedding 14 specific frontier-model names as shipped plugin payload creates a maintenance contract not committed to. Names age faster than release cadence."
+    evidence: "frontier-models.json ships 14 entries. Risks section says 'worth a reflection if cadence becomes onerous' — not a maintenance plan."
+    disposition: rejected
+    disposition_rationale: "Embedded seed list is intentional starter content. Plugin patch releases for seed updates are an acceptable operational cost given the value of an immediately-functional plugin on first install. The 'fetch-from-remote' alternative the objection proposes would couple the plugin to an external service the author does not control — a worse maintenance contract than periodic patch releases. If the cadence becomes painful, the seed list can be slimmed or fetched dynamically in a future version."
+  - id: O9
+    category: specification quality
+    severity: medium
+    claim: "Several configurability decisions underspecified: (a) --out flag (file or directory?), (b) provider-name resolution rules, (c) re-run-section <N> reference (template number or summary number?), (d) 'Top 3 most-cited' metric."
+    evidence: "create command flags described once with no semantics; review summary mentions 'top 3 most-cited' without defining metric; provider resolution says 'agent infers from research' which is not a rule."
+    disposition: rejected
+    disposition_rationale: "Rejected as a spec-time blocker. The plugin author and implementer are the same person and will resolve these ambiguities consistently during implementation. The plan will pin: --out as a directory override (cards still go to <provider>/<model-name>.md beneath it); provider resolution as agent-inferred with user confirmation in the review step (already in spec); re-run-section <N> as template section number 1-10; 'Top 3 most-cited' as raw citation count. Recording these picks here so they're visible at adjudication time."
+  - id: O10
+    category: specification quality
+    severity: medium
+    claim: "Mitchell-extended Section 10 described as comma-separated wishlist not schema. No required-vs-optional marking, no per-field schema (pricing currency? as-of date?), no agent rule for missing field-level claims."
+    evidence: "Section 10 lists pricing, context window, knowledge cutoff, supported APIs/SDKs, latency tier, tool/structured-output, function calling, fine-tuning availability, rate limits in one sentence."
+    disposition: rejected
+    disposition_rationale: "Section 10 fields are an evolving list; locking down a strict schema in v0.1.0 would be premature optimisation. Real cards will reveal which fields matter and which are routinely opaque. The implementation will treat all listed fields as best-effort with field-level 'Not publicly available' as the canonical missing-data answer (extending the section-level honesty rule); future schema strictness can be added once enough cards exist to inform it."
+  - id: O11
+    category: alternatives
+    severity: medium
+    claim: "Extending Mitchell from 9 to 10 sections produces non-standard artefact. Simpler alternative — 9 sections + Operational Details in frontmatter — preserves interoperability with downstream Mitchell-aware tooling."
+    evidence: "Q3 rationale invokes 'industry-recognised' as a benefit of Mitchell then breaks the recognition by adding section 10. Trade-off not weighed."
+    disposition: rejected
+    disposition_rationale: "Mitchell-extended is a deliberate choice to capture consumer-evaluator data the original framework lacks. Interoperability with strict-Mitchell tooling is not a stated goal of this plugin. The objection's frontmatter alternative is reasonable; the chosen 10-section approach was selected during brainstorming for self-documentation (an empty section is more visible than a missing frontmatter key) and the trade-off is accepted. Cards from this plugin are 'Mitchell-shaped, with operational details' — the honest framing is the section-10 form."
+  - id: O12
+    category: scope
+    severity: medium
+    claim: "v0.1.0 ships 'no harness, no hooks, no scripts' but the existing version-consistency CI reads ai-literacy-superpowers/.claude-plugin/plugin.json singular — likely won't see the new plugin's version. Spec assumes existing harness covers what's needed without verifying."
+    evidence: "Architecture asserts no new scaffolding; testing strategy says existing harness covers it; CLAUDE.md describes version-consistency as singular check."
+    disposition: rejected
+    disposition_rationale: "Valid CI integration concern but not a spec-blocker. The implementation plan will include a small task to extend version-check.yml to enumerate plugins via marketplace.json's plugins[] array OR add a separate per-plugin version-check job. The 'YAGNI applies' framing in the spec was overconfident — this is a known scope item that will surface in the plan, not a hidden landmine."
+---
+
+## O1 — premise — high
+
+### Claim
+
+The spec claims the conditions for revisit set by yesterday's reflection are satisfied because "the user is the user." That claim is load-bearing — it is the bridge between yesterday's "no" and today's "yes" — and it is weak. Yesterday's reflection asked for "downstream consumer asks for it with a concrete use case." The author asking themselves, on the same day they wrote the reflection, is not the test the reflection was designed to apply.
+
+### Evidence
+
+The spec's Cross-references section explicitly invokes Driver 2 from yesterday's Conditions for Revisit list as satisfied by "the user is the user; this spec is the implementation."
+
+### Why this matters
+
+The reflection's "wait for a downstream consumer" condition exists precisely to protect against the failure mode the spec author is now exhibiting — building because they want to, not because anyone has asked. If the test for "we have a downstream consumer" can be satisfied by the author naming themselves, the test does no work. The honest reframe is "I want to build this for myself; here is the cheapest shape that meets that need" — and then alternatives like a personal repo or a CLI tool become available. Dressing personal curiosity in marketplace-contribution clothing is the failure mode the reflection log was warning against.
+
+## O2 — premise — high
+
+### Claim
+
+The "separate plugin" pivot relocates the dilution risk that killed Options A-E yesterday rather than dissolving it. The audience-asymmetry argument shows the new plugin would be a poor fit for the *existing plugin's* users; it does not show the new plugin is a good fit for the *marketplace's* users.
+
+### Evidence
+
+The Marketplace integration section adds a second `plugins[]` entry and bumps the listing version 0.2.3 → 0.3.0. The spec does not articulate who the new plugin's users are beyond the author and a hypothetical "evaluator" cohort whose existence is not evidenced.
+
+### Why this matters
+
+A marketplace is a contract with consumers. Adding plugins to a shared marketplace listing imposes a "should I install this?" cognitive cost on every consumer. The audience-asymmetry argument is a one-sided ledger: it accounts for cost imposed on the existing plugin's users by the new content, but not for cost imposed on marketplace consumers by the new listing entry. Yesterday's O5 surfaced this concern.
+
+## O3 — alternatives — high
+
+### Claim
+
+The Decisions table walks through six clarifying questions and reaches a sister-plugin shape — but the question "should this be a plugin at all?" is missing. Cheaper shapes were not weighed: a personal git repo, a CLI tool, a single skill in the existing plugin, a docs page with a templated card. Plugin-with-marketplace-listing is the most expensive shape on the menu.
+
+### Evidence
+
+The Decisions table goes from "what models?" (Q1) directly to "tiered sources" (Q2), then through "card format", "invocation", "storage", "seed", "plugin name". Q6a debates only the name suffix. The fork "is the right shape a plugin, a CLI, a skill, or a doc?" is absent.
+
+### Why this matters
+
+At spec time, alternative shapes are still cheap to consider. After implementation begins, "we should have just made it a CLI" becomes academic. The spec's reasoning chain assumes plugin-shape from Q1 onward — every subsequent decision inherits that assumption. If the right shape is a CLI tool or a personal repo, the entire downstream plan is wasted.
+
+## O4 — risk — high
+
+### Claim
+
+Hallucination-and-staleness risk treated as documentation problem with the wrong primitives. A card that LOOKS authoritative — Mitchell-format frontmatter, [T1.1] per-claim citations, ten well-organised sections — is precisely what users trust without re-verifying. Citations are evidence the agent fetched something, not evidence the agent understood it correctly.
+
+### Evidence
+
+The Risks section says citations make verification cheap and `last_researched` date makes staleness visible. Honesty rules say tier-1 wins conflicts. There is no rule for what happens when a tier-4 claim has no tier-1 to conflict with.
+
+### Why this matters
+
+Cross-references explicitly link this plugin to MODEL_ROUTING.md. That elevates the cards from "personal evaluation notes" to "input to operational decisions." A subtly-hallucinated pricing field, context-window number, or rate-limit description, presented in an authoritative format with citations, is exactly the failure mode that erodes trust in the whole plugin. "Per-claim citations make verification cheap" is true; the implicit assumption is "and so users will verify" — which is the assumption that fails.
+
+## O5 — risk — high
+
+### Claim
+
+Agent training cutoff bounds what it knows about model identity. Several seed-list entries may not exist or be misnamed. Spec does not describe agent behaviour for "model name resolves to nothing in any tier" — does it produce a card full of "Not publicly available" (which looks authoritative for a model that may not exist), abort, or warn the user?
+
+### Evidence
+
+Seed list includes gpt-5, o4, o4-mini, gemini-2.5-pro, llama-4, mistral-large-3, grok-4, qwen3-coder. Honesty rules apply per-claim, not per-card.
+
+### Why this matters
+
+This is the most likely real-world failure mode for the seed command. A user runs `/model-card seed`, gets 14 files in their library, opens one for `o4`, sees a Mitchell-formatted card full of "Not publicly available" with sparse tier-4 citations to news articles, and concludes either (a) the model is real but opaque, or (b) the agent did its best. Neither conclusion is "this model may not exist under this name." "Refuse to create a card when tier-1 + tier-2 are both unreachable for the model itself" is a reasonable rule the spec lacks.
+
+## O6 — risk — medium
+
+### Claim
+
+Per-user library at `~/.claude/model-cards/` is global; agent has WebFetch access. WebFetch can return content from authenticated URLs (logged-in HuggingFace, paid API portals, internal corporate proxies). No spec-level prohibition on excerpting from authenticated URLs and pasting fragments into a global file.
+
+### Evidence
+
+Tools list includes WebFetch + Write. Default path is global per-user. Honesty rules cover fabrication and conflict resolution; not content-class safety.
+
+### Why this matters
+
+Library location is global and persistent. A card containing an excerpt from a logged-in page outlives the research session. If the user later shares a card, they share whatever leaked. Mitigation is small (one-line agent-charter rule); spec does not have it.
+
+## O7 — risk — medium
+
+### Claim
+
+Seed flow describes a happy path with no semantics for partial state. 14 sequential web operations over 30-60 minutes will hit rate limits, network blips, 4xx/5xx in real conditions. Spec does not describe resumability, idempotency for partial cards, or rate-limit backoff.
+
+### Evidence
+
+Seed flow steps describe iteration and final summary; one-line "failed" counter; nothing on resume or partial-write semantics.
+
+### Why this matters
+
+Once seed has run partially and crashed, the user is in undefined state. Re-running seed will skip cards that exist (good) but will not repair half-researched cards. The first-run experience for the marquee feature is the most likely place a real user encounters failure. Resumability is a spec-level concern (affects command shape: --resume? --retry-failed? failure log?), not implementation detail.
+
+## O8 — scope — medium
+
+### Claim
+
+Embedding 14 specific frontier-model names as shipped plugin payload creates a maintenance contract the spec does not commit to. Names age faster than release cadence.
+
+### Evidence
+
+frontier-models.json ships 14 entries. Risks section disposes the cadence concern with "worth a reflection if cadence becomes onerous" — not a maintenance plan.
+
+### Why this matters
+
+Either (a) plugin gets out of date and users see stale seed lists embedded in v0.1.x for months, or (b) plugin requires patch releases just to refresh the list, churning CHANGELOG and version state for content that was never load-bearing. Cheaper shape — empty seed shipped with `--add` semantics, or fetch-from-remote with offline fallback — not weighed.
+
+## O9 — specification quality — medium
+
+### Claim
+
+Several configurability decisions specified at one level above where two reasonable implementers will diverge: (a) `--out path` (file or directory?), (b) provider-name resolution rules, (c) `re-run-section <N>` reference, (d) "Top 3 most-cited" metric.
+
+### Evidence
+
+`--out path` described once with no semantics; "Top 3 most-cited" with no metric; provider resolution says "agent infers from research" which is not a rule.
+
+### Why this matters
+
+Each ambiguity will be resolved during implementation by an implementer who picks an answer; the picks may not be consistent with each other or with author intent. Spec-time is the cheap moment to fix this.
+
+## O10 — specification quality — medium
+
+### Claim
+
+Mitchell-extended Section 10 described as comma-separated wishlist, not schema. No required-vs-optional marking, no per-field schema, no agent rule for missing field-level claims.
+
+### Evidence
+
+Section 10 lists pricing, context window, knowledge cutoff, supported APIs/SDKs, latency tier, tool/structured-output support, function calling, fine-tuning availability, rate limit notes — all in one sentence.
+
+### Why this matters
+
+If a card omits "fine-tuning availability" silently, is that a research gap or a "not applicable" signal? Implementer cannot tell from the spec. Future `/model-card compare` will be unable to compare cards reliably because the field set isn't fixed.
+
+## O11 — alternatives — medium
+
+### Claim
+
+Extending Mitchell from 9 to 10 sections produces a non-standard artefact. Simpler alternative — 9 sections + Operational Details in YAML frontmatter, or as a sibling document — preserves interoperability with downstream tooling.
+
+### Evidence
+
+Q3 rationale invokes "industry-recognised" as a benefit of Mitchell, then breaks the recognition by adding section 10. The trade-off is not weighed.
+
+### Why this matters
+
+Once extended, cards are no longer Mitchell — they are a derivative. Tooling that consumes Mitchell cards will either ignore section 10 or reject the card. Frontmatter is an existing extension point and would carry operational details without breaking canon.
+
+## O12 — scope — medium
+
+### Claim
+
+v0.1.0 ships 'no harness, no hooks, no scripts' but existing version-consistency CI reads `ai-literacy-superpowers/.claude-plugin/plugin.json` singular — likely won't see the new plugin's version. Spec assumes existing harness covers it without verifying.
+
+### Evidence
+
+Architecture asserts no new scaffolding; testing strategy says existing harness covers it; CLAUDE.md describes version-consistency as a singular check.
+
+### Why this matters
+
+If the version-consistency check reads only the existing plugin's files, the new plugin's version and changelog ship unchecked. Either the check already handles N plugins (then say so), or the spec's scope quietly grows.
+
+## Explicitly not objecting to
+
+- **The hybrid review-before-commit design (Q4)**: AI-generated content needs a human checkpoint before persistent library entry — correct and well-reasoned.
+- **The tiered source strategy (Q2) at the conceptual level**: cheap-then-expensive ordering is sound.
+- **The decision to defer compare/refresh/list to tracking issues**: scoping discipline is correct.
+- **The Option A choice on plugin_version**: correctly applies yesterday's lesson.
+- **The agent's tool boundary (no Edit, no Bash)**: appropriate for a research-and-author agent.
+- **The spec's structural rigour**: tables and cross-references are spec hygiene done right.
+- **The CHANGELOG and semver discipline for the new plugin**: mirrors existing pattern correctly.
+- **The explicit deferrals in Non-goals**: clearly marked, correctly excluded.

--- a/docs/superpowers/plans/2026-04-29-model-cards-plugin.md
+++ b/docs/superpowers/plans/2026-04-29-model-cards-plugin.md
@@ -1,0 +1,1272 @@
+# model-cards plugin v0.1.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a sister plugin (`model-cards`) in the existing marketplace repo that researches and authors Mitchell-extended model cards from a model name, ships with a 14-model frontier seed list, and integrates cleanly with the existing marketplace and CI without disrupting `ai-literacy-superpowers`.
+
+**Architecture:** The plugin lives at `model-cards/` next to `ai-literacy-superpowers/` with the same layout convention (`.claude-plugin/`, `agents/`, `commands/`, `skills/`, `templates/`, `seed/`, `CHANGELOG.md`, `README.md`). One agent (`model-card-researcher`) and one command (`/model-card create|seed` with subcommand dispatch). Cards land at `~/.claude/model-cards/<provider>/<model-name>.md` by default. Marketplace listing bumps to v0.3.0; per-plugin version-consistency check extended to enumerate `plugins[]`.
+
+**Tech Stack:** Markdown templates, YAML frontmatter, JSON config, bash for any glue scripts, GitHub Actions (existing workflows extended). No new test framework — relies on markdownlint + manual integration smoke tests, consistent with the repo's existing TEST_STRATEGY.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md`
+**Diaboli (adjudicated)**: `docs/superpowers/objections/model-cards-plugin-design.md`
+**Stories (adjudicated)**: `docs/superpowers/stories/model-cards-plugin-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `model-cards/.claude-plugin/plugin.json` | Create | Plugin manifest, v0.1.0 |
+| `model-cards/README.md` | Create | Plugin landing page; what it does, install, two subcommands |
+| `model-cards/CHANGELOG.md` | Create | Starts with v0.1.0 entry |
+| `model-cards/templates/MODEL_CARD.md` | Create | 10-section Mitchell-extended template |
+| `model-cards/skills/model-cards/SKILL.md` | Create | Framework guidance: when each section applies, citation discipline, honesty rules |
+| `model-cards/agents/model-card-researcher.agent.md` | Create | Charter: tiered sources, per-section research, citation discipline, card-level + claim-level honesty rules |
+| `model-cards/commands/model-card.md` | Create | `/model-card create|seed` subcommand dispatch with hybrid review-before-commit |
+| `model-cards/seed/frontier-models.json` | Create | 14-model frontier seed list |
+| `.claude-plugin/marketplace.json` | Modify | Add second `plugins[]` entry; bump listing version 0.2.3 → 0.3.0 |
+| `.github/workflows/version-check.yml` | Modify | Enumerate plugins via `marketplace.json` `plugins[]` array (per O12 disposition) |
+| `AGENTS.md` | Modify | New ARCH_DECISIONS entry promoting the trust-architecture pattern (per stories 7+8 promotion) |
+
+---
+
+## Task 1: Plugin scaffold — `plugin.json`, `CHANGELOG.md`, `README.md`
+
+**Files:**
+
+- Create: `model-cards/.claude-plugin/plugin.json`
+- Create: `model-cards/CHANGELOG.md`
+- Create: `model-cards/README.md`
+
+- [ ] **Step 1: Create `model-cards/.claude-plugin/plugin.json`**
+
+```json
+{
+  "name": "model-cards",
+  "version": "0.1.0",
+  "description": "Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web). Hybrid review-before-commit flow.",
+  "author": {"name": "Russ Miles"},
+  "keywords": ["model-cards", "model-research", "ai-evaluation", "mitchell-2019", "ai-literacy"]
+}
+```
+
+- [ ] **Step 2: Verify JSON well-formed**
+
+Run: `jq . model-cards/.claude-plugin/plugin.json > /dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Create `model-cards/CHANGELOG.md`**
+
+```markdown
+# Changelog
+
+## 0.1.0 — 2026-04-29
+
+### Added
+
+- Initial release. `/model-card create <name>` for research-and-author flow with
+  hybrid review-before-commit. `/model-card seed` for bulk-populate from the
+  shipped 14-model frontier seed list.
+- Mitchell-extended card template (9 canonical sections + Operational Details).
+- Tiered source strategy: provider docs → HuggingFace → arXiv → web search.
+- Per-claim citation format: `[T<n>.<m>]` resolving via per-card frontmatter.
+- Default library at `~/.claude/model-cards/<provider>/<model-name>.md`;
+  configurable via `--out` flag (directory override) and `MODEL_CARDS_DIR` env var.
+- Spec, diaboli adjudication, and choice-cartograph stories preserved at
+  `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` and the
+  matching objections / stories records.
+```
+
+- [ ] **Step 4: Create `model-cards/README.md`**
+
+```markdown
+# model-cards
+
+Research and author Mitchell-extended model cards from a model name.
+
+A sister plugin to [ai-literacy-superpowers](../ai-literacy-superpowers/) in
+the same marketplace. Aimed at evaluators researching new models.
+
+## What it does
+
+- `/model-card create <model-name> [--provider X] [--out path]` — researches
+  the model through a tiered source strategy (provider docs → HuggingFace →
+  arXiv → web), produces a draft card, presents a review summary, and (on
+  accept) writes the card to your library.
+- `/model-card seed` — populates the library with cards for a shipped list of
+  14 frontier LLMs from major providers.
+
+## Install
+
+```bash
+# In Claude Code
+claude plugin install model-cards@ai-literacy-superpowers
+
+# In Copilot CLI
+copilot plugin install model-cards@ai-literacy-superpowers
+```
+
+## Library location
+
+Default: `~/.claude/model-cards/<provider>/<model-name>.md`
+
+Override with the `--out` flag (directory override; cards still land beneath
+it as `<provider>/<model-name>.md`) or the `MODEL_CARDS_DIR` env var.
+
+## Card format
+
+10-section Mitchell-extended:
+
+1. Model Details
+2. Intended Use
+3. Factors
+4. Metrics
+5. Evaluation Data
+6. Training Data
+7. Quantitative Analyses
+8. Ethical Considerations
+9. Caveats and Recommendations
+10. Operational Details (this plugin's extension — pricing, context window,
+    knowledge cutoff, supported APIs/SDKs, latency, tool/structured-output
+    support, function calling, fine-tuning availability, rate limit notes)
+
+Cards include per-claim citations of the form `[T<n>.<m>]` where `n` is the
+source tier (1 = provider docs, 2 = HuggingFace, 3 = arXiv, 4 = web).
+
+## Honesty rules
+
+- Sections that the agent cannot find information for are filled with "Not
+  publicly available" — never fabricated.
+- If tier-1 and tier-2 are both silent on the model itself (the agent
+  cannot confirm the model exists), the agent refuses to create the card and
+  surfaces the result to the user. Cards are not produced for non-existent or
+  unconfirmed model names.
+- If a tier-4 (web) claim conflicts with a tier-1 (provider docs) claim,
+  tier-1 wins; the conflict is flagged in Caveats.
+
+## Roadmap
+
+- `/model-card list` — browse the library (issue #233)
+- `/model-card compare <a> <b>` — side-by-side card comparison (issue #234)
+- `/model-card refresh <name>` — re-research a specific card (issue #235)
+```
+
+- [ ] **Step 5: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 "model-cards/**/*.md"`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add model-cards/.claude-plugin/plugin.json model-cards/CHANGELOG.md model-cards/README.md
+git commit -m "model-cards: scaffold plugin manifest, CHANGELOG, README (v0.1.0)"
+```
+
+---
+
+## Task 2: Card template — `MODEL_CARD.md`
+
+**Files:**
+
+- Create: `model-cards/templates/MODEL_CARD.md`
+
+- [ ] **Step 1: Create the template**
+
+```markdown
+---
+model_name: <provider>/<model-name>
+provider: <Anthropic | OpenAI | Google | Meta | Mistral | xAI | Cohere | Alibaba | other>
+model_version: <as-stated-by-provider>
+last_researched: YYYY-MM-DD
+card_version: 0.1.0
+researcher: model-card-researcher (claude-opus-4-7[1m])
+sources:
+  - tier: 1
+    url: <provider docs URL>
+    fetched: YYYY-MM-DD
+  - tier: 2
+    url: <huggingface URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 3
+    url: <arxiv URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 4
+    url: <web URL or "n/a">
+    fetched: YYYY-MM-DD
+---
+
+# Model Card: <provider>/<model-name>
+
+## 1. Model Details
+
+What this model is, who released it, when, what kind of model it is. Cite
+provider-stated identity, release date, model family, parameter count if
+disclosed.
+
+## 2. Intended Use
+
+Primary uses, primary users, out-of-scope uses (per the provider's published
+statements).
+
+## 3. Factors
+
+Relevant subgroups, environmental factors, instrumentation factors. Often
+sparse for proprietary API-served models — fill with "Not publicly available"
+where the provider has not disclosed.
+
+## 4. Metrics
+
+Performance measures the provider reports. Cite each metric with its source
+tier; prefer tier-1 (provider docs) and tier-3 (release paper).
+
+## 5. Evaluation Data
+
+Datasets used to evaluate (per the provider's published statements). Often
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 6. Training Data
+
+Datasets used to train (per the provider's published statements). Frequently
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 7. Quantitative Analyses
+
+Disaggregated performance, where provider has published this. Cite metrics
+table from release paper or provider docs; record the date of the analysis.
+
+## 8. Ethical Considerations
+
+Risks, mitigations, known failure modes — preferring the release paper as
+primary source (tier 3); supplemented by provider statements (tier 1) and
+independent evaluations (tier 4) where relevant.
+
+## 9. Caveats and Recommendations
+
+What this card cannot tell you (sections marked "Not publicly available" and
+why). Recommendations for use given the model's documented strengths and
+limitations. Conflicts between tier-1 and tier-4 sources are recorded here.
+
+## 10. Operational Details
+
+Best-effort structured fields; missing values are written as "Not publicly
+available" rather than omitted:
+
+- **Pricing** — input/output cost per million tokens; pricing tier; as-of
+  date. Cite the pricing page (tier 1).
+- **Context window** — maximum input + output tokens.
+- **Knowledge cutoff** — provider-stated training cutoff date.
+- **Supported APIs/SDKs** — provider's API name(s); language SDKs; OpenAI
+  Chat Completions compatibility if applicable.
+- **Latency tier** — provider's stated latency tier or category, if any.
+- **Tool / structured-output support** — function calling, JSON mode, tool
+  use, parallel tool calls.
+- **Function calling** — supported, parallel-supported, schema format.
+- **Fine-tuning availability** — yes/no/limited; cite the fine-tuning docs
+  page if available.
+- **Rate-limit notes** — provider-published rate limit tiers or quotas.
+```
+
+- [ ] **Step 2: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 model-cards/templates/MODEL_CARD.md`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add model-cards/templates/MODEL_CARD.md
+git commit -m "model-cards: 10-section Mitchell-extended template"
+```
+
+---
+
+## Task 3: Seed list — `frontier-models.json`
+
+**Files:**
+
+- Create: `model-cards/seed/frontier-models.json`
+
+- [ ] **Step 1: Create the seed list**
+
+```json
+[
+  {"name": "claude-opus-4-7", "provider": "anthropic"},
+  {"name": "claude-sonnet-4-6", "provider": "anthropic"},
+  {"name": "claude-haiku-4-5", "provider": "anthropic"},
+  {"name": "gpt-5", "provider": "openai"},
+  {"name": "gpt-5-mini", "provider": "openai"},
+  {"name": "o4", "provider": "openai"},
+  {"name": "o4-mini", "provider": "openai"},
+  {"name": "gemini-2.5-pro", "provider": "google"},
+  {"name": "gemini-2.5-flash", "provider": "google"},
+  {"name": "llama-4", "provider": "meta"},
+  {"name": "mistral-large-3", "provider": "mistral"},
+  {"name": "grok-4", "provider": "xai"},
+  {"name": "command-r-plus", "provider": "cohere"},
+  {"name": "qwen3-coder", "provider": "alibaba"}
+]
+```
+
+- [ ] **Step 2: Verify JSON well-formed and structurally sound**
+
+```bash
+jq '. | length' model-cards/seed/frontier-models.json
+jq '.[].name' model-cards/seed/frontier-models.json | wc -l
+jq '.[].provider' model-cards/seed/frontier-models.json | sort -u
+```
+
+Expected: `14`, `14`, and a list of 8 unique provider strings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add model-cards/seed/frontier-models.json
+git commit -m "model-cards: 14-model frontier seed list"
+```
+
+---
+
+## Task 4: Skill — Mitchell-extended framework guidance
+
+**Files:**
+
+- Create: `model-cards/skills/model-cards/SKILL.md`
+
+- [ ] **Step 1: Create the skill**
+
+```markdown
+---
+name: model-cards
+description: Use when authoring or interpreting Mitchell-extended model cards in this plugin. Covers when each of the 10 sections applies, the citation discipline, the honesty rules (claim-level and card-level), and the tiered source strategy. Reference for the model-card-researcher agent and the /model-card command.
+---
+
+# Mitchell-Extended Model Cards
+
+This plugin produces 10-section model cards: Mitchell et al.'s 9 canonical
+sections plus an "Operational Details" 10th section for the consumer-evaluator
+audience. This skill is the reference for what each section is for and how
+to fill it honestly.
+
+## The ten sections
+
+### 1. Model Details
+
+What the model IS — name, provider, family, release date, parameter count
+where disclosed. Tier 1 (provider docs) is primary; tier 2 (HuggingFace) is
+secondary for open-source / fine-tuned models.
+
+### 2. Intended Use
+
+What the model is for — primary uses, intended users, explicitly out-of-scope
+uses. The provider's documentation usually makes this explicit; quote it
+faithfully and cite.
+
+### 3. Factors
+
+Subgroups, environmental factors, instrumentation. Often sparse for
+proprietary API-served models — write "Not publicly available" rather than
+fabricate.
+
+### 4. Metrics
+
+Performance measures the provider reports. Distinguish provider-reported
+benchmarks from independent evaluations (tier 1 vs tier 4).
+
+### 5. Evaluation Data
+
+Datasets used to evaluate. Frequently "Not publicly available" for
+proprietary models. Tier 3 (release paper) is the most likely source.
+
+### 6. Training Data
+
+Datasets used to train. Almost always "Not publicly available" for proprietary
+models — say so. Tier 3 is the only source likely to disclose.
+
+### 7. Quantitative Analyses
+
+Disaggregated performance — by demographic, by task category, by language.
+Tier 3 (release paper) is primary.
+
+### 8. Ethical Considerations
+
+Risks, mitigations, known failure modes. Tier 3 is the most honest source
+(release papers are usually more frank than marketing pages); tier 1 is
+secondary; tier 4 (independent evaluations) is tertiary but valuable for
+reality-check.
+
+### 9. Caveats and Recommendations
+
+The "what this card cannot tell you" section. Lists which sections came up
+"Not publicly available" and why. Records conflicts between tiers.
+Recommendations for use given the model's documented profile.
+
+### 10. Operational Details
+
+This plugin's extension. Best-effort structured fields:
+
+- Pricing (input/output per million tokens)
+- Context window
+- Knowledge cutoff
+- Supported APIs/SDKs
+- Latency tier
+- Tool / structured-output support
+- Function calling
+- Fine-tuning availability
+- Rate-limit notes
+
+Each field gets "Not publicly available" if absent; the field is never
+omitted. This makes downstream comparison (`/model-card compare`) reliable.
+
+## Citation discipline
+
+Every factual claim ends with `[T<n>.<m>]` where:
+
+- `n` is the source tier: 1 = provider docs, 2 = HuggingFace, 3 = arXiv,
+  4 = web search
+- `m` is the source index within that tier (1, 2, 3...)
+
+Example:
+
+```text
+Knowledge cutoff: January 2026 [T1.1]. Context window: 1M tokens [T1.2].
+Pricing: $5/$25 per million tokens (input/output) at standard tier [T1.3].
+```
+
+URLs for each citation resolve via the per-card frontmatter `sources` block.
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is silent
+  and lower tiers cannot confirm. Never fabricate.
+- "Per the provider's published statements" framing is preferred over
+  assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim, tier-1 wins;
+  the conflict is flagged in Section 9 (Caveats).
+
+### Card-level
+
+- If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on the
+  model's existence — the agent cannot confirm the model exists at all — the
+  agent refuses to create the card and surfaces the result to the dispatching
+  command. The command reports back to the user. **Cards are not produced
+  for non-existent or unconfirmed model names.** This rule prevents
+  authoritative-looking cards for hallucinated models.
+
+## Tiered source strategy
+
+| Tier | Source | Used for |
+|---|---|---|
+| 1 | Provider docs | Model Details, Intended Use, Operational Details |
+| 2 | HuggingFace | Open-source / fine-tuned models; fallback for tier-1 gaps |
+| 3 | arXiv release paper | Factors, Metrics, Evaluation Data, Training Data, Quantitative Analyses, Ethical Considerations |
+| 4 | Web search | Anything tiers 1-3 don't cover; independent evaluations |
+
+The agent researches **section-by-section** using each section's primary
+tier (see the table in `agents/model-card-researcher.agent.md`). This is
+more efficient than fetching all sources upfront.
+
+## When to use this skill
+
+- Authoring a card by hand (without the agent)
+- Interpreting a card (which sections to trust most)
+- Designing extensions to the card schema (e.g. adding fields to Section 10)
+- Building tooling that consumes cards (e.g. the future `/model-card compare`)
+```
+
+- [ ] **Step 2: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 model-cards/skills/model-cards/SKILL.md`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add model-cards/skills/model-cards/SKILL.md
+git commit -m "model-cards: skill — Mitchell-extended framework guidance"
+```
+
+---
+
+## Task 5: Research agent — `model-card-researcher.agent.md`
+
+**Files:**
+
+- Create: `model-cards/agents/model-card-researcher.agent.md`
+
+- [ ] **Step 1: Create the agent definition**
+
+```markdown
+---
+name: model-card-researcher
+description: Use to research a model and produce a Mitchell-extended model card. Given a model name (and optional provider hint), the agent applies a tiered source strategy and returns the full card content. Refuses to produce a card when tier-1 + tier-2 are both silent on model existence — never fabricates a card for an unconfirmed model. Output is a markdown string returned to the dispatching command; the command writes the file.
+tools: WebFetch, WebSearch, Read, Write, Glob, Grep
+model: inherit
+---
+
+# Charter
+
+You are the **model-card-researcher**. Given a model name (and optionally a
+provider hint), you produce a Mitchell-extended model card by researching
+the model through a tiered source strategy. You cite every factual claim.
+You write "Not publicly available" rather than fabricate.
+
+## Inputs
+
+- **Model name** (required) — e.g. `claude-opus-4-7`, `meta-llama/llama-4`,
+  `gpt-5-mini`
+- **Provider hint** (optional) — e.g. `anthropic`, `openai`, `huggingface`,
+  `meta`. If absent, you infer from the model name.
+
+## Output
+
+A single markdown string containing the full card content (frontmatter + 10
+sections per the template at `model-cards/templates/MODEL_CARD.md`).
+
+You do **not** write the file. The dispatching command persists the output
+after a human-in-the-loop review step.
+
+## Tools
+
+`WebFetch`, `WebSearch`, `Read`, `Write`, `Glob`, `Grep`. No `Edit`, no
+`Bash`. The trust boundary is "research and emit content"; persistence is
+the dispatcher's job.
+
+## Tiered source strategy
+
+| Tier | Source | Discovery |
+|---|---|---|
+| 1 | Provider docs | URL inferred from this provider→docs-root mapping |
+| 2 | HuggingFace | `https://huggingface.co/<owner>/<model>` if model is on HF |
+| 3 | arXiv release paper | `WebSearch` for `"<model-name>" arxiv` |
+| 4 | Web search | `WebSearch` with explicit queries; prefer recent results |
+
+### Provider→docs-root mapping (tier 1)
+
+- `anthropic` → `https://docs.anthropic.com`
+- `openai` → `https://platform.openai.com/docs/models`
+- `google` → `https://ai.google.dev/gemini-api/docs/models`
+- `meta` → `https://ai.meta.com/llama` and the model's GitHub repo
+- `mistral` → `https://docs.mistral.ai`
+- `xai` → `https://docs.x.ai`
+- `cohere` → `https://docs.cohere.com`
+- `alibaba` → `https://qwenlm.github.io` or the relevant model's docs page
+- For any other provider, search-discover via `WebSearch` for
+  `"<provider>" "<model-name>" docs`.
+
+### Per-section primary source
+
+| Section | Primary | Fallback |
+|---|---|---|
+| Model Details | Tier 1 | Tier 2 → 4 |
+| Intended Use | Tier 1 | Tier 2 → 4 |
+| Factors | Tier 3 | Tier 1 → 2 |
+| Metrics | Tier 1 + Tier 3 | — |
+| Evaluation Data | Tier 3 | Tier 1 |
+| Training Data | Tier 3 | Tier 1 (often "Not publicly available") |
+| Quantitative Analyses | Tier 3 | Tier 1 |
+| Ethical Considerations | Tier 3 + Tier 1 | Tier 4 |
+| Caveats and Recommendations | Synthesised | — |
+| Operational Details | Tier 1 | Tier 4 |
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is silent
+  and lower tiers cannot confirm. Never fabricate.
+- "Per the provider's published statements" framing is preferred over
+  assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim, tier-1 wins;
+  the conflict is flagged in Section 9 (Caveats).
+
+### Card-level (model existence check)
+
+If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on the
+model's existence — neither has a page, doc, or model card matching the
+input name — you **refuse to produce the card**. Return:
+
+```text
+REFUSED: Could not confirm existence of model "<name>" via tier-1
+(provider docs) or tier-2 (HuggingFace). Searched: <list of URLs / queries>.
+The model may not exist under this name, may have been retired, or may
+be too recent for available sources. The dispatching command should
+surface this to the user before any file is written.
+```
+
+The dispatcher will not write a file when this REFUSED string is the agent
+output. This prevents authoritative-looking cards for hallucinated or
+non-existent models.
+
+## Citation format
+
+Every factual claim ends with `[T<n>.<m>]` where:
+
+- `n` is the source tier (1-4)
+- `m` is the source index within that tier (1, 2, 3...)
+
+URLs resolve via the frontmatter `sources` block of the card you produce.
+Aggregate sources at top of the card.
+
+## Output structure
+
+Use the exact 10-section structure from `model-cards/templates/MODEL_CARD.md`.
+Populate frontmatter:
+
+- `model_name`
+- `provider`
+- `model_version` (use the input model name if provider doesn't disclose
+  a separate version)
+- `last_researched` (today's date in YYYY-MM-DD)
+- `card_version` (always `0.1.0` for this plugin's v0.1.0)
+- `researcher` (always `model-card-researcher (claude-opus-4-7[1m])`)
+- `sources` (full URL per tier consulted; "n/a" for tiers not consulted)
+
+## Anti-patterns
+
+- Fabricating a citation. If you didn't fetch a URL, don't cite it.
+- Producing a card after the model-existence check fails. Return the REFUSED
+  string instead.
+- Writing files. Your tools include Write but the dispatcher writes; the
+  Write capability is reserved for one specific use only: writing your
+  output to a temp path the dispatcher will read. **Default behaviour is to
+  return content as your final message** — only use Write if the dispatcher
+  has explicitly asked for a temp-file output.
+- Dropping a section because it came up sparse. Every section appears in
+  every card; sparse sections are filled with "Not publicly available."
+```
+
+- [ ] **Step 2: Verify YAML frontmatter parseable**
+
+Run:
+
+```bash
+python3 -c "
+import yaml
+content = open('model-cards/agents/model-card-researcher.agent.md').read()
+fm = yaml.safe_load(content.split('---', 2)[1])
+print('Name:', fm['name'])
+print('Tools:', fm['tools'])
+print('Model:', fm['model'])
+"
+```
+
+Expected:
+
+```text
+Name: model-card-researcher
+Tools: WebFetch, WebSearch, Read, Write, Glob, Grep
+Model: inherit
+```
+
+- [ ] **Step 3: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 model-cards/agents/model-card-researcher.agent.md`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add model-cards/agents/model-card-researcher.agent.md
+git commit -m "model-cards: model-card-researcher agent (tiered sources, honesty rules)"
+```
+
+---
+
+## Task 6: Command — `/model-card create|seed`
+
+**Files:**
+
+- Create: `model-cards/commands/model-card.md`
+
+- [ ] **Step 1: Create the command**
+
+```markdown
+---
+name: model-card
+description: Research and author Mitchell-extended model cards. /model-card create <name> for one-card hybrid review-before-commit flow; /model-card seed for bulk-populate from the shipped frontier seed list.
+---
+
+# /model-card \<subcommand\> [args]
+
+Subcommands:
+
+- `create <model-name> [--provider X] [--out path]`
+- `seed [--force]`
+
+Future subcommands tracked as issues:
+
+- `/model-card list` — issue #233
+- `/model-card compare <a> <b>` — issue #234
+- `/model-card refresh <name>` — issue #235
+
+## Subcommand: `create`
+
+### Usage
+
+```text
+/model-card create <model-name> [--provider X] [--out path]
+```
+
+### Flow
+
+1. **Parse args**
+   - `model-name` (required, positional)
+   - `--provider` (optional hint; if absent, agent infers)
+   - `--out` (optional library directory override; cards still land beneath
+     it as `<provider>/<model-name>.md`)
+
+2. **Resolve target path**
+   - Default: `~/.claude/model-cards/<provider>/<model-name>.md`
+   - If `MODEL_CARDS_DIR` env var is set, use it as the library root
+   - If `--out` flag is passed, use it as the library root (highest priority)
+   - The provider sub-directory and `<model-name>.md` filename always apply
+     beneath whatever library root was resolved
+
+3. **Check for existing card at target path**
+   - If present, ask the user: `overwrite / skip / load-existing-as-base`
+   - On `skip`, abort the flow with no file change
+   - On `load-existing-as-base`, pass the existing card content to the agent
+     as starting context
+
+4. **Dispatch the `model-card-researcher` agent**
+   - Pass the model name and provider hint
+   - Agent returns either:
+     - A full markdown card content string, OR
+     - A `REFUSED:` string indicating the model-existence check failed
+
+5. **Handle REFUSED**
+   - If the agent's output starts with `REFUSED:`, surface the refusal
+     reason to the user verbatim and abort the flow with no file written.
+
+6. **Show review summary**
+   - Sources used per section (tier breakdown — counts of `[T1.x]`,
+     `[T2.x]`, `[T3.x]`, `[T4.x]` citations)
+   - Sections that came up thin — list of section numbers (1-10) where
+     "Not publicly available" appears at section level
+   - Top 3 most-cited claims by raw citation count, with their source URLs
+   - Estimated token cost of the research (rough — sum of fetched-content
+     sizes at ~4 chars/token approximation)
+
+7. **Ask for disposition**
+   - `accept` — write the card to target path, confirm with full path
+   - `edit` — open the draft in `$EDITOR` (or `vi` if unset), then re-prompt
+     with the edited content
+   - `re-run-section <N>` — re-dispatch the agent with a section-specific
+     prompt focusing on template section number N (1-10); replace just that
+     section in the draft, then re-prompt
+   - `abort` — discard the draft, no file written
+
+8. **On accept**
+   - `mkdir -p $(dirname target_path)`
+   - Write the card content to `target_path`
+   - Print: `Card written: <full_path>`
+
+### Specification picks (from spec O9 disposition)
+
+- `--out path` — directory override; card filename and provider sub-dir
+  still apply beneath
+- Provider name resolution — agent-inferred; if ambiguous, command prompts
+  user during step 6 to confirm provider sub-directory before write
+- `re-run-section <N>` — N is the template section number 1-10
+- "Top 3 most-cited claims" — raw citation count per claim
+
+## Subcommand: `seed`
+
+### Usage
+
+```text
+/model-card seed [--force]
+```
+
+### Flow
+
+1. **Read seed list**
+   - Source: `${CLAUDE_PLUGIN_ROOT}/seed/frontier-models.json`
+   - Format: `[{"name": "...", "provider": "..."}, ...]`
+
+2. **Show user the list and total count**
+
+3. **Ask once for confirmation**
+   - `Research <N> cards into <library-root>? [y/N]`
+   - On `y`, proceed
+   - On any other input, abort
+
+4. **For each model in list (sequential)**
+   - Resolve target path (as in `create` step 2)
+   - If card exists at target path AND `--force` is not set, skip with
+     one-line message
+   - Dispatch `model-card-researcher`
+   - If REFUSED, log skip with reason (one line); continue to next model
+   - Else write card to target path; log creation (one line)
+
+5. **Print summary**
+   - Created: N
+   - Skipped (existed): N
+   - Skipped (refused): N
+   - Failed (other): N
+
+### Note on resumability
+
+`seed` is idempotent for the common-case "ran partially, want to retry" — the
+existence check at step 4 skips already-written cards. To re-research existing
+cards, use `--force` (overwrites) or run `/model-card create <name>` per model
+(interactive review).
+
+If failure modes prove common in real use, `--resume` and `--retry-failed`
+flags can be added in a v0.1.x patch without spec rework.
+```
+
+- [ ] **Step 2: Verify YAML frontmatter parseable**
+
+Run:
+
+```bash
+python3 -c "
+import yaml
+content = open('model-cards/commands/model-card.md').read()
+fm = yaml.safe_load(content.split('---', 2)[1])
+print('Name:', fm['name'])
+"
+```
+
+Expected: `Name: model-card`
+
+- [ ] **Step 3: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 model-cards/commands/model-card.md`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add model-cards/commands/model-card.md
+git commit -m "model-cards: /model-card command (create + seed subcommands)"
+```
+
+---
+
+## Task 7: Marketplace integration — second `plugins[]` entry + listing version bump
+
+**Files:**
+
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Read current state**
+
+Run: `cat .claude-plugin/marketplace.json`
+
+Expected to show:
+
+```json
+{
+  "name": "ai-literacy-superpowers",
+  "version": "0.2.3",
+  "plugin_version": "0.31.1",
+  "plugins": [
+    {"name": "ai-literacy-superpowers", "source": "./ai-literacy-superpowers", "version": "0.31.1", "...": "..."}
+  ]
+}
+```
+
+- [ ] **Step 2: Edit `.claude-plugin/marketplace.json`**
+
+Change `version` from `0.2.3` to `0.3.0` (per CLAUDE.md "Marketplace
+Versioning": adding a plugin entry to the array bumps the listing version).
+
+Append a second entry to the `plugins` array:
+
+```json
+    {
+      "name": "model-cards",
+      "source": "./model-cards",
+      "description": "Researches and authors Mitchell-extended model cards from a model name.",
+      "version": "0.1.0"
+    }
+```
+
+Final shape:
+
+```json
+{
+  "name": "ai-literacy-superpowers",
+  "owner": {"name": "Russ Miles"},
+  "version": "0.3.0",
+  "plugin_version": "0.31.1",
+  "description": "...",
+  "repository": {"type": "git", "url": "https://github.com/Habitat-Thinking/ai-literacy-superpowers"},
+  "plugins": [
+    {"name": "ai-literacy-superpowers", "source": "./ai-literacy-superpowers", "description": "...", "version": "0.31.1"},
+    {"name": "model-cards", "source": "./model-cards", "description": "Researches and authors Mitchell-extended model cards from a model name.", "version": "0.1.0"}
+  ]
+}
+```
+
+- [ ] **Step 3: Verify JSON well-formed**
+
+Run: `jq . .claude-plugin/marketplace.json > /dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Verify both plugins listed**
+
+Run: `jq '.plugins[] | .name' .claude-plugin/marketplace.json`
+Expected:
+
+```text
+"ai-literacy-superpowers"
+"model-cards"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "marketplace: add model-cards plugin (listing v0.2.3 → v0.3.0)"
+```
+
+---
+
+## Task 8: CI — extend `version-check.yml` to enumerate plugins
+
+**Files:**
+
+- Modify: `.github/workflows/version-check.yml`
+
+Per the spec's adjudication of O12: the existing workflow reads
+`ai-literacy-superpowers/.claude-plugin/plugin.json` singular. It needs to
+read each plugin enumerated in `marketplace.json`'s `plugins[]` array.
+
+- [ ] **Step 1: Read current state**
+
+Run: `cat .github/workflows/version-check.yml | head -60`
+
+Confirm that `Extract versions from all locations` step reads only
+`ai-literacy-superpowers/.claude-plugin/plugin.json`.
+
+- [ ] **Step 2: Edit `.github/workflows/version-check.yml`**
+
+Replace the `Extract versions from all locations` step's `PLUGIN_VERSION`
+extraction logic with multi-plugin enumeration. Specifically — change this
+block:
+
+```yaml
+          # plugin.json version
+          PLUGIN_VERSION=$(grep '"version"' ai-literacy-superpowers/.claude-plugin/plugin.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "plugin=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
+```
+
+to:
+
+```yaml
+          # ai-literacy-superpowers plugin.json version (canonical plugin)
+          PLUGIN_VERSION=$(grep '"version"' ai-literacy-superpowers/.claude-plugin/plugin.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "plugin=$PLUGIN_VERSION" >> "$GITHUB_OUTPUT"
+
+          # All plugins enumerated from marketplace.json plugins[]
+          # Each entry's source path + .claude-plugin/plugin.json version is verified
+          # against its marketplace.json plugins[] entry's version (per-plugin sync).
+          PLUGIN_NAMES=$(jq -r '.plugins[].name' .claude-plugin/marketplace.json)
+          PLUGIN_MISMATCHES=""
+          for name in $PLUGIN_NAMES; do
+            source=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source' .claude-plugin/marketplace.json)
+            mp_version=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .version' .claude-plugin/marketplace.json)
+            pj_version=$(jq -r '.version' "${source}/.claude-plugin/plugin.json" 2>/dev/null || echo "MISSING")
+            echo "  $name: marketplace=$mp_version, plugin.json=$pj_version"
+            if [ "$mp_version" != "$pj_version" ]; then
+              PLUGIN_MISMATCHES="$PLUGIN_MISMATCHES $name(mp=$mp_version,pj=$pj_version)"
+            fi
+          done
+          if [ -n "$PLUGIN_MISMATCHES" ]; then
+            echo "::error::Plugin version mismatches:$PLUGIN_MISMATCHES"
+            echo "Each plugin's plugin.json version must match its marketplace.json plugins[] entry's version."
+            exit 1
+          fi
+          echo "All per-plugin versions in sync"
+```
+
+This adds a per-plugin sync check while preserving the existing canonical
+`PLUGIN_VERSION` for the README/CHANGELOG-of-canonical-plugin checks.
+
+- [ ] **Step 3: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/version-check.yml'))" && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/version-check.yml
+git commit -m "ci: version-check enumerates all marketplace plugins (per O12)"
+```
+
+---
+
+## Task 9: AGENTS.md ARCH_DECISIONS — promote trust-architecture pattern
+
+**Files:**
+
+- Modify: `AGENTS.md`
+
+Per stories #7 and #8 promotion in `docs/superpowers/stories/model-cards-plugin-design.md`.
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "^## ARCH_DECISIONS" AGENTS.md`
+
+The new entry goes immediately after the section heading, before the
+existing first ARCH_DECISIONS bullet.
+
+- [ ] **Step 2: Insert the new ARCH_DECISIONS bullet**
+
+In `AGENTS.md`, just below the `## ARCH_DECISIONS` header and any HTML
+comment block, insert:
+
+```markdown
+- Decision: content-emitting agents in this codebase use a three-part trust
+  architecture — **agent-emit + dispatcher-persist + human-disposes**. The
+  agent's tool boundary is research-and-author only (no Edit, no Bash); the
+  agent returns content as a string; the dispatching command writes the file
+  after a structured human review (accept / edit / re-run / abort). This
+  pattern is in production across three agents: `advocatus-diaboli`,
+  `choice-cartographer`, and `model-card-researcher`. Three repetitions
+  promote it from convention to named architecture (Hunt/Thomas's Rule of
+  Three). Future research-and-author agents in this codebase should default
+  to this shape unless an explicit reason argues otherwise. The two halves
+  are: (1) tool-boundary — minimum-trust-surface, no shell, no edit; (2)
+  human-gate — structured review summary, named dispositions, command
+  refuses to persist when the agent emits a refusal string (e.g.
+  model-card-researcher's REFUSED: line for unconfirmed model existence).
+  Source: `docs/superpowers/stories/model-cards-plugin-design.md` stories
+  #7 and #8 (promoted disposition).
+```
+
+- [ ] **Step 3: Verify markdownlint**
+
+Run: `npx markdownlint-cli2 AGENTS.md`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "AGENTS.md: promote trust-architecture pattern from cartograph stories #7+#8"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Markdownlint over the whole new plugin and changed root files**
+
+Run:
+
+```bash
+npx markdownlint-cli2 \
+  "model-cards/**/*.md" \
+  "AGENTS.md" \
+  "docs/superpowers/specs/2026-04-29-*.md" \
+  "docs/superpowers/objections/model-cards-plugin-design.md" \
+  "docs/superpowers/stories/model-cards-plugin-design.md" \
+  "docs/superpowers/plans/2026-04-29-model-cards-plugin.md"
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: JSON validity**
+
+Run:
+
+```bash
+jq . .claude-plugin/marketplace.json > /dev/null && \
+jq . model-cards/.claude-plugin/plugin.json > /dev/null && \
+jq . model-cards/seed/frontier-models.json > /dev/null && \
+echo OK
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: YAML frontmatter validity for new agent and command**
+
+Run:
+
+```bash
+python3 -c "
+import yaml
+for f in ['model-cards/agents/model-card-researcher.agent.md',
+          'model-cards/commands/model-card.md',
+          'model-cards/skills/model-cards/SKILL.md']:
+    content = open(f).read()
+    yaml.safe_load(content.split('---', 2)[1])
+    print(f'OK: {f}')
+"
+```
+
+Expected: three `OK:` lines.
+
+- [ ] **Step 4: Per-plugin version consistency**
+
+Run:
+
+```bash
+for name in $(jq -r '.plugins[].name' .claude-plugin/marketplace.json); do
+  source=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source' .claude-plugin/marketplace.json)
+  mp_version=$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .version' .claude-plugin/marketplace.json)
+  pj_version=$(jq -r '.version' "${source}/.claude-plugin/plugin.json")
+  echo "$name: marketplace=$mp_version, plugin.json=$pj_version"
+  [ "$mp_version" = "$pj_version" ] || { echo "MISMATCH"; exit 1; }
+done
+echo OK
+```
+
+Expected:
+
+```text
+ai-literacy-superpowers: marketplace=0.31.1, plugin.json=0.31.1
+model-cards: marketplace=0.1.0, plugin.json=0.1.0
+OK
+```
+
+- [ ] **Step 5: gitleaks scan**
+
+Run: `gitleaks detect --source . --no-banner --exit-code 1`
+Expected: no leaks.
+
+- [ ] **Step 6: Manual integration smoke test**
+
+In a fresh terminal with the plugin installed (or with `${CLAUDE_PLUGIN_ROOT}`
+pointed at the new `model-cards/` path):
+
+1. Run: `/model-card create claude-opus-4-7 --provider anthropic`
+2. Confirm the agent dispatches, performs research (10-30 web fetches), and
+   returns a draft card
+3. Confirm the review summary shows source-tier counts, sparse-section list,
+   top-3 cited claims, estimated cost
+4. Accept the draft
+5. Confirm the card lands at `~/.claude/model-cards/anthropic/claude-opus-4-7.md`
+6. Confirm the card has populated frontmatter, 10 sections, real citations
+   resolving via the `sources` block
+
+Then test the refusal path:
+
+1. Run: `/model-card create totally-fake-nonexistent-model --provider nowhere`
+2. Confirm the agent returns `REFUSED:` and the command surfaces the refusal
+   reason
+3. Confirm no file was written to `~/.claude/model-cards/`
+
+Then test seed (with a trimmed list for speed):
+
+1. Backup `model-cards/seed/frontier-models.json`
+2. Replace with a 3-model trimmed version
+3. Run: `/model-card seed`
+4. Confirm the user prompt shows 3 models, accept
+5. Confirm 3 cards land in the library
+6. Restore the original seed list
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin model-cards-plugin
+gh pr create --title "model-cards: new sister plugin (v0.1.0)" --body "$(cat <<'EOF'
+## Summary
+
+Adds a new sister plugin `model-cards` to the marketplace. Researches and
+authors Mitchell-extended model cards from a model name with hybrid
+review-before-commit. Ships with a 14-model frontier seed list.
+
+Spec: \`docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-29-model-cards-plugin.md\`
+Diaboli (adjudicated): \`docs/superpowers/objections/model-cards-plugin-design.md\`
+Stories (adjudicated): \`docs/superpowers/stories/model-cards-plugin-design.md\`
+
+## What's in the PR
+
+- New plugin at `model-cards/` (manifest, README, CHANGELOG, template, seed,
+  skill, agent, command)
+- Marketplace listing bumped 0.2.3 → 0.3.0; second `plugins[]` entry added
+- `version-check.yml` extended to enumerate plugins via `marketplace.json`
+- `AGENTS.md` ARCH_DECISIONS gains a promotion entry for the
+  trust-architecture pattern (per cartograph stories #7+#8)
+
+## Tracking issues created during planning
+
+- #232 chore: explore removal of marketplace.json top-level plugin_version
+- #233 model-cards: /model-card list subcommand
+- #234 model-cards: /model-card compare subcommand
+- #235 model-cards: /model-card refresh subcommand
+
+## Test plan
+
+- [x] markdownlint clean
+- [x] JSON validity (marketplace.json, plugin.json, frontier-models.json)
+- [x] YAML frontmatter parseable for agent and command
+- [x] Per-plugin version consistency (both plugins in sync)
+- [x] gitleaks scan clean
+- [x] Manual integration smoke: create succeeds for known model
+- [x] Manual integration smoke: REFUSED path for unknown model
+- [x] Manual integration smoke: trimmed-seed populate
+- [ ] CI green
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Coverage check** against spec sections:
+
+- Goals 1-6 (single-command flow, tiered sources, hybrid review, per-user
+  library, seed subcommand, honest about limits) → Tasks 5, 6 (agent +
+  command); Task 4 (skill); Task 2 (template); Task 3 (seed list)
+- Architecture (file layout) → Task 1 (scaffold); Tasks 2-6 (per-component
+  files)
+- Card template → Task 2
+- Citation scheme → Task 2 (template), Task 4 (skill), Task 5 (agent
+  charter)
+- Honesty rules (claim-level + card-level) → Task 5 (agent charter); Task 4
+  (skill); Task 1 (README)
+- Research agent + tiered strategy → Task 5
+- Commands and flows → Task 6
+- Storage and library → Task 6 (path resolution logic in command)
+- Marketplace integration → Task 7
+- Plugin self-versioning → Task 1
+- Testing strategy → Task 10 (final verification)
+
+Spec gaps not in tasks:
+
+- O5 card-level honesty rule (model-existence check) — covered in Task 5 +
+  Task 4 + Task 6 (REFUSED handling)
+- O9 specification picks (--out semantics, etc.) — covered in Task 6
+- O10 field-level "Not publicly available" — covered in Task 4 + Task 5
+- O12 version-check workflow — covered in Task 8
+- Stories #7+#8 promotion — covered in Task 9
+
+All spec content has a task.
+
+**Type/name consistency**:
+
+- Plugin name `model-cards` — same in plugin.json, marketplace.json, README,
+  CHANGELOG, file paths
+- Command name `/model-card` (singular, no -s) with subcommands — same in
+  command file frontmatter, README, agent charter
+- Agent name `model-card-researcher` — same in agent file, command file
+  references, README, AGENTS.md promotion entry
+- Citation format `[T<n>.<m>]` — same in template, skill, agent charter
+- Library path `~/.claude/model-cards/<provider>/<model-name>.md` — same in
+  README, command, spec
+- Tier numbering 1=provider docs, 2=HuggingFace, 3=arXiv, 4=web — same
+  throughout
+
+**Placeholder scan**: no TBD/TODO/FIXME placeholders. Every step has actual
+code or actual commands. Where the agent's content is partly free-form
+(e.g. card body), the constraints (10 sections, citation format, honesty
+rules) are explicit.
+
+**Scope check**: 10 tasks, single concern (build the plugin), single PR.
+Tracking issues capture deferred scope. Tractable.

--- a/docs/superpowers/plans/2026-04-29-model-cards-plugin.md
+++ b/docs/superpowers/plans/2026-04-29-model-cards-plugin.md
@@ -17,7 +17,7 @@
 ## File Structure
 
 | File | Action | Responsibility |
-|---|---|---|
+| --- | --- | --- |
 | `model-cards/.claude-plugin/plugin.json` | Create | Plugin manifest, v0.1.0 |
 | `model-cards/README.md` | Create | Plugin landing page; what it does, install, two subcommands |
 | `model-cards/CHANGELOG.md` | Create | Starts with v0.1.0 entry |
@@ -460,7 +460,7 @@ URLs for each citation resolve via the per-card frontmatter `sources` block.
 ## Tiered source strategy
 
 | Tier | Source | Used for |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Provider docs | Model Details, Intended Use, Operational Details |
 | 2 | HuggingFace | Open-source / fine-tuned models; fallback for tier-1 gaps |
 | 3 | arXiv release paper | Factors, Metrics, Evaluation Data, Training Data, Quantitative Analyses, Ethical Considerations |
@@ -539,7 +539,7 @@ the dispatcher's job.
 ## Tiered source strategy
 
 | Tier | Source | Discovery |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Provider docs | URL inferred from this provider→docs-root mapping |
 | 2 | HuggingFace | `https://huggingface.co/<owner>/<model>` if model is on HF |
 | 3 | arXiv release paper | `WebSearch` for `"<model-name>" arxiv` |
@@ -561,7 +561,7 @@ the dispatcher's job.
 ### Per-section primary source
 
 | Section | Primary | Fallback |
-|---|---|---|
+| --- | --- | --- |
 | Model Details | Tier 1 | Tier 2 → 4 |
 | Intended Use | Tier 1 | Tier 2 → 4 |
 | Factors | Tier 3 | Tier 1 → 2 |

--- a/docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
@@ -1,0 +1,487 @@
+# Spec: model-cards plugin (v0.1.0)
+
+**Date**: 2026-04-29
+**Author**: Russ Miles + assistant (via brainstorming skill)
+**Driving signal**: User curiosity (evaluating models for own use) + marketplace gap (no model-card plugin in the Claude Code marketplace) + sister-plugin opportunity for the existing `Habitat-Thinking/ai-literacy-superpowers` marketplace repo
+**Status**: design — awaiting spec-mode `/diaboli` and user review
+
+## Problem
+
+The `ai-literacy-superpowers` marketplace currently hosts one plugin —
+`ai-literacy-superpowers` — focused on AI literacy for software
+engineering teams *using* commercial LLMs. A complementary need is
+**evaluating** models: when a new frontier model ships, what does it
+do, what are its limitations, what does it cost, what data can route
+to it? The 2026-04-29 exploration of "should we add model cards to
+the existing plugin?" concluded Option F (no-op) on audience-asymmetry
+grounds — but a *separate* plugin targeting evaluators directly does
+not have that asymmetry problem.
+
+This spec designs the second plugin in the marketplace:
+**`model-cards`** — a research-and-authoring plugin that, given a
+model name, autonomously researches the model and produces a
+Mitchell et al. (2019) style card extended with operational details
+relevant to consumers (pricing, context window, knowledge cutoff,
+SDK support).
+
+## Goals
+
+1. **Single-command research-and-author flow** — user types
+   `/model-card create <name>`, plugin researches the model and
+   produces a draft card.
+2. **Tiered source strategy** — provider docs first, HuggingFace
+   second, arXiv third, web search as fallback. Cheap sources before
+   expensive ones; explicit per-claim citation.
+3. **Hybrid review-before-commit** — agent presents a draft summary;
+   user accepts / edits / re-runs sections / aborts before the card
+   lands in the library.
+4. **Per-user library by default** — cards live at
+   `~/.claude/model-cards/<provider>/<model-name>.md` so they survive
+   across projects (configurable via env var or flag).
+5. **Seed subcommand** — `/model-card seed` populates the library
+   with a shipped frontier-LLM list on demand.
+6. **Honest about limits** — "Not publicly available" rather than
+   fabrication for proprietary opacity. Source provenance per claim.
+
+## Non-goals (this v0.1.0)
+
+- **Comparison of cards** — `/model-card compare` is captured as a
+  future subcommand and a tracking issue. Not implemented in v0.1.0.
+- **Refresh on new releases** — `/model-card refresh` is a future
+  subcommand; tracking issue. Not in v0.1.0.
+- **Library browsing UX** — beyond `cards/<provider>/<model-name>.md`
+  folder convention, no list / index / browse surface. Future.
+- **Schema cleanup of marketplace.json `plugin_version` field** —
+  separate concern; tracking issue created. This PR uses Option A
+  (keep field, point at canonical plugin).
+- **Sharing / publishing cards externally** — out of scope.
+- **Continuous monitoring** — out of scope.
+
+## Decisions
+
+The design space was explored through six clarifying questions during
+brainstorming. The decisions:
+
+| # | Decision axis | Choice | Rationale |
+|---|---|---|---|
+| Q1 | Model scope | **Any named model**, with shipped default = frontier LLMs from major providers (concrete seed list) | Matches stated use case (curiosity-driven evaluation); seed list gives instant library on first install |
+| Q2 | Research sources | **Tiered: provider docs → HuggingFace → arXiv → web search** | Cheap sources before expensive ones; per-section primary-source mapping; explicit provenance |
+| Q3 | Card format | **Mitchell-extended**: 9 canonical sections + 10th "Operational Details" section | Industry-recognised + fills the consumer-evaluator gap; one template, "Not publicly available" for proprietary opacity |
+| Q4 | Invocation pattern | **Hybrid: command + autonomous research + review-before-commit** | AI-researched content is hallucination-prone; review checkpoint before library entry is load-bearing for trustworthy cards |
+| Q5 | Storage location | **Configurable, default `~/.claude/model-cards/<provider>/<model-name>.md`** | Per-user (not per-project) matches stated use case; configurable via `--out` flag and `MODEL_CARDS_DIR` env var |
+| Q5b | Seed command | **Ship `/model-card seed`** with bundled `frontier-models.json` list (14 models) | "Shipped default" interpretation; instant library on install; users can extend the JSON list |
+| Q6a | Plugin name | **`model-cards`** | Short, descriptive; `-superpowers` suffix reads as "another big plugin" but this one is intentionally small |
+| Q6b | Command shape | **`/model-card <subcommand>`** (subcommand pattern, mirrors `/worktree spin/merge/clean`) | Plugin focused around one noun; subcommands cleaner than 3-5 top-level slash commands |
+| Schema | `plugin_version` field handling | **Option A — keep, point at canonical `ai-literacy-superpowers`** | Backward-compatible for v0.1.0; cleanup deferred to a separate tracking issue per yesterday's lesson on not riding convention changes in on feature PRs |
+
+## Architecture
+
+A second plugin at the repo root, mirroring `ai-literacy-superpowers/`'s
+layout convention.
+
+```text
+model-cards/
+├── .claude-plugin/
+│   └── plugin.json                              ← name "model-cards", v0.1.0
+├── agents/
+│   └── model-card-researcher.agent.md           ← the research agent
+├── commands/
+│   └── model-card.md                            ← /model-card create|seed
+├── skills/
+│   └── model-cards/
+│       └── SKILL.md                             ← Mitchell-extended framework guidance
+├── templates/
+│   └── MODEL_CARD.md                            ← the 10-section template
+├── seed/
+│   └── frontier-models.json                     ← JSON list of frontier LLMs
+├── CHANGELOG.md                                 ← starts at v0.1.0
+└── README.md                                    ← plugin landing page
+```
+
+**No hooks, no scripts/, no harness for v0.1.0.** YAGNI applies. Can
+be added when there's load-bearing need.
+
+### Component responsibilities
+
+| Component | Responsibility | Reads | Writes |
+|---|---|---|---|
+| `plugin.json` | Plugin manifest | — | — |
+| `model-card-researcher.agent.md` | Charter for research agent: tiered sources, per-section research, citation discipline, honest "Not publicly available" for opacity | input from dispatcher | output content (markdown string) returned to dispatcher |
+| `model-card.md` (command) | Subcommand dispatcher: parses args, routes to create/seed flow, runs hybrid review, writes file | agent output, seed JSON | card files in library, stdout |
+| `MODEL_CARD.md` (template) | The 10-section structure with frontmatter shape and citation format | — | — |
+| `model-cards/SKILL.md` | Mitchell-extended framework guidance: when each section applies, citation discipline, honesty rules | — | — |
+| `frontier-models.json` | Seed list for `/model-card seed` | — | — |
+
+## Card template
+
+`templates/MODEL_CARD.md` — frontmatter + 10 sections, with per-claim
+citation footnotes resolving via the frontmatter `sources` block.
+
+```markdown
+---
+model_name: <provider>/<model-name>
+provider: <Anthropic | OpenAI | Google | …>
+model_version: <as-stated-by-provider>
+last_researched: YYYY-MM-DD
+card_version: 0.1.0
+researcher: model-card-researcher (claude-opus-4-7[1m])
+sources:
+  - tier: 1
+    url: <provider docs URL>
+    fetched: YYYY-MM-DD
+  - tier: 2
+    url: <huggingface URL>
+    fetched: YYYY-MM-DD
+  - tier: 3
+    url: <arxiv URL>
+    fetched: YYYY-MM-DD
+  - tier: 4
+    url: <web URL>
+    fetched: YYYY-MM-DD
+---
+
+# Model Card: <provider>/<model-name>
+
+## 1. Model Details
+What this model is, who released it, when, what kind of model.
+
+## 2. Intended Use
+Primary uses, primary users, out-of-scope uses (per the provider).
+
+## 3. Factors
+Relevant subgroups, environmental factors, instrumentation factors.
+
+## 4. Metrics
+Performance measures the provider reports.
+
+## 5. Evaluation Data
+Datasets used to evaluate (per the provider's published statements).
+
+## 6. Training Data
+Datasets used to train (per the provider's published statements).
+
+## 7. Quantitative Analyses
+Disaggregated performance — when provider has published this.
+
+## 8. Ethical Considerations
+Risks, mitigations, known failure modes.
+
+## 9. Caveats and Recommendations
+What this card cannot tell you. Recommendations for use.
+
+## 10. Operational Details
+Pricing (input/output per million tokens), context window, knowledge
+cutoff, supported APIs/SDKs, latency tier, tool/structured-output
+support, function calling, fine-tuning availability, rate limit notes.
+```
+
+### Citation scheme
+
+Per-claim footnote-style: `[T<n>.<m>]` where `n` is the tier (1-4)
+and `m` is the source index within that tier.
+
+Example:
+
+```markdown
+Knowledge cutoff: January 2026 [T1.1]. Context window: 1M tokens
+[T1.2]. Pricing: $5/$25 per million tokens (input/output) at standard
+tier [T1.3].
+```
+
+`T1.1`, `T1.2`, `T1.3` resolve via the frontmatter `sources` list.
+
+### Honesty rules (in agent charter)
+
+- "Not publicly available" is the canonical answer when tier-1 is
+  silent and lower tiers cannot confirm. Never fabricate.
+- "Per the provider's published statements" framing is preferred
+  over assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim,
+  tier-1 wins; the conflict is flagged in Section 9 (Caveats).
+
+## Research agent
+
+`agents/model-card-researcher.agent.md`.
+
+**Charter** (system prompt):
+
+> You are the model-card-researcher. Given a model name (and optional
+> provider hint), you produce a Mitchell-extended model card by
+> researching the model through a tiered source strategy. You cite
+> every factual claim. You write "Not publicly available" rather
+> than fabricate.
+
+**Tools**: `WebFetch`, `WebSearch`, `Read`, `Write`, `Glob`, `Grep`.
+No `Edit`, no `Bash` — research and authoring only.
+
+**Tiered source strategy**:
+
+| Tier | Source | Discovery |
+|---|---|---|
+| 1 | Provider docs | URL inferred from a provider→docs-root mapping shipped in agent context |
+| 2 | HuggingFace card | `huggingface.co/<owner>/<model>` if model is on HF |
+| 3 | arXiv release paper | Discovered via `WebSearch` for `"<model-name>" arxiv` |
+| 4 | Web search | `WebSearch` with explicit query, prefer recent results |
+
+**Per-section primary source mapping**:
+
+| Section | Primary source | Fallback |
+|---|---|---|
+| Model Details | Tier 1 | Tier 2 → 4 |
+| Intended Use | Tier 1 | Tier 2 → 4 |
+| Factors | Tier 3 (paper) | Tier 1, then 2 |
+| Metrics | Tier 1 + Tier 3 | — |
+| Evaluation Data | Tier 3 | Tier 1 |
+| Training Data | Tier 3 | Tier 1 (often "Not publicly available") |
+| Quantitative Analyses | Tier 3 | Tier 1 |
+| Ethical Considerations | Tier 3 + Tier 1 | Tier 4 |
+| Caveats and Recommendations | Synthesised | — |
+| Operational Details | Tier 1 | Tier 4 (especially pricing) |
+
+**Output**: a single markdown string (full card content). The
+dispatching command writes the file. This separation mirrors
+`advocatus-diaboli`'s pattern.
+
+## Commands
+
+`commands/model-card.md` — single command with subcommand dispatch.
+
+### `/model-card create <model-name> [--provider X] [--out path]`
+
+Hybrid flow:
+
+```text
+1. Parse args
+2. Resolve target path (default ~/.claude/model-cards/<provider>/<model-name>.md;
+   apply MODEL_CARDS_DIR env var if set; apply --out flag if passed)
+3. Check for existing card at target path
+   If present: warn user, ask "overwrite / skip / load-existing-as-base"
+4. Dispatch model-card-researcher agent
+5. Show review summary
+   - Sources used per section (tier breakdown)
+   - Sections that came up thin ("Not publicly available" count)
+   - Top 3 most-cited claims with their sources
+   - Estimated token cost of the research
+6. Ask: accept / edit / re-run-section <N> / abort
+   - accept: write to target path
+   - edit: open in $EDITOR, then re-prompt accept
+   - re-run-section <N>: re-dispatch agent with section-specific prompt
+   - abort: discard draft, no file written
+7. On accept: write file, print confirmation with full path
+```
+
+### `/model-card seed`
+
+Non-interactive bulk research over the shipped frontier list:
+
+```text
+1. Read seed list from ${CLAUDE_PLUGIN_ROOT}/seed/frontier-models.json
+2. Show user the list and total count
+3. Ask once: "Research N cards into <library-path>? [y/N]"
+4. For each model in list:
+   a. Skip if card exists at target path (unless --force flag)
+   b. Dispatch model-card-researcher
+   c. Write result without per-card review
+   d. Print one-line progress
+5. Print summary: created, skipped, failed
+```
+
+### Future subcommands (out of v0.1.0 scope)
+
+Tracking issues created post-spec-commit:
+
+- `/model-card list` — browse the library
+- `/model-card compare <a> <b>` — side-by-side comparison
+- `/model-card refresh <name>` — re-research a specific card
+
+### Initial seed list
+
+`seed/frontier-models.json` for v0.1.0:
+
+```json
+[
+  {"name": "claude-opus-4-7", "provider": "anthropic"},
+  {"name": "claude-sonnet-4-6", "provider": "anthropic"},
+  {"name": "claude-haiku-4-5", "provider": "anthropic"},
+  {"name": "gpt-5", "provider": "openai"},
+  {"name": "gpt-5-mini", "provider": "openai"},
+  {"name": "o4", "provider": "openai"},
+  {"name": "o4-mini", "provider": "openai"},
+  {"name": "gemini-2.5-pro", "provider": "google"},
+  {"name": "gemini-2.5-flash", "provider": "google"},
+  {"name": "llama-4", "provider": "meta"},
+  {"name": "mistral-large-3", "provider": "mistral"},
+  {"name": "grok-4", "provider": "xai"},
+  {"name": "command-r-plus", "provider": "cohere"},
+  {"name": "qwen3-coder", "provider": "alibaba"}
+]
+```
+
+14 models — equal Anthropic and OpenAI representation. ~3-5 minutes
+of research per card on average → seed run is a 30-60 minute one-off
+operation. Users can extend the JSON.
+
+## Storage and library
+
+**Default path**: `~/.claude/model-cards/<provider>/<model-name>.md`
+
+**Override mechanisms** (in priority order):
+
+1. `--out <path>` flag on `create` (per-invocation override)
+2. `MODEL_CARDS_DIR` environment variable (session-level)
+3. Default: `~/.claude/model-cards/`
+
+**Provider name resolution**: the agent infers from research; for
+ambiguous cases the command prompts the user during the review step
+to confirm provider directory.
+
+**Library structure**: just folders. No index file, no metadata
+aggregation, no browse surface — YAGNI applies; add only when real
+demand surfaces.
+
+## Marketplace integration
+
+`.claude-plugin/marketplace.json` gains a second `plugins[]` entry.
+
+**Before**:
+
+```json
+{
+  "name": "ai-literacy-superpowers",
+  "version": "0.2.3",
+  "plugin_version": "0.31.1",
+  "plugins": [
+    {"name": "ai-literacy-superpowers", "source": "./ai-literacy-superpowers", "version": "0.31.1"}
+  ]
+}
+```
+
+**After**:
+
+```json
+{
+  "name": "ai-literacy-superpowers",
+  "version": "0.3.0",
+  "plugin_version": "0.31.1",
+  "plugins": [
+    {"name": "ai-literacy-superpowers", "source": "./ai-literacy-superpowers", "version": "0.31.1"},
+    {"name": "model-cards", "source": "./model-cards", "version": "0.1.0", "description": "Researches and authors Mitchell-extended model cards from a model name."}
+  ]
+}
+```
+
+**Listing version**: 0.2.3 → 0.3.0 (per CLAUDE.md "Marketplace
+Versioning": adding a plugin entry to the array bumps the listing
+version).
+
+**`plugin_version` field**: kept, points at the canonical
+`ai-literacy-superpowers` plugin (Option A). The asymmetry — one
+plugin is "primary" while others sit alongside — is honest and
+backward-compatible. Schema cleanup deferred to a separate issue so
+this PR's scope stays clean.
+
+## Plugin self-versioning
+
+`model-cards/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "model-cards",
+  "version": "0.1.0",
+  "description": "Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web). Hybrid review-before-commit flow.",
+  "author": {"name": "Russ Miles"},
+  "keywords": ["model-cards", "model-research", "ai-evaluation", "mitchell-2019", "ai-literacy"]
+}
+```
+
+Pre-1.0 semver discipline (mirrors `ai-literacy-superpowers`):
+
+- 0.MINOR.0 — new commands, agents, or behavioural changes
+- 0.x.PATCH — bug fixes, doc-only changes
+
+`model-cards/CHANGELOG.md` is created at v0.1.0 with the initial release.
+
+## Testing strategy
+
+Per Q5/3 decision: no new executable test runner.
+
+- **markdownlint** runs over the new plugin's templates and any
+  committed seed cards (existing CI applies if path globs include
+  `model-cards/**/*.md`; if not, this PR adds the include)
+- **Manual smoke test before merge**: run
+  `/model-card create claude-opus-4-7 --provider anthropic` in dev
+  environment; verify the produced card has populated sections,
+  real citations, and writes to the expected library path
+- **Manual seed test**: run `/model-card seed` against a *trimmed*
+  seed list (3 models) in dev; verify all 3 land in the library
+- **No new harness for the plugin** — the existing repo-level harness
+  covers what's needed (markdownlint, gitleaks, ShellCheck where
+  applicable). YAGNI applies.
+
+## Risks and open questions
+
+- **Token cost of seed run** — 14 models at ~3-5 min of research each
+  is non-trivial. The user opts in once; per-card review is skipped
+  for seed. If actual cost is significantly higher than estimated,
+  add an opt-in subset to seed (e.g., `--providers anthropic,openai`).
+- **Provider docs change shape** — the agent's tier-1 strategy
+  depends on stable provider docs URLs. If a provider restructures
+  their docs site, the agent falls back to web search. Worth a
+  reflection capture if this becomes a recurring problem.
+- **Knowledge-cutoff hallucination risk** — research about new
+  models may pull stale information. Mitigation: the
+  `last_researched` frontmatter date makes staleness visible;
+  per-claim citations make verification cheap.
+- **Frontier seed list ages** — the `frontier-models.json` list is
+  a maintainable artefact, not a contract. Update when new models
+  ship. Worth a reflection if the cadence becomes onerous.
+
+## Process
+
+This spec is the first commit on branch `model-cards-plugin`. After
+spec approval the project's full feature pipeline applies:
+
+1. **Spec-time `/diaboli`** — adversarial review of the spec
+   producing
+   `docs/superpowers/objections/2026-04-29-model-cards-plugin-design.md`
+2. **Adjudicate** — resolve every disposition (no `pending` values)
+3. **`/choice-cartograph`** — surface implicit decision terrain;
+   produces `docs/superpowers/stories/2026-04-29-model-cards-plugin-design.md`
+4. **Adjudicate stories** — every story has `accepted` / `revisit`
+   / `promoted` disposition
+5. **Plan via writing-plans skill** — implementation plan
+6. **Implementation**
+7. **Code-time `/diaboli`** — adversarial review of implementation
+8. **Adjudicate code-mode objections**
+9. **Integration** — open PR, watch CI, merge
+
+Steps 1-4 must complete before step 5 to avoid wasted plan work if
+spec changes.
+
+## Tracking issues to create after spec commit
+
+| Issue | Type | Purpose |
+|---|---|---|
+| `/model-card list` subcommand | feature | Browse / list cards in the library; designed and implemented after v0.1.0 ships and we have real cards |
+| `/model-card compare <a> <b>` subcommand | feature | Side-by-side comparison of two model cards; designed after v0.1.0 |
+| `/model-card refresh <name>` subcommand | feature | Re-research a specific card; designed after v0.1.0 (informed by observed staleness in real use) |
+| Explore top-level `plugin_version` removal in marketplace.json | chore | Schema cleanup: remove ambiguous root field; update version-check.yml to read per-plugin entries; update HARNESS.md / CLAUDE.md / ONBOARDING.md / .windsurf/rules/constraints.md docs |
+
+## Cross-references
+
+- `2026-04-29` REFLECTION_LOG entry on the abandoned model-cards
+  exploration in the existing `ai-literacy-superpowers` plugin —
+  Option F decision and conditions for revisit (Driver 2 from the
+  reflection's Conditions for Revisit list — "downstream consumer
+  asks for it with a concrete use case" — has been satisfied: the
+  user is the user; this spec is the implementation)
+- `ai-literacy-superpowers/skills/model-sovereignty/SKILL.md` —
+  decision-layer companion skill; this plugin extends the
+  framework's model coverage from "which model to use" to "what
+  is this model"
+- `ai-literacy-superpowers/MODEL_ROUTING.md` — per-agent model
+  routing with sovereignty considerations; cards from this plugin
+  inform routing decisions
+- Mitchell, M. et al. (2019). "Model Cards for Model Reporting."
+  ACM FAccT — the canonical reference for the 9-section framework
+  this plugin extends

--- a/docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
@@ -63,7 +63,7 @@ The design space was explored through six clarifying questions during
 brainstorming. The decisions:
 
 | # | Decision axis | Choice | Rationale |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Q1 | Model scope | **Any named model**, with shipped default = frontier LLMs from major providers (concrete seed list) | Matches stated use case (curiosity-driven evaluation); seed list gives instant library on first install |
 | Q2 | Research sources | **Tiered: provider docs → HuggingFace → arXiv → web search** | Cheap sources before expensive ones; per-section primary-source mapping; explicit provenance |
 | Q3 | Card format | **Mitchell-extended**: 9 canonical sections + 10th "Operational Details" section | Industry-recognised + fills the consumer-evaluator gap; one template, "Not publicly available" for proprietary opacity |
@@ -104,7 +104,7 @@ be added when there's load-bearing need.
 ### Component responsibilities
 
 | Component | Responsibility | Reads | Writes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `plugin.json` | Plugin manifest | — | — |
 | `model-card-researcher.agent.md` | Charter for research agent: tiered sources, per-section research, citation discipline, honest "Not publicly available" for opacity | input from dispatcher | output content (markdown string) returned to dispatcher |
 | `model-card.md` (command) | Subcommand dispatcher: parses args, routes to create/seed flow, runs hybrid review, writes file | agent output, seed JSON | card files in library, stdout |
@@ -217,7 +217,7 @@ No `Edit`, no `Bash` — research and authoring only.
 **Tiered source strategy**:
 
 | Tier | Source | Discovery |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Provider docs | URL inferred from a provider→docs-root mapping shipped in agent context |
 | 2 | HuggingFace card | `huggingface.co/<owner>/<model>` if model is on HF |
 | 3 | arXiv release paper | Discovered via `WebSearch` for `"<model-name>" arxiv` |
@@ -226,7 +226,7 @@ No `Edit`, no `Bash` — research and authoring only.
 **Per-section primary source mapping**:
 
 | Section | Primary source | Fallback |
-|---|---|---|
+| --- | --- | --- |
 | Model Details | Tier 1 | Tier 2 → 4 |
 | Intended Use | Tier 1 | Tier 2 → 4 |
 | Factors | Tier 3 (paper) | Tier 1, then 2 |
@@ -461,7 +461,7 @@ spec changes.
 ## Tracking issues to create after spec commit
 
 | Issue | Type | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `/model-card list` subcommand | feature | Browse / list cards in the library; designed and implemented after v0.1.0 ships and we have real cards |
 | `/model-card compare <a> <b>` subcommand | feature | Side-by-side comparison of two model cards; designed after v0.1.0 |
 | `/model-card refresh <name>` subcommand | feature | Re-research a specific card; designed after v0.1.0 (informed by observed staleness in real use) |

--- a/docs/superpowers/stories/model-cards-plugin-design.md
+++ b/docs/superpowers/stories/model-cards-plugin-design.md
@@ -1,0 +1,207 @@
+---
+spec: docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md
+date: 2026-04-29
+mode: spec
+cartographer_model: claude-opus-4-7[1m]
+stories:
+  - id: 1
+    lens: [alternatives, defaults, consequences]
+    title: Plugin shape inherited from question framing
+    disposition: accepted
+    disposition_rationale: "Plugin shape was deliberate, just unevidenced in the Decisions table. The diaboli's O3 adjudication recorded the substantive reasons (CLI lacks Claude-Code coupling; personal repo lacks discoverability; single-skill lacks coherent invocation surface). Accepted as-written."
+  - id: 2
+    lens: [alternatives, consequences]
+    title: Mitchell-extended makes cards a derivative
+    disposition: accepted
+    disposition_rationale: "Honesty is in the naming. 'Mitchell-extended' is a permanent flag that future readers can use to distinguish this plugin's cards from canon. Interoperability with strict-Mitchell tooling is not a stated goal of this plugin. Accepted as-written."
+  - id: 3
+    lens: [forces, consequences]
+    title: Per-user global library outside any project
+    disposition: accepted
+    disposition_rationale: "Matches stated use case (personal evaluation across whatever project the user is working in). Configurability via --out and MODEL_CARDS_DIR preserves revocability. Team-use scenario is not a v0.1.0 concern; revisit if real team users emerge."
+  - id: 4
+    lens: [consequences, patterns]
+    title: Tier order baked into citation provenance
+    disposition: revisit
+    disposition_rationale: "Revisit if any source class displaces another in trust hierarchy (e.g. HuggingFace becomes more reliable than provider docs for certain model classes; arXiv preprints become tier-1 for research-disclosed models). Mitigation cost when revisited: add tier-scheme version to card frontmatter and migrate older cards on read. Not a v0.1.0 blocker."
+  - id: 5
+    lens: [forces, alternatives, consequences]
+    title: Seed list as shipped plugin payload
+    disposition: revisit
+    disposition_rationale: "Revisit after first patch cycle exposes actual maintenance cost. Cadence baseline to commit to in the implementation plan: review seed list quarterly aligned with the plugin's own quarterly operational cadence. If the cadence becomes painful, the dispatch-from-remote alternative or empty-seed-with-add semantics should be reconsidered then."
+  - id: 6
+    lens: [consequences, patterns]
+    title: Section 10 wishlist becomes downstream contract
+    disposition: revisit
+    disposition_rationale: "Revisit before /model-card compare lands. The wishlist is committed enough to ship and not committed enough to depend on for cross-card analysis. The compare subcommand will force a schema decision; that's the right time to lock the field set, informed by 5+ real cards."
+  - id: 7
+    lens: [forces, patterns]
+    title: Hybrid review as Human-in-the-Loop gate
+    disposition: promoted
+    disposition_rationale: "Promoted to AGENTS.md ARCH_DECISIONS as part of the 'trust architecture for content-emitting agents' pattern (paired with story 8). Pattern recurs across three agents (advocatus-diaboli, choice-cartographer, model-card-researcher) — Rule of Three — and naming it explicitly compresses the design cost of every future research-and-author agent in this codebase. Promotion happens in the implementation phase, alongside the new agent's introduction."
+  - id: 8
+    lens: [defaults, patterns]
+    title: Research-only tool boundary mirrors diaboli
+    disposition: promoted
+    disposition_rationale: "Promoted to AGENTS.md ARCH_DECISIONS jointly with story 7. The two stories together articulate one pattern with two halves: tool-boundary (this story) + human-disposition (story 7). Promotion entry will name both halves and reference all three agents that exemplify it."
+---
+
+## Story #1 — Plugin shape inherited from question framing
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Decisions table; Q1–Q6b)
+**Lens:** alternatives / defaults / consequences
+**Refs:** O3
+
+**Context.** The Decisions table walks Q1 ("what models?") → Q2 ("what sources?") → ... → Q6a ("what name?") → Q6b ("subcommand or multiple top-level?"). Plugin-shape is the substrate every other decision rests on, but it never appears as its own row. The question "should this be a plugin at all?" is answered by the framing of Q1, not by deliberation.
+
+**Forces.** Marketplace discoverability and Claude-Code-native invocation pull toward plugin-shape. Setup cost (manifest, version dance, listing entry, CHANGELOG, README) and the audience-asymmetry reasoning that killed yesterday's Option A–E pull toward smaller shapes. The spec resolves toward plugin-shape silently because the brainstorming session opened with "this plugin" framing and never re-opened it.
+
+**Options not taken.** A personal git repo (cards-as-notes, no Claude-Code coupling). A single skill in the existing `ai-literacy-superpowers` plugin (rejected yesterday on audience grounds, not re-considered today as still viable since "evaluator skill" is a smaller commitment than "evaluator plugin"). A standalone CLI tool invoked from outside Claude Code. A docs page with a copy-paste template.
+
+**Choice as written.** Sister plugin in the existing marketplace, with full plugin scaffolding (manifest, agents/, commands/, skills/, templates/, seed/, CHANGELOG, README). The spec chose plugin-shape by question framing rather than by tabulated trade-off — and the diaboli's O3 rejection rationale records the choice was deliberate, just unevidenced in the Decisions table.
+
+**Consequences.** Plugin-shape now carries forward as a load-bearing assumption for every downstream decision: marketplace listing bump, version-consistency CI scope, semver discipline for the new plugin, CHANGELOG maintenance, tracking-issue cadence for `/model-card list|compare|refresh`. Migrating to a smaller shape later means deprecating the marketplace listing entry (a public-contract change) and migrating any user libraries built against the plugin install path.
+
+**Pattern.** Implicit framing assumption — the spec's first form (a brainstorm) committed to plugin-shape as the unit of work; subsequent specification reasoned within that frame. Closest named cousin is Christopher Alexander's "fundamental error" — the wrong frame produces a coherent answer to the wrong question.
+
+**Notes.** This is the load-bearing decision the diaboli surfaced as O3 and the author adjudicated as accepted. The cartographer's role is to record what's been committed to so that revisiting the plugin shape later is recognisably *that* — a frame revisit, not a tweak.
+
+## Story #2 — Mitchell-extended makes cards a derivative
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Card template; Decisions Q3)
+**Lens:** alternatives / consequences
+**Refs:** O11
+
+**Context.** Q3 chose "Mitchell-extended: 9 canonical sections + 10th 'Operational Details' section." The rationale invokes "industry-recognised" as a benefit of Mitchell, then extends Mitchell — a card produced by this plugin is no longer a Mitchell card in the strict sense.
+
+**Forces.** Recognition (Mitchell is a known schema; downstream tooling may consume it) vs. completeness for the consumer-evaluator audience (Mitchell pre-dates the API-pricing / context-window / SDK-support concerns this plugin centres). Self-documentation (an empty Section 10 is more visible than a missing frontmatter field) vs. interoperability (a strict-Mitchell consumer rejects or ignores a 10th section).
+
+**Options not taken.** Strict 9-section Mitchell with operational details in YAML frontmatter (preserves interop; the diaboli's O11 alternative). Two artefacts per model — one strict-Mitchell card and one operational-details sibling. Mitchell-shaped output emitted alongside a separate "operational profile" file. None tabulated in the Decisions table.
+
+**Choice as written.** A 10-section template with Operational Details as the canonical Section 10. Cards from this plugin are "Mitchell-shaped, with operational details" — the diaboli's O11 disposition records this framing explicitly.
+
+**Consequences.** Cards are not portable to strict-Mitchell tooling without dropping or relocating Section 10. Future `/model-card compare` will compare cards within this plugin's schema, not against external Mitchell cards. If a strict-Mitchell standard tightens later (e.g. ACM FAccT publishes a v2), cards in user libraries are derivative artefacts that need migration. The "Mitchell-extended" name is a permanent flag that future readers will use to tell this plugin's cards from canon.
+
+**Pattern.** Schema extension — naming the variant explicitly (Mitchell-*extended*) is the honest framing; the alternative (silent extension under the original name) would be the dishonest one. Closest named pattern: "embrace and extend" carries connotations the spec does not intend; the more neutral framing is "named-derivative schema."
+
+**Notes.** The honesty is in the naming. The decision worth surfacing is not "extend or not" — it is "the fact of extension, and the trade-off accepted, are now part of the plugin's identity, not just its template."
+
+## Story #3 — Per-user global library outside any project
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Storage and library)
+**Lens:** forces / consequences
+**Refs:** —
+
+**Context.** Default storage is `~/.claude/model-cards/<provider>/<model-name>.md`. The choice is global-per-user, not project-local. Override mechanisms (`--out`, `MODEL_CARDS_DIR`) layer atop the default but the default is the path 14 cards land in on `seed`.
+
+**Forces.** Cards-as-personal-reference (cross-project value; one researched card serves every project the user works on) vs. cards-as-project-artefact (committed to a repo, version-controlled, shared with collaborators). Persistence across projects (the user's stated use case) vs. portability with a project (no commit dance, no migration when switching machines).
+
+**Options not taken.** Project-local `.claude/model-cards/` (mirrors how many Claude Code conventions live alongside the project they apply to). Repo-committed at a project-chosen path with the plugin reading a project setting. Both-default with the plugin asking on first use.
+
+**Choice as written.** Global-per-user as default; project/path override available but not promoted. The spec frames this as "matches stated use case" — and indeed it does, for a single-user evaluator. It does not weigh the consequence for a team using this plugin.
+
+**Consequences.** Cards built in one project's research session are visible in every other project the same user opens — convenient for the author, surprising for someone discovering the plugin in a team setting where they expect project artefacts to be project-scoped. Revoking the global-default later means migrating users' card collections (a one-time pain that scales with library size) or supporting both defaults indefinitely (config-surface growth). Cards are not version-controlled by default — a card researched today is the only copy unless the user has set up `~/.claude/` backups.
+
+**Pattern.** User-scoped cache — closest cousin in the Claude Code ecosystem is `~/.claude/plugins/marketplaces/`. The decision is consistent with that scoping, which makes it inherited rather than examined.
+
+**Notes.** The configurability options (`--out`, env var) make this revocable in principle; the question is what happens to the libraries already populated against the original default.
+
+## Story #4 — Tier order baked into citation provenance
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Citation scheme; Tiered source strategy)
+**Lens:** consequences / patterns
+**Refs:** —
+
+**Context.** Citations resolve as `[T<n>.<m>]` where `n` is the tier (1–4) and `m` is the source index. The tier numbering is the priority order: provider docs (1) → HuggingFace (2) → arXiv (3) → web search (4). The provenance format embeds the priority order into every card.
+
+**Forces.** Compactness (a two-token citation is cheap to read) vs. semantic stability (the meaning of `T1` is "provider docs" only as long as the priority order holds). Per-claim tier-visibility (a reader can tell at a glance whether a claim came from primary or fallback) vs. tier-order portability (changing the priority later changes what `T1` means in old cards).
+
+**Options not taken.** Citations resolved by source-type label (`[provider]`, `[hf]`, `[arxiv]`, `[web]`) — verbose but tier-order-independent. Citations as numbered footnotes with full source detail per claim — verbose but complete. Citations carrying both tier and type (`[T1:provider.1]`) — belt and braces.
+
+**Choice as written.** Tier-only `[T<n>.<m>]` with the meaning of `n` defined by the per-card frontmatter `sources` block. The frontmatter records the URL per tier, so a card is internally consistent — but two cards from different tier orderings would mean different things by the same `[T1.1]` token.
+
+**Consequences.** Changing the priority order later (e.g. demoting HuggingFace from tier 2 to tier 3 because of staleness, or inserting a new tier) changes how a future reader interprets older cards' citations. Mitigation requires either (a) keeping tier-order stable forever, (b) versioning the tier scheme in card frontmatter, or (c) re-running every existing card on tier-order change. None of these are committed to in the spec. The `last_researched` date is the closest signal but does not encode tier-scheme version.
+
+**Pattern.** Provenance-as-format — citation IS the source-trust chain rather than just pointing at it. Closest named pattern: an inversion of canonical-form (Henney) where the format itself encodes the meaning rather than referencing it.
+
+**Notes.** This is a quiet commitment that compounds: every card written under v0.1.0's tier scheme is forever interpretable only against v0.1.0's priority order. Worth `revisit` consideration if any source class displaces another in trust hierarchy.
+
+## Story #5 — Seed list as shipped plugin payload
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Initial seed list; `frontier-models.json`)
+**Lens:** forces / alternatives / consequences
+**Refs:** O8
+
+**Context.** `seed/frontier-models.json` ships 14 named frontier models (Anthropic ×3, OpenAI ×4, Google ×2, Meta, Mistral, xAI, Cohere, Alibaba). The list is part of the plugin payload — installing the plugin installs the list.
+
+**Forces.** Instant value on first install (a fresh install with a populated seed list lets `/model-card seed` do something the moment it arrives) vs. content currency (named frontier models age fast — names like `gpt-5`, `o4`, `llama-4`, `grok-4` may be retired or renamed within a release cycle). Author-curated quality (14 hand-picked models, balanced across providers) vs. user-extensibility (the list is a JSON file the user can edit, but each plugin update may overwrite local edits).
+
+**Options not taken.** Empty seed shipped with `--add` semantics (user populates from zero — no staleness risk, no instant-value either). Fetch-from-remote with offline fallback (current list always; couples plugin to an external service the author does not control — the diaboli's O8 alternative the author judged worse). Provider-grouped sub-seeds (ship `--providers anthropic,openai` defaults, full set on flag).
+
+**Choice as written.** Embedded JSON list as shipped content. The diaboli's O8 disposition records the trade-off: patch releases for seed updates are the operational cost the author accepts in exchange for instant-functional first-install.
+
+**Consequences.** The plugin now has a content-maintenance contract not implied by code-only plugins: seed updates require version bumps and CHANGELOG entries. Trimming the list later removes content from the install — users who installed v0.1.x and ran `/model-card seed` may have cards in their library for models the new shipped list no longer mentions. Adding models (especially as new frontier entries appear) is the more common direction, but each addition is a patch release. Renaming a model in the list (e.g. `o4` → `o5`) leaves users with cards under the old name unless `/model-card refresh` (a future subcommand) bridges them.
+
+**Pattern.** Curated-default-as-content — the package ships taste, not just code. Common in Linux distro defaults and editor starter configs; less common in plugin-shaped tooling. Closest named pattern: opinionated defaults (Rails) but applied to data rather than configuration.
+
+**Notes.** The implementation plan should record the cadence the author is committing to (e.g. "review seed list quarterly") so that "worth a reflection if cadence becomes onerous" has a baseline to compare against.
+
+## Story #6 — Section 10 wishlist becomes downstream contract
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Card template, Section 10)
+**Lens:** consequences / patterns
+**Refs:** O10
+
+**Context.** Section 10 is described in one sentence: "Pricing (input/output per million tokens), context window, knowledge cutoff, supported APIs/SDKs, latency tier, tool/structured-output support, function calling, fine-tuning availability, rate limit notes." No required-vs-optional marking, no per-field schema, no per-field honesty rule for absence vs. inapplicability.
+
+**Forces.** Schema strictness (downstream tooling — especially the future `/model-card compare` — needs a stable field set to compare reliably) vs. schema discovery (locking down fields in v0.1.0 risks committing to the wrong set before real cards reveal which fields matter). Author velocity (one-sentence wishlist is fast) vs. implementer determinism (two reasonable implementers will produce different field sets given the same sentence).
+
+**Options not taken.** A sub-template within Section 10 with explicit required/optional markers per field. A YAML schema in frontmatter (machine-readable; enforceable; forecloses Section 10 as the rendering surface). A "minimum viable Section 10" naming only the 3–4 highest-priority fields with the rest as optional extensions.
+
+**Choice as written.** Comma-separated wishlist with field-level "Not publicly available" as the canonical absence signal (per the diaboli's O10 disposition). The implementation will treat all listed fields as best-effort.
+
+**Consequences.** The set of fields named in Section 10's sentence becomes the de facto contract for what downstream tooling expects. Adding a field later means existing cards lack it (silently or explicitly?). Removing a field means existing cards have it as residue. `/model-card compare` cannot rely on field presence/absence to distinguish "research gap" from "not applicable to this model." Schema migration tools become a v0.2 problem because v0.1 has no schema to migrate from — only a wishlist that ossifies into one.
+
+**Pattern.** Wishlist-as-schema — common in early-version specs and almost universally regretted at v0.x → v1.0. The diaboli's O10 disposition acknowledges this risk and accepts it; the cartographer's role is to record that the wishlist IS the schema until something replaces it.
+
+**Notes.** The honest disposition for this story is likely `revisit` — the field set is committed enough to ship and not committed enough to depend on for cross-card analysis.
+
+## Story #7 — Hybrid review as Human-in-the-Loop gate
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Q4; `/model-card create` flow)
+**Lens:** forces / patterns
+**Refs:** —
+
+**Context.** Q4 chose "command + autonomous research + review-before-commit." The create flow ends in a review step where the user accepts / edits / re-runs / aborts before the card lands in the library. The diaboli explicitly did not object to this — the design is named load-bearing for trustworthy cards.
+
+**Forces.** Throughput (autonomous research over a 14-model seed list completes faster without per-card review) vs. trust integrity (AI-generated content lands in a global library that the user reads later as if it were a researched note). Author cognitive load (review is friction) vs. failure-cost asymmetry (a bad card in the library is much costlier to find and fix than a moment of review).
+
+**Options not taken.** Fully autonomous (write directly; trust the agent's citation discipline). Fully manual (agent presents research; human authors the card). Async review (write to a staging path; user reviews and promotes later) — tabulated nowhere but a real shape.
+
+**Choice as written.** Synchronous review-before-commit, with structured summary (sources per section, "Not publicly available" count, top 3 most-cited claims, estimated cost) — a designed checkpoint, not an afterthought. The seed flow opts out of per-card review and replaces it with a single batch confirmation, which makes the seed flow's trust profile different from create's and is worth noting as a related sub-decision.
+
+**Consequences.** Trust in the library depends on review actually being exercised — a user who routinely accepts without reading recreates the failure mode the gate exists to prevent. The gate is structurally identical to `advocatus-diaboli`'s human-disposition gate (agent emits, human disposes) — and inherits the same limitation: a checkbox that no one looks at is not a gate.
+
+**Pattern.** Human-in-the-Loop with structured summary — close to Norman's "forcing function" applied to AI output. In the project's own pattern language, this mirrors the diaboli/cartographer disposition gate: agent-emit + human-decide + tool-boundary-prevents-bypass. Naming the pattern matters because future research-and-author agents in this codebase should default to it; without the name, each new agent re-derives the design.
+
+**Notes.** This is the cartographer's highest-leverage move on this spec — naming the pattern compresses the cognitive cost of every future agent in this family. The design is sound; the story's job is to make the pattern explicit so it can be reused by name.
+
+## Story #8 — Research-only tool boundary mirrors diaboli
+
+**Source:** `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` (Research agent; Tools)
+**Lens:** defaults / patterns
+**Refs:** #7
+
+**Context.** The model-card-researcher agent is given `WebFetch, WebSearch, Read, Write, Glob, Grep` and explicitly denied `Edit` and `Bash`. Output is a single markdown string returned to the dispatching command, which writes the file.
+
+**Forces.** Capability completeness (research needs web fetch and search; output needs write) vs. blast radius (Edit + Bash add code-modification and shell-execution surfaces an authoring agent does not need). Agent autonomy (more tools = more independent operation) vs. trust-boundary clarity (fewer tools = clearer reasoning about what the agent could possibly do).
+
+**Options not taken.** Full toolset minus an explicit denylist (more permissive default). Read-only research with a separate writer agent (more processes, fewer tools per agent). Single tool (`WebFetch` only) with research-as-text and the dispatcher doing the rest.
+
+**Choice as written.** Minimum-trust-surface for research-and-author: tools sufficient for the job, denied for everything beyond. The agent does not write the file directly — the command writes it after review. This separation of "agent emits content" from "command persists content" is the same separation the cartographer agent itself uses (Read/Glob/Grep only, output returned for the orchestrator to write).
+
+**Consequences.** The pattern of "agent emits, dispatcher persists, human reviews" is now repeated three times in this codebase (diaboli, cartographer, model-card-researcher). Three repetitions are a pattern (Hunt/Thomas's *Rule of Three*) — the project should consider naming it explicitly in AGENTS.md so future agents inherit by reference rather than convention.
+
+**Pattern.** Read-only-emitter + write-by-dispatcher — a project-local pattern not yet named. Closest cousins in the literature: the Two-Phase Commit pattern (the agent's "prepare" is the emit; the dispatcher's "commit" is the persist) and the Command-Query Separation principle (agent answers a query; command performs the action).
+
+**Notes.** Story #7 named the human-disposition gate; this story names the agent-tool-boundary half of the same pattern. Together they form the project's de facto trust architecture for content-emitting agents — and that architecture is worth promoting (per the disposition's `promoted` value) to AGENTS.md as an ARCH_DECISION so the next research-and-author agent inherits it without re-derivation.

--- a/model-cards/.claude-plugin/plugin.json
+++ b/model-cards/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "model-cards",
+  "version": "0.1.0",
+  "description": "Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web). Hybrid review-before-commit flow.",
+  "author": {"name": "Russ Miles"},
+  "keywords": ["model-cards", "model-research", "ai-evaluation", "mitchell-2019", "ai-literacy"]
+}

--- a/model-cards/CHANGELOG.md
+++ b/model-cards/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.0 — 2026-04-29
+
+### Added
+
+- Initial release. `/model-card create <name>` for research-and-author flow with
+  hybrid review-before-commit. `/model-card seed` for bulk-populate from the
+  shipped 14-model frontier seed list.
+- Mitchell-extended card template (9 canonical sections + Operational Details).
+- Tiered source strategy: provider docs → HuggingFace → arXiv → web search.
+- Per-claim citation format: `[T<n>.<m>]` resolving via per-card frontmatter.
+- Default library at `~/.claude/model-cards/<provider>/<model-name>.md`;
+  configurable via `--out` flag (directory override) and `MODEL_CARDS_DIR` env var.
+- Spec, diaboli adjudication, and choice-cartograph stories preserved at
+  `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md` and the
+  matching objections / stories records.

--- a/model-cards/README.md
+++ b/model-cards/README.md
@@ -12,7 +12,8 @@ the same marketplace. Aimed at evaluators researching new models.
   arXiv → web), produces a draft card, presents a review summary, and (on
   accept) writes the card to your library.
 - `/model-card seed` — populates the library with cards for a shipped list of
-  14 frontier LLMs from major providers.
+  14 frontier LLMs from major providers. Use `--force` to overwrite existing
+  cards in the library.
 
 ## Install
 

--- a/model-cards/README.md
+++ b/model-cards/README.md
@@ -1,0 +1,69 @@
+# model-cards
+
+Research and author Mitchell-extended model cards from a model name.
+
+A sister plugin to [ai-literacy-superpowers](../ai-literacy-superpowers/) in
+the same marketplace. Aimed at evaluators researching new models.
+
+## What it does
+
+- `/model-card create <model-name> [--provider X] [--out path]` — researches
+  the model through a tiered source strategy (provider docs → HuggingFace →
+  arXiv → web), produces a draft card, presents a review summary, and (on
+  accept) writes the card to your library.
+- `/model-card seed` — populates the library with cards for a shipped list of
+  14 frontier LLMs from major providers.
+
+## Install
+
+```bash
+# In Claude Code
+claude plugin install model-cards@ai-literacy-superpowers
+
+# In Copilot CLI
+copilot plugin install model-cards@ai-literacy-superpowers
+```
+
+## Library location
+
+Default: `~/.claude/model-cards/<provider>/<model-name>.md`
+
+Override with the `--out` flag (directory override; cards still land beneath
+it as `<provider>/<model-name>.md`) or the `MODEL_CARDS_DIR` env var.
+
+## Card format
+
+10-section Mitchell-extended:
+
+1. Model Details
+2. Intended Use
+3. Factors
+4. Metrics
+5. Evaluation Data
+6. Training Data
+7. Quantitative Analyses
+8. Ethical Considerations
+9. Caveats and Recommendations
+10. Operational Details (this plugin's extension — pricing, context window,
+    knowledge cutoff, supported APIs/SDKs, latency, tool/structured-output
+    support, function calling, fine-tuning availability, rate limit notes)
+
+Cards include per-claim citations of the form `[T<n>.<m>]` where `n` is the
+source tier (1 = provider docs, 2 = HuggingFace, 3 = arXiv, 4 = web).
+
+## Honesty rules
+
+- Sections that the agent cannot find information for are filled with "Not
+  publicly available" — never fabricated.
+- If tier-1 and tier-2 are both silent on the model itself (the agent
+  cannot confirm the model exists), the agent refuses to create the card and
+  surfaces the result to the user. Cards are not produced for non-existent or
+  unconfirmed model names.
+- If a tier-4 (web) claim conflicts with a tier-1 (provider docs) claim,
+  tier-1 wins; the conflict is flagged in Caveats.
+
+## Roadmap
+
+- `/model-card list` — browse the library (issue #233)
+- `/model-card compare <a> <b>` — side-by-side card comparison (issue #234)
+- `/model-card refresh <name>` — re-research a specific card (issue #235)

--- a/model-cards/agents/model-card-researcher.agent.md
+++ b/model-cards/agents/model-card-researcher.agent.md
@@ -1,7 +1,7 @@
 ---
 name: model-card-researcher
 description: Use to research a model and produce a Mitchell-extended model card. Given a model name (and optional provider hint), the agent applies a tiered source strategy and returns the full card content. Refuses to produce a card when tier-1 + tier-2 are both silent on model existence — never fabricates a card for an unconfirmed model. Output is a markdown string returned to the dispatching command; the command writes the file.
-tools: WebFetch, WebSearch, Read, Write, Glob, Grep
+tools: WebFetch, WebSearch, Read, Glob, Grep
 model: inherit
 ---
 
@@ -29,9 +29,12 @@ after a human-in-the-loop review step.
 
 ## Tools
 
-`WebFetch`, `WebSearch`, `Read`, `Write`, `Glob`, `Grep`. No `Edit`, no
-`Bash`. The trust boundary is "research and emit content"; persistence is
-the dispatcher's job.
+`WebFetch`, `WebSearch`, `Read`, `Glob`, `Grep`. No `Write`, no `Edit`,
+no `Bash`. The trust boundary is "research and emit content"; persistence
+is the dispatcher's job. This matches the read-only-emitter pattern of
+`advocatus-diaboli` and `choice-cartographer` (per AGENTS.md
+ARCH_DECISIONS, the project's trust architecture for content-emitting
+agents).
 
 ## Tiered source strategy
 
@@ -128,10 +131,9 @@ Populate frontmatter:
 - Fabricating a citation. If you didn't fetch a URL, don't cite it.
 - Producing a card after the model-existence check fails. Return the REFUSED
   string instead.
-- Writing files. Your tools include Write but the dispatcher writes; the
-  Write capability is reserved for one specific use only: writing your
-  output to a temp path the dispatcher will read. **Default behaviour is to
-  return content as your final message** — only use Write if the dispatcher
-  has explicitly asked for a temp-file output.
+- Trying to write files. You have no `Write` tool. Return content as
+  your final message; the dispatcher writes the file after a human
+  review checkpoint. This separation is load-bearing — the human gate
+  catches hallucinations before they land in the library.
 - Dropping a section because it came up sparse. Every section appears in
   every card; sparse sections are filled with "Not publicly available."

--- a/model-cards/agents/model-card-researcher.agent.md
+++ b/model-cards/agents/model-card-researcher.agent.md
@@ -1,0 +1,137 @@
+---
+name: model-card-researcher
+description: Use to research a model and produce a Mitchell-extended model card. Given a model name (and optional provider hint), the agent applies a tiered source strategy and returns the full card content. Refuses to produce a card when tier-1 + tier-2 are both silent on model existence — never fabricates a card for an unconfirmed model. Output is a markdown string returned to the dispatching command; the command writes the file.
+tools: WebFetch, WebSearch, Read, Write, Glob, Grep
+model: inherit
+---
+
+# Charter
+
+You are the **model-card-researcher**. Given a model name (and optionally a
+provider hint), you produce a Mitchell-extended model card by researching
+the model through a tiered source strategy. You cite every factual claim.
+You write "Not publicly available" rather than fabricate.
+
+## Inputs
+
+- **Model name** (required) — e.g. `claude-opus-4-7`, `meta-llama/llama-4`,
+  `gpt-5-mini`
+- **Provider hint** (optional) — e.g. `anthropic`, `openai`, `huggingface`,
+  `meta`. If absent, you infer from the model name.
+
+## Output
+
+A single markdown string containing the full card content (frontmatter + 10
+sections per the template at `model-cards/templates/MODEL_CARD.md`).
+
+You do **not** write the file. The dispatching command persists the output
+after a human-in-the-loop review step.
+
+## Tools
+
+`WebFetch`, `WebSearch`, `Read`, `Write`, `Glob`, `Grep`. No `Edit`, no
+`Bash`. The trust boundary is "research and emit content"; persistence is
+the dispatcher's job.
+
+## Tiered source strategy
+
+| Tier | Source | Discovery |
+| --- | --- | --- |
+| 1 | Provider docs | URL inferred from this provider→docs-root mapping |
+| 2 | HuggingFace | `https://huggingface.co/{{owner}}/{{model}}` if model is on HF |
+| 3 | arXiv release paper | `WebSearch` for `"{{model-name}}" arxiv` |
+| 4 | Web search | `WebSearch` with explicit queries; prefer recent results |
+
+### Provider→docs-root mapping (tier 1)
+
+- `anthropic` → `https://docs.anthropic.com`
+- `openai` → `https://platform.openai.com/docs/models`
+- `google` → `https://ai.google.dev/gemini-api/docs/models`
+- `meta` → `https://ai.meta.com/llama` and the model's GitHub repo
+- `mistral` → `https://docs.mistral.ai`
+- `xai` → `https://docs.x.ai`
+- `cohere` → `https://docs.cohere.com`
+- `alibaba` → `https://qwenlm.github.io` or the relevant model's docs page
+- For any other provider, search-discover via `WebSearch` for
+  `"{{provider}}" "{{model-name}}" docs`.
+
+### Per-section primary source
+
+| Section | Primary | Fallback |
+| --- | --- | --- |
+| Model Details | Tier 1 | Tier 2 → 4 |
+| Intended Use | Tier 1 | Tier 2 → 4 |
+| Factors | Tier 3 | Tier 1 → 2 |
+| Metrics | Tier 1 + Tier 3 | — |
+| Evaluation Data | Tier 3 | Tier 1 |
+| Training Data | Tier 3 | Tier 1 (often "Not publicly available") |
+| Quantitative Analyses | Tier 3 | Tier 1 |
+| Ethical Considerations | Tier 3 + Tier 1 | Tier 4 |
+| Caveats and Recommendations | Synthesised | — |
+| Operational Details | Tier 1 | Tier 4 |
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is silent
+  and lower tiers cannot confirm. Never fabricate.
+- "Per the provider's published statements" framing is preferred over
+  assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim, tier-1 wins;
+  the conflict is flagged in Section 9 (Caveats).
+
+### Card-level (model existence check)
+
+If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on the
+model's existence — neither has a page, doc, or model card matching the
+input name — you **refuse to produce the card**. Return:
+
+```text
+REFUSED: Could not confirm existence of model "<name>" via tier-1
+(provider docs) or tier-2 (HuggingFace). Searched: <list of URLs / queries>.
+The model may not exist under this name, may have been retired, or may
+be too recent for available sources. The dispatching command should
+surface this to the user before any file is written.
+```
+
+The dispatcher will not write a file when this REFUSED string is the agent
+output. This prevents authoritative-looking cards for hallucinated or
+non-existent models.
+
+## Citation format
+
+Every factual claim ends with `[T{{n}}.{{m}}]` where:
+
+- `n` is the source tier (1-4)
+- `m` is the source index within that tier (1, 2, 3...)
+
+URLs resolve via the frontmatter `sources` block of the card you produce.
+Aggregate sources at top of the card.
+
+## Output structure
+
+Use the exact 10-section structure from `model-cards/templates/MODEL_CARD.md`.
+Populate frontmatter:
+
+- `model_name`
+- `provider`
+- `model_version` (use the input model name if provider doesn't disclose
+  a separate version)
+- `last_researched` (today's date in YYYY-MM-DD)
+- `card_version` (always `0.1.0` for this plugin's v0.1.0)
+- `researcher` (always `model-card-researcher (claude-opus-4-7[1m])`)
+- `sources` (full URL per tier consulted; "n/a" for tiers not consulted)
+
+## Anti-patterns
+
+- Fabricating a citation. If you didn't fetch a URL, don't cite it.
+- Producing a card after the model-existence check fails. Return the REFUSED
+  string instead.
+- Writing files. Your tools include Write but the dispatcher writes; the
+  Write capability is reserved for one specific use only: writing your
+  output to a temp path the dispatcher will read. **Default behaviour is to
+  return content as your final message** — only use Write if the dispatcher
+  has explicitly asked for a temp-file output.
+- Dropping a section because it came up sparse. Every section appears in
+  every card; sparse sections are filled with "Not publicly available."

--- a/model-cards/commands/model-card.md
+++ b/model-cards/commands/model-card.md
@@ -1,0 +1,133 @@
+---
+name: model-card
+description: Research and author Mitchell-extended model cards. /model-card create <name> for one-card hybrid review-before-commit flow; /model-card seed for bulk-populate from the shipped frontier seed list.
+---
+
+# /model-card \<subcommand\> [args]
+
+Subcommands:
+
+- `create <model-name> [--provider X] [--out path]`
+- `seed [--force]`
+
+Future subcommands tracked as issues:
+
+- `/model-card list` — issue #233
+- `/model-card compare <a> <b>` — issue #234
+- `/model-card refresh <name>` — issue #235
+
+## Subcommand: `create`
+
+### Usage
+
+```text
+/model-card create <model-name> [--provider X] [--out path]
+```
+
+### Flow
+
+1. **Parse args**
+   - `model-name` (required, positional)
+   - `--provider` (optional hint; if absent, agent infers)
+   - `--out` (optional library directory override; cards still land beneath
+     it as `<provider>/<model-name>.md`)
+
+2. **Resolve target path**
+   - Default: `~/.claude/model-cards/<provider>/<model-name>.md`
+   - If `MODEL_CARDS_DIR` env var is set, use it as the library root
+   - If `--out` flag is passed, use it as the library root (highest priority)
+   - The provider sub-directory and `<model-name>.md` filename always apply
+     beneath whatever library root was resolved
+
+3. **Check for existing card at target path**
+   - If present, ask the user: `overwrite / skip / load-existing-as-base`
+   - On `skip`, abort the flow with no file change
+   - On `load-existing-as-base`, pass the existing card content to the agent
+     as starting context
+
+4. **Dispatch the `model-card-researcher` agent**
+   - Pass the model name and provider hint
+   - Agent returns either:
+     - A full markdown card content string, OR
+     - A `REFUSED:` string indicating the model-existence check failed
+
+5. **Handle REFUSED**
+   - If the agent's output starts with `REFUSED:`, surface the refusal
+     reason to the user verbatim and abort the flow with no file written.
+
+6. **Show review summary**
+   - Sources used per section (tier breakdown — counts of `[T1.x]`,
+     `[T2.x]`, `[T3.x]`, `[T4.x]` citations)
+   - Sections that came up thin — list of section numbers (1-10) where
+     "Not publicly available" appears at section level
+   - Top 3 most-cited claims by raw citation count, with their source URLs
+   - Estimated token cost of the research (rough — sum of fetched-content
+     sizes at ~4 chars/token approximation)
+
+7. **Ask for disposition**
+   - `accept` — write the card to target path, confirm with full path
+   - `edit` — open the draft in `$EDITOR` (or `vi` if unset), then re-prompt
+     with the edited content
+   - `re-run-section <N>` — re-dispatch the agent with a section-specific
+     prompt focusing on template section number N (1-10); replace just that
+     section in the draft, then re-prompt
+   - `abort` — discard the draft, no file written
+
+8. **On accept**
+   - `mkdir -p $(dirname target_path)`
+   - Write the card content to `target_path`
+   - Print: `Card written: <full_path>`
+
+### Specification picks (from spec O9 disposition)
+
+- `--out path` — directory override; card filename and provider sub-dir
+  still apply beneath
+- Provider name resolution — agent-inferred; if ambiguous, command prompts
+  user during step 6 to confirm provider sub-directory before write
+- `re-run-section <N>` — N is the template section number 1-10
+- "Top 3 most-cited claims" — raw citation count per claim
+
+## Subcommand: `seed`
+
+### Usage
+
+```text
+/model-card seed [--force]
+```
+
+### Flow
+
+1. **Read seed list**
+   - Source: `${CLAUDE_PLUGIN_ROOT}/seed/frontier-models.json`
+   - Format: `[{"name": "...", "provider": "..."}, ...]`
+
+2. **Show user the list and total count**
+
+3. **Ask once for confirmation**
+   - `Research <N> cards into <library-root>? [y/N]`
+   - On `y`, proceed
+   - On any other input, abort
+
+4. **For each model in list (sequential)**
+   - Resolve target path (as in `create` step 2)
+   - If card exists at target path AND `--force` is not set, skip with
+     one-line message
+   - Dispatch `model-card-researcher`
+   - If REFUSED, log skip with reason (one line); continue to next model
+   - Else write card to target path; log creation (one line)
+
+5. **Print summary**
+   - Created: N
+   - Skipped (existed): N
+   - Skipped (refused): N
+   - Failed (other): N
+
+### Note on resumability
+
+`seed` is idempotent for the common-case "ran partially, want to retry" — the
+existence check at step 4 skips already-written cards. To re-research existing
+cards, use `--force` (overwrites) or run `/model-card create <name>` per model
+(interactive review).
+
+If failure modes prove common in real use, `--resume` and `--retry-failed`
+flags can be added in a v0.1.x patch without spec rework.

--- a/model-cards/commands/model-card.md
+++ b/model-cards/commands/model-card.md
@@ -73,9 +73,31 @@ Future subcommands tracked as issues:
      section in the draft, then re-prompt
    - `abort` — discard the draft, no file written
 
-8. **On accept**
+8. **Validation checkpoint**
+
+   Before writing, validate the draft against the template format (per
+   the project's CLAUDE.md "Output Validation Checkpoints" convention,
+   joined by `/diaboli`, `/choice-cartograph`, `/harness-health`,
+   `/assess`, etc.):
+
+   1. YAML frontmatter parseable; required keys present (`model_name`,
+      `provider`, `model_version`, `last_researched`, `card_version`,
+      `researcher`, `sources`)
+   2. All 10 numbered section headings present in canonical order
+      (`## 1. Model Details` through `## 10. Operational Details`)
+   3. Every per-claim citation matches `\[T[1-4]\.\d+\]` and resolves
+      via the frontmatter `sources` block
+   4. Section 10 fields use field-level "Not publicly available" rather
+      than silent omission (the schema-discovery contract from spec O10
+      disposition)
+
+   Fix any deviations in place — do not re-dispatch the agent. If a
+   citation references a missing source index, surface the gap to the
+   user before write.
+
+9. **On accept (post-validation)**
    - `mkdir -p $(dirname target_path)`
-   - Write the card content to `target_path`
+   - Write the validated card content to `target_path`
    - Print: `Card written: <full_path>`
 
 ### Specification picks (from spec O9 disposition)

--- a/model-cards/seed/frontier-models.json
+++ b/model-cards/seed/frontier-models.json
@@ -1,0 +1,16 @@
+[
+  {"name": "claude-opus-4-7", "provider": "anthropic"},
+  {"name": "claude-sonnet-4-6", "provider": "anthropic"},
+  {"name": "claude-haiku-4-5", "provider": "anthropic"},
+  {"name": "gpt-5", "provider": "openai"},
+  {"name": "gpt-5-mini", "provider": "openai"},
+  {"name": "o4", "provider": "openai"},
+  {"name": "o4-mini", "provider": "openai"},
+  {"name": "gemini-2.5-pro", "provider": "google"},
+  {"name": "gemini-2.5-flash", "provider": "google"},
+  {"name": "llama-4", "provider": "meta"},
+  {"name": "mistral-large-3", "provider": "mistral"},
+  {"name": "grok-4", "provider": "xai"},
+  {"name": "command-r-plus", "provider": "cohere"},
+  {"name": "qwen3-coder", "provider": "alibaba"}
+]

--- a/model-cards/skills/model-cards/SKILL.md
+++ b/model-cards/skills/model-cards/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: model-cards
+description: Use when authoring or interpreting Mitchell-extended model cards in this plugin. Covers when each of the 10 sections applies, the citation discipline, the honesty rules (claim-level and card-level), and the tiered source strategy. Reference for the model-card-researcher agent and the /model-card command.
+---
+
+# Mitchell-Extended Model Cards
+
+This plugin produces 10-section model cards: Mitchell et al.'s 9 canonical
+sections plus an "Operational Details" 10th section for the consumer-evaluator
+audience. This skill is the reference for what each section is for and how
+to fill it honestly.
+
+## The ten sections
+
+### 1. Model Details
+
+What the model IS — name, provider, family, release date, parameter count
+where disclosed. Tier 1 (provider docs) is primary; tier 2 (HuggingFace) is
+secondary for open-source / fine-tuned models.
+
+### 2. Intended Use
+
+What the model is for — primary uses, intended users, explicitly out-of-scope
+uses. The provider's documentation usually makes this explicit; quote it
+faithfully and cite.
+
+### 3. Factors
+
+Subgroups, environmental factors, instrumentation. Often sparse for
+proprietary API-served models — write "Not publicly available" rather than
+fabricate.
+
+### 4. Metrics
+
+Performance measures the provider reports. Distinguish provider-reported
+benchmarks from independent evaluations (tier 1 vs tier 4).
+
+### 5. Evaluation Data
+
+Datasets used to evaluate. Frequently "Not publicly available" for
+proprietary models. Tier 3 (release paper) is the most likely source.
+
+### 6. Training Data
+
+Datasets used to train. Almost always "Not publicly available" for proprietary
+models — say so. Tier 3 is the only source likely to disclose.
+
+### 7. Quantitative Analyses
+
+Disaggregated performance — by demographic, by task category, by language.
+Tier 3 (release paper) is primary.
+
+### 8. Ethical Considerations
+
+Risks, mitigations, known failure modes. Tier 3 is the most honest source
+(release papers are usually more frank than marketing pages); tier 1 is
+secondary; tier 4 (independent evaluations) is tertiary but valuable for
+reality-check.
+
+### 9. Caveats and Recommendations
+
+The "what this card cannot tell you" section. Lists which sections came up
+"Not publicly available" and why. Records conflicts between tiers.
+Recommendations for use given the model's documented profile.
+
+### 10. Operational Details
+
+This plugin's extension. Best-effort structured fields:
+
+- Pricing (input/output per million tokens)
+- Context window
+- Knowledge cutoff
+- Supported APIs/SDKs
+- Latency tier
+- Tool / structured-output support
+- Function calling
+- Fine-tuning availability
+- Rate-limit notes
+
+Each field gets "Not publicly available" if absent; the field is never
+omitted. This makes downstream comparison (`/model-card compare`) reliable.
+
+## Citation discipline
+
+Every factual claim ends with `[T<n>.<m>]` where:
+
+- `n` is the source tier: 1 = provider docs, 2 = HuggingFace, 3 = arXiv,
+  4 = web search
+- `m` is the source index within that tier (1, 2, 3...)
+
+Example:
+
+```text
+Knowledge cutoff: January 2026 [T1.1]. Context window: 1M tokens [T1.2].
+Pricing: $5/$25 per million tokens (input/output) at standard tier [T1.3].
+```
+
+URLs for each citation resolve via the per-card frontmatter `sources` block.
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is silent
+  and lower tiers cannot confirm. Never fabricate.
+- "Per the provider's published statements" framing is preferred over
+  assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim, tier-1 wins;
+  the conflict is flagged in Section 9 (Caveats).
+
+### Card-level
+
+- If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on the
+  model's existence — the agent cannot confirm the model exists at all — the
+  agent refuses to create the card and surfaces the result to the dispatching
+  command. The command reports back to the user. **Cards are not produced
+  for non-existent or unconfirmed model names.** This rule prevents
+  authoritative-looking cards for hallucinated models.
+
+## Tiered source strategy
+
+| Tier | Source | Used for |
+| --- | --- | --- |
+| 1 | Provider docs | Model Details, Intended Use, Operational Details |
+| 2 | HuggingFace | Open-source / fine-tuned models; fallback for tier-1 gaps |
+| 3 | arXiv release paper | Factors, Metrics, Evaluation Data, Training Data, Quantitative Analyses, Ethical Considerations |
+| 4 | Web search | Anything tiers 1-3 don't cover; independent evaluations |
+
+The agent researches **section-by-section** using each section's primary
+tier (see the table in `agents/model-card-researcher.agent.md`). This is
+more efficient than fetching all sources upfront.
+
+## When to use this skill
+
+- Authoring a card by hand (without the agent)
+- Interpreting a card (which sections to trust most)
+- Designing extensions to the card schema (e.g. adding fields to Section 10)
+- Building tooling that consumes cards (e.g. the future `/model-card compare`)

--- a/model-cards/templates/MODEL_CARD.md
+++ b/model-cards/templates/MODEL_CARD.md
@@ -1,0 +1,91 @@
+---
+model_name: <provider>/<model-name>
+provider: <Anthropic | OpenAI | Google | Meta | Mistral | xAI | Cohere | Alibaba | other>
+model_version: <as-stated-by-provider>
+last_researched: YYYY-MM-DD
+card_version: 0.1.0
+researcher: model-card-researcher (claude-opus-4-7[1m])
+sources:
+  - tier: 1
+    url: <provider docs URL>
+    fetched: YYYY-MM-DD
+  - tier: 2
+    url: <huggingface URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 3
+    url: <arxiv URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 4
+    url: <web URL or "n/a">
+    fetched: YYYY-MM-DD
+---
+
+# Model Card: {{provider}}/{{model-name}}
+
+## 1. Model Details
+
+What this model is, who released it, when, what kind of model it is. Cite
+provider-stated identity, release date, model family, parameter count if
+disclosed.
+
+## 2. Intended Use
+
+Primary uses, primary users, out-of-scope uses (per the provider's published
+statements).
+
+## 3. Factors
+
+Relevant subgroups, environmental factors, instrumentation factors. Often
+sparse for proprietary API-served models — fill with "Not publicly available"
+where the provider has not disclosed.
+
+## 4. Metrics
+
+Performance measures the provider reports. Cite each metric with its source
+tier; prefer tier-1 (provider docs) and tier-3 (release paper).
+
+## 5. Evaluation Data
+
+Datasets used to evaluate (per the provider's published statements). Often
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 6. Training Data
+
+Datasets used to train (per the provider's published statements). Frequently
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 7. Quantitative Analyses
+
+Disaggregated performance, where provider has published this. Cite metrics
+table from release paper or provider docs; record the date of the analysis.
+
+## 8. Ethical Considerations
+
+Risks, mitigations, known failure modes — preferring the release paper as
+primary source (tier 3); supplemented by provider statements (tier 1) and
+independent evaluations (tier 4) where relevant.
+
+## 9. Caveats and Recommendations
+
+What this card cannot tell you (sections marked "Not publicly available" and
+why). Recommendations for use given the model's documented strengths and
+limitations. Conflicts between tier-1 and tier-4 sources are recorded here.
+
+## 10. Operational Details
+
+Best-effort structured fields; missing values are written as "Not publicly
+available" rather than omitted:
+
+- **Pricing** — input/output cost per million tokens; pricing tier; as-of
+  date. Cite the pricing page (tier 1).
+- **Context window** — maximum input + output tokens.
+- **Knowledge cutoff** — provider-stated training cutoff date.
+- **Supported APIs/SDKs** — provider's API name(s); language SDKs; OpenAI
+  Chat Completions compatibility if applicable.
+- **Latency tier** — provider's stated latency tier or category, if any.
+- **Tool / structured-output support** — function calling, JSON mode, tool
+  use, parallel tool calls.
+- **Function calling** — supported, parallel-supported, schema format.
+- **Fine-tuning availability** — yes/no/limited; cite the fine-tuning docs
+  page if available.
+- **Rate-limit notes** — provider-published rate limit tiers or quotas.


### PR DESCRIPTION
## Summary

Adds a new sister plugin **model-cards** to the marketplace. Researches and authors Mitchell-extended model cards from a model name, with hybrid review-before-commit. Ships with a 14-model frontier seed list. The marketplace listing bumps from v0.2.3 to v0.3.0.

- **Spec**: `docs/superpowers/specs/2026-04-29-model-cards-plugin-design.md`
- **Plan**: `docs/superpowers/plans/2026-04-29-model-cards-plugin.md`
- **Diaboli (adjudicated)**: `docs/superpowers/objections/model-cards-plugin-design.md` — 12 objections, all rejected with rationales recording trade-offs
- **Choice cartograph (adjudicated)**: `docs/superpowers/stories/model-cards-plugin-design.md` — 8 stories: 3 accepted, 3 revisit, 2 promoted to AGENTS.md ARCH_DECISIONS

## What's in the PR

**New plugin** at `model-cards/` (plugin manifest, README, CHANGELOG, 10-section Mitchell-extended template, Mitchell-extended skill, research agent, /model-card command with create+seed subcommands, 14-model frontier seed list).

**Repo-level integration**:
- `.claude-plugin/marketplace.json`: second `plugins[]` entry; listing version 0.2.3 → 0.3.0; `plugin_version` field unchanged at 0.31.1 (Option A from spec — points at canonical plugin)
- `.github/workflows/version-check.yml`: extended to enumerate plugins via marketplace.json `plugins[]` and verify per-plugin sync
- `AGENTS.md`: new ARCH_DECISIONS bullet promoting the trust-architecture pattern (per cartograph stories #7+#8 promotion). The pattern names *agent-emit + dispatcher-persist + human-disposes* across three agents (advocatus-diaboli, choice-cartographer, model-card-researcher) — Rule-of-Three.

## Tracking issues created during planning

- #232 chore: explore removal of marketplace.json top-level `plugin_version`
- #233 model-cards: `/model-card list` subcommand
- #234 model-cards: `/model-card compare <a> <b>` subcommand
- #235 model-cards: `/model-card refresh <name>` subcommand
- #236 model-cards: docs/how-to/research-a-model-card.md (deferred from this PR per reviewer's suggestion #4)

## Final review feedback applied

Final code review surfaced 5 minor suggestions; 3 fixed inline (validation checkpoint added to /model-card create flow per CLAUDE.md "Output Validation Checkpoints"; `Write` tool dropped from research agent's tool list to align with diaboli/cartographer's read-only-emitter pattern; README documents `--force` flag). One deferred to issue #236 (docs how-to). One non-blocking note about plan-file lint (matches yesterday's pattern).

## Test plan

- [x] markdownlint clean over plugin files + AGENTS.md + design artefacts
- [x] JSON validity (marketplace.json, plugin.json, frontier-models.json)
- [x] YAML frontmatter parseable for agent, command, skill
- [x] Per-plugin version sync: ai-literacy-superpowers 0.31.1=0.31.1, model-cards 0.1.0=0.1.0
- [x] gitleaks scan clean
- [x] Spec-first commit ordering: first commit `4ca6267` is spec-only ✓
- [ ] CI green
- [ ] Manual integration smoke (requires Claude Code session with plugin installed): create succeeds for known model, REFUSED path for unknown model, trimmed-seed populate

The manual integration smoke test will run after merge against the installed plugin; if it surfaces issues, a v0.1.1 patch follows.