### PR TITLE
fix: rewrite Liquid {% link %} tags to migrated model-cards paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ engineering**, **agent orchestration**, **decision archaeology**,
 | Plugin | What it does | Get started |
 | ------ | ------------ | ----------- |
 | **[ai-literacy-superpowers]({% link plugins/ai-literacy-superpowers/index.md %})** | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. 30 skills, 13 agents, 24 commands. | [Tutorial]({% link plugins/ai-literacy-superpowers/getting-started.md %}) |
-| **[model-cards]({% link plugins/model-cards/index.md %})** | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy with refusal-on-unconfirmed-existence honesty rule. | [Tutorial]({% link plugins/model-cards/seed-your-library.md %}) |
+| **[model-cards]({% link plugins/model-cards/index.md %})** | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy with refusal-on-unconfirmed-existence honesty rule. | [Tutorial]({% link plugins/model-cards/how-to/seed-your-library.md %}) |
 
 The marketplace is on track to ship more sister plugins as the
 framework grows. New plugins land under
@@ -132,7 +132,7 @@ using the [Diataxis framework](https://diataxis.fr/).
 | Plugin | Documentation |
 | ------ | ------------- |
 | ai-literacy-superpowers | [Landing]({% link plugins/ai-literacy-superpowers/index.md %}) · [Tutorials]({% link plugins/ai-literacy-superpowers/index.md %}#tutorials--learning-oriented) · [How-to]({% link plugins/ai-literacy-superpowers/index.md %}#how-to-guides--task-oriented) · [Reference]({% link plugins/ai-literacy-superpowers/index.md %}#reference--exact-details) · [Explanation]({% link plugins/ai-literacy-superpowers/index.md %}#explanation--concepts) |
-| model-cards | [Landing]({% link plugins/model-cards/index.md %}) · [Tutorial]({% link plugins/model-cards/seed-your-library.md %}) · [How-to]({% link plugins/model-cards/research-a-model-card.md %}) · [Reference]({% link plugins/model-cards/commands.md %}) · [Explanation]({% link plugins/model-cards/mitchell-extended-cards.md %}) |
+| model-cards | [Landing]({% link plugins/model-cards/index.md %}) · [Tutorial]({% link plugins/model-cards/how-to/seed-your-library.md %}) · [How-to]({% link plugins/model-cards/how-to/research-a-model-card.md %}) · [Reference]({% link plugins/model-cards/reference/commands.md %}) · [Explanation]({% link plugins/model-cards/explanation/mitchell-extended-cards.md %}) |
 
 See the [Plugins index]({% link plugins/index.md %}) for the canonical
 list.

--- a/docs/plugins/model-cards/explanation/mitchell-extended-cards.md
+++ b/docs/plugins/model-cards/explanation/mitchell-extended-cards.md
@@ -202,11 +202,11 @@ because its source was the most authoritative for that claim type.
 
 ## Related
 
-- [Skill: model-cards]({% link plugins/model-cards/skills.md %}) —
+- [Skill: model-cards]({% link plugins/model-cards/reference/skills.md %}) —
   the operational reference for each section.
-- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+- [Agent: model-card-researcher]({% link plugins/model-cards/reference/agents.md %}) —
   how the rules are enforced in code.
-- [Card template]({% link plugins/model-cards/card-template.md %}) —
+- [Card template]({% link plugins/model-cards/reference/card-template.md %}) —
   the canonical structure.
 - [Adversarial review]({% link plugins/ai-literacy-superpowers/adversarial-review.md %}) —
   the broader read-only-emitter pattern this plugin's agent follows.

--- a/docs/plugins/model-cards/how-to/research-a-model-card.md
+++ b/docs/plugins/model-cards/how-to/research-a-model-card.md
@@ -19,7 +19,7 @@ human-in-the-loop review checkpoint before the file is written.
 Use this when you want fine-grained control over a single card —
 inspecting source coverage, re-running a thin section, or editing the
 draft before it lands on disk. To bulk-populate a library, use the
-[seed your library]({% link plugins/model-cards/seed-your-library.md %})
+[seed your library]({% link plugins/model-cards/how-to/seed-your-library.md %})
 tutorial instead.
 
 ---
@@ -78,7 +78,7 @@ Card exists at <path>. [overwrite / skip / load-existing-as-base]
 
 The agent dispatches with the model name and provider hint, then
 researches section-by-section using each section's primary source tier
-(see the [agent reference]({% link plugins/model-cards/agents.md %})
+(see the [agent reference]({% link plugins/model-cards/reference/agents.md %})
 for the per-section tier table).
 
 Research can take 1-3 minutes depending on how much source material is
@@ -188,7 +188,7 @@ be too recent for available sources.
 
 No file is written. This is by design — the existence-check rule
 prevents authoritative-looking cards for hallucinated or non-existent
-models. See [the explanation page]({% link plugins/model-cards/mitchell-extended-cards.md %}#card-level-honesty)
+models. See [the explanation page]({% link plugins/model-cards/explanation/mitchell-extended-cards.md %}#card-level-honesty)
 for why this matters.
 
 If the refusal looks wrong (e.g. you know the model exists), pass an
@@ -206,9 +206,9 @@ resolves.
 
 ## Next steps
 
-- [Seed your library]({% link plugins/model-cards/seed-your-library.md %}) —
+- [Seed your library]({% link plugins/model-cards/how-to/seed-your-library.md %}) —
   bulk-populate from the shipped frontier-models seed list.
-- [Card template reference]({% link plugins/model-cards/card-template.md %}) —
+- [Card template reference]({% link plugins/model-cards/reference/card-template.md %}) —
   the canonical structure each card is validated against.
-- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+- [Agent: model-card-researcher]({% link plugins/model-cards/reference/agents.md %}) —
   inside the research loop and refusal logic.

--- a/docs/plugins/model-cards/how-to/seed-your-library.md
+++ b/docs/plugins/model-cards/how-to/seed-your-library.md
@@ -107,7 +107,7 @@ The library now lives at `~/.claude/model-cards/` (or whatever
 ## 4. Inspect a card
 
 Open any of the generated cards. Every card has the same 10-section
-structure (see the [card template]({% link plugins/model-cards/card-template.md %})
+structure (see the [card template]({% link plugins/model-cards/reference/card-template.md %})
 reference) and a frontmatter `sources` block listing every URL the
 agent fetched, grouped by tier.
 
@@ -152,7 +152,7 @@ the source material has changed, re-research a single card with:
 /model-card create <model-name> --provider <provider>
 ```
 
-This is the same flow as the [research a model card]({% link plugins/model-cards/research-a-model-card.md %})
+This is the same flow as the [research a model card]({% link plugins/model-cards/how-to/research-a-model-card.md %})
 how-to. When prompted about the existing card, choose `overwrite` or
 `load-existing-as-base`.
 
@@ -167,9 +167,9 @@ library — the existence-check rule guarantees this.
 
 ## Next steps
 
-- [Research a model card]({% link plugins/model-cards/research-a-model-card.md %}) —
+- [Research a model card]({% link plugins/model-cards/how-to/research-a-model-card.md %}) —
   add a card for a model that wasn't in the seed list.
-- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+- [Mitchell-extended model cards]({% link plugins/model-cards/explanation/mitchell-extended-cards.md %}) —
   understand why the cards are structured the way they are.
-- [Card template reference]({% link plugins/model-cards/card-template.md %}) —
+- [Card template reference]({% link plugins/model-cards/reference/card-template.md %}) —
   the template every generated card conforms to.

--- a/docs/plugins/model-cards/reference/agents.md
+++ b/docs/plugins/model-cards/reference/agents.md
@@ -43,7 +43,7 @@ model's existence cannot be confirmed.
 
 A single markdown string containing the full card content — frontmatter
 plus all 10 sections per the
-[card template]({% link plugins/model-cards/card-template.md %}).
+[card template]({% link plugins/model-cards/reference/card-template.md %}).
 
 The agent does **not** write the file. The dispatching command
 persists the output after a human-in-the-loop review checkpoint.
@@ -180,11 +180,11 @@ produces. The agent aggregates sources at the top of the card.
 
 ## Related
 
-- [`/model-card` command]({% link plugins/model-cards/commands.md %}) —
+- [`/model-card` command]({% link plugins/model-cards/reference/commands.md %}) —
   the dispatcher that uses this agent.
-- [`model-cards` skill]({% link plugins/model-cards/skills.md %}) —
+- [`model-cards` skill]({% link plugins/model-cards/reference/skills.md %}) —
   authoring reference for the 10-section card structure.
-- [Card template]({% link plugins/model-cards/card-template.md %}) —
+- [Card template]({% link plugins/model-cards/reference/card-template.md %}) —
   the canonical structure the agent populates.
-- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+- [Mitchell-extended model cards]({% link plugins/model-cards/explanation/mitchell-extended-cards.md %}) —
   why the agent works the way it does.

--- a/docs/plugins/model-cards/reference/card-template.md
+++ b/docs/plugins/model-cards/reference/card-template.md
@@ -182,9 +182,9 @@ frontmatter) are surfaced to the user before write.
 
 ## Related
 
-- [Skill: model-cards]({% link plugins/model-cards/skills.md %}) —
+- [Skill: model-cards]({% link plugins/model-cards/reference/skills.md %}) —
   authoring guidance for each section.
-- [Agent: model-card-researcher]({% link plugins/model-cards/agents.md %}) —
+- [Agent: model-card-researcher]({% link plugins/model-cards/reference/agents.md %}) —
   how the agent populates the template.
-- [Commands: /model-card]({% link plugins/model-cards/commands.md %}) —
+- [Commands: /model-card]({% link plugins/model-cards/reference/commands.md %}) —
   including the validation checkpoint flow.

--- a/docs/plugins/model-cards/reference/commands.md
+++ b/docs/plugins/model-cards/reference/commands.md
@@ -48,7 +48,7 @@ where `<library-root>` is the first of:
 2. **Resolve target path** using the priority order above.
 3. **Existing-card prompt** — if the target exists, ask
    `overwrite / skip / load-existing-as-base`.
-4. **Dispatch** the [`model-card-researcher`]({% link plugins/model-cards/agents.md %})
+4. **Dispatch** the [`model-card-researcher`]({% link plugins/model-cards/reference/agents.md %})
    agent. Output is either a markdown card body or a `REFUSED:` string.
 5. **Handle REFUSED** — if the agent's output starts with `REFUSED:`,
    surface the refusal verbatim and abort. No file is written.
@@ -64,7 +64,7 @@ where `<library-root>` is the first of:
 9. **Write the card** to the resolved target path. Print
    `Card written: <full-path>`.
 
-See the [research a model card]({% link plugins/model-cards/research-a-model-card.md %})
+See the [research a model card]({% link plugins/model-cards/how-to/research-a-model-card.md %})
 how-to for a step-by-step walkthrough.
 
 ### Disposition options
@@ -132,7 +132,7 @@ pattern — the existence check at step 4 skips already-written cards.
 To re-research existing cards, either pass `--force` (overwrites all)
 or run `/model-card create <name>` per-model (interactive review).
 
-See the [seed your library]({% link plugins/model-cards/seed-your-library.md %})
+See the [seed your library]({% link plugins/model-cards/how-to/seed-your-library.md %})
 tutorial for an end-to-end walkthrough.
 
 ---

--- a/docs/plugins/model-cards/reference/skills.md
+++ b/docs/plugins/model-cards/reference/skills.md
@@ -162,7 +162,7 @@ should follow the same rule.
 | 4 | Web search | Anything tiers 1-3 don't cover; independent evaluations |
 
 The agent researches **section by section** using each section's
-primary tier (see the [agent reference]({% link plugins/model-cards/agents.md %})
+primary tier (see the [agent reference]({% link plugins/model-cards/reference/agents.md %})
 for the full table). This is more efficient than fetching all sources
 upfront and produces a sharper provenance trail.
 
@@ -170,9 +170,9 @@ upfront and produces a sharper provenance trail.
 
 ## Related
 
-- [Card template]({% link plugins/model-cards/card-template.md %}) —
+- [Card template]({% link plugins/model-cards/reference/card-template.md %}) —
   the structural template every card conforms to.
-- [Agent reference]({% link plugins/model-cards/agents.md %}) — how
+- [Agent reference]({% link plugins/model-cards/reference/agents.md %}) — how
   the agent applies this skill end-to-end.
-- [Mitchell-extended model cards]({% link plugins/model-cards/mitchell-extended-cards.md %}) —
+- [Mitchell-extended model cards]({% link plugins/model-cards/explanation/mitchell-extended-cards.md %}) —
   conceptual background on why the cards are structured this way.

--- a/scripts/migrations/move-map-model-cards-liquid.tsv
+++ b/scripts/migrations/move-map-model-cards-liquid.tsv
@@ -1,0 +1,7 @@
+plugins/model-cards/research-a-model-card.md	plugins/model-cards/how-to/research-a-model-card.md
+plugins/model-cards/seed-your-library.md	plugins/model-cards/how-to/seed-your-library.md
+plugins/model-cards/agents.md	plugins/model-cards/reference/agents.md
+plugins/model-cards/card-template.md	plugins/model-cards/reference/card-template.md
+plugins/model-cards/commands.md	plugins/model-cards/reference/commands.md
+plugins/model-cards/skills.md	plugins/model-cards/reference/skills.md
+plugins/model-cards/mitchell-extended-cards.md	plugins/model-cards/explanation/mitchell-extended-cards.md


### PR DESCRIPTION
## Summary

Phase 1 (PR #263) shipped the model-cards Diataxis reorg, but the
rewrite-docs-links.sh script's move-map only matched repo-rooted paths
(\`docs/plugins/model-cards/X.md\`). Liquid \`{% link %}\` tags use
Jekyll source-relative paths (\`plugins/model-cards/X.md\`), so the
rewrite missed every one of them. Result: the Pages build on main
([run 25553092043](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/runs/25553092043))
failed with:

\`\`\`
Liquid Exception: Could not find document 'plugins/model-cards/card-template.md'
in tag 'link'.
\`\`\`

This PR adds a second move-map TSV with the \`docs/\`-stripped form
and runs the same rewriter against it. 8 files updated.

## Why fix label

Self-contained build break with no design work. Standard \`fix/\`
branch prefix exemption applies.

## Test plan

- [x] Created \`scripts/migrations/move-map-model-cards-liquid.tsv\` with 7 rows.
- [x] Ran \`scripts/migrations/rewrite-docs-links.sh\` against it.
- [x] Repo-wide grep confirms no remaining \`{% link plugins/model-cards/<old-flat-path> %}\` references to migrated pages.
- [x] markdownlint clean across all 8 modified files.
- [ ] CI green.
- [ ] Pages workflow on main builds successfully after merge (the load-bearing check this PR exists to fix).

## Lesson for Phase 2

The move-map for the \`ai-literacy-superpowers\` flagship migration
must include BOTH path forms (with and without \`docs/\` prefix) so
both markdown links AND Liquid \`{% link %}\` tags get rewritten in
a single pass. The Phase 2 plan should call this out as a gotcha.