### PR TITLE
chore: multi-plugin tag conventions (model-cards-vX.Y.Z for sister plugins)

### DIFF
--- a/.github/workflows/auto-tag-model-cards.yml
+++ b/.github/workflows/auto-tag-model-cards.yml
@@ -1,0 +1,52 @@
+# Auto-tag on model-cards version bump.
+#
+# When model-cards/.claude-plugin/plugin.json version changes on push
+# to main, creates a git tag `model-cards-vX.Y.Z` pointing at the
+# merge commit. Per-plugin tag convention: sister plugins use a
+# plugin-name prefix to disambiguate from the marketplace's primary
+# plugin (ai-literacy-superpowers), which uses bare `vX.Y.Z`.
+# See HARNESS.md "Release traceability" for the full rule.
+
+name: Auto Tag (model-cards)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'model-cards/.claude-plugin/plugin.json'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create model-cards version tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check if tag needed
+        id: check
+        run: |
+          VERSION=$(grep '"version"' model-cards/.claude-plugin/plugin.json | sed 's/.*"version": "\(.*\)".*/\1/')
+          TAG="model-cards-v${VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          if git tag -l "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists — skipping"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG does not exist — will create"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git tag "${{ steps.check.outputs.tag }}"
+          git push origin "${{ steps.check.outputs.tag }}"
+          echo "Created and pushed tag ${{ steps.check.outputs.tag }}"

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -102,7 +102,7 @@ jobs:
           done < <(find . -name "*.sh" -not -path "./.git/*")
           exit $failed
 
-      - name: "GC: Release tag completeness"
+      - name: "GC: Release tag completeness (ai-literacy-superpowers — bare vX.Y.Z)"
         run: |
           missing=0
           while IFS= read -r version; do
@@ -122,7 +122,38 @@ jobs:
           done < <(grep -oP '(?<=^## )\d+\.\d+\.\d+' CHANGELOG.md)
 
           if [ "$missing" -eq 0 ]; then
-            echo "All release tags present"
+            echo "All ai-literacy-superpowers release tags present"
+          else
+            exit 1
+          fi
+
+      - name: "GC: Release tag completeness (model-cards — model-cards-vX.Y.Z)"
+        run: |
+          if [ ! -f model-cards/CHANGELOG.md ]; then
+            echo "No model-cards/CHANGELOG.md — skipping"
+            exit 0
+          fi
+
+          missing=0
+          while IFS= read -r version; do
+            tag="model-cards-v$version"
+            if ! git tag -l "$tag" | grep -q "$tag"; then
+              echo "::warning::Missing tag: $tag"
+              # Auto-fix: find the merge commit that introduced this version
+              commit=$(git log --all --format="%H" --grep="$version" -- model-cards/CHANGELOG.md | head -1)
+              if [ -n "$commit" ]; then
+                echo "Creating tag $tag at $commit"
+                git tag "$tag" "$commit"
+                git push origin "$tag"
+              else
+                echo "::error::Cannot find commit for $tag — manual tag needed"
+                missing=1
+              fi
+            fi
+          done < <(grep -oP '(?<=^## )\d+\.\d+\.\d+' model-cards/CHANGELOG.md)
+
+          if [ "$missing" -eq 0 ]; then
+            echo "All model-cards release tags present"
           else
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## 0.32.0 — 2026-05-01
 
+### Chore — Multi-plugin tag conventions
+
+Documents and operationalises the per-plugin tag-naming convention now
+that the marketplace ships multiple plugins. The two-plugin convention:
+
+- **`ai-literacy-superpowers`** (primary): continues to use bare
+  `vX.Y.Z` tags. 51 historical tags through `v0.32.0` are unchanged;
+  new tags follow the same form. CHANGELOG at `CHANGELOG.md` (root).
+- **`model-cards`** (sister): uses `model-cards-vX.Y.Z` tags.
+  CHANGELOG at `model-cards/CHANGELOG.md`. Backfilled
+  `model-cards-v0.1.0` at commit `0053b36` (initial release).
+
+The asymmetry is deliberate — the primary plugin keeps its existing
+51-tag history (no migration risk to external links / Releases UI /
+subscribers), and sister plugins occupy a clearly-namespaced tier.
+Future sister plugins follow the same shape: `<plugin-name>-vX.Y.Z`.
+
+Touched files:
+
+- `.github/workflows/auto-tag-model-cards.yml` — new workflow that
+  fires on changes to `model-cards/.claude-plugin/plugin.json` and
+  creates `model-cards-vX.Y.Z` tags. Mirrors the existing
+  `auto-tag.yml` for ai-literacy-superpowers.
+- `.github/workflows/gc.yml` — release-tag-completeness GC rule
+  extended into two steps: one scans `CHANGELOG.md` for
+  ai-literacy-superpowers `vX.Y.Z`, the other scans
+  `model-cards/CHANGELOG.md` for `model-cards-vX.Y.Z`. Both
+  auto-create missing tags.
+- `HARNESS.md` — `Release traceability` constraint wording updated
+  to document the per-plugin convention and the four
+  workflows/rules involved.
+
+No plugin version bump (changes are root-level: `.github/`,
+`HARNESS.md`, `CHANGELOG.md` only).
+
 ### Feature — Reflection log archival (Path 1 + Path 2 + read-side filtering)
 
 Implements the design at

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -160,22 +160,37 @@
 
 ### Release traceability
 
