### PR TITLE
docs: expand CLAUDE.md spec-first exemptions section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,31 @@ section.
 
 No plugin version bump (docs change outside `ai-literacy-superpowers/`).
 
+### Docs — CLAUDE.md spec-first exemptions section
+
+Renames CLAUDE.md's `Cross-Repo Spec-First Discipline` section to
+`Spec-First Exemptions` and expands it to list all five exemption
+labels (`bug`, `fix`, `chore`, `maintenance`, `cross-repo`) and their
+branch-prefix alternatives (`fix/`, `chore/`, `cross-repo/`), each
+with one-sentence guidance on the kind of change it applies to.
+
+The previous section only documented the `cross-repo` exemption
+explicitly, even though the `Spec-First Check` workflow at
+`.github/workflows/spec-first-check.yml` accepts all five labels and
+three branch prefixes. The narrow framing made the answer harder to
+find than it needed to be — discovered while shipping the docs PRs
+for the harness-tuning-loop and harness-lifecycle pages, where the
+correct exemption was `chore` but had to be inferred from the
+workflow file. See REFLECTION_LOG entry 2026-05-07.
+
+The cross-repo case retains its two sub-options (copy spec into
+`docs/superpowers/specs/`, or use the exemption alone) and the
+guidance to link to the upstream spec in the PR description.
+
+Closes #250.
+
+No plugin version bump (docs change to root file).
+
 ### Docs — Harness lifecycle explainer
 
 Adds a second integrative Explanation page,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,8 @@ making:
 | `maintenance` label | Refactors, dependency bumps, infrastructure tweaks that do not change behaviour | _(none — use the `chore` form)_ |
 | `cross-repo` label or `cross-repo/` branch prefix | The spec lives in another repository (typically `ai-literacy-for-software-engineers`) | `cross-repo/<short-name>` |
 
-Apply the label at PR creation time, per the *Label PRs at creation
-time* constraint in `HARNESS.md`. Adding the label at creation avoids
+Apply the label at PR creation time, per the _Label PRs at creation
+time_ constraint in `HARNESS.md`. Adding the label at creation avoids
 the friction of having to re-trigger the check after the fact and
 keeps the PR's check history clean.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,23 +95,43 @@ Bump when the listing contract itself changes:
 The listing version follows the same semver rules as the plugin while
 pre-1.0. A listing-only change does not require a plugin version bump.
 
-## Cross-Repo Spec-First Discipline
+## Spec-First Exemptions
 
-When work in this plugin is driven by a spec in another repo (typically
-`ai-literacy-for-software-engineers`), the spec-first CI check cannot
-see the spec. Two options:
+Feature and behaviour-change PRs require a spec committed as the first
+commit on the branch under
+`docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. The
+`Spec-First Check` CI workflow at `.github/workflows/spec-first-check.yml`
+enforces this. PRs that do not need a spec are exempt via labels or
+branch prefixes — pick the one that matches the kind of change you are
+making:
+
+| Exemption | Use for | Branch prefix alternative |
+| --- | --- | --- |
+| `bug` label | An identified bug that does not need a fresh design | _(none — use the `fix` form)_ |
+| `fix` label or `fix/` branch prefix | A targeted bug fix or correction where no design work is needed | `fix/<short-name>` |
+| `chore` label or `chore/` branch prefix | Maintenance, housekeeping, docs additions outside the plugin directory, formatting and metadata fixes | `chore/<short-name>` |
+| `maintenance` label | Refactors, dependency bumps, infrastructure tweaks that do not change behaviour | _(none — use the `chore` form)_ |
+| `cross-repo` label or `cross-repo/` branch prefix | The spec lives in another repository (typically `ai-literacy-for-software-engineers`) | `cross-repo/<short-name>` |
+
+Apply the label at PR creation time, per the *Label PRs at creation
+time* constraint in `HARNESS.md`. Adding the label at creation avoids
+the friction of having to re-trigger the check after the fact and
+keeps the PR's check history clean.
+
+For cross-repo work, two further options apply on top of the
+`cross-repo` exemption:
 
 1. **Copy the spec** into `docs/superpowers/specs/` as the first commit
    on the branch. This satisfies the spec-first gate and keeps a local
    record of what drove the change. Preferred for large feature work.
 
-2. **Use the cross-repo exemption** — name the branch `cross-repo/...`
-   or add the `cross-repo` label to the PR. The spec-first check will
-   skip. Use this for sync-driven changes where the spec already exists
-   upstream and copying it would be redundant.
+2. **Use the `cross-repo` exemption alone** — name the branch
+   `cross-repo/...` or add the `cross-repo` label to the PR. Use this
+   for sync-driven changes where the spec already exists upstream and
+   copying it would be redundant.
 
-In the PR description, always link to the upstream spec regardless of
-which option you choose.
+In the PR description for cross-repo work, always link to the upstream
+spec regardless of which option you choose.
 
 ## Output Validation Checkpoints
 


### PR DESCRIPTION
Closes #250.

## Summary

Renames CLAUDE.md's `Cross-Repo Spec-First Discipline` section to `Spec-First Exemptions` and expands it to list all five exemption labels and the corresponding branch-prefix alternatives the `Spec-First Check` workflow actually accepts.

| Exemption | Use for | Branch prefix |
| --- | --- | --- |
| `bug` label | An identified bug that does not need a fresh design | _(none — use `fix`)_ |
| `fix` label | A targeted bug fix where no design work is needed | `fix/<short-name>` |
| `chore` label | Maintenance, housekeeping, docs additions outside the plugin directory, formatting fixes | `chore/<short-name>` |
| `maintenance` label | Refactors, dependency bumps, infrastructure tweaks that do not change behaviour | _(none — use `chore`)_ |
| `cross-repo` label | The spec lives in another repository | `cross-repo/<short-name>` |

The cross-repo case retains its two sub-options (copy spec into `docs/superpowers/specs/`, or use the exemption alone) and the existing guidance to link to the upstream spec in the PR description.

## Why

Discovered while shipping the docs PRs for the harness-tuning-loop and harness-lifecycle pages: the correct exemption for a docs-only PR outside the plugin directory was `chore`, but the previous CLAUDE.md section only documented `cross-repo` explicitly, so the answer had to be inferred from the workflow file. See `REFLECTION_LOG.md` entry 2026-05-07.

## Files changed

- `CLAUDE.md` — section rename + expanded exemption table + clarified cross-repo special-case sub-options
- `CHANGELOG.md` — entry appended under `0.32.0` (docs-only, no version bump)

## Versioning

No plugin version bump. The change is to a root file (`CLAUDE.md`), outside `ai-literacy-superpowers/`, per the existing CLAUDE.md rule.

## Test plan

- [ ] CI green (chore + documentation labels applied at creation; `chore` exempts spec-first)
- [ ] CHANGELOG version-consistency check passes
- [ ] Section rename does not break any internal anchor link (verified: no other doc links to `#cross-repo-spec-first-discipline` anchor)