### PR TITLE
chore: bump HARNESS.md template-version marker to 0.33.0

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.31.1 -->
+<!-- template-version: 0.33.0 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Bumps the `template-version` marker in `HARNESS.md` from `0.31.1` to `0.33.0` after running `/harness-upgrade`
- No new constraints or GC rules adopted — the project's HARNESS.md already contains every active item from the current template plus 13 project-specific constraints and 4 project-specific GC rules
- Two upstream "updated items" (the adjudication constraints) were skipped because they have project-local customisations (specific cutoff dates `2026-04-19` and `2026-04-27`) that take precedence

## Why

The `Template currency` GC rule flags drift between the in-file marker and `plugin.json`. After confirming there is nothing material to adopt from versions `0.32.0`–`0.33.0`, this records the review and silences the rule.

## Test plan

- [x] `/harness-upgrade` ran with no findings to apply
- [x] CHANGELOG: not required (marker-only change, plugin version unchanged)
- [ ] CI green (chore exemption used for spec-first; marketplace/version checks not applicable)