### PR TITLE
chore: pull_request workflows re-evaluate on label changes

### DIFF
--- a/.github/workflows/spec-first-check.yml
+++ b/.github/workflows/spec-first-check.yml
@@ -8,6 +8,7 @@ name: Spec-First Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -8,6 +8,7 @@ name: Version Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,32 @@ tuning loop entry.
 
 No plugin version bump (docs change outside `ai-literacy-superpowers/`).
 
+### Chore — pull_request workflows re-evaluate on label changes
+
+Adds `types: [opened, synchronize, reopened, labeled, unlabeled]` to
+the `pull_request:` triggers of:
+
+- `.github/workflows/spec-first-check.yml` — branches on the
+  `bug | fix | chore | maintenance | cross-repo` exemption labels.
+- `.github/workflows/version-check.yml` — branches on the `no-bump`
+  exemption label for formatting-only fixes.
+
+Without the explicit `types` list, GitHub Actions defaults to
+`opened, synchronize, reopened`, which means adding or removing an
+exemption label after a check has run does not re-evaluate the check.
+That race condition forced a manual empty-commit re-trigger on PR
+#248 when the `chore` label was applied after the spec-first check
+had already failed (see REFLECTION_LOG entry 2026-05-07). With the
+explicit list, label changes now fire the workflow and the check
+re-evaluates against the new label set automatically.
+
+`harness.yml` and `lint-markdown.yml` are unaffected — neither
+branches on PR labels, so the trigger change would not add value.
+
+Closes #251.
+
+No plugin version bump (CI config change outside `ai-literacy-superpowers/`).
+
 ## 0.31.1 — 2026-04-29
 
 ### Docs — README reframed for the marketplace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,9 +169,9 @@ the `pull_request:` triggers of:
 Without the explicit `types` list, GitHub Actions defaults to
 `opened, synchronize, reopened`, which means adding or removing an
 exemption label after a check has run does not re-evaluate the check.
-That race condition forced a manual empty-commit re-trigger on PR
-#248 when the `chore` label was applied after the spec-first check
-had already failed (see REFLECTION_LOG entry 2026-05-07). With the
+That race condition forced a manual empty-commit re-trigger on
+PR #248, when the `chore` label was applied after the spec-first
+check had already failed (see REFLECTION_LOG entry 2026-05-07). With the
 explicit list, label changes now fire the workflow and the check
 re-evaluates against the new label set automatically.
 


### PR DESCRIPTION
Closes #251.

## Summary

Adds `types: [opened, synchronize, reopened, labeled, unlabeled]` to the `pull_request:` triggers of two workflows that branch on PR label state:

- **`.github/workflows/spec-first-check.yml`** — branches on the `bug | fix | chore | maintenance | cross-repo` exemption labels.
- **`.github/workflows/version-check.yml`** — branches on the `no-bump` exemption label for formatting-only fixes.

Without the explicit `types` list, GitHub Actions defaults to `opened, synchronize, reopened` — `labeled` and `unlabeled` are excluded. That means adding (or removing) an exemption label after a check has already run does not re-evaluate the check. The PR's check status sticks at the failed state until something else fires `synchronize`, typically a manual empty-commit push.

This race condition bit PR #248 directly: the `chore` label was added after the spec-first check had failed, but `gh workflow run` against `workflow_dispatch` produced a separate run record that did not update the PR's check status. The fix that day was a manual empty-commit re-trigger. The reflection on 2026-05-07 (`REFLECTION_LOG.md`) flagged this for follow-up; this PR is the follow-up.

## Workflows reviewed but unchanged

Two other workflows in the repo use `pull_request:` triggers but do not branch on labels:

- **`.github/workflows/harness.yml`** — has no label-conditional logic; the trigger change would not add value.
- **`.github/workflows/lint-markdown.yml`** — runs on `**/*.md` path filters; no label logic.

So they are unmodified.

## Files changed

- `.github/workflows/spec-first-check.yml` — `types` list added
- `.github/workflows/version-check.yml` — `types` list added
- `CHANGELOG.md` — entry appended under `0.32.0` (CI config change outside the plugin directory; no version bump)

## How this PR's exemption itself works

This PR uses the `chore/` branch prefix exemption rather than the `chore` label exemption. Branch-prefix matching happens before label matching in the spec-first workflow (it is the first check, against `github.head_ref`), so it is immune to the very race condition this PR fixes. Belt and braces — the `chore` and `enhancement` labels are also applied at PR creation time per the existing `Label PRs at creation time` constraint.

## Versioning

No plugin version bump. The change is to root-level CI config files, outside `ai-literacy-superpowers/`.

## Test plan

- [ ] Spec-first check passes on this PR via the `chore/` branch prefix
- [ ] Markdownlint passes (no markdown changed)
- [ ] Version consistency check passes (no plugin code changed)
- [ ] Manual smoke test on a follow-up PR: add a `chore` label after the fact and verify the spec-first check re-evaluates without an empty re-trigger commit