### PR TITLE
docs: per-plugin section + full model-cards docs (PR 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## 0.31.1 — 2026-04-29
 
+### Docs — Per-plugin docs section + full model-cards documentation (PR 1 of 3)
+
+First of three PRs restructuring the docs site to plugin-first
+organisation, motivated by the new sister plugin `model-cards`
+shipping in the same marketplace.
+
+- **New top-level docs section: `docs/plugins/`.** Landing page at
+  `docs/plugins/index.md` introduces the per-plugin structure and
+  lists available plugins.
+- **Full model-cards documentation under `docs/plugins/model-cards/`:**
+  - `index.md` — landing page with install, quick start, and Diataxis-
+    organised navigation.
+  - `seed-your-library.md` — tutorial for `/model-card seed`.
+  - `research-a-model-card.md` — how-to for `/model-card create`.
+  - `commands.md`, `agents.md`, `skills.md`, `card-template.md` —
+    reference pages for the command, agent, skill, and template.
+  - `mitchell-extended-cards.md` — explanation page covering why the
+    cards have ten sections, the citation-tier discipline, the
+    existence-check refusal rule, and the read-only-emitter trust
+    boundary the agent inherits from `advocatus-diaboli` /
+    `choice-cartographer`.
+- **`docs/index.md` updated** to surface the new Plugins section in
+  the top-level navigation table.
+- **No file moves yet.** Existing `ai-literacy-superpowers` docs stay
+  at their current paths and URLs continue to work. PR 2 will migrate
+  them under `docs/plugins/ai-literacy-superpowers/` with
+  `redirect_from:` frontmatter to preserve bookmarks; PR 3 will sweep
+  cross-references in `README.md` and skill/agent/command files.
+
 ### Chore — Bump HARNESS.md template-version marker to 0.31.1
 
 Ran `/harness-upgrade` against the 0.31.1 template. No new constraints,

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,3 +77,10 @@ This documentation follows the [Diataxis framework](https://diataxis.fr/):
 | [How-to Guides](how-to/) | Task-oriented instructions | You need to do something specific |
 | [Reference](reference/) | Technical descriptions | You need exact details |
 | [Explanation](explanation/) | Understanding-oriented discussion | You want to understand the concepts |
+| [Plugins](plugins/) | Per-plugin documentation | You're working with a specific plugin in this marketplace |
+
+The top-level Tutorials, How-to Guides, Reference, and Explanation
+sections currently document `ai-literacy-superpowers` only and will
+be migrated under the per-plugin structure in a follow-up. New sister
+plugins (such as [model-cards]({% link plugins/model-cards/index.md %}))
+go straight into the Plugins section.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,0 +1,35 @@
+---
+title: Plugins
+layout: default
+nav_order: 6
+has_children: true
+---
+
+# Plugins
+
+The `ai-literacy-superpowers` marketplace ships more than one plugin.
+This section documents each plugin individually, with its own tutorials,
+how-to guides, reference material, and explanation pages.
+
+The top-level [Tutorials]({% link tutorials/index.md %}),
+[How-to Guides]({% link how-to/index.md %}),
+[Reference]({% link reference/index.md %}), and
+[Explanation]({% link explanation/index.md %}) sections currently
+document `ai-literacy-superpowers` only and will be migrated under this
+Plugins section in a follow-up. New sister plugins go straight into the
+Plugins section.
+
+## Available plugins
+
+| Plugin | What it does | Docs |
+| ------ | ------------ | ---- |
+| [model-cards]({% link plugins/model-cards/index.md %}) | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy, refusal-on-unconfirmed-existence honesty rule. | [→ model-cards docs]({% link plugins/model-cards/index.md %}) |
+
+## Why per-plugin documentation
+
+Each plugin in the marketplace has its own commands, agents, skills,
+templates, and operational shape. Mixing them into one global reference
+makes it harder to discover what belongs to which plugin and harder for
+each plugin to evolve at its own pace. Per-plugin sub-sections keep
+each plugin's documentation cohesive while still letting cross-cutting
+concepts live in shared explanation pages.

--- a/docs/plugins/model-cards/agents.md
+++ b/docs/plugins/model-cards/agents.md
@@ -1,0 +1,185 @@
+---
+title: Agent — model-card-researcher
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 4
+---
+
+# Agent: model-card-researcher
+
+A read-only research agent that produces a Mitchell-extended model card
+from a model name and an optional provider hint. The agent emits the
+card content as its final message; the `/model-card create` command
+writes the file after a human review checkpoint.
+
+---
+
+## Charter
+
+Given a model name (and optionally a provider hint), produce a
+Mitchell-extended model card by researching the model through a tiered
+source strategy. Cite every factual claim. Write "Not publicly
+available" rather than fabricate. Refuse to produce a card when the
+model's existence cannot be confirmed.
+
+---
+
+## Inputs
+
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| Model name | yes | E.g. `claude-opus-4-7`, `meta-llama/llama-4`, `gpt-5-mini`. |
+| Provider hint | no | E.g. `anthropic`, `openai`, `huggingface`, `meta`. If absent, the agent infers from the model name. |
+
+---
+
+## Output
+
+A single markdown string containing the full card content — frontmatter
+plus all 10 sections per the
+[card template]({% link plugins/model-cards/card-template.md %}).
+
+The agent does **not** write the file. The dispatching command
+persists the output after a human-in-the-loop review checkpoint.
+
+If the existence check fails, the agent returns a `REFUSED:` string
+instead of a card body. The dispatcher detects this prefix and aborts
+without writing anything.
+
+---
+
+## Tools
+
+`WebFetch`, `WebSearch`, `Read`, `Glob`, `Grep`.
+
+No `Write`. No `Edit`. No `Bash`.
+
+The trust boundary is **research and emit content**; persistence is
+the dispatcher's responsibility. This matches the read-only-emitter
+pattern used by `advocatus-diaboli` and `choice-cartographer` in the
+sister `ai-literacy-superpowers` plugin (see the project's `AGENTS.md`
+ARCH_DECISIONS for the broader trust architecture).
+
+The separation is **load-bearing**: the human review gate between
+agent output and file write catches hallucinated claims, fabricated
+citations, or refusal-conditions the agent should have surfaced. An
+agent with `Write` access bypasses that gate.
+
+---
+
+## Tiered source strategy
+
+| Tier | Source | Discovery |
+| ---- | ------ | --------- |
+| 1 | Provider docs | URL inferred from a provider→docs-root mapping. |
+| 2 | HuggingFace | `https://huggingface.co/{owner}/{model}` if the model is hosted on HF. |
+| 3 | arXiv release paper | `WebSearch` for `"{model-name}" arxiv`. |
+| 4 | Web search | `WebSearch` with explicit queries; prefer recent results. |
+
+### Provider → docs-root mapping (tier 1)
+
+| Provider | Docs root |
+| -------- | --------- |
+| `anthropic` | `https://docs.anthropic.com` |
+| `openai` | `https://platform.openai.com/docs/models` |
+| `google` | `https://ai.google.dev/gemini-api/docs/models` |
+| `meta` | `https://ai.meta.com/llama` and the model's GitHub repo |
+| `mistral` | `https://docs.mistral.ai` |
+| `xai` | `https://docs.x.ai` |
+| `cohere` | `https://docs.cohere.com` |
+| `alibaba` | `https://qwenlm.github.io` or the model's docs page |
+
+For any other provider, the agent search-discovers via `WebSearch` for
+`"{provider}" "{model-name}" docs`.
+
+### Per-section primary source
+
+| Section | Primary | Fallback |
+| ------- | ------- | -------- |
+| 1. Model Details | Tier 1 | Tier 2 → 4 |
+| 2. Intended Use | Tier 1 | Tier 2 → 4 |
+| 3. Factors | Tier 3 | Tier 1 → 2 |
+| 4. Metrics | Tier 1 + Tier 3 | — |
+| 5. Evaluation Data | Tier 3 | Tier 1 |
+| 6. Training Data | Tier 3 | Tier 1 (often "Not publicly available") |
+| 7. Quantitative Analyses | Tier 3 | Tier 1 |
+| 8. Ethical Considerations | Tier 3 + Tier 1 | Tier 4 |
+| 9. Caveats and Recommendations | Synthesised from above | — |
+| 10. Operational Details | Tier 1 | Tier 4 |
+
+The agent researches **section by section** using each section's primary
+tier rather than fetching all sources upfront. This is more efficient
+and produces a sharper provenance trail.
+
+---
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is
+  silent and lower tiers cannot confirm. **Never fabricate.**
+- "Per the provider's published statements" framing is preferred over
+  bare assertion — preserves the source-trust chain.
+- If a tier-4 (web) claim conflicts with a tier-1 (provider docs)
+  claim, **tier-1 wins**; the conflict is recorded in Section 9
+  (Caveats).
+
+### Card-level — model existence check
+
+If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on
+the model's existence — neither has a page, doc, or model card matching
+the input name — the agent **refuses to produce the card** and returns:
+
+```text
+REFUSED: Could not confirm existence of model "<name>" via tier-1
+(provider docs) or tier-2 (HuggingFace). Searched: <list of URLs / queries>.
+The model may not exist under this name, may have been retired, or may
+be too recent for available sources. The dispatching command should
+surface this to the user before any file is written.
+```
+
+The dispatcher detects the `REFUSED:` prefix and writes nothing. This
+prevents authoritative-looking cards for hallucinated or non-existent
+models.
+
+---
+
+## Citation format
+
+Every factual claim ends with `[T<n>.<m>]` where:
+
+- `n` is the source tier (1-4)
+- `m` is the source index within that tier (1, 2, 3, ...)
+
+URLs resolve via the frontmatter `sources` block of the card the agent
+produces. The agent aggregates sources at the top of the card.
+
+---
+
+## Anti-patterns
+
+- **Fabricating a citation.** If the agent didn't fetch a URL, it must
+  not cite it.
+- **Producing a card after the model-existence check fails.** Return
+  the `REFUSED:` string instead.
+- **Trying to write files.** The agent has no `Write` tool. Content is
+  returned as the final message; the dispatcher writes the file after
+  the human review checkpoint.
+- **Dropping a section because it came up sparse.** Every section
+  appears in every card; sparse sections are filled with "Not publicly
+  available" — never omitted.
+
+---
+
+## Related
+
+- [`/model-card` command]({% link plugins/model-cards/commands.md %}) —
+  the dispatcher that uses this agent.
+- [`model-cards` skill]({% link plugins/model-cards/skills.md %}) —
+  authoring reference for the 10-section card structure.
+- [Card template]({% link plugins/model-cards/card-template.md %}) —
+  the canonical structure the agent populates.
+- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+  why the agent works the way it does.

--- a/docs/plugins/model-cards/card-template.md
+++ b/docs/plugins/model-cards/card-template.md
@@ -1,0 +1,185 @@
+---
+title: Card Template
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 6
+---
+
+# Card Template
+
+Every model card produced by the plugin conforms to a single template:
+`model-cards/templates/MODEL_CARD.md`. This page reproduces the
+template structure for reference — it is what the validation
+checkpoint in `/model-card create` checks against, and what
+hand-authored cards should match.
+
+---
+
+## Frontmatter
+
+```yaml
+---
+model_name: <provider>/<model-name>
+provider: <Anthropic | OpenAI | Google | Meta | Mistral | xAI | Cohere | Alibaba | other>
+model_version: <as-stated-by-provider>
+last_researched: YYYY-MM-DD
+card_version: 0.1.0
+researcher: model-card-researcher (claude-opus-4-7[1m])
+sources:
+  - tier: 1
+    url: <provider docs URL>
+    fetched: YYYY-MM-DD
+  - tier: 2
+    url: <huggingface URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 3
+    url: <arxiv URL or "n/a">
+    fetched: YYYY-MM-DD
+  - tier: 4
+    url: <web URL or "n/a">
+    fetched: YYYY-MM-DD
+---
+```
+
+### Required keys
+
+| Key | Description |
+| --- | ----------- |
+| `model_name` | The model's canonical identifier as published by the provider. |
+| `provider` | The provider company name. |
+| `model_version` | Version as stated by the provider. If the provider does not disclose a separate version, use the input model name. |
+| `last_researched` | Date the agent (or hand-author) last fetched sources, in `YYYY-MM-DD`. |
+| `card_version` | The card schema version. Always `0.1.0` for this plugin's v0.1.0. |
+| `researcher` | Identifier for who or what produced the card. Agent uses `model-card-researcher (claude-opus-4-7[1m])`. |
+| `sources` | One entry per tier consulted. Tiers not consulted use `url: "n/a"`. The validation checkpoint requires at least the tiers actually cited in the body. |
+
+---
+
+## Body — the ten sections
+
+The body must contain **all ten sections** in canonical order, with
+the exact heading text shown below. Sparse sections are filled with
+"Not publicly available" rather than omitted — the validation
+checkpoint enforces presence, not depth.
+
+```markdown
+# Model Card: {provider}/{model-name}
+
+## 1. Model Details
+
+What this model is, who released it, when, what kind of model it is. Cite
+provider-stated identity, release date, model family, parameter count if
+disclosed.
+
+## 2. Intended Use
+
+Primary uses, primary users, out-of-scope uses (per the provider's published
+statements).
+
+## 3. Factors
+
+Relevant subgroups, environmental factors, instrumentation factors. Often
+sparse for proprietary API-served models — fill with "Not publicly available"
+where the provider has not disclosed.
+
+## 4. Metrics
+
+Performance measures the provider reports. Cite each metric with its source
+tier; prefer tier-1 (provider docs) and tier-3 (release paper).
+
+## 5. Evaluation Data
+
+Datasets used to evaluate (per the provider's published statements). Often
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 6. Training Data
+
+Datasets used to train (per the provider's published statements). Frequently
+"Not publicly available" for proprietary models — say so explicitly.
+
+## 7. Quantitative Analyses
+
+Disaggregated performance, where provider has published this. Cite metrics
+table from release paper or provider docs; record the date of the analysis.
+
+## 8. Ethical Considerations
+
+Risks, mitigations, known failure modes — preferring the release paper as
+primary source (tier 3); supplemented by provider statements (tier 1) and
+independent evaluations (tier 4) where relevant.
+
+## 9. Caveats and Recommendations
+
+What this card cannot tell you (sections marked "Not publicly available" and
+why). Recommendations for use given the model's documented strengths and
+limitations. Conflicts between tier-1 and tier-4 sources are recorded here.
+
+## 10. Operational Details
+
+Best-effort structured fields; missing values are written as "Not publicly
+available" rather than omitted:
+
+- **Pricing** — input/output cost per million tokens; pricing tier; as-of
+  date. Cite the pricing page (tier 1).
+- **Context window** — maximum input + output tokens.
+- **Knowledge cutoff** — provider-stated training cutoff date.
+- **Supported APIs/SDKs** — provider's API name(s); language SDKs; OpenAI
+  Chat Completions compatibility if applicable.
+- **Latency tier** — provider's stated latency tier or category, if any.
+- **Tool / structured-output support** — function calling, JSON mode, tool
+  use, parallel tool calls.
+- **Function calling** — supported, parallel-supported, schema format.
+- **Fine-tuning availability** — yes/no/limited; cite the fine-tuning docs
+  page if available.
+- **Rate-limit notes** — provider-published rate limit tiers or quotas.
+```
+
+---
+
+## Section 10 — field-level "Not publicly available"
+
+Section 10 (Operational Details) is special: every field listed in the
+template appears in every card, even if the value is unknown.
+Field-level "Not publicly available" entries replace silent omission.
+
+```markdown
+- **Pricing** — Not publicly available [T1.4]
+- **Context window** — 1M tokens [T1.2]
+- **Knowledge cutoff** — January 2026 [T1.1]
+- **Fine-tuning availability** — Not publicly available
+```
+
+This makes downstream comparison reliable — the future
+`/model-card compare` (issue #234) can diff cards field-by-field
+without having to special-case missing fields.
+
+---
+
+## Validation checkpoint
+
+The validation step in `/model-card create` checks four things before
+writing:
+
+1. YAML frontmatter parses; required keys are present.
+2. All 10 numbered section headings are present in canonical order
+   (`## 1. Model Details` through `## 10. Operational Details`).
+3. Every per-claim citation matches `\[T[1-4]\.\d+\]` and resolves
+   via the frontmatter `sources` block.
+4. Section 10 fields use field-level "Not publicly available" rather
+   than silent omission.
+
+Deviations are fixed in place — the agent is not re-dispatched.
+Citation gaps (e.g. a `[T2.1]` reference with no source 2.1 in
+frontmatter) are surfaced to the user before write.
+
+---
+
+## Related
+
+- [Skill: model-cards]({% link plugins/model-cards/skills.md %}) —
+  authoring guidance for each section.
+- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+  how the agent populates the template.
+- [Commands: /model-card]({% link plugins/model-cards/commands.md %}) —
+  including the validation checkpoint flow.

--- a/docs/plugins/model-cards/commands.md
+++ b/docs/plugins/model-cards/commands.md
@@ -1,0 +1,148 @@
+---
+title: Commands
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 3
+---
+
+# Commands
+
+The `model-cards` plugin exposes a single slash command, `/model-card`,
+with two subcommands today and three more on the roadmap.
+
+---
+
+## /model-card create
+
+```text
+/model-card create <model-name> [--provider X] [--out path]
+```
+
+Researches a single model and produces a Mitchell-extended card after
+a human-in-the-loop review checkpoint.
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+| `<model-name>` | yes | Model name as published by the provider, e.g. `claude-opus-4-7`, `gpt-5-mini`, `meta-llama/llama-4`. |
+| `--provider X` | no | Provider hint — e.g. `anthropic`, `openai`, `google`, `meta`, `mistral`, `xai`, `cohere`, `alibaba`. If omitted, the agent infers from the model name. |
+| `--out path` | no | Library directory override. Cards still land beneath this path as `<provider>/<model-name>.md`. Highest-priority path resolver. |
+
+### Path resolution
+
+The resolved target path is `<library-root>/<provider>/<model-name>.md`,
+where `<library-root>` is the first of:
+
+1. `--out` flag value (highest priority)
+2. `MODEL_CARDS_DIR` environment variable
+3. `~/.claude/model-cards/` (default)
+
+### Flow
+
+1. **Parse args** — model name, provider hint, output path.
+2. **Resolve target path** using the priority order above.
+3. **Existing-card prompt** — if the target exists, ask
+   `overwrite / skip / load-existing-as-base`.
+4. **Dispatch** the [`model-card-researcher`]({% link plugins/model-cards/agents.md %})
+   agent. Output is either a markdown card body or a `REFUSED:` string.
+5. **Handle REFUSED** — if the agent's output starts with `REFUSED:`,
+   surface the refusal verbatim and abort. No file is written.
+6. **Show review summary** — sources used per section, sections that
+   came up thin, top 3 most-cited claims with URLs, estimated research
+   token cost.
+7. **Disposition prompt** — `accept / edit / re-run-section <N> / abort`.
+8. **Validation checkpoint** (on `accept`) — frontmatter parseable,
+   all 10 sections present in canonical order, every `[T<n>.<m>]`
+   citation resolves to a frontmatter source, Section 10 fields use
+   field-level "Not publicly available" rather than silent omission.
+   Deviations are fixed in place; agent is not re-dispatched.
+9. **Write the card** to the resolved target path. Print
+   `Card written: <full-path>`.
+
+See the [research a model card]({% link plugins/model-cards/research-a-model-card.md %})
+how-to for a step-by-step walkthrough.
+
+### Disposition options
+
+| Choice | Effect |
+| ------ | ------ |
+| `accept` | Validate, then write the card to the target path. |
+| `edit` | Open the draft in `$EDITOR` (or `vi` if unset); on save, the edited content replaces the draft and the disposition prompt re-asks. |
+| `re-run-section <N>` | Re-dispatch the agent with a section-specific prompt for template section `N` (1-10). Replaces just that section in the draft, then re-prompts. |
+| `abort` | Discard the draft. No file is written. |
+
+### Exit behaviours
+
+- **REFUSED** — model existence not confirmed via tier-1 + tier-2.
+  Refusal reason printed; no file written. Exits with status 0.
+- **Abort** — user chose `abort` or the existing-card prompt returned
+  `skip`. No file written. Exits with status 0.
+- **Validation failure** — citation references a missing source index
+  in frontmatter. Surfaced to user before write; user is given the
+  chance to edit or abort. No file written until validation passes.
+- **Success** — card written; full path printed. Exits with status 0.
+
+---
+
+## /model-card seed
+
+```text
+/model-card seed [--force]
+```
+
+Bulk-populates the library with cards for a shipped list of 14
+frontier models.
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+| `--force` | no | Overwrite existing cards in the library. Without `--force`, existing cards are skipped. |
+
+### Flow
+
+1. **Read the seed list** at `${CLAUDE_PLUGIN_ROOT}/seed/frontier-models.json` —
+   format `[{"name": "...", "provider": "..."}, ...]`.
+2. **Print the list and total count.**
+3. **Single confirmation** — `Research <N> cards into <library-root>? [y/N]`.
+   Anything other than `y` aborts.
+4. **For each model** (sequential):
+   - Resolve target path (same logic as `create`).
+   - If card exists at target path AND `--force` is not set, skip with
+     a one-line message.
+   - Dispatch `model-card-researcher`.
+   - If REFUSED, log the skip with reason (one line); continue.
+   - Else, write the card and log creation (one line).
+5. **Print summary**:
+
+   ```text
+   Created: N
+   Skipped (existed): N
+   Skipped (refused): N
+   Failed (other): N
+   ```
+
+### Idempotency
+
+`seed` is idempotent for the common-case "ran partially, want to retry"
+pattern — the existence check at step 4 skips already-written cards.
+To re-research existing cards, either pass `--force` (overwrites all)
+or run `/model-card create <name>` per-model (interactive review).
+
+See the [seed your library]({% link plugins/model-cards/seed-your-library.md %})
+tutorial for an end-to-end walkthrough.
+
+---
+
+## Roadmap subcommands
+
+The following subcommands are tracked as GitHub issues but are not yet
+implemented:
+
+| Subcommand | Issue | Purpose |
+| ---------- | ----- | ------- |
+| `/model-card list` | [#233](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/233) | Browse the library — list cards by provider, by date researched, by version. |
+| `/model-card compare <a> <b>` | [#234](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/234) | Side-by-side card comparison across the 10-section structure. |
+| `/model-card refresh <name>` | [#235](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/235) | Re-research a specific card non-interactively, preserving the existing card as the base. |
+
+These are deliberately deferred — `create` + `seed` cover the bootstrap
+flow for v0.1.0. The shape of `list`, `compare`, and `refresh` will
+firm up as adoption signal arrives.

--- a/docs/plugins/model-cards/index.md
+++ b/docs/plugins/model-cards/index.md
@@ -1,0 +1,110 @@
+---
+title: model-cards
+layout: default
+parent: Plugins
+nav_order: 1
+has_children: true
+---
+
+# model-cards
+
+Research and author Mitchell-extended model cards from a model name.
+
+`model-cards` is a sister plugin to `ai-literacy-superpowers` in the same
+marketplace. It is aimed at evaluators researching new models, and
+produces 10-section cards (Mitchell et al.'s 9 canonical sections plus
+an "Operational Details" section for consumer-evaluator audiences) with
+per-claim citations and tiered source provenance.
+
+The plugin's source lives at [`model-cards/`](https://github.com/Habitat-Thinking/ai-literacy-superpowers/tree/main/model-cards)
+in the repository.
+
+---
+
+## Install
+
+```bash
+# In Claude Code
+claude plugin install model-cards@ai-literacy-superpowers
+
+# In Copilot CLI
+copilot plugin install model-cards@ai-literacy-superpowers
+```
+
+The marketplace `ai-literacy-superpowers` must be added first; see the
+top-level [Get Started]({% link tutorials/getting-started.md %}) tutorial
+for the install flow.
+
+---
+
+## Quick start
+
+```text
+/model-card create claude-opus-4-7
+```
+
+Researches the model through a tiered source strategy (provider docs →
+HuggingFace → arXiv → web), shows a review summary, and writes the card
+to your library on accept. See the
+[research a model card]({% link plugins/model-cards/research-a-model-card.md %})
+how-to for the full flow.
+
+To populate the library with cards for a shipped list of 14 frontier
+models in one shot:
+
+```text
+/model-card seed
+```
+
+See [seed your library]({% link plugins/model-cards/seed-your-library.md %}).
+
+---
+
+## Documentation
+
+### Tutorials — start here
+
+- [Seed your model card library]({% link plugins/model-cards/seed-your-library.md %}) —
+  walk through `/model-card seed` end-to-end and inspect the resulting library.
+
+### How-to guides — task-oriented
+
+- [Research a model card]({% link plugins/model-cards/research-a-model-card.md %}) —
+  produce a card for a single model with `/model-card create`.
+
+### Reference — exact details
+
+- [Commands]({% link plugins/model-cards/commands.md %}) — `/model-card`
+  and its subcommands, flags, and exit behaviours.
+- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+  the read-only research agent's charter, tools, and refusal behaviour.
+- [Skill: model-cards]({% link plugins/model-cards/skills.md %}) —
+  authoring reference for the 10-section card structure.
+- [Card template]({% link plugins/model-cards/card-template.md %}) —
+  the `MODEL_CARD.md` template each card is generated against.
+
+### Explanation — concepts
+
+- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+  why the cards have ten sections, what the citation tiers buy you,
+  and how the existence-check refusal pattern prevents authoritative-
+  looking cards for hallucinated models.
+
+---
+
+## Honesty rules at a glance
+
+- **"Not publicly available"** is the canonical answer when a tier-1
+  source is silent and lower tiers cannot confirm. The agent never
+  fabricates.
+- **Existence check** — if tier-1 (provider docs) **and** tier-2
+  (HuggingFace) are both silent on the model itself, the agent
+  refuses to produce a card and surfaces the refusal to the user. No
+  file is written.
+- **Source-tier conflict resolution** — when a tier-4 (web) claim
+  conflicts with a tier-1 (provider docs) claim, tier-1 wins; the
+  conflict is recorded in the card's Caveats section.
+
+These rules are documented in detail in the
+[Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %})
+explanation page.

--- a/docs/plugins/model-cards/mitchell-extended-cards.md
+++ b/docs/plugins/model-cards/mitchell-extended-cards.md
@@ -1,0 +1,207 @@
+---
+title: Mitchell-Extended Model Cards
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 7
+---
+
+# Mitchell-Extended Model Cards
+
+The cards produced by this plugin extend the Mitchell et al. (2019)
+"Model Cards for Model Reporting" specification. This page explains
+why — what the original specification covers, why an extension was
+needed for the consumer-evaluator audience, and why the citation-tier
+discipline and existence-check refusal rule are load-bearing.
+
+---
+
+## What Mitchell et al. proposed
+
+Mitchell et al.'s 2019 paper, *Model Cards for Model Reporting*,
+proposed a 9-section structured document that accompanies every
+released ML model. The sections — Model Details, Intended Use, Factors,
+Metrics, Evaluation Data, Training Data, Quantitative Analyses, Ethical
+Considerations, Caveats and Recommendations — answer the question
+*what should be disclosed when releasing a model*.
+
+The paper's argument was that under-specified model releases produce
+predictable harms: misuse outside intended scope, surprise failure on
+underrepresented subgroups, and a general inability for downstream
+users to make informed adoption decisions. A standardised disclosure
+document would shift the cost of evaluation from the consumer back to
+the producer.
+
+The proposal landed. Major model providers now publish documents they
+call "model cards", though the structural conformance varies. Some
+follow the original 9-section structure closely; others publish ad-hoc
+documents that carry the name without the discipline.
+
+---
+
+## Why a 10th section
+
+The original 9 sections answer *what was released*. They do not answer
+*how to use the model operationally* — pricing, context window,
+knowledge cutoff, supported APIs, function-calling support,
+fine-tuning availability, rate limits.
+
+For the **consumer-evaluator audience** (engineers picking which model
+to integrate, evaluators comparing options, platform teams making
+procurement decisions), the operational profile matters more than the
+training-data lineage. A card that documents Section 6 (Training Data)
+in detail but says nothing about pricing or context window is not
+useful for the choice these audiences are actually making.
+
+Section 10 — **Operational Details** — fills this gap. It is best-
+effort structured: every field listed in the template appears in every
+card, even if the value is unknown ("Not publicly available"). This
+guarantees that downstream tooling (e.g. the future
+`/model-card compare`) can diff cards field-by-field without
+special-casing missing fields.
+
+The choice to add a 10th section rather than fork the spec entirely
+preserves Mitchell et al.'s structural commitment. A consumer who
+already knows the 9-section layout can read these cards without
+relearning anything; the 10th section is additive.
+
+---
+
+## Why per-claim citations
+
+The original Mitchell paper does not mandate citation discipline.
+Many published model cards rely on the producer's authority — claims
+appear without sources, and the reader is implicitly trusting the
+producing organisation.
+
+This plugin produces cards from research, not from authoritative
+disclosure. A card the agent generates is a synthesis of public
+sources of varying tier. **Without per-claim citations, the card
+becomes indistinguishable from the producer's own card** — and that
+indistinguishability is dangerous, because the agent's claims have a
+different epistemic status than the producer's.
+
+The `[T<n>.<m>]` citation format makes the source tier explicit at
+the point of claim:
+
+- `T1.x` — provider docs (most authoritative for what the producer
+  claims about their own model).
+- `T2.x` — HuggingFace (authoritative for open-source / fine-tuned
+  models; secondary for proprietary models).
+- `T3.x` — arXiv release paper (authoritative for training and
+  evaluation data; often more candid about limitations than provider
+  marketing).
+- `T4.x` — web search (independent evaluations, third-party
+  benchmarks; valuable for reality-check but lowest tier).
+
+A reader can then judge each claim by its tier without needing to
+re-research it. A claim citing `T1.3` (provider pricing page) is
+trustworthy in a different way than a claim citing `T4.7` (independent
+benchmark blog post).
+
+The citation discipline also catches **fabrication**. If a citation
+appears in the body but the corresponding source is missing from the
+frontmatter `sources` block, the validation checkpoint flags it
+before the card is written. The agent cannot cite a URL it didn't
+fetch.
+
+---
+
+## Card-level honesty
+
+The most consequential rule in the plugin is the **existence-check
+refusal**: if tier-1 (provider docs) AND tier-2 (HuggingFace) are
+both silent on the model's existence — the agent cannot confirm the
+model exists at all — the agent **refuses to produce the card**.
+
+This rule prevents a specific failure mode that would otherwise be
+catastrophic: an authoritative-looking model card for a hallucinated
+model.
+
+LLMs hallucinate model names. If you ask an LLM about
+`gpt-7-ultra-pro`, it will often produce plausible-sounding details:
+"GPT-7 Ultra Pro is OpenAI's most advanced reasoning model, released
+in early 2027, with a 5M token context window..." — none of which is
+true. The model doesn't exist.
+
+If the plugin produced a card for `gpt-7-ultra-pro` containing such
+content, the card would inherit the structural authority of every
+other card in the library. A reader skimming a populated library
+would have no signal that this particular card was fabricated. The
+fabricated card would be cited by downstream tooling, included in
+comparisons, and treated as data.
+
+The existence check breaks this loop. The agent must find the model
+in tier-1 OR tier-2 — both authoritative producer-side sources —
+before writing anything. If it can't, it returns `REFUSED:` with the
+URLs it searched, the dispatcher surfaces the refusal verbatim, and
+no file is written.
+
+This means a populated library has a guaranteed property: every card
+in it corresponds to a model that at least one authoritative source
+confirms exists. That guarantee is the foundation everything else
+rests on.
+
+---
+
+## The trust boundary
+
+The agent has only `WebFetch`, `WebSearch`, `Read`, `Glob`, and `Grep`.
+No `Write`. No `Edit`. No `Bash`.
+
+This is the **read-only-emitter** pattern. The agent's job is to
+research and emit content. Persistence — writing the file — is the
+dispatching command's job, after a human review checkpoint.
+
+The separation is load-bearing. The human review gate sits between
+agent output and file write, and catches:
+
+- Hallucinated claims that survived the existence check.
+- Fabricated citations (a `[T2.1]` reference with no actual source 2.1).
+- Refusal conditions the agent should have surfaced.
+- Sections that came up too thin to be useful.
+
+An agent with `Write` access bypasses that gate. Once the file is on
+disk, downstream tooling treats it as data; the human review window
+has closed. The pattern matches the trust architecture used by
+`advocatus-diaboli` and `choice-cartographer` in the sister
+`ai-literacy-superpowers` plugin (see
+[the adversarial-review explanation]({% link explanation/adversarial-review.md %})
+for the broader argument).
+
+---
+
+## Tiered sources, not majority votes
+
+A naive aggregator might treat sources as votes — "three out of four
+sources agree, so the claim is true". This plugin doesn't.
+
+Sources are **tiered**, not weighted. A claim from tier 1 (provider
+docs) **wins** over a claim from tier 4 (web), even if tier 4 has
+more sources. The conflict is recorded in Section 9 (Caveats), not
+resolved by majority.
+
+Why: tier 4 sources are often downstream of tier 1. A blog post
+discussing pricing usually reflects what the pricing page said at the
+time the post was written. If three blog posts cite an old pricing
+page and the current pricing page disagrees, the blog posts are
+**evidence of a past state**, not contradictory current evidence.
+Treating them as votes against the current provider docs would
+systematically privilege stale information.
+
+The tiered approach also makes the trust chain auditable. A reader
+can see *why* a claim won — not because it had the most sources, but
+because its source was the most authoritative for that claim type.
+
+---
+
+## Related
+
+- [Skill: model-cards]({% link plugins/model-cards/skills.md %}) —
+  the operational reference for each section.
+- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+  how the rules are enforced in code.
+- [Card template]({% link plugins/model-cards/card-template.md %}) —
+  the canonical structure.
+- [Adversarial review]({% link explanation/adversarial-review.md %}) —
+  the broader read-only-emitter pattern this plugin's agent follows.

--- a/docs/plugins/model-cards/research-a-model-card.md
+++ b/docs/plugins/model-cards/research-a-model-card.md
@@ -1,0 +1,209 @@
+---
+title: Research a Model Card
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 2
+---
+
+# Research a Model Card
+
+Produce a Mitchell-extended model card for a single model with a
+human-in-the-loop review checkpoint before the file is written.
+
+Use this when you want fine-grained control over a single card —
+inspecting source coverage, re-running a thin section, or editing the
+draft before it lands on disk. To bulk-populate a library, use the
+[seed your library]({% link plugins/model-cards/seed-your-library.md %})
+tutorial instead.
+
+---
+
+## Prerequisites
+
+- The `model-cards` plugin installed.
+- The model name you want to research. A provider hint is optional —
+  the agent will infer it if not supplied.
+
+---
+
+## 1. Start the research
+
+```text
+/model-card create <model-name> [--provider <provider>] [--out <path>]
+```
+
+Examples:
+
+```text
+/model-card create claude-opus-4-7
+/model-card create gpt-5-mini --provider openai
+/model-card create meta-llama/llama-4 --out ./team-models
+```
+
+| Flag | Effect |
+| ---- | ------ |
+| `--provider X` | Provider hint; if omitted, the agent infers from the model name. |
+| `--out PATH` | Library directory override. Cards still land beneath it as `<provider>/<model-name>.md`. Highest-priority path resolver. |
+
+The default library root is `~/.claude/model-cards/`. The
+`MODEL_CARDS_DIR` environment variable also overrides the default;
+`--out` wins over both.
+
+---
+
+## 2. Handle the existing-card prompt (if any)
+
+If a card already exists at the resolved target path, the command
+asks:
+
+```text
+Card exists at <path>. [overwrite / skip / load-existing-as-base]
+```
+
+| Choice | Effect |
+| ------ | ------ |
+| `overwrite` | Continue research; replace the existing card on accept. |
+| `skip` | Abort with no file change. |
+| `load-existing-as-base` | Pass the existing card to the agent as starting context. Useful for refreshing a stale card. |
+
+---
+
+## 3. Wait for research to complete
+
+The agent dispatches with the model name and provider hint, then
+researches section-by-section using each section's primary source tier
+(see the [agent reference]({% link plugins/model-cards/agents.md %})
+for the per-section tier table).
+
+Research can take 1-3 minutes depending on how much source material is
+available. The agent uses `WebFetch` and `WebSearch` only — it has no
+write access. The trust boundary is "research and emit content";
+persistence is the command's job after your review.
+
+---
+
+## 4. Review the research summary
+
+When the agent returns, the command prints a structured summary:
+
+```text
+Sources used per section:
+  Section 1 (Model Details):     T1×3
+  Section 2 (Intended Use):      T1×2
+  Section 3 (Factors):           T3×1, T1×1
+  Section 4 (Metrics):           T1×4, T3×2
+  ...
+
+Sections that came up thin:
+  Section 5 (Evaluation Data) — "Not publicly available"
+  Section 6 (Training Data)   — "Not publicly available"
+
+Top 3 most-cited claims:
+  1. Pricing: $5/$25 per million tokens (T1.3)
+     https://docs.anthropic.com/...
+  2. Knowledge cutoff: January 2026 (T1.1)
+     https://docs.anthropic.com/...
+  3. Context window: 1M tokens (T1.2)
+     https://docs.anthropic.com/...
+
+Estimated research cost: ~14k tokens
+```
+
+Read this carefully. It is the only structured view you get of where
+the card's evidence comes from before you commit to writing it.
+
+---
+
+## 5. Choose a disposition
+
+```text
+Disposition: [accept / edit / re-run-section <N> / abort]
+```
+
+| Choice | Effect |
+| ------ | ------ |
+| `accept` | Validate the draft, then write to the target path. |
+| `edit` | Open the draft in `$EDITOR` (or `vi` if unset). The edited content replaces the draft, then you are re-prompted. |
+| `re-run-section <N>` | Re-dispatch the agent with a section-specific prompt focused on template section `N` (1-10). Replaces just that section in the draft, then re-prompts. |
+| `abort` | Discard the draft. No file is written. |
+
+Use `re-run-section` when the summary shows a section is thin and you
+suspect the agent missed a relevant source. Use `edit` to make narrow
+factual corrections you can verify yourself.
+
+---
+
+## 6. Validation checkpoint runs automatically
+
+On `accept`, the command validates the draft before writing:
+
+1. YAML frontmatter parseable; required keys present.
+2. All 10 numbered section headings present in canonical order.
+3. Every `[T<n>.<m>]` citation resolves to a source in the frontmatter
+   `sources` block.
+4. Section 10 fields use field-level "Not publicly available" rather
+   than silent omission.
+
+Deviations are fixed in place — the agent is not re-dispatched.
+Citation gaps (e.g. a `[T2.1]` reference with no source 2.1 in
+frontmatter) are surfaced to you before write.
+
+This validation is the same pattern enforced by the project-wide
+"Output Validation Checkpoints" convention — see
+[the harness conventions]({% link how-to/run-a-harness-audit.md %})
+for the broader context.
+
+---
+
+## 7. Confirm the write
+
+```text
+Card written: ~/.claude/model-cards/anthropic/claude-opus-4-7.md
+```
+
+The card is now on disk at the resolved path. Open it in your editor
+to inspect the full content; every claim resolves to a citation, and
+every citation resolves to a URL in the frontmatter `sources` block.
+
+---
+
+## What happens on REFUSED
+
+If the agent cannot confirm the model exists via tier-1 or tier-2
+sources, it returns a `REFUSED:` string instead of a draft. The
+command surfaces the refusal verbatim and aborts:
+
+```text
+REFUSED: Could not confirm existence of model "<name>" via tier-1
+(provider docs) or tier-2 (HuggingFace). Searched: <list of URLs>.
+The model may not exist under this name, may have been retired, or may
+be too recent for available sources.
+```
+
+No file is written. This is by design — the existence-check rule
+prevents authoritative-looking cards for hallucinated or non-existent
+models. See [the explanation page]({% link plugins/model-cards/mitchell-extended-cards.md %}#card-level-honesty)
+for why this matters.
+
+If the refusal looks wrong (e.g. you know the model exists), pass an
+explicit `--provider` hint to disambiguate, or use a different
+spelling of the model name.
+
+---
+
+## What you have now
+
+A single Mitchell-extended model card on disk at the resolved target
+path, with per-claim citations and tiered source provenance. Validation
+guarantees the card is structurally correct and every citation
+resolves.
+
+## Next steps
+
+- [Seed your library]({% link plugins/model-cards/seed-your-library.md %}) —
+  bulk-populate from the shipped frontier-models seed list.
+- [Card template reference]({% link plugins/model-cards/card-template.md %}) —
+  the canonical structure each card is validated against.
+- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+  inside the research loop and refusal logic.

--- a/docs/plugins/model-cards/seed-your-library.md
+++ b/docs/plugins/model-cards/seed-your-library.md
@@ -1,0 +1,170 @@
+---
+title: Seed Your Library
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 1
+---
+
+# Seed Your Model Card Library
+
+Populate your model card library with cards for a shipped list of 14
+frontier models in a single command.
+
+This is the fastest way to get a working library you can browse,
+compare, and reference. After this tutorial you will have one card per
+frontier model on disk, ready for downstream tooling.
+
+---
+
+## Prerequisites
+
+- The `model-cards` plugin installed — see the
+  [model-cards landing]({% link plugins/model-cards/index.md %}#install).
+- A working internet connection. The agent fetches provider docs,
+  HuggingFace pages, arXiv papers, and web sources during research.
+
+---
+
+## 1. Run the seed command
+
+```text
+/model-card seed
+```
+
+The command reads the shipped seed list at
+`${CLAUDE_PLUGIN_ROOT}/seed/frontier-models.json`, prints the list and
+total count, and asks for one confirmation:
+
+```text
+Research 14 cards into ~/.claude/model-cards? [y/N]
+```
+
+Type `y` to proceed. Anything else aborts.
+
+---
+
+## 2. Watch the per-model log
+
+The command processes models sequentially. For each one you will see
+a one-line status:
+
+```text
+[1/14] anthropic/claude-opus-4-7      created
+[2/14] anthropic/claude-sonnet-4-6    created
+[3/14] anthropic/claude-haiku-4-5     created
+[4/14] openai/gpt-5                    skipped (refused: not confirmed)
+...
+```
+
+Three outcomes are possible per model:
+
+| Status | Meaning |
+| ------ | ------- |
+| `created` | Card written to the library. |
+| `skipped (existed)` | A card already exists at the target path; left untouched. Use `--force` to overwrite. |
+| `skipped (refused: <reason>)` | The agent could not confirm the model exists via tier-1 (provider docs) or tier-2 (HuggingFace). No file is written. The refusal reason is logged. |
+
+Refusals are normal for models that are recent, retired, or whose
+provider has not published documentation under the exact model name in
+the seed list.
+
+---
+
+## 3. Review the summary
+
+When the run completes, the command prints a four-line summary:
+
+```text
+Created: 11
+Skipped (existed): 0
+Skipped (refused): 3
+Failed (other): 0
+```
+
+The library now lives at `~/.claude/model-cards/` (or whatever
+`MODEL_CARDS_DIR` was set to). Cards are organised by provider:
+
+```text
+~/.claude/model-cards/
+├── anthropic/
+│   ├── claude-opus-4-7.md
+│   ├── claude-sonnet-4-6.md
+│   └── claude-haiku-4-5.md
+├── google/
+│   ├── gemini-2.5-pro.md
+│   └── gemini-2.5-flash.md
+└── ...
+```
+
+---
+
+## 4. Inspect a card
+
+Open any of the generated cards. Every card has the same 10-section
+structure (see the [card template]({% link plugins/model-cards/card-template.md %})
+reference) and a frontmatter `sources` block listing every URL the
+agent fetched, grouped by tier.
+
+A typical card opens like this:
+
+```yaml
+---
+model_name: claude-opus-4-7
+provider: Anthropic
+model_version: claude-opus-4-7
+last_researched: 2026-04-29
+card_version: 0.1.0
+researcher: model-card-researcher (claude-opus-4-7[1m])
+sources:
+  - tier: 1
+    url: https://docs.anthropic.com/...
+    fetched: 2026-04-29
+  ...
+---
+
+# Model Card: Anthropic/claude-opus-4-7
+
+## 1. Model Details
+
+Claude Opus 4.7 is Anthropic's most capable model in the Claude 4
+family [T1.1] ...
+```
+
+Every factual claim ends with a `[T<n>.<m>]` citation marker. `n` is
+the source tier (1 = provider docs, 2 = HuggingFace, 3 = arXiv,
+4 = web). `m` is the index within that tier. Resolve the URL by looking
+it up in the frontmatter `sources` block.
+
+---
+
+## 5. Re-research a card
+
+If a card came up thin (lots of "Not publicly available" sections) or
+the source material has changed, re-research a single card with:
+
+```text
+/model-card create <model-name> --provider <provider>
+```
+
+This is the same flow as the [research a model card]({% link plugins/model-cards/research-a-model-card.md %})
+how-to. When prompted about the existing card, choose `overwrite` or
+`load-existing-as-base`.
+
+---
+
+## What you have now
+
+A populated model card library on disk, with one card per confirmed
+frontier model. Each card carries per-claim citations and tiered source
+provenance. Refusals are logged but no fabricated cards exist in the
+library — the existence-check rule guarantees this.
+
+## Next steps
+
+- [Research a model card]({% link plugins/model-cards/research-a-model-card.md %}) —
+  add a card for a model that wasn't in the seed list.
+- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+  understand why the cards are structured the way they are.
+- [Card template reference]({% link plugins/model-cards/card-template.md %}) —
+  the template every generated card conforms to.

--- a/docs/plugins/model-cards/skills.md
+++ b/docs/plugins/model-cards/skills.md
@@ -1,0 +1,173 @@
+---
+title: Skill — model-cards
+layout: default
+parent: model-cards
+grand_parent: Plugins
+nav_order: 5
+---
+
+# Skill: model-cards
+
+Authoring and interpretation reference for Mitchell-extended model
+cards. Used by the `model-card-researcher` agent and the `/model-card`
+command. Useful directly when authoring a card by hand or designing
+extensions to the card schema.
+
+---
+
+## When to use this skill
+
+- Authoring a card by hand (without the agent).
+- Interpreting a card — knowing which sections to trust most.
+- Designing extensions to the card schema (e.g. adding fields to
+  Section 10).
+- Building tooling that consumes cards (e.g. the future
+  `/model-card compare`).
+
+---
+
+## The ten sections
+
+The plugin produces 10-section cards: Mitchell et al.'s 9 canonical
+sections plus an "Operational Details" 10th section for the consumer-
+evaluator audience. Each section's purpose, primary source tier, and
+honesty norm are summarised below.
+
+### 1. Model Details
+
+What the model **is** — name, provider, family, release date, parameter
+count where disclosed. Tier 1 (provider docs) is primary; tier 2
+(HuggingFace) is secondary for open-source / fine-tuned models.
+
+### 2. Intended Use
+
+What the model is **for** — primary uses, intended users, explicitly
+out-of-scope uses. The provider's documentation usually makes this
+explicit; quote it faithfully and cite.
+
+### 3. Factors
+
+Subgroups, environmental factors, instrumentation. Often sparse for
+proprietary API-served models. Write "Not publicly available" rather
+than fabricate.
+
+### 4. Metrics
+
+Performance measures the provider reports. Distinguish provider-
+reported benchmarks from independent evaluations (tier 1 vs tier 4).
+
+### 5. Evaluation Data
+
+Datasets used to evaluate. Frequently "Not publicly available" for
+proprietary models. Tier 3 (release paper) is the most likely source.
+
+### 6. Training Data
+
+Datasets used to train. Almost always "Not publicly available" for
+proprietary models — say so. Tier 3 is the only source likely to
+disclose.
+
+### 7. Quantitative Analyses
+
+Disaggregated performance — by demographic, by task category, by
+language. Tier 3 (release paper) is primary.
+
+### 8. Ethical Considerations
+
+Risks, mitigations, known failure modes. Tier 3 is the most honest
+source (release papers are usually more frank than marketing pages);
+tier 1 is secondary; tier 4 (independent evaluations) is tertiary but
+valuable for reality-check.
+
+### 9. Caveats and Recommendations
+
+The "what this card cannot tell you" section. Lists which sections
+came up "Not publicly available" and why. Records conflicts between
+tiers. Recommendations for use given the model's documented profile.
+
+### 10. Operational Details
+
+This plugin's extension. Best-effort structured fields:
+
+- Pricing (input / output per million tokens)
+- Context window
+- Knowledge cutoff
+- Supported APIs / SDKs
+- Latency tier
+- Tool / structured-output support
+- Function calling
+- Fine-tuning availability
+- Rate-limit notes
+
+Each field gets "Not publicly available" if absent; the field is never
+omitted. This makes downstream comparison (`/model-card compare`)
+reliable — every card has the same field surface.
+
+---
+
+## Citation discipline
+
+Every factual claim ends with `[T<n>.<m>]` where:
+
+- `n` is the source tier: 1 = provider docs, 2 = HuggingFace, 3 = arXiv,
+  4 = web search.
+- `m` is the source index within that tier (1, 2, 3, ...).
+
+Example:
+
+```text
+Knowledge cutoff: January 2026 [T1.1]. Context window: 1M tokens [T1.2].
+Pricing: $5/$25 per million tokens (input/output) at standard tier [T1.3].
+```
+
+URLs for each citation resolve via the per-card frontmatter `sources`
+block.
+
+---
+
+## Honesty rules
+
+### Claim-level
+
+- "Not publicly available" is the canonical answer when tier-1 is
+  silent and lower tiers cannot confirm. **Never fabricate.**
+- "Per the provider's published statements" framing is preferred over
+  assertion — preserves the source-trust chain.
+- If a tier-4 web claim conflicts with a tier-1 provider claim,
+  tier-1 wins; the conflict is flagged in Section 9 (Caveats).
+
+### Card-level
+
+If tier-1 (provider docs) AND tier-2 (HuggingFace) are both silent on
+the model's existence — the card author cannot confirm the model
+exists at all — the card is **not produced**. This rule prevents
+authoritative-looking cards for hallucinated models. The agent enforces
+this automatically by returning a `REFUSED:` string; a hand-author
+should follow the same rule.
+
+---
+
+## Tiered source strategy
+
+| Tier | Source | Used for |
+| ---- | ------ | -------- |
+| 1 | Provider docs | Model Details, Intended Use, Operational Details |
+| 2 | HuggingFace | Open-source / fine-tuned models; fallback for tier-1 gaps |
+| 3 | arXiv release paper | Factors, Metrics, Evaluation Data, Training Data, Quantitative Analyses, Ethical Considerations |
+| 4 | Web search | Anything tiers 1-3 don't cover; independent evaluations |
+
+The agent researches **section by section** using each section's
+primary tier (see the [agent reference]({% link plugins/model-cards/agents.md %})
+for the full table). This is more efficient than fetching all sources
+upfront and produces a sharper provenance trail.
+
+---
+
+## Related
+
+- [Card template]({% link plugins/model-cards/card-template.md %}) —
+  the structural template every card conforms to.
+- [Agent reference]({% link plugins/model-cards/agents.md %}) — how
+  the agent applies this skill end-to-end.
+- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+  conceptual background on why the cards are structured this way.


### PR DESCRIPTION
## Summary

First of three PRs restructuring the docs site to **plugin-first** organisation, motivated by the new sister plugin `model-cards` shipping in the same marketplace.

This PR is **additive only** — no existing docs files are moved or renamed, so all current URLs continue to work. PR 2 will do the migration; PR 3 will sweep cross-references.

## What changes

### New top-level section: `docs/plugins/`

- `docs/plugins/index.md` — Plugins landing page (top-nav entry, `nav_order: 6`).

### Full model-cards documentation: `docs/plugins/model-cards/`

| File | Diataxis | Purpose |
| ---- | -------- | ------- |
| `index.md` | landing | Install, quick start, navigation, honesty rules summary |
| `seed-your-library.md` | tutorial | End-to-end `/model-card seed` walkthrough |
| `research-a-model-card.md` | how-to | `/model-card create` flow with all dispositions |
| `commands.md` | reference | `/model-card` subcommands, flags, exit behaviours |
| `agents.md` | reference | `model-card-researcher` charter, tools, refusal logic |
| `skills.md` | reference | 10-section authoring reference |
| `card-template.md` | reference | Canonical template + validation checkpoint |
| `mitchell-extended-cards.md` | explanation | Why 10 sections, why citation tiers, why existence-check refusal, why read-only-emitter trust boundary |

### Updated

- `docs/index.md` — surfaces the new Plugins section in the top-level Diataxis table.

## Why a flatter structure

`just-the-docs` defaults to 3 nav levels. A 4-level hierarchy `Plugins → model-cards → How-to Guides → page` exceeds that. Diataxis is preserved as **organisation within** the plugin's `index.md` rather than as a directory layer — pages live as direct children of the plugin (e.g. `docs/plugins/model-cards/research-a-model-card.md`). Matches typical product-docs patterns (Stripe, Hashicorp).

## Why no `jekyll-redirect-from` yet

PR 1 only adds new files at new paths — no URL break risk. The redirect plugin is needed in PR 2 when existing pages move. Adding it here would be premature surface.

## Sequencing reminder

- **PR 1 (this PR)** — additive only; new section + full model-cards docs.
- **PR 2** — migrate 82 ai-literacy-superpowers docs into `docs/plugins/ai-literacy-superpowers/`, update 175 internal `{% link %}` references, add `jekyll-redirect-from` and `redirect_from:` frontmatter on every moved page.
- **PR 3** (optional polish) — sweep `README.md` and any deep links in skills/agents/commands that reference docs URLs; add a deprecation timeline for the redirects.

## Test plan

- [x] `npx markdownlint-cli2` — clean across all 11 files
- [x] All 15 `{% link %}` targets verified to resolve
- [ ] CI green (markdownlint, version check, spec-first, harness-enforcer)
- [ ] GitHub Pages build succeeds and the new `/plugins/` URLs are reachable after merge