### PR TITLE
chore: bump HARNESS.md template-version marker to 0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 0.31.1 — 2026-04-29
 
+### Chore — Bump HARNESS.md template-version marker to 0.31.1
+
+Ran `/harness-upgrade` against the 0.31.1 template. No new constraints,
+GC rules, or sections to adopt — the live `HARNESS.md` is already a
+superset of the template, with all template items present (a few
+customised with project-specific dates and file references). Only the
+`<!-- template-version: -->` marker needed updating, from `0.29.0` to
+`0.31.1`, to silence the SessionStart upgrade nudge. The
+`.claude/.harness-upgrade-dismissed` marker was also bumped (gitignored,
+local-only).
+
 ### Docs — Sync Naur as a strand of the Intellectual Foundations
 
 Synced from the upstream framework

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.29.0 -->
+<!-- template-version: 0.31.1 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Ran `/harness-upgrade` against the 0.31.1 template.
- No new constraints, GC rules, or sections to adopt — the live `HARNESS.md` is already a **superset** of the template.
- Bumped the `<!-- template-version: -->` marker in `HARNESS.md` from `0.29.0` → `0.31.1` to silence the SessionStart upgrade nudge.

## Why this is a one-line change

Every template item is already present in `HARNESS.md`. Several are customised with project-specific dates (`2026-04-19`, `2026-04-27`) or file references (`CLAUDE.md`); per the upgrade rules, customised items take precedence and were skipped. There is nothing to merge in from the template — only the marker needed updating.

The `.claude/.harness-upgrade-dismissed` marker was also bumped to `0.31.1` (gitignored, local-only — not in this PR).

## Notes

- Implementation gap observed: prior `/harness-upgrade` runs appear to have written `.harness-upgrade-dismissed` (was `0.31.0`) without writing the marker back into `HARNESS.md` (was `0.29.0`). Worth a future spec to investigate whether the dismissal hook should also bump the in-file marker.
- Template-version drift in the upstream template itself: `templates/HARNESS.md` ships with `template-version: 0.29.0` even at plugin v0.31.1 — meaning the template content has not changed across 0.30.x and 0.31.x. Worth a separate cleanup or a GC rule that flags template-version drift in the template itself.

## Test plan

- [x] `npx markdownlint-cli2 HARNESS.md CHANGELOG.md` — clean
- [ ] CI green (markdownlint, version check)