-- **Rule**: Every version in `plugin.json` must have a matching
-  `## X.Y.Z — YYYY-MM-DD` heading in `CHANGELOG.md` and a `vX.Y.Z`
-  git tag. The changelog heading must match at PR time. The git tag
-  is created automatically on merge by the auto-tag workflow.
+- **Rule**: Every version of every plugin in this marketplace must
+  have a matching `## X.Y.Z — YYYY-MM-DD` heading in that plugin's
+  CHANGELOG and a corresponding git tag. The changelog heading must
+  match at PR time. The git tag is created automatically on merge by
+  the per-plugin auto-tag workflow.
+- **Per-plugin tag conventions** (multi-plugin marketplace):
+  - **`ai-literacy-superpowers`** (primary plugin): bare `vX.Y.Z`
+    tags. CHANGELOG at `CHANGELOG.md` (root). 51 historical tags
+    follow this convention; new tags continue to.
+  - **`model-cards`** (sister plugin): `model-cards-vX.Y.Z` tags.
+    CHANGELOG at `model-cards/CHANGELOG.md`.
+  - Future sister plugins follow the same shape: `<plugin-name>-vX.Y.Z`,
+    with their own per-plugin CHANGELOG.
 - **Enforcement**: deterministic
-- **Tool**: .github/workflows/version-check.yml (changelog match),
-  .github/workflows/auto-tag.yml (tag creation)
+- **Tool**:
+  - `.github/workflows/version-check.yml` (changelog match — PR gate)
+  - `.github/workflows/auto-tag.yml` (ai-literacy-superpowers post-merge)
+  - `.github/workflows/auto-tag-model-cards.yml` (model-cards post-merge)
+  - `.github/workflows/gc.yml` (release-tag-completeness GC, both plugins)
 - **Scope**: pr + post-merge
 - **Governance requirement**: All published plugin versions must have
   a corresponding changelog entry and a tag on GitHub
-- **Operational meaning**: PR is blocked if `CHANGELOG.md` top heading
-  does not match `plugin.json` version. On merge to main, CI creates a
-  `vX.Y.Z` git tag if one does not already exist. A GC rule verifies
-  completeness and auto-creates any missing tags.
+- **Operational meaning**: PR is blocked if a plugin's `plugin.json`
+  version doesn't match its CHANGELOG top heading. On merge to main,
+  the appropriate auto-tag workflow creates the tag (using the
+  per-plugin convention) if one does not already exist. A GC rule
+  verifies completeness for both plugins and auto-creates any missing
+  tags.
 - **Verification method**: deterministic — version-check CI (PR gate),
-  auto-tag CI (post-merge), release-tag-completeness GC (periodic)
+  auto-tag CI per plugin (post-merge), release-tag-completeness GC
+  (periodic, both plugins)
 - **Evidence**: CI check output, git tag list, GC run logs
 - **Failure action**: block merge (changelog mismatch); auto-create
   tag (GC finding)


### PR DESCRIPTION
## Summary

Documents and operationalises the per-plugin tag-naming convention for the marketplace's two plugins. Adds a new auto-tag workflow for `model-cards` and extends the release-tag-completeness GC rule to scan both plugins' CHANGELOGs.

The `model-cards-v0.1.0` backfill tag was created and pushed before opening this PR (at commit `0053b36`, the original sister-plugin release).

## Convention

- **`ai-literacy-superpowers`** (primary): bare `vX.Y.Z` tags. 51 historical tags from `v0.1.0` to `v0.32.0` unchanged. New tags continue the same form.
- **`model-cards`** (sister): `model-cards-vX.Y.Z` tags. `model-cards-v0.1.0` backfilled to commit `0053b36` before this PR.
- **Future sister plugins**: same shape — `<plugin-name>-vX.Y.Z`.

The asymmetry is deliberate: the primary plugin keeps its 51-tag history (no migration risk to external links / Releases UI / subscribers), and sister plugins occupy a clearly-namespaced tier. Matches Lerna/Yarn-workspace primary-package convention and npm scoped-package patterns.

## Changes

| File | Change |
| ---- | ------ |
| `.github/workflows/auto-tag-model-cards.yml` (new) | Fires on changes to `model-cards/.claude-plugin/plugin.json`. Reads version, creates `model-cards-vX.Y.Z` tag, pushes. Mirrors the existing `auto-tag.yml` for ai-literacy-superpowers. |
| `.github/workflows/gc.yml` | Existing release-tag-completeness step renamed to clarify it covers ai-literacy-superpowers; **new step added** that scans `model-cards/CHANGELOG.md` and creates missing `model-cards-vX.Y.Z` tags. |
| `HARNESS.md` | `Release traceability` constraint wording extended to document the per-plugin convention and the four workflows/rules involved. |
| `CHANGELOG.md` | Chore entry under `0.32.0` documenting the convention. |

No plugin version bump — all changes are root-level (`.github/`, `HARNESS.md`, `CHANGELOG.md`).

## Test plan

- [x] `python3 -c 'yaml.safe_load(...)'` → both workflow YAML files parse cleanly
- [x] `markdownlint-cli2 HARNESS.md CHANGELOG.md` → clean
- [x] `model-cards-v0.1.0` tag created at `0053b36` and pushed (visible in `git tag -l 'model-cards-*'`)
- [ ] CI green
- [ ] Future verification: when `model-cards/.claude-plugin/plugin.json` next bumps version, the new auto-tag workflow fires and creates the corresponding `model-cards-vX.Y.Z` tag