### PR TITLE
chore: audit-driven /harness-sync and lifecycle docs simplification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.3.0",
-  "plugin_version": "0.34.1",
+  "plugin_version": "0.35.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.34.1"
+      "version": "0.35.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.35.0 — 2026-05-08
+
+### Feature — Audit-driven `/harness-sync`
+
+Restructures `/harness-sync` so it runs `/harness-audit`'s detection
+logic internally via a new shared `harness-audit-engine` skill. The
+unified drift table now includes every audit finding tagged `[auto]`
+or `[manual]`. Mechanical fixes (convention files, ONBOARDING.md,
+snapshot regen via `/harness-health`, HARNESS.md Status section regen
+via `/harness-audit`) auto-apply when selected. Judgement-required
+fixes (`/harness-upgrade`, `/harness-constrain`) print the suggested
+command without writing — preserving the trust boundary.
+
+`/harness-audit` keeps its standalone diagnostic role unchanged. Both
+commands now share the same engine; surface coverage evolves in one
+place.
+
+### Docs — Lifecycle simplification
+
+Three explanation pages are rewritten to converge on a single
+canonical narrative:
+
+- `the-harness-lifecycle` is now the everyday three-state model
+  (in sync, drifted, behind upstream) with `/harness-sync`,
+  `/harness-upgrade`, and `/harness-constrain` as the everyday entry
+  points.
+- `the-harness-tuning-loop` refocuses on the signal-capture →
+  constraint-promotion sub-flow specifically.
+- `self-improving-harness` trims to the conceptual core (why
+  iteration matters, the compound-learning principle).
+
+How-to pages for sync-harness and run-a-harness-audit are updated
+to reflect the audit-driven flow and the diagnostic-vs-everyday split.
+Touch-ups across tutorials, plugin landing, CLAUDE.md (root +
+template), and README align command descriptions.
+
+### Internal
+
+- New skill: `harness-audit-engine` documents the shared
+  drift-detection contract.
+
 ## 0.34.1 — 2026-05-08
 
 ### Docs — Migrate site infrastructure from Jekyll/just-the-docs to MkDocs Material

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,10 @@ Light-touch health check (every 30 days, between quarterly anchor weeks):
 1. `/governance-health` — governance constraint health snapshot
 2. Reflection review — scan `REFLECTION_LOG.md` for new entries worth
    promoting to `AGENTS.md`
+3. `/harness-sync` — bring every push-direction surface into alignment
+   with HARNESS.md (convention files, ONBOARDING.md, snapshot, Status
+   section). Surfaces template drift and recurring reflection patterns
+   as `[manual]` items for follow-up.
 
 ## Sync from Source
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.3.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.34.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.35.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)
@@ -27,7 +27,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.34.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **30 skills, 13 agents, 25 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.35.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **30 skills, 13 agents, 25 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 
 The bulk of this README documents the **`ai-literacy-superpowers`** plugin specifically — its skills, agents, commands, hooks, templates, enforcement loops, and pipelines. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md). Future sister plugins will land in this marketplace under `<plugin-name>/` with their own docs at `docs/plugins/<plugin-name>/`.

--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ A coordinated team that handles the full development lifecycle.
 | `/harness-status` | Quick harness health read |
 | `/harness-constrain` | Add or promote a constraint |
 | `/harness-gc` | Manage and run garbage collection rules |
-| `/harness-audit` | Full meta-verification of the harness |
+| `/harness-audit` | Read-only diagnostic. Same engine as `/harness-sync` but prints findings without prompting to fix. Use for inspection-without-commitment, CI scripts, or the quarterly cadence anchor. |
 | `/reflect` | Capture a post-task reflection |
 | `/worktree` | Git worktree lifecycle — spin, merge, clean |
 | `/assess` | AI literacy assessment with immediate fixes, workflow recommendations, and prioritised improvement plans |
 | `/harness-health` | Harness health snapshot — enforcement ratio, trends, meta-observability checks |
 | `/extract-conventions` | Guided session — surfaces tacit team conventions and maps them to CLAUDE.md and HARNESS.md |
-| `/harness-sync` | Multi-surface entry point — detects drift across convention files and ONBOARDING.md, applies fixes via the underlying primitives in one interactive pass |
+| `/harness-sync` | Everyday lifecycle entry. Runs the shared audit-engine to detect drift across every surface (convention files, ONBOARDING.md, snapshot, Status section, template, constraint regressions, recurring reflection patterns), presents a unified drift table tagged `[auto]`/`[manual]`, and applies the fixes you select. Mechanical fixes auto-apply via existing primitives; judgement-required fixes print suggested commands. |
 | `/convention-sync` | Sync HARNESS.md conventions to Cursor, Copilot, and Windsurf convention files |
 | `/portfolio-assess` | Multi-repo AI literacy assessment — aggregate across local repos, GitHub orgs, or topic tags |
 | `/cost-capture` | Capture AI tool cost data — record spend, compare to previous snapshot, update model routing |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-audit.md
+++ b/ai-literacy-superpowers/commands/harness-audit.md
@@ -7,6 +7,11 @@ description: Run a full meta-verification of the harness — check whether HARNE
 
 Full meta-verification of the harness itself.
 
+Read the `harness-audit-engine` skill from this plugin before
+proceeding. The engine defines the shared drift-detection logic and
+the drift-report shape. This command is the read-only inspection
+caller; `/harness-sync` is the read-then-fix caller.
+
 ## Process
 
 ### 1. Check HARNESS.md Exists

--- a/ai-literacy-superpowers/commands/harness-sync.md
+++ b/ai-literacy-superpowers/commands/harness-sync.md
@@ -26,6 +26,12 @@ it composes existing commands and does not introduce new propagation logic.
   the status table. Useful for dry-run from CI or as the deep-scan step inside
   `/harness-health --deep`.
 
+Read the `harness-audit-engine` skill from this plugin before
+proceeding. The engine defines the shared drift-detection logic and
+the drift-report shape. This command is the read-then-fix caller; it
+runs the engine, builds a unified drift table including every audit
+finding, and applies fixes via the existing primitives.
+
 ## Process
 
 ### 1. Branch Enforcement
@@ -80,7 +86,7 @@ the user:
 
 Exit without making any changes.
 
-### 3. Phase 1 — Drift Scan
+### 3. Phase 1 — Drift Scan via audit-engine
 
 **If invoked with `--check`, the command stops after this phase — see exit semantics at the end of this section.**
 
@@ -90,94 +96,115 @@ the user:
 > No `HARNESS.md` found. Run `/harness-init` first, then re-run
 > `/harness-sync`.
 
-For each push-direction surface, evaluate its state against the current
-`HARNESS.md` content. Reuse the drift detection logic described by the
-`convention file sync` and `ONBOARDING.md staleness` GC rules in `HARNESS.md`
-— do _not_ invent new drift criteria; reference those GC rules by name.
+Invoke the `harness-audit-engine` skill to scan all surfaces. The engine
+returns a list of findings in the structured shape documented in the
+skill: each finding has `surface`, `status`, `details`, `action_command`,
+and `auto_fixable`.
 
-#### Surface evaluation
+Surfaces the engine evaluates include (this list mirrors the table in the
+audit-engine skill — when surfaces are added there, they appear here
+automatically):
 
-For each surface, determine its state using the named GC rule as the
-canonical detector. States: `missing` (files absent), `drifted` (files exist
-but diverge from HARNESS.md), `in sync` (files match), `managed` (not
-actionable here).
-
-**`.cursor/rules/`** — Apply the `convention file sync` GC rule's check
-against `.cursor/rules/conventions.mdc` and `.cursor/rules/constraints.mdc`.
-
-**`.github/copilot-instructions.md`** — Apply the `convention file sync` GC
-rule's check against `.github/copilot-instructions.md`.
-
-**`.windsurf/rules/`** — Apply the `convention file sync` GC rule's check
-against `.windsurf/rules/conventions.md` and `.windsurf/rules/constraints.md`.
-
-**`ONBOARDING.md`** — Apply the `ONBOARDING.md staleness` GC rule's check:
-compare `ONBOARDING.md` against the current state of `HARNESS.md`, `AGENTS.md`,
-and `REFLECTION_LOG.md` (modification times and content alignment).
-
-**CI / CD (constraint scope)** — Always report as `managed`. Handled at
-runtime by the `harness-enforcer` agent; surfaced for completeness only.
+- `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`
+- `ONBOARDING.md`
+- Most recent snapshot in `observability/snapshots/`
+- HARNESS.md Status section accuracy
+- Template version drift
+- Constraint regressions (deterministic constraints whose tool fails)
+- Recurring reflection patterns (the `Reflection-driven regression detection` GC rule's findings)
+- CI / CD (informational only)
 
 #### Drift scan output table
 
-Build and print this structured table, substituting the evaluated statuses:
+Build and print this structured table from the findings. Each row's
+`Action on apply` column carries `[auto]` or `[manual]` based on the
+finding's `auto_fixable` field:
 
 ```text
-Surface                                              Status      Action on apply
-───────────────────────────────────────────────────  ──────────  ─────────────────────────
-.cursor/rules/                                       drifted     /convention-sync
-.github/copilot-instructions.md                      in sync     —
-.windsurf/rules/                                     missing     /convention-sync (create)
-ONBOARDING.md                                        drifted     /harness-onboarding
-CI / CD (constraint scope)                           managed     handled at runtime
-─────────────────────────────────────────────────────────────────────────────────────────
-5 surfaces tracked · 2 drifted · 1 missing · 1 in sync · 1 managed at runtime
+Surface / Finding                              Status      Action on apply
+─────────────────────────────────────────────  ──────────  ────────────────────────
+.cursor/rules/                                 drifted     /convention-sync       [auto]
+.github/copilot-instructions.md                in sync     —
+.windsurf/rules/                               missing     /convention-sync       [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
+HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
+Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
+Constraint regression: ShellCheck unverified   drifted     /harness-constrain     [manual]
+Reflection pattern: Output validation x3       candidate   /harness-constrain     [manual]
+CI / CD (constraint scope)                     managed     handled at runtime
+─────────────────────────────────────────────────────────────────────────────────────
+N surfaces tracked · X drifted · Y missing · Z in sync · W managed · K candidates
 ```
 
 State vocabulary:
 
-- `drifted` — file exists but does not match HARNESS.md.
+- `drifted` — file or fact exists but does not match HARNESS.md / reality.
 - `missing` — file is not present; would be created on apply.
-- `in sync` — file matches HARNESS.md.
+- `in sync` — matches HARNESS.md / reality.
 - `managed` — runtime-managed; surfaced for completeness, not actionable here.
+- `candidate` — not strict drift but warrants review (recurring reflection patterns; deferred constraints).
 
-If `--check` was passed, stop here and exit zero (or non-zero if any surface
-is `drifted` or `missing`, so CI can gate on drift). Do not proceed to
+If `--check` was passed, stop here and exit zero (or non-zero if any
+finding is `drifted`, `missing`, or `candidate`). Do not proceed to
 Phase 2.
 
 ### 4. Phase 2 — Selection
 
-If all surfaces are `in sync` or `managed`, tell the user:
+If all findings are `in sync` or `managed`, tell the user:
 
-> All surfaces are in sync. Nothing to apply.
+> All surfaces and audit checks are in sync. Nothing to apply.
 
 Exit cleanly with no changes.
 
 Otherwise, present a multi-select prompt. Use `AskUserQuestion` with
-`multiSelect: true`. List each `drifted` or `missing` surface as a separate
-option. Default selection is _all_ drifted/missing surfaces. The `managed` row
-never appears as a selectable option.
+`multiSelect: true`. List each `drifted`, `missing`, or `candidate`
+finding as a separate option, with the `[auto]` / `[manual]` tag from
+the table. Default selection is _all_ actionable findings.
+
+Group options visually so `[auto]` items appear before `[manual]`
+items. The `managed` row never appears as a selectable option.
 
 ```json
 {
   "type": "AskUserQuestion",
   "multiSelect": true,
-  "question": "Select which surfaces to bring in sync. All drifted/missing surfaces are selected by default.",
+  "question": "Select which findings to address. [auto] items run via existing primitives; [manual] items print the suggested command for you to run separately.",
   "options": [
     {
       "id": "cursor",
-      "label": ".cursor/rules/  [drifted — /convention-sync]",
+      "label": ".cursor/rules/  [auto: /convention-sync]",
       "selected": true
     },
     {
       "id": "windsurf",
-      "label": ".windsurf/rules/  [missing — /convention-sync (create)]",
+      "label": ".windsurf/rules/  [auto: /convention-sync (create)]",
       "selected": true
     },
     {
       "id": "onboarding",
-      "label": "ONBOARDING.md  [drifted — /harness-onboarding]",
+      "label": "ONBOARDING.md  [auto: /harness-onboarding]",
       "selected": true
+    },
+    {
+      "id": "snapshot",
+      "label": "Snapshot staleness  [auto: /harness-health]",
+      "selected": true
+    },
+    {
+      "id": "status",
+      "label": "HARNESS.md Status accuracy  [auto: /harness-audit]",
+      "selected": true
+    },
+    {
+      "id": "template",
+      "label": "Template drift  [manual: /harness-upgrade]",
+      "selected": false
+    },
+    {
+      "id": "regression",
+      "label": "Constraint regression  [manual: /harness-constrain]",
+      "selected": false
     },
     {
       "id": "none",
@@ -188,53 +215,77 @@ never appears as a selectable option.
 }
 ```
 
-The options above are illustrative. Construct the actual options list from the
-Phase 1 scan results — include one option per surface that is `drifted` or
-`missing`, plus the always-present "Apply nothing" option.
+Construct the actual options list from the Phase 1 findings. `[auto]`
+items default to `selected: true`; `[manual]` items default to
+`selected: false` (the user must opt in to running judgement-required
+remediations, even via just printing the command).
 
-Only include options for surfaces that are `drifted` or `missing`. Omit
-options for `in sync` surfaces. Always include the "Apply nothing" option.
-
-If the user selects "Apply nothing — exit without changes" (or deselects all
-surfaces), exit cleanly with no changes.
+If the user selects "Apply nothing — exit without changes" (or
+deselects all surfaces), exit cleanly with no changes.
 
 ### 5. Phase 3 — Apply
 
-For each surface the user selected, invoke the corresponding primitive
-_in series_ (not in parallel — order matters for the verification scan):
+For each selected finding, branch on its `auto_fixable` classification:
 
-1. **`.cursor/rules/` or `.windsurf/rules/`** — invoke `/convention-sync`.
-   This handles all three convention-file surfaces in a single run; if both
-   are selected they share the same invocation.
+#### `[auto]` items — run the action command
+
+For each `[auto]` selected finding, invoke its `action_command` _in
+series_ (not in parallel — order matters for the verification scan):
+
+1. **`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`** — invoke `/convention-sync`. This handles all three convention-file surfaces in a single run; if multiple are selected they share the same invocation.
 2. **`ONBOARDING.md`** — invoke `/harness-onboarding`.
+3. **Snapshot staleness** — invoke `/harness-health`.
+4. **HARNESS.md Status section accuracy** — invoke `/harness-audit`. (Audit updates Status as a side-effect of running.)
 
-If an underlying command errors out for one surface:
+If an underlying command errors out for one finding:
 
-- Continue with the remaining selected surfaces.
-- Mark the errored surface as `still drifted (error)` in the verification
+- Continue with the remaining selected `[auto]` findings.
+- Mark the errored finding as `still drifted (error)` in the verification
   scan.
 - The overall run will exit non-zero (see step 6 below).
 
+#### `[manual]` items — print the suggested command
+
+For each `[manual]` selected finding, do NOT invoke the action command.
+Instead, print a "next step" line:
+
+```text
+Manual remediation suggested for: Template version drift
+Run: /harness-upgrade
+```
+
+The user runs these separately. `/harness-sync` does not invoke them
+to preserve the trust boundary — these commands require user judgement
+(which template content to adopt, which constraint to add).
+
 ### 6. Verification Scan
 
-After all selected surfaces are applied, re-run the drift scan from Phase 1.
-Build and print the delta table:
+After all selected `[auto]` items are applied, re-invoke the
+`harness-audit-engine` skill and build the delta table:
 
 ```text
 Apply complete — verification scan:
 
-Surface                                              Before      After
-───────────────────────────────────────────────────  ──────────  ──────────
-.cursor/rules/                                       drifted     in sync ✓
-.windsurf/rules/                                     missing     in sync ✓
-ONBOARDING.md                                        drifted     in sync ✓
+Surface / Finding                              Before      After
+─────────────────────────────────────────────  ──────────  ─────────────
+.cursor/rules/                                 drifted     in sync ✓
+.windsurf/rules/                               missing     in sync ✓
+ONBOARDING.md                                  drifted     in sync ✓
+Snapshot staleness                             drifted     in sync ✓
+HARNESS.md Status accuracy                     drifted     in sync ✓
+Template drift                                 drifted     drifted (manual — see suggestion above)
 ```
 
-If any selected surface is _not_ now `in sync`, mark it as
+If any selected `[auto]` finding is _not_ now `in sync`, mark it as
 `still drifted (error)` in the After column. Do _not_ proceed to commit.
-Report the failed surfaces and exit non-zero.
+Report the failed findings and exit non-zero.
 
-If all selected surfaces are now `in sync`, proceed to the trust-boundary
+`[manual]` findings that the user selected are reported in the After
+column with the `(manual — see suggestion above)` note, not flagged
+as errors. They were not auto-applied.
+
+If all selected `[auto]` findings are now `in sync` (and any `[manual]`
+findings have their suggestions printed), proceed to the trust-boundary
 guard.
 
 ### 7. Trust-Boundary Pre-Commit Guard

--- a/ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md
+++ b/ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: harness-audit-engine
+description: Use when running the shared drift-detection logic that backs /harness-audit and /harness-sync — produces a structured drift report covering convention files, ONBOARDING.md, snapshot staleness, template drift, constraint regressions, recurring reflection patterns, and HARNESS.md Status section accuracy.
+---
+
+# Harness Audit Engine
+
+## Overview
+
+The harness audit-engine is the shared drift-detection layer that both
+`/harness-audit` and `/harness-sync` invoke. Audit is read-only; sync
+uses the same engine to drive its multi-select prompt. This skill
+defines the contract — what surfaces are scanned, the drift-report
+shape, and the per-finding `[auto]` / `[manual]` classification rule.
+
+`/harness-audit` and `/harness-sync` are the two callers. Their UX
+differs (audit prints, sync prompts), but the underlying findings are
+the same.
+
+## What the engine scans
+
+The engine evaluates every surface or fact that could be out of sync
+with `HARNESS.md`. The current scan covers:
+
+| Category | Finding | Auto-fixable? |
+| --- | --- | --- |
+| Convention files | `.cursor/rules/` matches HARNESS.md | yes — `/convention-sync` |
+| Convention files | `.github/copilot-instructions.md` matches HARNESS.md | yes — `/convention-sync` |
+| Convention files | `.windsurf/rules/` matches HARNESS.md | yes — `/convention-sync` |
+| Onboarding | `ONBOARDING.md` matches HARNESS.md + AGENTS.md + REFLECTION_LOG.md | yes — `/harness-onboarding` |
+| Observability | Most recent snapshot in `observability/snapshots/` is < 30 days old | yes — `/harness-health` |
+| Status section | `HARNESS.md` Status block matches actual constraint enforcement counts | yes — `/harness-audit` (audit updates Status as a side-effect) |
+| Template currency | `<!-- template-version: X -->` in HARNESS.md matches installed plugin version | manual — `/harness-upgrade` |
+| Constraint regression | Any constraint marked `deterministic` whose tool no longer succeeds | manual — `/harness-constrain` |
+| Reflection pattern | Recurring failure pattern in REFLECTION_LOG.md (2+ similar entries, not yet a constraint) | manual — `/harness-constrain` |
+| CI / CD | Constraint scope handled at runtime by harness-enforcer | informational — handled at runtime |
+
+New surfaces added to the engine appear in both commands automatically.
+
+## Drift-report shape
+
+The engine returns a list of findings. Each finding has:
+
+- `surface` — short label (e.g. `.cursor/rules/`, `Snapshot staleness`)
+- `status` — one of `drifted`, `missing`, `in sync`, `managed`, `candidate`
+- `details` — short string with the specific evidence (e.g. `last: 2026-04-15`, `HARNESS: 0.31, plugin: 0.34`)
+- `action_command` — the slash command that remediates this finding (e.g. `/convention-sync`, `/harness-upgrade`)
+- `auto_fixable` — `true` if the action runs without further user judgement; `false` if the action requires user input
+
+## State vocabulary
+
+- `drifted` — file or fact exists but does not match HARNESS.md / reality.
+- `missing` — file expected but not present.
+- `in sync` — matches HARNESS.md / reality.
+- `managed` — handled at runtime by other layers (CI/CD); informational only.
+- `candidate` — finding that is not strict drift but warrants review (recurring reflection patterns; deferred constraints).
+
+## Auto-fixable classification rule
+
+A finding is `auto_fixable: true` only when:
+
+1. There is a deterministic remediation (a specific command that, given the same HARNESS.md state, would always produce the same fix).
+2. The remediation writes to allow-listed paths (the four push-direction surfaces) OR mutates HARNESS.md only in defined ways (Status section regen via `/harness-audit`, snapshot creation via `/harness-health`).
+3. No user judgement is required between detection and remediation.
+
+Findings that need user input — choosing which constraint to add, deciding whether enforcement should be promoted, deciding when to take an upstream template upgrade — are `auto_fixable: false`. Sync surfaces them as `[manual]` rows; selecting them prints the suggested command without writing.
+
+## Caller contract
+
+Each caller is responsible for its own UX:
+
+- `/harness-audit` prints the findings in its existing format and updates `HARNESS.md` Status section.
+- `/harness-sync` builds its drift table from the findings, prompts for selection, and dispatches the action commands.
+
+The engine itself does not print or prompt. It returns the findings and exits.
+
+## Adding a new surface to the engine
+
+When a new check is added to the engine:
+
+1. Document the surface in the Categories table above.
+2. Decide its `auto_fixable` classification using the rule.
+3. Define the `action_command` it maps to.
+4. Both `/harness-audit` and `/harness-sync` pick up the new finding without further code changes.
+
+This is the value of factoring the engine: surface coverage evolves in one place.

--- a/ai-literacy-superpowers/templates/CLAUDE.md
+++ b/ai-literacy-superpowers/templates/CLAUDE.md
@@ -193,6 +193,18 @@ are current.
 
 Include docs changes in the same PR as the implementation, not as a follow-up.
 
+## Monthly Operations
+
+Light-touch health check (every 30 days, between quarterly anchor weeks):
+
+1. `/governance-health` — governance constraint health snapshot
+2. Reflection review — scan `REFLECTION_LOG.md` for new entries worth
+   promoting to `AGENTS.md`
+3. `/harness-sync` — bring every push-direction surface into alignment
+   with HARNESS.md (convention files, ONBOARDING.md, snapshot, Status
+   section). Surfaces template drift and recurring reflection patterns
+   as `[manual]` items for follow-up.
+
 ## Project Constraints
 
 <!-- Example:

--- a/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
@@ -11,252 +11,102 @@ redirect_from:
 
 # The Self-Improving Harness
 
-A static harness reflects the team's understanding at one point in time and requires manual effort to improve. This plugin adds a self-improving layer: reflections captured after each session accumulate in a learnings log, agents read past learnings when reviewing new code, and the harness-audit agent analyzes violation history to propose new or strengthened constraints. The harness treats its own operational record as input data, generating improvement proposals that humans accept or reject -- closing the loop between observation and enforcement.
-
-For the introductory treatment of compound learning and the curation process, see [Compound Learning](compound-learning.md). This page goes deeper into the mechanics: the data structures, the agent reading windows, the automated proposal pipeline, and the feedback loop that makes the harness self-referential.
-
----
-
-## The Reflection Mechanism
-
-A reflection is a structured note captured after a piece of work. It records what was surprising, what failed, what a future session should know, and -- critically -- whether the surprise suggests a new constraint. The `/reflect` command drives the capture process.
-
-### What Gets Captured
-
-Each reflection entry contains seven fields:
-
-```text
----
-
-- **Date**: YYYY-MM-DD
-- **Agent**: [who did the work]
-- **Task**: [one-sentence summary]
-- **Surprise**: [anything unexpected during the work]
-- **Proposal**: [pattern or gotcha to consider for AGENTS.md, or "none"]
-- **Improvement**: [what would make the process smoother next time]
-- **Signal**: [context | instruction | workflow | failure | none]
-- **Constraint**: [proposed constraint text, or "none"]
-```
-
-The **Surprise** field is the most important. Surprises are signals. An edge case you did not anticipate, an assumption that broke, a tool that did not behave as documented -- each of these is raw material for improving the harness. The field exists to force the question: *what did the environment fail to tell the agent?*
-
-The **Proposal** field captures a candidate for promotion to `AGENTS.md` -- a gotcha, a style note, an architectural decision that emerged during the work. The **Improvement** field captures process-level observations: a check that should have run earlier, a context document that was missing information, a tool configuration that needs updating.
-
-The **Constraint** field is populated by the auto-constraint proposal step, described below. If the reflection describes a preventable failure -- a lint error that slipped through, a wrong branch, a missing check -- the `/reflect` command drafts a constraint and offers it to the user for acceptance.
-
-The **Signal** field classifies what kind of learning the reflection represents, using the taxonomy from Birgitta Boeckeler's [Feedback Flywheel](https://martinfowler.com/articles/reduce-friction-ai/feedback-flywheel.html). A `context` signal means the priming document was missing something -- a convention, a version, a domain detail. An `instruction` signal means a prompt or command produced notably better or worse results. A `workflow` signal means a process pattern succeeded or failed in a way worth recording. A `failure` signal means the error was preventable -- a check that should have run, a tool that was misconfigured. The classification guides where the learning should route during curation: context signals route to HARNESS.md, instruction signals to skills or commands, workflow signals to AGENTS.md, and failure signals to constraints.
-
-### When Reflections Are Captured
-
-Reflections are captured at the end of a pipeline run by the integration agent, or manually by a developer using the `/reflect` command at the end of any coding session. The integration agent appends reflections automatically as part of its post-merge cleanup. Manual reflections are lightweight -- two minutes of thought, not an essay.
-
-### The `/reflect` Command
-
-The command follows a structured process:
-
-1. Gather context -- what was worked on, what was surprising, what should future agents know.
-2. Format the entry using the standard template.
-3. Classify the signal type: review the Surprise and Improvement fields and propose a signal type (`context`, `instruction`, `workflow`, `failure`, or `none`) with a one-sentence rationale. The user confirms or overrides.
-4. Run the auto-constraint proposal step: review the Surprise and Improvement fields for preventable failures. If one is found, draft a constraint with a rule, enforcement type, tool, and scope. A `failure` signal from step 3 feeds directly into this step.
-5. If the user accepts the proposed constraint, invoke `/harness-constrain` to add it to `HARNESS.md` immediately. Record the constraint in the reflection entry.
-6. Append the entry to `REFLECTION_LOG.md`.
-7. Commit the updated log.
-
-The constraint proposal step is what makes `/reflect` more than a journal. It is the mechanism that converts operational experience into enforcement infrastructure, with the human deciding which proposals deserve promotion.
-
----
-
-## REFLECTION_LOG.md
-
-`REFLECTION_LOG.md` is an append-only log. Entries are never modified or deleted. New entries are appended after the last existing entry, separated by `---` markers. The log grows over the lifetime of the project, accumulating the operational history of every session.
-
-### Structure
-
-The file opens with a header comment that explains the entry format and states the cardinal rule: entries propose changes to `AGENTS.md` but never modify it directly. The comment block serves as a contract between the agents that write to the log and the humans who curate it.
-
-```text
-# Reflection Log
-
-<!-- Each entry is appended by integration-agent at the end of a pipeline run.
-     Entries capture what was surprising, what went wrong, and what should be
-     proposed for addition to AGENTS.md.
-
-     Do NOT modify AGENTS.md directly from this log — only propose. Humans
-     curate AGENTS.md. -->
-```
-
-After the header, entries accumulate chronologically. The most recent entry is at the bottom of the file.
-
-### How Agents Read the Log
-
-Different agents read different windows of the log, calibrated to their role and the cost of reading context:
-
-| Agent | Reading window | Purpose |
-| --- | --- | --- |
-| Orchestrator | 20 most recent entries | Inform pipeline strategy -- avoid repeating past failures, adjust agent dispatch order |
-| Harness enforcer | 10 most recent entries | Calibrate scrutiny -- pay attention to patterns that past reflections flagged as missed |
-| Harness GC | 10 most recent entries | Detect entropy signals -- reflections mentioning drift, staleness, or documentation rot guide GC focus |
-
-The orchestrator reads the deepest window because it makes strategic decisions that affect the entire pipeline. If a past reflection mentions a failure in the area about to be worked on, the orchestrator adjusts its strategy -- dispatching deterministic checks earlier, briefing subagents about known pitfalls, or allocating extra review cycles.
-
-The enforcer reads reflections to catch patterns that agent-based review has previously missed. If a reflection says "the enforcer did not catch direct database access in the handler," the enforcer pays particular attention to that pattern in the current review. Reflections are evidence of where agent review has been insufficient.
-
-The GC agent reads reflections to detect slow-burning entropy that declarative GC rules might not cover. A reflection about documentation drift is a signal that the documentation freshness rule needs tighter criteria or that a new GC rule is warranted.
-
----
-
-## AGENTS.md and Compound Learning
-
-Where `REFLECTION_LOG.md` is raw material, `AGENTS.md` is refined knowledge. It is the project's persistent memory across AI sessions -- curated patterns, gotchas, architectural decisions, and test strategy that every agent reads at session start.
-
-### The Sections
-
-`AGENTS.md` is organised into five sections, each serving a distinct purpose:
-
-- **STYLE** -- patterns and idioms that work well in this codebase. Each entry states what to do and why it works here.
-- **GOTCHAS** -- traps, surprises, and non-obvious constraints. Each entry states what the trap is and how to avoid it.
-- **ARCH_DECISIONS** -- key architectural decisions with reasoning and rejected alternatives.
-- **TEST_STRATEGY** -- how tests are structured, where they live, what patterns to follow.
-- **DESIGN_DECISIONS** -- stable interface contracts and data shapes that agents should not second-guess.
-
-### The Promotion Process
-
-Reflections do not flow into `AGENTS.md` automatically. The path from raw reflection to curated entry requires human judgement:
-
-1. A reflection is captured in `REFLECTION_LOG.md` with a non-empty Proposal field.
-2. During a curation session (weekly or fortnightly), the developer reads recent reflections and asks: *does this keep happening?*
-3. A gotcha that appeared once is an anecdote. A gotcha that appeared three times is a convention waiting to be written.
-4. The developer promotes the recurring pattern into the appropriate section of `AGENTS.md`, writing it up with specificity -- not "better error handling" but "catch exceptions in service methods, wrap them in AppError with a code and message, and let the controller handle the HTTP response."
-5. From that point forward, every agent reads the new entry at session start.
-
-### Why Human Curation Matters
-
-The log header states it plainly: "Do NOT modify AGENTS.md directly from this log -- only propose. Humans curate AGENTS.md."
-
-This is a deliberate design choice, not a limitation. Raw reflections are noisy. Sometimes the AI got confused because of a bad prompt, not because of a missing convention. Sometimes the edge case was genuinely rare. Sometimes the reflection captures frustration rather than insight.
-
-Human curation is the filter that separates signal from noise. An entry in GOTCHAS that does not reflect an actual problem that was actually solved is noise that increases the cognitive cost of every future session. The cost of a false positive in `AGENTS.md` is not a wrong entry -- it is a wrong entry read by every agent on every invocation, forever, until someone removes it.
-
-The asymmetry is important: it is cheap to leave a reflection in the log (it costs nothing if no one promotes it) and expensive to promote a bad reflection to `AGENTS.md` (it costs tokens and attention on every session). The curation step enforces this asymmetry.
-
----
-
-## Automated Constraint Proposals
-
-The `/reflect` command does not only capture observations. It actively proposes constraints when the observation describes a preventable failure.
-
-### The Auto-Constraint Pipeline
-
-After formatting a reflection entry, `/reflect` reviews the Surprise and Improvement fields:
-
-1. If either field describes a failure that a tool or check should have caught -- a lint error that slipped through, a wrong branch, a missing validation, a security check that did not run -- the command drafts a constraint proposal.
-2. The proposal includes four elements:
-   - **Rule**: a one-sentence description of what the constraint enforces
-   - **Enforcement**: `deterministic` (tool-backed) or `agent` (LLM-reviewed)
-   - **Tool**: the command that checks it, if known
-   - **Scope**: when it runs -- `commit`, `pr`, `session-end`
-3. The proposal is presented to the user. Accept or decline.
-4. If accepted, `/reflect` invokes `/harness-constrain` to add the constraint to `HARNESS.md` immediately, with the specified enforcement type and scope.
-5. The reflection entry records the outcome: either the constraint description and enforcement type, or "none."
-
-This pipeline converts operational surprise into enforcement infrastructure in a single step. The human remains the decision-maker, but the work of identifying what could be automated -- noticing that a failure was preventable and drafting the rule -- is delegated to the agent.
-
-### The Harness-Audit Agent's Role
-
-The harness-audit agent operates at a different timescale. Where `/reflect` proposes constraints from individual sessions, the auditor analyses violation history across sessions to identify systemic patterns.
-
-When the harness-audit agent runs, it does not only check whether current constraints are being met. It looks at the history of constraint violations to identify recurring patterns:
-
-- Are the same constraints being violated repeatedly? That is a signal that the constraint needs a stronger enforcement mechanism -- promotion from agent to deterministic.
-- Are violations clustered in a specific area of the codebase? That suggests the context document does not explain the rationale clearly enough for that area.
-- Are constraints being violated despite clear documentation? That may indicate the constraint itself is wrong and needs to be reconsidered.
-
-The auditor detects drift in both directions: constraints that are declared but not actually enforced (the tool is missing, the config is stale), and enforcement that exists but is not declared in `HARNESS.md` (a linter is running in CI but not listed as a constraint). Both directions represent a gap between what the team believes is true and what is actually true.
-
----
-
-## The Feedback Loop
-
-The complete self-improvement cycle has five stages:
-
-**Work.** Agents and developers write code, guided by the current state of the habitat -- `CLAUDE.md`, `HARNESS.md`, `AGENTS.md`, and the constraint enforcement infrastructure.
-
-**Reflect.** At the end of a session, the `/reflect` command captures what was surprising, what failed, what should change. If the reflection describes a preventable failure, a constraint is proposed.
-
-**Curate.** Periodically, a developer reads recent reflections and promotes recurring patterns into `AGENTS.md` -- a new GOTCHA, a refined ARCH_DECISION, a TEST_STRATEGY update. Patterns that do not recur are left in the log without promotion.
-
-**Promote.** Constraints that have proven their value at one enforcement level move up the [progressive hardening](progressive-hardening.md) ladder. An unverified constraint becomes agent-backed when a review prompt is written. An agent-backed constraint becomes deterministic when the pattern is understood well enough to encode as a script. The harness-audit agent identifies candidates for promotion by detecting recurring violations at a given level.
-
-**Environment improves.** The updated `AGENTS.md` entries inform the next session's agents. The promoted constraints catch violations that previously slipped through. The new GC rules detect entropy that previously accumulated silently. The baseline is higher.
-
-Then the cycle repeats. The work is better because the environment is better. The reflections are deeper because the basic mistakes have been eliminated. The curated entries are more subtle because the obvious patterns have already been captured. The constraints are tighter because the easy promotions have already happened.
-
-This is why the learning compounds. Each pass through the loop raises the floor, which changes the character of the work, which changes the character of the observations, which changes the character of the improvements. The harness does not merely accumulate rules. It matures.
-
----
-
-## Regression Detection
-
-The append-only structure of `REFLECTION_LOG.md` makes it a natural source for regression detection. When the same failure appears in multiple reflections over time, that recurrence is a signal that the environment has not adequately addressed the underlying cause.
-
-### Mining the Log
-
-The harness-audit agent mines the log for recurring themes during its periodic runs. Two patterns trigger action:
-
-**Repeated constraint violations.** If reflections mention the same constraint being violated across multiple sessions, the constraint's enforcement level is insufficient. An unverified constraint that keeps being violated needs agent enforcement. An agent-enforced constraint that keeps being violated needs deterministic enforcement -- or the rule itself needs to be rewritten to be clearer.
-
-**Repeated entropy observations.** If reflections mention the same kind of drift -- documentation going stale in a particular area, dead code accumulating in a specific module, a naming convention eroding in new files -- that pattern suggests a missing or inadequate GC rule.
-
-### The Regression Suite GC Rule
-
-The GC agent has a specific responsibility: when running garbage collection, it reads the 10 most recent reflections and looks for entropy signals. Reflections that mention drift, staleness, or documentation rot are not merely interesting observations -- they are inputs to the GC agent's decision-making about where to focus its sweep.
-
-If the GC agent finds that its declared rules do not cover a class of entropy that reflections keep mentioning, it reports that gap. The report becomes a prompt for the team to add a new GC rule, closing the loop between observation and enforcement.
-
----
-
-## Bootstrapping
-
-A self-improving harness needs a starting point. If the harness starts empty, the improvement loop has nothing to improve. If the harness requires weeks of manual configuration before it delivers value, teams will not adopt it.
-
-### Harness-Init and Code Inference
-
-The `/harness-init` command solves the cold-start problem. Rather than requiring the team to specify every convention and constraint from scratch, it dispatches a discovery agent to scan the existing codebase and infer what is already true:
-
-- What tech stack and versions are in use
-- What linters, formatters, and CI checks already exist
-- What convention documentation is already written
-- What pre-commit hooks are in place
-
-The discoverer presents its findings and asks the developer to confirm, reject, or refine each inference. The human remains the authority -- the agent does the tedious work of reading the project and proposing a starting point. The initial cost of building the harness is substantially reduced because the agent bootstraps a candidate `HARNESS.md` from observed patterns rather than asking the developer to recall every convention from memory.
-
-### Incremental Adoption
-
-`/harness-init` supports selective feature configuration. Teams choose which areas to configure on the first run:
-
-| Feature | What it configures |
-| --- | --- |
-| Context engineering | Stack declaration and conventions |
-| Architectural constraints | Enforcement rules and secret detection |
-| Garbage collection | Periodic entropy checks |
-| CI configuration | GitHub Actions workflow and auto-enforcer |
-| Observability | README badge and status section |
-
-Unselected features are marked with a placeholder in `HARNESS.md`. Re-running `/harness-init` later detects which sections are already configured and which are not, defaulting to configuring only the unconfigured sections. Existing configuration is preserved across runs.
-
-This means a team can start with just context engineering and constraints -- the two features that deliver the most immediate value. Once the value is proven, they add garbage collection and CI enforcement. The harness grows with the team's maturity rather than demanding full commitment upfront.
-
-The incremental adoption model also means the feedback loop starts turning sooner. A team with just context and constraints can capture reflections, promote patterns to `AGENTS.md`, and experience the compound learning effect without needing the full infrastructure. Each feature they add later plugs into the existing loop and amplifies it.
-
----
-
-## Further reading
-
-- [Compound Learning](compound-learning.md) -- the introductory treatment: the Groundhog Day problem, raw reflections, curation, and the flywheel
-- [Harness Engineering](harness-engineering.md) -- the full harness framework: context, constraints, garbage collection, and the three enforcement loops
-- [HARNESS.md, the Document](harness-md.md) -- the central document the audit runs against; how it compares to `AGENTS.md`, CI config, and hooks
-- [Progressive Hardening](progressive-hardening.md) -- the promotion ladder from unverified to agent to deterministic
-- [The Three Enforcement Loops](three-enforcement-loops.md) -- inner, middle, and outer loops operating at different timescales
-- [Garbage Collection](garbage-collection.md) -- fighting entropy with periodic checks and scheduled agents
-- [Habitat Engineering](habitat-engineering.md) -- the broader environment that contains and shapes the harness
-- [The Feedback Flywheel](https://martinfowler.com/articles/reduce-friction-ai/feedback-flywheel.html) -- Birgitta Boeckeler's framework for converting session-level learning into shared infrastructure through four signal types and four cadences
+> A harness that doesn't evolve becomes a museum exhibit. The
+> conventions that worked last quarter may not work this quarter.
+> The constraints that mattered when the team was small may be
+> ceremony when the team is large. The harness has to keep up — and
+> the cheapest way to do that is to make every session a contribution.
+
+## Why iteration matters
+
+The conventions captured in HARNESS.md were correct *when they were
+written*. The codebase changes; the team changes; tooling changes;
+expectations change. Without a path for the harness to evolve in
+response, three failure modes appear:
+
+- **Drift** — what's enforced no longer matches what should be enforced.
+  Either too strict (ceremony) or too lax (escape hatches). Either
+  way, trust in the harness erodes.
+- **Calcification** — the team stops pushing back on bad rules
+  because the rules are "what we do." Conventions become identity
+  rather than judgement.
+- **Stagnation** — patterns the team has actually learned in the
+  trenches never make it into the harness, because no one writes
+  them down. Knowledge stays in heads.
+
+The cure is to make every session a chance for the harness to
+update.
+
+## How sessions become contributions
+
+The plugin shapes sessions so that lessons accumulate without
+requiring a separate "process":
+
+- **`/reflect`** captures one session's surprise, classified by
+  signal (`failure`, `workflow`, `context`, `none`). Cheap to write,
+  cheap to merge via PR.
+- **`REFLECTION_LOG.md`** is the running journal. Most entries stay
+  there forever as historical record.
+- **The `Reflection-driven regression detection` GC rule** fires
+  weekly to find recurring patterns — the signal that a one-off
+  surprise has become a class of surprise.
+- **`/harness-sync`** surfaces those recurring patterns in its drift
+  table as `[manual]` candidate-constraint rows.
+- **`/harness-constrain`** authors the new constraint when the
+  pattern warrants it.
+- **`AGENTS.md`** is the curated subset — the lessons the team has
+  decided are part of the project's identity, not just the log.
+
+Every session contributes raw material. The aggregating mechanisms
+(GC rule, sync, constrain) turn that into structured, enforced
+knowledge over time.
+
+## The compound-learning principle
+
+Two ideas underlie this:
+
+**Lessons compound.** A team that captures lessons consistently is
+strictly better off than a team that doesn't, regardless of which
+specific lessons. The activation cost of `/reflect` (write three
+lines) is low enough that it's worth doing for every session — the
+compound effect over a year of sessions is large.
+
+**Curation is human.** The plugin captures aggressively (every
+reflection is appended) but promotes conservatively (only patterns
+recurring twice or more become constraints, only after the GC rule
+finds them, only after a human runs `/harness-constrain`). This
+asymmetry is deliberate. False captures cost nothing; false promotions
+add ceremony. The harness errs on the side of capturing too much and
+promoting too little.
+
+## What "self-improving" actually means
+
+It does not mean the harness rewrites itself autonomously. Every
+mutation is human-initiated:
+
+- A reflection is written by a human (or by an agent the human
+  reviews).
+- A constraint is promoted by a human running `/harness-constrain`.
+- A template upgrade is accepted by a human running `/harness-upgrade`.
+
+It means the harness has the *machinery* for evolution wired in: the
+journal, the recurrence detector, the promotion path, the curation
+target. Without that machinery, evolution requires a separate
+discipline that can be skipped under pressure. With it, evolution is
+a side effect of normal work.
+
+## Where this fits in the lifecycle
+
+The self-improving aspect is the long-arc view of the
+"drifted → in sync" transition described in
+[The Harness Lifecycle](the-harness-lifecycle.md). What looks like
+drift in one session is signal for the next session's improvement.
+
+## Related reading
+
+- [The Harness Lifecycle](the-harness-lifecycle.md) — the everyday
+  three-state model.
+- [The Harness Tuning Loop](the-harness-tuning-loop.md) — the focused
+  signal-capture → constraint-promotion sub-flow.
+- [Compound Learning](compound-learning.md) — the deeper conceptual
+  background on why lessons compound.

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
@@ -11,280 +11,130 @@ redirect_from:
 
 # The Harness Lifecycle
 
-A harness has a life. It is born when `/harness-init` runs for the first time and writes a skeletal `HARNESS.md` from a template. It takes its first steps as reflections accumulate, conventions are extracted, and the first hand-authored constraints get promoted. It reaches maturity when the tuning loop runs continuously and the four operational cadences (`/reflect`, `/harness-health`, `/assess`, `/cost-capture`) anchor the team's rhythm. It renews itself when template upgrades arrive through `/harness-upgrade`. It is forced to rebuild when the team, the codebase, or the platform underneath it changes. This page walks one harness through that arc.
-
-[The Harness Tuning Loop](the-harness-tuning-loop.md) cuts the harness on the *vertical* axis — one operational surprise, every enforcement surface, traced in a single turn of the loop. This page cuts the same harness on the *horizontal* axis — one harness, six stages, over months and years. Together the two pages answer the question "how does a harness work?" along both axes. The previous page is the propagation cut; this is the temporal cut.
-
-The page threads a fictional six-engineer team through their first twelve months. Their stack is deliberately polyglot — a Python backend service (`ruff`, `mypy`, `pytest`), a TypeScript frontend (`eslint`, `tsc`, `vitest`), and Terraform infrastructure-as-code (`tflint`, `terraform fmt`) — so the artefact tables show realistic multi-stack behaviour rather than a monoculture. No single team member is fluent in all three stacks. Each stage also carries one *In this plugin's case* sidebar that points to a verifiable real event in this plugin's own harness, so the temporal arc is rooted in something that actually happened, not invented to fit the narrative.
-
----
-
-## The shape of one full lifecycle
-
-Six stages. The first five are the per-harness arc; the sixth applies whenever change forces a rebuild, regardless of where on the arc the harness sits.
-
-| Stage | Defining artefact at the end | Dominant cadence |
-| --- | --- | --- |
-| 1. Day Zero — Initialisation | A skeletal `HARNESS.md` with the Status section unverified | One-shot |
-| 2. First Month — Bootstrapping | First hand-authored constraints; first promoted `AGENTS.md` entries | Per-session |
-| 3. Quarter One — First Steady State | First `/harness-audit` complete; first `/harness-health` snapshot | Weekly + monthly |
-| 4. Year One — Maturity | Tuning loop in continuous operation; archival rules running | Daily + monthly + quarterly |
-| 5. Renewal Years — Upgrades and Refresh | At least one `/harness-upgrade` accepted; convention files in sync | Quarterly + on plugin release |
-| 6. When the Harness Has to Change | Rebuilt artefacts after team / codebase / platform shift | Triggered by change |
-
-Each stage below has the same internal structure: a framing paragraph, a worked-example beat for the fictional team, a real-plugin sidebar, the substantive content, two summary tables (tools and artefacts), and a connective paragraph that ties them together.
-
----
-
-## Stage 1 — Day Zero — Initialisation
-
-The cold-start. The team has decided to put a harness around its AI-assisted work, but has nothing yet — no `HARNESS.md`, no `AGENTS.md`, no `REFLECTION_LOG.md`, no hooks. The defining artefact at the end of this stage is a complete-but-unverified `HARNESS.md` that describes what the team thinks it cares about, with the actual enforcement still mostly to be wired up.
-
-The fictional team runs `/harness-init` from a clean checkout. The `harness-discoverer` agent reads `pyproject.toml`, `package.json`, the Terraform configs, and the existing GitHub Actions workflow. It surfaces what is already true: `ruff` and `mypy` and `pytest` running on the Python service; `eslint` and `tsc` and `vitest` on the TypeScript frontend; `tflint` and `terraform fmt` on the IaC. It proposes a starting `HARNESS.md` with three deterministic constraints already wired (one per stack), three unverified placeholder constraints describing things the team should enforce but currently does not, and a Status section showing 3/6 verified. Each inference is presented for confirmation; nothing is auto-accepted. They commit the file and push.
-
-> *In this plugin's case:* the very first `/harness-init` ran on the plugin's own codebase on 2026-04-06 (commit `8b30ea3` "Initialize project harness with HARNESS.md"). The discoverer found `markdownlint`, `gitleaks`, and `shellcheck` already in CI. Six constraints were declared and five reached deterministic enforcement on the first run, because the codebase is markdown and bash — projects with application code typically start with more unverified or agent-level constraints. See [`REFLECTION_LOG.md`](https://github.com/Habitat-Thinking/ai-literacy-superpowers/blob/main/REFLECTION_LOG.md) entry 2026-04-06.
-
-The output of Day Zero is not a finished harness. It is a *starting line that is honest about what is real today*. The Status section showing 3/6 verified is the truthful claim. The three unverified placeholders are not failures; they are declared intent that has not yet been wired to enforcement. The whole point of the stages that follow is to turn declared intent into verified enforcement, one constraint at a time.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Command | `/harness-init` | Cold-start setup; orchestrates discovery, generates `HARNESS.md`, scaffolds `AGENTS.md` and `REFLECTION_LOG.md`, configures hooks |
-| Skill | [`harness-engineering`](harness-engineering.md) | Provides the conceptual framework that `/harness-init` operates within |
-| Agent | `harness-discoverer` | Read-only scanner that infers stack, linters, CI checks, and existing convention documentation |
-| Hook | `SessionStart` + rotating `Stop` | Installed and declared in `.claude/settings.local.json`; ready to fire from the next session onward |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | Skeleton with three deterministic and three unverified constraints; Status 3/6 | Created from the plugin's `HARNESS.md` template |
-| `AGENTS.md` | Five empty section headers (STYLE, GOTCHAS, ARCH_DECISIONS, TEST_STRATEGY, DESIGN_DECISIONS) | Created from template |
-| `REFLECTION_LOG.md` | Header comment block; no entries | Created from template |
-| Hook configuration | `SessionStart` + rotating `Stop` declared in `.claude/settings.local.json` | Configured at `/harness-init` time |
-
-**How they work together:** `/harness-init` is the single command that brings every other surface into existence. The `harness-discoverer` agent does the reading work that would otherwise require the team to recall every convention from memory; the [`harness-engineering`](harness-engineering.md) skill provides the conceptual scaffolding the agent operates against. The four artefacts created in this stage are all in their starting state — the skeleton from which everything else accretes. The hooks are the only thing that becomes operationally active immediately; the rest of the artefacts will not start changing until the team works in this codebase again. For the deep mechanics of the bootstrap process, see [Harness Engineering](harness-engineering.md#bootstrapping) and the tutorial [Harness for an Existing Codebase](../tutorials/harness-from-scratch.md).
-
----
-
-## Stage 2 — First Month — Bootstrapping
-
-The harness is alive but largely empty. Reflections start appearing as the team uses AI assistants in earnest. Conventions that lived in scattered places — Slack pins, `CONTRIBUTING.md` excerpts, comments in `pyproject.toml` — start being surfaced explicitly. The first hand-authored constraints land in `HARNESS.md`. The first promoted entries appear in `AGENTS.md`. The defining property of this stage is *accretion under human curation*.
-
-The fictional team has eight reflection entries by the end of week two. One captures an agent committing a SQL query that bypassed the team's repository abstraction, going straight to `cursor.execute()`. `/reflect` flags this as a `failure` signal during the entry capture and proposes an agent-enforced constraint there and then. The team accepts; `/harness-constrain` writes the constraint into `HARNESS.md` (with `agent` enforcement, `scope: pr`, tool `code-reviewer agent`). A week later, after the same kind of surprise hasn't recurred, a developer reads through recent reflections during a curation session and promotes the gotcha into `AGENTS.md`'s GOTCHAS section: "always route DB writes through `repositories/` — agents tend to inline `cursor.execute()`." Separately, the team runs `/extract-conventions` in a thirty-minute structured session that surfaces three more tacit conventions worth promoting.
-
-> *In this plugin's case:* by 2026-04-08, the auto-constraint proposal pipeline was firing on reflections and the `Signal` field had been added to the entry template (see `REFLECTION_LOG.md` 2026-04-08, the first signal-classified entries). The integration agent began appending reflections automatically at the end of pipeline runs, and the assessment skill stack started taking shape iteratively across PRs #79–#90 as documented in the 2026-04-09 reflection.
-
-The work of First Month is mostly conversational — `/reflect` after sessions, `/extract-conventions` once or twice, occasional `/harness-constrain` calls to lock in a real pattern. The artefacts are accreting slowly. By the end of the month, the team typically has five to ten reflection entries, three to five new constraints in `HARNESS.md` (some still unverified), and a handful of GOTCHAS and ARCH_DECISIONS in `AGENTS.md`. The Status section's verified ratio has not necessarily improved much; verification slots take real engineering work to wire, and First Month is mostly about declared intent.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Command | `/reflect` | Captures a reflection at session end; proposes a constraint when the surprise looks preventable |
-| Command | `/extract-conventions` | Structured discovery session that surfaces tacit team knowledge |
-| Skill | [`convention-extraction`](../how-to/extract-conventions.md) | Supports `/extract-conventions` with the question framework |
-| Command | `/harness-constrain` | Interactive promotion of a proposal into `HARNESS.md`; configures the verification slot when deterministic |
-| Skill | [`constraint-design`](constraints-and-enforcement.md) + [`verification-slots`](../how-to/set-up-verification-slots.md) | Support `/harness-constrain` |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | 6–10 constraints; some hand-authored, some still unverified | New constraints appended via `/harness-constrain`; Status section unchanged |
-| `AGENTS.md` | First entries in GOTCHAS and ARCH_DECISIONS; STYLE has a few items from `/extract-conventions` | First promoted entries from `REFLECTION_LOG.md` and from extraction session |
-| `REFLECTION_LOG.md` | 5–10 entries, mostly `failure` and `workflow` signals | First entries appended from sessions; first auto-constraint proposals fired |
-| Hook configuration | Unchanged from Day Zero | None |
-
-**How they work together:** The flow at this stage is: a session happens, the developer or agent runs `/reflect`, the entry lands in `REFLECTION_LOG.md`, sometimes `/reflect` proposes a constraint inline and the developer accepts, `/harness-constrain` writes it into `HARNESS.md`. Separately, on a slower cadence (weekly or fortnightly), the developer reviews recent reflections and promotes recurring patterns into `AGENTS.md`. `/extract-conventions` runs as a one-shot bootstrap — the team only needs to do it once or twice early on to capture the conventions that already exist. The deep mechanics of how reflections become constraints and how `AGENTS.md` curation works are covered in [Compound Learning](compound-learning.md) and [The Self-Improving Harness](self-improving-harness.md).
-
----
-
-## Stage 3 — Quarter One — First Steady State
-
-The harness has stopped being purely declarative and has started doing work the team can feel. The first `/harness-audit` runs and reveals what the Status section actually means. The first `/harness-health` snapshot lands and gives the team a baseline to compare against. The rotating `Stop` hook has cycled through every deterministic GC rule at least once. The defining property of this stage is *observability of the harness's own state* — the team can now see whether their harness is doing what they thought it was doing.
-
-The fictional team runs their first `/harness-audit` six weeks in. The `harness-auditor` agent compares declared constraints in `HARNESS.md` against the enforcement actually present in the codebase and CI. Two findings: the unverified constraint about TypeScript bundle size has no tool wired anywhere, and the deterministic Terraform constraint references a `tflint` config that no longer exists in the repo (someone moved it). The team writes a verification slot for the bundle-size constraint and updates the path reference for the `tflint` one. The auditor updates the Status section: 5/6 verified. Separately, `/harness-health` produces the team's baseline snapshot — enforcement ratio 0.6, learning velocity nominal, no regression flags.
-
-> *In this plugin's case:* the baseline `harness-health` snapshot was generated on 2026-04-06 alongside the gitleaks integration (see `REFLECTION_LOG.md` 2026-04-06, second entry — "Initialized the project's own harness... and generated the baseline health snapshot"). The reflection notes the unusual deterministic-enforcement ratio of 5/6 on first init, which is specific to a markdown-and-bash codebase; an application codebase will typically start lower and climb across Quarter One.
-
-By the end of Quarter One the team has roughly 15–25 reflection entries, the first two or three constraints have been promoted from unverified to verified-deterministic, the rotating Stop hook is producing sub-five-second advisory findings every session, and the weekly `gc.yml` workflow has run a dozen times. The team can now answer "is our harness healthy?" with evidence — a snapshot, an enforcement ratio, a count of GC findings. They could not answer it with evidence in First Month.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Command | `/harness-audit` | Full meta-verification; updates Status section in `HARNESS.md` |
-| Agent | `harness-discoverer` + `harness-auditor` | Read-only scan + read-write Status update |
-| Command | `/harness-status` (lighter) and `/harness-health --deep` (heavier alternative) | Faster spot-checks of the same thing |
-| Command | `/harness-health` | Generates a snapshot of enforcement ratio, learning velocity, regression flags |
-| Hook | rotating `Stop` | Picks one deterministic GC rule per session by day-of-year, runs it as a sub-5s advisory |
-| CI workflow | `gc.yml` | Runs all deterministic GC rules every Monday 09:00 UTC |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | 8–12 constraints; Status section maintained by audits; promotion ladder visible | Status updated by `harness-auditor`; verification slots added; some `unverified` → `verified-agent` or `verified-deterministic` |
-| `AGENTS.md` | Steady accretion of curated entries every 2–4 weeks | New entries from `REFLECTION_LOG.md` curation |
-| `REFLECTION_LOG.md` | 15–25 entries; signal-tagging is routine; first reflection-driven regression detection runs | Continues to accumulate; GC rule scans it weekly |
-| Hook configuration | Unchanged; rotation has now hit every declared deterministic GC rule | None |
-| `observability/snapshots/` | First snapshot file present | Created by first `/harness-health` run |
-
-**How they work together:** `/harness-audit` and `/harness-health` are the two observability commands that turn the harness from a silent infrastructure into something the team can reason about. The auditor writes the Status section; the health command writes snapshots. The rotating Stop hook and the `gc.yml` workflow form the [Three Enforcement Loops](three-enforcement-loops.md)' outer (scheduled, investigative) loop — they catch entropy that no single change introduces. By the end of Quarter One the harness has stopped being something the team built and has started being something the team operates. The lighter command `/harness-status` is what most teams reach for between full audits; deep mechanics are in [Run a Harness Audit](../how-to/run-a-harness-audit.md).
-
----
-
-## Stage 4 — Year One — Maturity
-
-The tuning loop runs continuously. Reflections come in, GC notices recurring patterns and files issues, the team promotes proposals into constraints, audits keep the Status section honest, propagation pushes new policies out to the convention files and CI workflows. The four operational cadences (`/reflect` per session, `/harness-health` monthly, `/assess` quarterly, `/cost-capture` quarterly) are anchoring the team's rhythm. The `REFLECTION_LOG.md` archival rules — Path 1 deterministic auto-archive of `Promoted`-tagged entries, Path 2 monthly aged-out review — start mattering as the log crosses 50 entries. The defining property of this stage is *the harness operates the team as much as the team operates the harness*.
-
-The fictional team is nine months in. GC's reflection-driven regression detection rule has filed three issues over the past two quarters, two of which have become constraints. The promotion ladder has moved one constraint from `agent` enforcement to `deterministic` after the team built the right verification tool. Quarterly `/assess` shows movement from Level 2 to Level 3. `REFLECTION_LOG.md` has crossed 60 entries. The first weekly archival sweep moves seven entries with `Promoted` lines into `reflections/archive/2026.md`; the agent verifies each entry's `Promoted` line resolves to actual `AGENTS.md` or `HARNESS.md` content before moving it. Read-side filtering caps every agent's intake at 50 entries / 90 days, so the working set stays bounded even as the archive grows.
-
-> *In this plugin's case:* the plugin is too young to have a real Year One artefact yet — it is five weeks old as this page is written. The closest real evidence is the bootstrap-circularity moment: `REFLECTION_LOG.md` 2026-05-01 captures the design and shipping of v0.32.0's archival rules, and the very entry that captures the lessons is now the first entry the system will be asked to manage. The Path 1 GC rule will scan that entry for a `Promoted` line; if a curator promotes a learning from it, the rule will archive the entry by its own logic. The mechanism is recursively self-applying from day zero.
-
-Year One is when the asymmetry that makes the whole system work becomes visible: the parts of the harness that *block* (constraints, hooks, CI) catch most surprises before they recur, while the parts that *report* (`/harness-gc`, `/harness-audit`) describe drift the blocking surfaces missed. Reports nudge; constraints stop. The two are now operating together at full cadence, each catching what the other cannot.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Command | `/harness-gc` | Weekly entropy detection; reads recent reflections; files issues for findings |
-| Skill | [`garbage-collection`](garbage-collection.md) | Supports `/harness-gc` with the rule taxonomy |
-| Agent | `harness-gc` | Read-write within bounds; cannot modify `HARNESS.md` itself (trust boundary) |
-| Command | `/assess` | Quarterly literacy assessment; surfaces gaps and produces an improvement plan |
-| Skill | `ai-literacy-assessment` | Supports `/assess` |
-| Agent | `assessor` | Scans the repo; scores across disciplines; writes the assessment document |
-| Command | `/governance-audit` | Quarterly semantic-drift detection on governance constraints |
-| Agent | `governance-auditor` | Reports never-modifies-`HARNESS.md` (mirrors `harness-gc` trust boundary) |
-| Command | `/cost-capture` | Quarterly snapshot of provider spend, tokens, model mix |
-| CI workflow | `gc.yml` (weekly), `harness-audit.yml` (where configured), per-PR constraint workflows | Continuous enforcement and entropy detection |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | Mature constraint set (15–25); governance constraints declared with falsifiability rules; Status section stable; promotion ladder has moved several constraints up | Constraints tightened; some promoted; governance section populated |
-| `AGENTS.md` | Stable entry base; new entries are subtle (the obvious patterns were caught in earlier stages) | Slow accretion of nuanced learnings |
-| `REFLECTION_LOG.md` + archive | 50+ entries in the live log; first entries moved to `reflections/archive/<YYYY>.md` by the Path 1 weekly auto-archive rule; Path 2 aged-out review running monthly for entries >180 days without `Promoted` | Archival mechanism active; read-side filtering caps intake |
-| `observability/snapshots/` | Multiple snapshots; trends visible; archive directory accumulating monthly snapshots older than 6 months | New snapshot per `/harness-health`; archival per the `Observability archive` GC rule |
-| Cost data | `MODEL_ROUTING.md` updated quarterly with observed routing patterns | New cost snapshots from `/cost-capture`; routing decisions adjusted on evidence |
-
-**How they work together:** The deep description of how all of this fits is in [The Harness Tuning Loop](the-harness-tuning-loop.md) (one full turn of the per-surprise loop) and [The Loops That Learn](the-loops-that-learn.md) (the four cadences interlocking). At the Year One scale, the most important thing happening is *the loops are interlocking*: reflections feed GC, GC produces issues, the team promotes proposals into constraints, audits confirm the constraints are real, snapshots prove they are working, assessments validate the team has moved up the literacy ladder, cost data informs the routing the team uses. Each loop's output is another loop's input; the whole system is cybernetic. The archival mechanism described in the v0.32.0 release notes ([CHANGELOG](https://github.com/Habitat-Thinking/ai-literacy-superpowers/blob/main/CHANGELOG.md#0320--2026-05-01)) is what keeps the working set bounded over multiple years.
-
----
-
-## Stage 5 — Renewal Years — Upgrades and Refresh
-
-The plugin ships new template content. New GC rules, new template-shipped constraints, new skills, refined agent prompts. None of this propagates automatically; the SessionStart hook surfaces a `/harness-upgrade` prompt when the installed plugin version moves ahead of the `<!-- template-version: -->` marker in `HARNESS.md`. The team reviews the diff and accepts what fits. The push-direction surfaces — convention files (`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`) and `ONBOARDING.md` — get re-generated together via `/harness-sync`, the unified multi-surface entry point that composes the underlying primitives (`/convention-sync` for the rule files; `/harness-onboarding` for the onboarding document) into one interactive pass. The defining property of this stage is *the harness adopts upstream improvements without losing the team's own accumulated tuning*.
-
-The fictional team is in their second year. Plugin v0.36 ships. Their next session opens with the SessionStart hook surfacing a `/harness-upgrade` prompt: "three new GC rules, one new template-shipped constraint, two refined skill descriptions." They review each item against their own context. The new constraint about CVE-bearing dependencies maps onto a real concern; they accept it and `/harness-upgrade` adds it to `HARNESS.md` with the verification slot pre-wired. Two of the three new GC rules fit; the third assumes a Java codebase, so they decline it. They run `/harness-sync` — the unified multi-surface entry point — which scans for drift across the convention files and `ONBOARDING.md` together; the team selects all three drifted surfaces and `/harness-sync` applies the underlying primitives (`/convention-sync` for the rule files; `/harness-onboarding` for `ONBOARDING.md`, since a new engineer is joining the team next week) in one pass.
-
-> *In this plugin's case:* the plugin's harness has not yet had a substantial Renewal moment because the plugin is the source of the upgrades, not a downstream consumer. What is real and verifiable is the propagation half: the rotating Stop hook ran the new "Reflection log archival of promoted entries" GC rule the same day v0.32.0 shipped (see `REFLECTION_LOG.md` 2026-05-01). The convention-sync mechanics are exercised continuously across the marketplace's plugins; per-plugin tag conventions stabilised in v0.32.0 (see CHANGELOG 0.32.0 chore section).
-
-Renewal is not a one-shot event; it is an ongoing rhythm punctuated by plugin releases. Most months, no renewal happens. When the plugin ships, the team has a small triage decision: which of the new items match our context, which do not, what would we keep regardless. The `/harness-upgrade` machinery does not auto-apply anything; it shows the diff and waits.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Hook | `SessionStart` | Surfaces `/harness-upgrade` prompts when template versions move |
-| Command | `/harness-upgrade` | Diffs current `HARNESS.md` against the latest template; presents new items for accept/reject |
-| Command | [`/harness-sync`](../how-to/sync-harness.md) | Multi-surface entry point: detects drift, multi-selects, applies via the underlying primitives in one pass |
-| Command | `/convention-sync` | Re-generates `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/` from `HARNESS.md` |
-| Skill | [`convention-sync`](../how-to/sync-conventions.md) | Supports `/convention-sync` |
-| Command | `/harness-onboarding` | Regenerates `ONBOARDING.md` from `HARNESS.md` + `AGENTS.md` + `REFLECTION_LOG.md` |
-| Skill | [`harness-onboarding`](../how-to/generate-onboarding.md) | Supports `/harness-onboarding` |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | New template-shipped constraints accepted; `<!-- template-version: -->` marker bumped to current | Diff applied via `/harness-upgrade`; Status section reflects new verified slots |
-| `AGENTS.md` | Largely unchanged; `/harness-upgrade` rarely modifies hand-curated learnings | Untouched by upgrade unless a structural reorganisation is part of the new template |
-| `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/` | Re-generated to match current `HARNESS.md` | Re-generated by `/convention-sync` |
-| `ONBOARDING.md` | Regenerated when new members join | Regenerated by `/harness-onboarding` |
-| `REFLECTION_LOG.md` | Continues to accumulate; older entries move to archive | Path 1 archival continues; Path 2 aged-out review continues |
-
-**How they work together:** The upgrade pipeline is deliberately serial: `SessionStart` hook surfaces the prompt → `/harness-upgrade` shows the diff → human accepts or rejects each item → `HARNESS.md` is updated → `/harness-sync` re-evaluates drift across all push-direction surfaces and applies the underlying primitives (`/convention-sync` for the convention files; `/harness-onboarding` for the onboarding document) in one interactive pass. No agent in this pipeline has the authority to write to `HARNESS.md` without confirmation. The propagation step closes the loop the same way the propagation half of [The Harness Tuning Loop](the-harness-tuning-loop.md#stage-5--propagate-the-change-to-the-enforcement-surfaces) closes it for newly-promoted constraints. For the deep mechanics of how `/harness-upgrade` parses templates and produces a diff, see [Upgrade Your Harness](../how-to/upgrade-your-harness.md); for `/harness-sync` itself, see [Sync Harness Surfaces](../how-to/sync-harness.md).
-
----
-
-## Stage 6 — When the Harness Has to Change
-
-This stage is not bound to the temporal arc. A team change in month three needs the same response as a team change in year three. A codebase split in week six needs the same response as one in year two. The stage is placed last for narrative reasons — it is the disruption that resets parts of the lifecycle — but it can apply at any point in the harness's life. The defining property of this stage is *the harness must absorb a change underneath it that breaks one of its assumptions*.
-
-Three forces typically trigger this stage:
-
-**Team change.** People leave; people join. Tacit knowledge departs; tacit knowledge has to be re-extracted. The fictional team loses two engineers and gains three. The departing engineers held conventions about error handling and logging that lived nowhere except in their heads and in code reviews. A `/extract-conventions` session — run as soon as possible after the announcement, ideally before the engineers actually leave — surfaces what they knew. New STYLE and ARCH_DECISIONS entries land in `AGENTS.md`. The new engineers are onboarded via `/harness-onboarding`'s output.
-
-**Codebase change.** A new subsystem in a new language, a major refactor, a service split. The fictional team carves out a new Go data-pipeline service for high-throughput work. They re-run `/harness-init` scoped to `data-pipeline/**`; the discoverer finds `govulncheck` and `staticcheck`. Two new constraints land, each scoped to the new directory. The existing constraints stay scoped to where they were. The `MODEL_ROUTING.md` document picks up a note that the data-pipeline service has different latency characteristics and may benefit from a different routing policy.
-
-**Platform change.** New AI tooling, new model tier, new CI provider, new package manager. `/cost-capture` typically detects this first — a quarterly snapshot shows model spend has shifted, and the routing assumptions need updating. `MODEL_ROUTING.md` is rewritten. If the change is large enough, `/superpowers-init` may need to re-run to reconfigure the broader habitat (model routing, observability cadences, the badge in the README).
-
-> *In this plugin's case:* the model-cards plugin shipped as a sister plugin in the same marketplace on 2026-04-29. That triggered a real change-driven moment: a new repo (`Habitat-Thinking/model-card-library`) was created and seeded; per-plugin tag conventions were introduced (CHANGELOG v0.32.0); a multi-repo scheduled agent was set up to walk both repos quarterly; the marketplace listing's `version` was decoupled from `plugin_version` to handle two plugins with independent release rhythms. The reflections of 2026-04-30 and 2026-05-01 capture both the surprises and the rebuilding moves.
-
-The common thread across all three forces: the rebuild moves are not new mechanism. They are the same `/extract-conventions`, `/harness-init`, `/cost-capture`, and `/harness-sync` commands the team already uses (with `/convention-sync` and `/harness-onboarding` continuing to serve as `/harness-sync`'s underlying primitives when the team wants focused single-surface work), applied in a different sequence and with a different focus. The harness does not need to invent special change-handling mechanism; it needs to apply its existing mechanism intentionally.
-
-### Tools at work
-
-| Surface | Name | Role |
-| --- | --- | --- |
-| Command | `/extract-conventions` | Re-run when team composition changes; surfaces the conventions the departing members held |
-| Command | `/harness-init` | Re-run scoped to a new subsystem; the discoverer finds the new stack |
-| Command | `/cost-capture` | Detects platform-level cost shifts that suggest routing assumptions need updating |
-| Command | `/superpowers-init` | Re-runs broader habitat configuration when the platform shifts substantially |
-| Command | [`/harness-sync`](../how-to/sync-harness.md) | Multi-surface entry point: propagates the rebuilt artefacts to the convention files and onboarding document by composing `/convention-sync` and `/harness-onboarding` in one pass |
-| Skill | [`cross-repo-orchestration`](../how-to/orchestrate-across-repos.md) | Guides multi-repo coordination when the change spans repositories |
-
-### Artefacts evolving here
-
-| Artefact | State at this stage | What changed since the previous stage |
-| --- | --- | --- |
-| `HARNESS.md` | New constraints scoped to new subsystems; existing scope preserved | New entries from re-run `/harness-init`; re-scoped from `/harness-constrain` |
-| `AGENTS.md` | New STYLE / ARCH_DECISIONS entries from `/extract-conventions`; departing-member conventions made explicit | Entries from extraction sessions; existing entries audited for relevance |
-| `MODEL_ROUTING.md` | Updated with new platform realities | Re-evaluated against `/cost-capture` data |
-| `ONBOARDING.md` | Regenerated to reflect new state | `/harness-onboarding` re-run |
-| `REFLECTION_LOG.md` | Continues to accumulate; pre-change reflections may be promoted before they are archived | Curators promote departing-member reflections to `AGENTS.md` deliberately |
-
-**How they work together:** The change-driven sequence is intentional but not heavyweight: notice the change → run the right extraction or init command → write what surfaces into the right artefact → propagate via `/harness-sync`, which composes `/convention-sync` and `/harness-onboarding` into one interactive pass against the rebuilt state. The trust boundary that protects `HARNESS.md` (only `/harness-constrain` writes constraints; only `harness-auditor` writes the Status section) holds across change events too — no agent gets to rewrite the harness because the team changed. The depth of how cross-repo coordination works during a change event is in [Orchestrate Across Repos](../how-to/orchestrate-across-repos.md). [Habitat Engineering](habitat-engineering.md) is the broader frame for thinking about the harness's environment when forces underneath it shift.
-
----
-
-## What the lifecycle earns
-
-A team that has run a harness through all six stages has something different from what they had at Day Zero. The `HARNESS.md` is no longer a record of what they thought was important when they started. It is a record of what their operational experience has taught them is worth enforcing — evidence-backed, audited, propagated, and re-applied through every change the team has been through.
-
-A team that has not run the lifecycle has the same `HARNESS.md` they had on day one. The reflections they did not capture do not exist. The patterns they did not promote do not block recurring surprises. The upgrades they did not adopt mean their harness is years behind the upstream. The harness still appears to operate, but it has stopped tuning, stopped renewing, and stopped adapting.
-
-The infrastructure is not the product. The lifecycle is the product. Every component on this page exists to make the next stage of the arc possible without imposing a cost the team cannot pay — two minutes for `/reflect`, weekly automated GC, an interactive `/harness-constrain` when a real pattern emerges, an annual triage when the plugin ships, and the existing extraction and init commands re-applied when the team or codebase or platform changes underneath the harness.
-
----
-
-## Where are you on this arc? — A reading map
-
-The map below organises the rest of the docs site by lifecycle position. A reader who is at *First Month* should be able to look at this map and know exactly which next pages to open.
-
-| Stage | Where you are — observable signals | Read deeper | Try it |
-| --- | --- | --- | --- |
-| **Day Zero** | No `HARNESS.md` yet, or one only just created from template | [Harness Engineering](harness-engineering.md) · [Habitat Engineering](habitat-engineering.md) | [Getting Started](../tutorials/getting-started.md) · [Harness From Scratch](../tutorials/harness-from-scratch.md) (tutorial) |
-| **First Month** | `HARNESS.md` has fewer than 5 hand-authored constraints; `AGENTS.md` mostly template-default; first reflections appearing | [Compound Learning](compound-learning.md) · [The Self-Improving Harness](self-improving-harness.md) | [Surfacing Tacit Knowledge](../tutorials/surfacing-tacit-knowledge.md) (tutorial) · [Add a Constraint](../how-to/add-a-constraint.md) · [Extract Conventions](../how-to/extract-conventions.md) |
-| **Quarter One** | First `/harness-audit` has run; first `/harness-health` snapshot exists; rotating Stop hook visible in session logs | [Three Enforcement Loops](three-enforcement-loops.md) · [Codebase Entropy](codebase-entropy.md) · [Constraints and Enforcement](constraints-and-enforcement.md) | [Run a Harness Audit](../how-to/run-a-harness-audit.md) · [Run a Calibration Review](../how-to/run-a-calibration-review.md) |
-| **Year One** | 50+ reflections; tuning loop running on its own; quarterly assessments cycling; first archival sweep has happened | [The Harness Tuning Loop](the-harness-tuning-loop.md) · [The Loops That Learn](the-loops-that-learn.md) · [Garbage Collection](garbage-collection.md) · [Regression Detection](regression-detection.md) | [Run an Assessment](../how-to/run-an-assessment.md) · [Run a Governance Audit](../how-to/run-a-governance-audit.md) · [Track AI Costs](../how-to/track-ai-costs.md) |
-| **Renewal Years** | At least one `/harness-upgrade` accepted; convention files in sync with `HARNESS.md`; `ONBOARDING.md` regenerated at least once | [Progressive Hardening](progressive-hardening.md) · [Governance as Meaning Alignment](governance-as-meaning-alignment.md) · [Determinacy Calibration](determinacy-calibration.md) | [Upgrade Your Harness](../how-to/upgrade-your-harness.md) · [Sync Conventions](../how-to/sync-conventions.md) · [Generate Onboarding](../how-to/generate-onboarding.md) |
-| **Change-driven** | Team composition just shifted, codebase just split, or platform just changed | [Decision Archaeology](decision-archaeology.md) · [Adversarial Review](adversarial-review.md) | [Extract Conventions](../how-to/extract-conventions.md) (re-run) · [Orchestrate Across Repos](../how-to/orchestrate-across-repos.md) |
-
-If you can't tell which stage you're in, the fastest tell is your `HARNESS.md`. A skeleton template with an unverified Status section means you are at Day Zero or early First Month. A Status section being maintained by audits means Quarter One has happened. Hand-authored governance constraints with falsifiability declarations mean Year One is well underway. A `<!-- template-version: -->` marker that lags the installed plugin version means the next move is `/harness-upgrade`. A team or codebase or platform shift you have not yet absorbed means the change-driven stage applies whatever your position on the linear arc.
-
----
-
-## Further reading
-
-Pages on the orthogonal axis or one level out:
-
-- [The Harness Tuning Loop](the-harness-tuning-loop.md) — the propagation cut: one surprise, every surface, in a single turn of the loop. Read alongside this page for both axes of harness operation.
-- [The Loops That Learn](the-loops-that-learn.md) — the four operational cadences (`/reflect`, `/harness-health`, `/assess`, `/cost-capture`) that drive the per-stage rhythm.
-- [The Three Enforcement Loops](three-enforcement-loops.md) — the timescale cut: inner (edit-time, advisory), middle (PR-time, blocking), outer (scheduled, investigative).
-- [Habitat Engineering](habitat-engineering.md) — the broader environment in which the harness lives.
-- [`HARNESS.md`, the Document](harness-md.md) — the reference for the central artefact whose evolution this page traces.
+> The harness has a simple lifecycle: **detect drift, heal it, pull
+> upstream when needed**. Three commands cover it. Everything else is
+> a deeper or specialised version of one of those three.
+
+## The three states a harness is ever in
+
+A harness is always in one of three states:
+
+1. **In sync.** HARNESS.md matches reality. Convention files reflect
+   the current rules. Reflections are captured. The Status section
+   accurately describes enforcement.
+2. **Drifted.** Something has fallen out of alignment. A convention
+   file is stale, a snapshot has aged out, a constraint regressed,
+   or a recurring reflection pattern hasn't been promoted yet.
+3. **Behind upstream.** The plugin has shipped new template content
+   the project hasn't reviewed yet — new constraint defaults, new GC
+   rules, new conventions.
+
+Every command in the plugin moves the harness between these states.
+Most are specialisations; a few are the everyday entry points.
+
+## The everyday entry points
+
+Three commands cover most lifecycle activity:
+
+### `/harness-sync` — the everyday command
+
+Detects drift across every surface and lets you fix it in one pass.
+Internally runs `/harness-audit`'s detection logic, presents a unified
+drift table, and applies the fixes you select. Mechanical fixes
+(convention files, ONBOARDING.md, snapshots, HARNESS.md Status
+accuracy) run automatically. Judgement-required fixes (which
+constraint to add, whether to take a template upgrade) print the
+suggested command for you to run separately.
+
+When in doubt, run `/harness-sync`. It tells you everything that's out
+of alignment and either fixes it or tells you what to run.
+
+### `/harness-upgrade` — pull upstream changes
+
+When the plugin has shipped new template content, `/harness-upgrade`
+diffs your `HARNESS.md` against the current template and presents new
+items for review. You accept, skip, or customise each one.
+
+`/harness-sync` will tell you when this is needed (the "Template
+version drift" row in its drift table). `/harness-upgrade` is the
+remediation; it doesn't auto-run because choosing what to adopt is a
+judgement call.
+
+### `/harness-constrain` — capture or promote a constraint
+
+When you want to add a new constraint to HARNESS.md, or promote an
+existing one from `unverified` to `agent` or `deterministic`,
+`/harness-constrain` walks you through the authoring with the
+constraint-design skill loaded.
+
+`/harness-sync` will surface "Recurring reflection pattern" findings
+when REFLECTION_LOG.md shows the same surprise twice. That's the
+signal that a constraint should exist for that pattern. `/harness-
+constrain` is the authoring path.
+
+## The specialised commands
+
+Behind the everyday three, there are deeper or focused tools:
+
+- **`/harness-audit`** is the inspection-only deep-dive. Same engine
+  as `/harness-sync` but read-only — no prompts, just a report.
+  Useful when you want to inspect without committing to action, or
+  when scripting / scheduling. The cadence in `HARNESS.md`
+  Observability ("Harness audit: quarterly") refers to this command.
+- **`/harness-status`** is a quick-look summary — enforcement ratio,
+  drift indicator, GC state. Faster than `/harness-audit` for "is
+  everything roughly OK?"
+- **`/harness-health`** generates a full snapshot to
+  `observability/snapshots/`. The longitudinal record of the harness
+  over time, with trends.
+- **`/harness-gc`** manages the periodic garbage-collection rules
+  that fight slow drift between PR-level enforcement events.
+- **`/convention-sync`** and **`/harness-onboarding`** are the
+  primitives `/harness-sync` calls. You can invoke them directly when
+  you only want one surface refreshed.
+
+## When each lifecycle state happens
+
+- **You write a constraint** → run `/harness-constrain`. Then later,
+  next time you run `/harness-sync`, the new constraint propagates to
+  the convention files automatically (it shows up as a drifted
+  surface that auto-fixes).
+- **You merge a PR** → run `/harness-sync` if the PR changed
+  HARNESS.md content. Convention files and ONBOARDING.md regenerate.
+- **You see a build break** related to harness state → run
+  `/harness-audit` for the read-only diagnostic, or `/harness-sync`
+  to also fix.
+- **You install a new plugin version** → run `/harness-upgrade`. The
+  SessionStart hook nudges you when the template version has moved.
+- **You notice a pattern of failures** in REFLECTION_LOG.md → run
+  `/harness-constrain` to encode the lesson.
+
+## Why this lifecycle works
+
+The lifecycle is built around two truths.
+
+**Truth one: HARNESS.md is the single source of truth.** Everything
+else is derived. Convention files are derived from the Conventions
+and Constraints sections. ONBOARDING.md is derived from HARNESS.md +
+AGENTS.md + REFLECTION_LOG.md. The snapshot is derived from the
+current state. The Status section is derived from actual enforcement.
+When anything diverges, regeneration brings it back into alignment.
+
+**Truth two: not every drift is mechanical.** Some drift signals a
+real choice — should we take the upstream template? Should this
+recurring reflection become a constraint? Mechanical regeneration
+works for derived surfaces; choices need a human. The
+`[auto]` / `[manual]` distinction in `/harness-sync`'s drift table
+makes this explicit, and keeps the trust boundary clear: the command
+applies mechanical fixes; choices stay with you.
+
+## Related reading
+
+- [The Harness Tuning Loop](the-harness-tuning-loop.md) — the focused
+  sub-flow for promoting reflection patterns into constraints.
+- [The Self-Improving Harness](self-improving-harness.md) — why a
+  harness needs to evolve and how compound learning fits in.
+- [How to: sync the harness](../how-to/sync-harness.md) — the
+  step-by-step for `/harness-sync`.
+- [How to: run a harness audit](../how-to/run-a-harness-audit.md) —
+  the diagnostic workflow.

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
@@ -11,166 +11,99 @@ redirect_from:
 
 # The Harness Tuning Loop
 
-A harness that cannot be tuned is a harness that calcifies. The loop on this page is what keeps it alive: a single recurring path that takes one operational surprise and converts it -- through six stages -- into a tightened policy and the enforcement surfaces that carry that policy. The simple version is that `REFLECTION_LOG.md` is the input, the GC agent is the watcher, `HARNESS.md` is the policy, and `AGENTS.md` / hooks / CI are the downstream surfaces that get re-tuned when the policy changes.
-
-Every other Explanation page in this section cuts the harness on a different axis: [The Loops That Learn](the-loops-that-learn.md) cuts it as **four cadences**, [Three Enforcement Loops](three-enforcement-loops.md) cuts it as **three timescales**, [The Self-Improving Harness](self-improving-harness.md) cuts it as **the reflection mechanism**, [Garbage Collection](garbage-collection.md) cuts it as **entropy detection**. This page is the integrative cut: one surprise, walked end to end through every surface it touches, with the concrete plumbing -- commands, skills, agents, hooks, workflows -- named at each stage.
-
----
-
-## A worked example, to make this concrete
-
-A developer is mid-session. The AI suggests adding a dependency the project already uses elsewhere, and the developer accepts it. A CVE check on the next CI run flags the version as having a known high-severity vulnerability. The merge is blocked, the dependency is downgraded, work continues.
-
-That is the **surprise**. The page traces it through all six stages: from the moment the developer captures it as a reflection, to the moment a constraint that prevents the same surprise from recurring is wired into the commit hook, the PR pipeline, and the convention files that every AI assistant reads at session start. By the end, the surprise stops being a surprise.
-
----
-
-## The shape of one full turn
-
-A complete turn of the loop has six stages. The first five form the per-surprise path; the sixth is the wider tuning frame that catches what the per-surprise path misses.
-
-| Stage | What happens | Where |
-| --- | --- | --- |
-| 1. Capture | Surprise is recorded against a structured template | `REFLECTION_LOG.md` |
-| 2. Detect | Recurring patterns are found and reported as proposals | GitHub issues |
-| 3. Promote | A human accepts a proposal and writes the constraint | `HARNESS.md` |
-| 4. Verify | The audit confirms the constraint is honest | `HARNESS.md` Status |
-| 5. Propagate | The new policy reaches the surfaces that enforce it | AGENTS.md / hooks / CI |
-| 6. Tune | Quarterly re-assessment surfaces gaps the loop did not catch | Assessment, governance |
-
-Two design choices govern the whole sequence:
-
-- **The trust boundary is between detection and writing.** Every read-write agent in the loop is allowed to **report** changes to `HARNESS.md` (as issues, as audit findings, as proposals). None is allowed to **write** them. The promotion step is a human-cognition gate, by design.
-- **Reports nudge; constraints stop.** Only one of the surfaces in this loop has the authority to block work, and it is not the one that detects drift. The asymmetry is what makes the whole thing safe to leave running.
-
-The rest of the page walks through each stage with the worked example threaded in italic.
-
----
-
-## Stage 1 — Capture the surprise
-
-The only entry point to the steady-state loop is the `/reflect` command. There are no agents, no skills loaded, no scans of the codebase. Three questions, one appended entry, a signal-type classification, and -- sometimes -- an immediate constraint proposal there and then.
-
-The questions are deliberately blunt: *what were you working on, what was surprising, what should future agents know?* The answers land in `REFLECTION_LOG.md` as a structured entry with seven fields (date, agent, task, surprise, proposal, improvement, signal, constraint). The append-only structure matters: entries are never modified, never deleted. The file becomes the operational record of every surprise the team has registered.
-
-The signal classification (`context | instruction | workflow | failure | none`) is the routing hint: failures route to constraints, context signals route to `HARNESS.md`, workflow signals route to `AGENTS.md`, instruction signals route to skills or commands. See [The Self-Improving Harness](self-improving-harness.md#the-reflection-mechanism) for the full taxonomy.
-
-Sometimes the surprise is clearly a preventable failure -- a check that should have run, a tool that should have caught it -- and `/reflect` proposes a constraint immediately, offering it to the user for acceptance. Often the surprise looks one-off and just gets logged. Both outcomes are correct. A reflection that does not propose a constraint is not a wasted reflection; it is a data point that may matter only when a second one joins it.
-
-> *Worked example.* The developer runs `/reflect`. The surprise field reads: "agent imported lodash@4.17.20 which has a known CVE; CI caught it but not before merge was attempted." `/reflect` classifies this as a `failure` signal. It drafts a constraint proposal: "Block merges that introduce dependencies with known CVEs." The developer hesitates -- they think this is a one-off -- and declines the immediate promotion. The reflection is logged with `Constraint: none`.
-
----
-
-## Stage 2 — Detect recurring patterns
-
-The garbage collector watches reflections accumulate. The specific GC rule that closes this loop is **reflection-driven regression detection**: it reads `REFLECTION_LOG.md`, looks for the same kind of surprise appearing across two or more entries without a corresponding constraint in `HARNESS.md`, and when it spots one it files a GitHub issue with evidence (reflection dates and quotes), a suggested enforcement type, and a suggested scope.
-
-The rule runs weekly under `/harness-gc`, executed either on schedule (the `gc.yml` workflow) or on demand. The agent that runs it is `harness-gc`, supported by the [garbage-collection](garbage-collection.md) skill. The agent is also reflection-aware in general: by design it reads recent `REFLECTION_LOG` entries before running any of its other rules, so reflections shape what it looks for beyond the declared rules. See [Garbage Collection](garbage-collection.md#the-gc-agent) for the full mechanics.
-
-Crucially, the GC agent **cannot write to `HARNESS.md`**. That is the trust boundary. It produces reports -- GitHub issues, summary outputs -- and nothing more. Humans decide what gets promoted.
-
-Adjacent GC rules touch the loop's other surfaces during the same agent run: `documentation freshness`, `command-prompt sync`, `convention file sync`, `secret scanner operational`, `snapshot staleness`, `dependency currency`. Together they catch drift across all the surfaces the per-surprise loop will eventually touch.
-
-> *Worked example.* Two weeks later, a different developer trips over the same problem: a different dependency this time, but the same shape of surprise. They `/reflect`, the entry lands. The next Monday's `/harness-gc` run reads the log, spots two `failure` reflections about CVE-bearing dependencies with no matching constraint in `HARNESS.md`, and files a GitHub issue. The issue cites both reflection dates, quotes the surprise text, and proposes: "deterministic constraint, scope=pr, tool=osv-scanner."
-
----
-
-## Stage 3 — Promote a proposal into HARNESS.md
-
-This is the only stage that writes new constraints into `HARNESS.md`, and it is deliberately interactive. No agent can bypass the human here. The command is `/harness-constrain`, supported by the [constraint-design](constraints-and-enforcement.md) and [verification-slots](../how-to/set-up-verification-slots.md) skills. No agents are dispatched.
-
-The interaction has two responsibilities. The first is to write the constraint into `HARNESS.md` in the canonical five-field format (rule, frequency, enforcement, tool, auto-fix). The second, when deterministic enforcement is selected, is to **configure the verification slot** -- the integration point that wires the named tool to the harness's enforcement engine. A constraint without a wired slot is a claim, not a check.
-
-The human-cognition gate is load-bearing. The GC agent's proposal might be wrong about scope. It might propose deterministic enforcement when the rule actually needs agent judgement. It might be a real pattern but not yet worth the cost of enforcement. The human is the filter that converts a proposal into a policy.
-
-> *Worked example.* The team triages the issue at their next planning session. They agree the surprise is real and recurring. A developer runs `/harness-constrain`, accepts the suggested rule, picks `enforcement: deterministic`, names `osv-scanner` as the tool, and sets `scope: pr`. The verification slot is configured to invoke `osv-scanner --recursive .` on every PR. The constraint lands in `HARNESS.md` under the appropriate section.
-
----
-
-## Stage 4 — Verify HARNESS.md is still honest
-
-A new constraint is a claim about reality. The audit step is what tests the claim. The commands are `/harness-audit` (full meta-verification) with the lighter alternatives `/harness-status` (no agents, fast) and `/harness-health --deep`. The agents are `harness-discoverer` (read-only scanner that finds enforcement in the wild) and `harness-auditor` (read-write meta-agent that compares declared against actual).
-
-The audit detects drift in **both directions**: declared-but-not-enforced (a constraint exists in `HARNESS.md` but the tool is missing from CI) and enforcement-present-but-not-declared (a linter is running in CI but is not listed as a constraint). Both directions represent a gap between what the team believes is true and what is actually true.
-
-The auditor is the **only** agent permitted to update the Status section of `HARNESS.md`. Nothing else writes there. The Status section is the audit's product, and keeping its authorship narrow is what prevents it from becoming a free-form scratchpad.
-
-> *Worked example.* The developer runs `/harness-audit`. The auditor confirms `osv-scanner` is installed in CI, the verification slot is wired, the PR workflow invokes it, and the constraint's status flips from `proposed` to `verified-deterministic`. The Status section is updated. The new constraint is now part of the harness's verified surface area.
-
----
-
-## Stage 5 — Propagate the change to the enforcement surfaces
-
-`HARNESS.md` is the source of truth, but the surfaces that actually enforce behaviour live elsewhere. A constraint that exists only in `HARNESS.md` does not yet shape what agents see at session start, what hooks fire at edit time, or what CI gates a pull request. Stage 5 is the propagation step that pushes the new policy out to those three surfaces and, just as importantly, the GC rules that keep those surfaces in step with `HARNESS.md` over time.
-
-### 5a — AGENTS.md / CLAUDE.md (turn-time context)
-
-This is what the AI sees at session start. The relevant commands are `/extract-conventions` (when a new tacit convention surfaces through the cycle, supported by the convention-extraction skill), `/convention-sync` (which generates Cursor / Copilot / Windsurf rule files from `HARNESS.md`), and `/harness-onboarding` (which regenerates `ONBOARDING.md` from `HARNESS.md` + `AGENTS.md` + `REFLECTION_LOG.md`). The unified entry point that runs `/convention-sync` and `/harness-onboarding` together in one interactive pass — detecting drift across all push-direction surfaces, presenting the full picture, applying the user's selected fixes — is `/harness-sync`. See [Sync Harness Surfaces](../how-to/sync-harness.md). The single-surface commands remain available for focused work.
-
-The GC rules that catch lag on this surface are `convention file sync` (weekly, agent-enforced), `command-prompt sync` (weekly, agent-enforced), and the monthly `ONBOARDING.md` staleness check. Together they ensure that when `HARNESS.md` changes, the convention files every AI assistant reads do not silently fall behind.
-
-### 5b — Hooks (edit-time and session-end)
-
-There is no dedicated slash command for hooks. They are configured at install time via the [harness-engineering](harness-engineering.md) skill and inventoried by `/harness-affordance discover`. The steady-state moving part is the **rotating Stop hook**: each session it picks one deterministic GC rule by day-of-year and runs it as a sub-five-second advisory check. Over a working week, every deterministic rule is checked at least once, even if scheduled CI does not run.
-
-The `SessionStart` hook is what surfaces `/harness-upgrade` prompts when template versions move, which is how new template-shipped GC rules and constraints reach existing harnesses without anyone having to remember to look.
-
-### 5c — CI/CD (PR-time and scheduled)
-
-There is no per-change command for CI propagation either. The constraint format itself declares scope (`commit | pr | scheduled`) and the CI workflow templates pick that up. The agent is `harness-enforcer` (read-only), the unified verification engine that CI dispatches -- the same agent runs both deterministic tools and agent-based reviews, so the CI surface treats all constraint outcomes uniformly.
-
-The `gc.yml` workflow runs deterministic GC rules weekly (Monday 09:00 UTC, plus `workflow_dispatch`). PR-scoped constraints fire on every pull request. Scheduled constraints fire on their declared cadence.
-
-The combination of all three surfaces -- session-start context, edit-time hooks, PR-time CI -- is what gives a single new constraint multiple chances to catch a future surprise before it lands.
-
-> *Worked example.* The next time `/convention-sync` runs, Cursor's rule file gains a new line about CVE-bearing dependencies; Copilot's instructions file gains the same; Windsurf's rules pick it up. The next CI run on a feature branch invokes `osv-scanner` and blocks a PR that includes a vulnerable transitive dependency. The rotating Stop hook may run `secret scanner operational` or `documentation freshness` on any given session, but `dependency currency` is now in its rotation too. Three surfaces, one constraint, multiple chances to catch the next CVE before it merges.
-
----
-
-## Stage 6 — The wider tuning frame
-
-Two commands sit one level out from the per-surprise loop and tune at quarterly cadence. They catch what the per-surprise path misses: gaps that no individual surprise has surfaced yet, or governance constraints that have drifted in meaning rather than in enforcement.
-
-`/assess` (supported by the [ai-literacy-assessment](../how-to/run-an-assessment.md) skill, dispatching the `assessor` agent) reassesses the literacy level, surfaces gaps, and produces an improvement plan that may itself add constraints, hooks, or CI workflows. It is the loop's check on its own progress: are we catching surprises faster, are recurring patterns getting promoted, are constraints getting tighter over time.
-
-`/governance-audit` (supported by the [governance-audit-practice](../how-to/run-a-governance-audit.md) and [governance-observability](../how-to/build-a-governance-dashboard.md) skills, dispatching the `governance-auditor` agent) does the same job for governance constraints specifically, with semantic-drift detection. Its trust boundary mirrors `harness-gc`: it writes audit reports, never modifies `HARNESS.md` directly.
-
-These commands sit outside the per-surprise loop because they answer different questions. The per-surprise loop asks "did anything surprising happen?" The quarterly frame asks "are we still working on the right things?"
-
-> *Worked example.* At the next quarterly `/assess`, the assessor finds the new CVE constraint, sees it has fired three times in the past 90 days (caught three real vulnerabilities, blocked three PRs), and notes that the gap that produced it is now closed. The assessment record updates accordingly. The improvement plan moves on to the next gap.
-
----
-
-## The asymmetry that makes the loop work
-
-It is worth keeping in plain sight the asymmetry that makes the whole thing safe to operate continuously: **GC produces reports, not blocks**.
-
-Every other part of the harness prevents bad changes. Constraints block merges. Hooks block commits. CI gates block PRs. Each of those surfaces has the authority to stop work, and each is appropriate to that authority because it is evaluating a specific change made by a specific person, where the fix is usually within that person's control.
-
-GC is different. The drift it detects -- stale documentation, lagging convention files, a `gitleaks` binary that has quietly disappeared from CI, the same surprise appearing in three reflections -- was not caused by any single person or any single change. Blocking on a finding that accumulated over weeks or months would penalise whoever happens to trigger the check, not the people who contributed to the drift. That creates exactly the wrong incentive: teams learn to avoid running GC rather than fixing what it finds.
-
-So GC describes drift. Humans decide. Constraints stop. Reports nudge. Continuous tuning needs both, in the right places.
-
-This is also the reason the trust boundaries in stages 2 and 6 matter. The agents that detect patterns and audit governance can write everywhere except `HARNESS.md` itself, because writing constraints is the one place in the loop where blocking authority is created. Keeping that authority in human hands is what keeps the loop honest.
-
----
-
-## What the loop earns over time
-
-A team that runs the loop for six months has a `HARNESS.md` that is no longer a record of what they thought was important when the project started. It is a record of what their operational experience has taught them is worth enforcing -- evidence-backed, audited, and propagated through every surface that shapes what their AI does next.
-
-A team that does not run the loop has the same `HARNESS.md` they had on day one. The reflections they did not capture do not exist. The patterns they did not detect do not get proposed. The constraints they did not promote do not block the surprises that recur. The harness still appears to operate, but it has stopped tuning.
-
-The infrastructure is not the product. The loop is the product. Every component on this page exists to make one full turn of the loop possible without imposing a cost the team cannot pay -- two minutes for `/reflect`, weekly automated GC, an interactive `/harness-constrain` when a real pattern emerges, and the propagation surfaces that pick up the change without anyone having to remember to update them by hand.
-
----
-
-## Further reading
-
-- [The Self-Improving Harness](self-improving-harness.md) -- the deeper read on the reflection mechanism, including agent reading windows and the auto-constraint pipeline
-- [Garbage Collection](garbage-collection.md) -- the mechanics of GC rules, the GC agent's trust boundary, and the rules that propagate to surfaces 5a/5b/5c
-- [The Loops That Learn](the-loops-that-learn.md) -- the four-cadence cut: reflect, health, assess, cost
-- [Three Enforcement Loops](three-enforcement-loops.md) -- the timescale cut: inner (edit time, advisory), middle (PR time, blocking), outer (scheduled, investigative)
-- [Compound Learning](compound-learning.md) -- the introductory framing of why captured learnings compound, and why uncaptured ones do not
-- [Constraints and Enforcement](constraints-and-enforcement.md) -- the anatomy of a constraint and the enforcement types referenced in stage 3
-- [Regression Detection](regression-detection.md) -- the related-but-distinct sense of regression: broken practices rather than recurring surprises
+> A harness improves over time through a specific sub-flow: surprises
+> get captured as reflections, recurring patterns become candidate
+> constraints, candidate constraints get promoted via
+> `/harness-constrain`. This page is about that sub-flow.
+
+For the broader picture, see [The Harness Lifecycle](the-harness-lifecycle.md).
+This page goes deeper on the part of the lifecycle that turns
+*lessons* into *enforcement*.
+
+## The four stages
+
+### 1. Capture — write the reflection
+
+When a session ends with something surprising — a wrong assumption,
+an unexpected gotcha, a workflow hole — the integration agent (or you,
+running `/reflect`) appends an entry to `REFLECTION_LOG.md`. Each
+entry has:
+
+- A one-sentence task summary
+- The surprise — what went wrong or wasn't expected
+- A proposal — what could prevent this next time
+- A signal — `failure`, `workflow`, `context`, or `none`
+- An optional proposed constraint
+
+`failure` and `workflow` signals are the ones that feed this loop.
+
+### 2. Detect — let the GC rule find recurring patterns
+
+The `Reflection-driven regression detection` GC rule runs weekly. It
+scans `REFLECTION_LOG.md` for recurring failure patterns — the same
+type of surprise across two or more entries. When it finds one, it
+flags the pattern as a candidate constraint.
+
+`/harness-sync`'s drift table includes these candidates as
+`[manual]` rows. The action command suggested is `/harness-constrain`.
+
+### 3. Promote — author the constraint
+
+`/harness-constrain` is the authoring path. It loads the
+`constraint-design` skill, which walks through:
+
+- The rule itself (must be falsifiable)
+- The enforcement level (`unverified`, `agent`, `deterministic`)
+- The tool, if deterministic
+- The scope (`commit`, `pr`, `weekly`, `manual`)
+
+The constraint gets added to `HARNESS.md`. From that point forward
+it appears in `/harness-sync`'s convention-file drift detection
+(if it changes the conventions text) and in `/harness-audit`'s
+enforcement-ratio reporting.
+
+### 4. Verify — let the constraint catch real violations
+
+The newly authored constraint enters the active enforcement set. Its
+behaviour over the next few PRs is the test of whether the promotion
+was correct:
+
+- If it catches real instances of the original surprise, promotion
+  was right.
+- If it never fires, the underlying assumption may have been wrong —
+  the surprise was a one-off, or the constraint's rule isn't falsifiable
+  enough to detect the real pattern. Either way, future reflections
+  will say so.
+- If it fires on innocent code, the constraint is too strict; the
+  next reflection should propose softening it.
+
+## Why the loop is structured this way
+
+The loop deliberately separates *capture* from *promotion*. Reflections
+should be cheap — write them down without judgement. The judgement
+happens later, with the benefit of recurrence. A single failure isn't
+enough evidence to add a constraint; two related failures often is.
+
+This is also why the GC rule fires weekly rather than on every
+reflection. Reflection-time pattern matching would over-promote
+(every surprise becomes a constraint). Aggregated weekly review
+catches genuine recurrence.
+
+## Where this fits in the lifecycle
+
+This loop is one of the contributors to the "drifted → in sync"
+transition described in [The Harness Lifecycle](the-harness-lifecycle.md).
+A recurring pattern is a kind of drift between *what should be
+constrained* and *what is constrained*. `/harness-constrain` is the
+remediation; the GC rule and `/harness-sync` are the detection.
+
+## Related reading
+
+- [The Harness Lifecycle](the-harness-lifecycle.md) — the broader
+  detect-heal-pull frame.
+- [The Self-Improving Harness](self-improving-harness.md) — why
+  iteration matters and how compound learning fits in.
+- [How to: write a governance constraint](../how-to/write-a-governance-constraint.md)
+  — the deeper case for governance-flavoured constraints.
+- [How to: add a constraint](../how-to/add-a-constraint.md) — the
+  step-by-step for `/harness-constrain`.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
@@ -11,8 +11,31 @@ redirect_from:
 
 # Run a Harness Audit
 
-Run `/harness-audit` to produce a full meta-verification of the harness and generate
-a health snapshot with trend data.
+> `/harness-audit` is the read-only diagnostic. It runs the shared
+> drift-detection engine across every surface and prints findings,
+> without prompting you to fix anything. Use it when you want
+> visibility without action. For everyday hygiene, prefer
+> [`/harness-sync`](sync-harness.md), which uses the same engine and
+> applies fixes.
+
+## Audit vs `/harness-sync`
+
+`/harness-audit` and `/harness-sync` use the same drift-detection
+engine. The difference is action:
+
+- **`/harness-audit`** is read-only. It prints findings and updates
+  the `HARNESS.md` Status section. It never prompts you to fix
+  anything. Useful when you want a clean diagnostic without
+  committing to action — for example from CI, or when scripting,
+  or when you suspect drift but aren't ready to deal with it yet.
+- **`/harness-sync`** runs the same engine but prompts you to apply
+  fixes. Mechanical fixes (convention files, ONBOARDING.md, snapshot,
+  Status section) auto-apply when selected. Judgement-required fixes
+  (template upgrade, constraint authoring) print suggested commands.
+
+**For everyday lifecycle hygiene, run `/harness-sync`.** Run
+`/harness-audit` when you specifically want the diagnostic without
+the action prompt.
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
@@ -9,169 +9,139 @@ redirect_from:
   - /how-to/sync-harness.html
 ---
 
-# Sync Harness Surfaces
+# Sync the harness
 
-Run `/harness-sync` to detect drift across all push-direction control surfaces
-and bring them back in line with `HARNESS.md` in a single pass. For
-single-surface deep dives, see
-[Sync Conventions](sync-conventions.md)
-(convention and constraint files) and
-[Generate an Onboarding Guide](generate-onboarding.md)
-(`ONBOARDING.md`).
+> Run `/harness-sync` to bring every surface into alignment with
+> `HARNESS.md`. Same engine as `/harness-audit` (the read-only
+> diagnostic), but with a multi-select prompt that lets you apply
+> the fixes.
 
----
+## When to run it
 
-## Prerequisites
+- After modifying `HARNESS.md` (new constraint, edited convention,
+  promoted enforcement level).
+- After merging a PR that touched `HARNESS.md` or any of the derived
+  surfaces.
+- When you suspect drift but want to see the full picture before
+  acting.
+- As a periodic check — once a sprint or whenever the SessionStart
+  hook nudges you.
 
-- `HARNESS.md` exists in the project root (created by `/harness-init`).
-- The working tree is clean — `/harness-sync` refuses to run on a dirty tree.
-  Stash or commit your work-in-progress first.
-- `gh` CLI is authenticated (needed for PR creation on a fresh `chore/` branch).
+## What you'll see
 
----
-
-## 1. Phase 1 — Drift scan
-
-```text
-/harness-sync
-```
-
-The command checks the current branch and working-tree state, then scans every
-push-direction surface and prints a status table:
+`/harness-sync` runs in three phases. Phase 1 is the drift scan via
+the shared audit-engine; it prints a unified drift table:
 
 ```text
-Surface                                              Status      Action on apply
-───────────────────────────────────────────────────  ──────────  ─────────────────────────
-.cursor/rules/                                       drifted     /convention-sync
-.github/copilot-instructions.md                      in sync     —
-.windsurf/rules/                                     missing     /convention-sync (create)
-ONBOARDING.md                                        drifted     /harness-onboarding
-CI / CD (constraint scope)                           managed     handled at runtime
-─────────────────────────────────────────────────────────────────────────────────────────
-5 surfaces tracked · 2 drifted · 1 missing · 1 in sync · 1 managed at runtime
+Surface / Finding                              Status      Action on apply
+─────────────────────────────────────────────  ──────────  ────────────────────────
+.cursor/rules/                                 drifted     /convention-sync       [auto]
+.github/copilot-instructions.md                in sync     —
+.windsurf/rules/                               missing     /convention-sync       [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
+HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
+Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
+Reflection pattern: Output validation x3       candidate   /harness-constrain     [manual]
+CI / CD (constraint scope)                     managed     handled at runtime
 ```
 
-State vocabulary:
+The `Action on apply` column has two flavours:
 
-| State | Meaning |
-| ----- | ------- |
-| `drifted` | File exists but diverges from `HARNESS.md` |
-| `missing` | File is absent; would be created on apply |
-| `in sync` | File matches `HARNESS.md` |
-| `managed` | Runtime-managed by `harness-enforcer`; surfaced for completeness only |
+- **`[auto]`** — the fix is mechanical. `/harness-sync` will run it
+  for you when you select the row.
+- **`[manual]`** — the fix needs a judgement call (which constraint
+  to add, whether to take a template upgrade). `/harness-sync` will
+  print the suggested command but won't run it.
 
-If all surfaces are `in sync` or `managed`, the command exits cleanly — nothing
-to do.
+## What you'll do
 
-Pass `--check` to run the scan without applying anything (useful from CI or as
-the deep-scan step inside `/harness-health --deep`). The flag exits after
-printing the table, non-zero if any surface is `drifted` or `missing`.
+After Phase 1 prints the drift table, Phase 2 prompts you with a
+multi-select. Every drifted, missing, or candidate finding appears
+as a checkbox. `[auto]` items default to checked; `[manual]` items
+default to unchecked.
 
----
+Pick which to address. Hit "Apply nothing — exit without changes" if
+you just wanted the diagnostic.
 
-## 2. Phase 2 — Selection
+Phase 3 applies the fixes. For each `[auto]` selection, `/harness-sync`
+invokes the underlying primitive (`/convention-sync`,
+`/harness-onboarding`, `/harness-health`, `/harness-audit`). For each
+`[manual]` selection, it prints a "next step" line:
 
-After the scan, `/harness-sync` presents a multi-select prompt listing each
-`drifted` or `missing` surface. All drifted/missing surfaces are selected by
-default. Deselect anything you want to handle separately.
+```text
+Manual remediation suggested for: Template version drift
+Run: /harness-upgrade
+```
 
-The `managed` row (CI / CD) never appears as a selectable option — it is status,
-not an action.
+You run those separately.
 
-An "Apply nothing — exit without changes" option is always present to make the
-no-op path an explicit choice.
+## Verification
 
----
-
-## 3. Phase 3 — Apply with verification
-
-For each selected surface, the command invokes the corresponding primitive in
-series:
-
-- `.cursor/rules/` _and_ `.windsurf/rules/` → `/convention-sync`
-- `ONBOARDING.md` → `/harness-onboarding`
-
-After applying, it re-runs the drift scan as a verification pass and prints a
+`/harness-sync` re-runs the audit-engine after applying and prints a
 delta table:
 
 ```text
 Apply complete — verification scan:
 
-Surface                                              Before      After
-───────────────────────────────────────────────────  ──────────  ──────────
-.cursor/rules/                                       drifted     in sync ✓
-.windsurf/rules/                                     missing     in sync ✓
-ONBOARDING.md                                        drifted     in sync ✓
+Surface / Finding                              Before      After
+─────────────────────────────────────────────  ──────────  ─────────────
+.cursor/rules/                                 drifted     in sync ✓
+.windsurf/rules/                               missing     in sync ✓
+ONBOARDING.md                                  drifted     in sync ✓
+Snapshot staleness                             drifted     in sync ✓
+HARNESS.md Status accuracy                     drifted     in sync ✓
+Template drift                                 drifted     drifted (manual — see suggestion above)
 ```
 
-If a surface fails to come into sync it is marked `still drifted (error)`, the
-command exits non-zero, and nothing is committed. Fix the underlying primitive
-and re-run.
+If any selected `[auto]` finding didn't reach `in sync`, the run exits
+non-zero and prints what failed. `[manual]` findings keep their
+"drifted" status with the suggestion note — they were never going to
+be auto-applied.
 
----
+## Branch and trust-boundary
 
-## 4. Branch and PR discipline
+`/harness-sync` refuses to run on `main`. If you're on `main` it
+offers to create `chore/sync-surfaces-YYYY-MM-DD` for you. The
+trust-boundary pre-commit guard restricts what gets staged: only
+`.cursor/rules/**`, `.github/copilot-instructions.md`,
+`.windsurf/rules/**`, and `ONBOARDING.md` may be committed.
+`HARNESS.md`, `AGENTS.md`, and `REFLECTION_LOG.md` are off-limits to
+this command.
 
-### Running on `main`
+If a `[auto]` action mutates HARNESS.md (the Status section update
+from `/harness-audit`, for example), that mutation lands as part of
+the action's own flow and is committed separately by the action's
+own logic. `/harness-sync`'s commit covers only the four push-direction
+surfaces.
 
-`/harness-sync` refuses to apply changes directly to `main`. It offers to
-create a `chore/sync-surfaces-YYYY-MM-DD` branch (you can supply a custom name
-instead). Once you confirm, it switches to the new branch and proceeds. After
-the verification pass it:
+## `--check` mode
 
-1. Stages only the surface files (`.cursor/rules/`, `.github/copilot-instructions.md`,
-   `.windsurf/rules/`, `ONBOARDING.md`).
-2. Commits with a parameterised message: `chore: sync convention files and ONBOARDING.md to HARNESS.md`.
-3. Pushes the branch and opens a PR with `--label chore`.
-4. Reports the PR URL and the verification delta.
+`/harness-sync --check` runs Phase 1 only. Prints the drift table and
+exits. Useful from CI or scripts when you just want to know if drift
+exists. Exits non-zero if any finding is drifted, missing, or candidate;
+zero otherwise.
 
-The `chore/` prefix satisfies the spec-first-check branch-prefix exemption —
-no spec document is required for this type of maintenance PR.
+## When `/harness-sync` isn't enough
 
-### Running on a feature branch
+Some drift can't be `[auto]`-fixed:
 
-If you are already on a feature branch, `/harness-sync` takes a lighter path:
-apply, verify, stage, commit. _No push, no PR._ The commit joins your existing
-branch and you push when ready.
+- **Template drift** — run `/harness-upgrade` and adjudicate the new
+  items.
+- **Constraint regression** — run `/harness-constrain` to either fix
+  the constraint or downgrade its enforcement level.
+- **Recurring reflection pattern** — run `/harness-constrain` to
+  promote the pattern into a constraint.
 
----
+`/harness-sync` will tell you which to run. You decide when.
 
-## 5. Refusal cases
+## Related
 
-| Situation | What happens |
-| --------- | ------------ |
-| Uncommitted changes on the working tree | Refuses to run; lists dirty paths; suggests `git stash` or commit-first |
-| Underlying primitive errors for one surface | Continues with remaining surfaces; marks the errored surface `still drifted (error)`; exits non-zero |
-| Verification scan still shows drift after apply | Exits non-zero; reports failed surfaces; does not commit |
-| User declines all surfaces in Phase 2 | Exits cleanly with no changes |
-| Pre-commit guard finds a path outside the allow-list | Refuses to commit; reports the unexpected path as a bug in the underlying primitive |
-
----
-
-## 6. Trust boundary
-
-`/harness-sync` _never_ writes to `HARNESS.md`, `AGENTS.md`, or
-`REFLECTION_LOG.md`. These are the harness source of truth; the command only
-writes to the generated surfaces derived from them (`.cursor/rules/`,
-`.github/copilot-instructions.md`, `.windsurf/rules/`, `ONBOARDING.md`).
-
-A pre-commit guard verifies every staged path against that allow-list before
-committing. Any path outside it is treated as a bug in the underlying
-primitive — the command refuses to commit and reports the offending path.
-
-This boundary mirrors the trust model used by `harness-gc` and
-`governance-auditor`: read the harness, write to the surfaces, never write to
-the harness itself.
-
----
-
-## See also
-
-- [Sync Conventions](sync-conventions.md)
-  — single-surface deep dive for convention and constraint files
-- [Generate an Onboarding Guide](generate-onboarding.md)
-  — single-surface deep dive for `ONBOARDING.md`
-- [The Harness Tuning Loop](../explanation/the-harness-tuning-loop.md)
-  — the Propagate stage (Stage 5) that `/harness-sync` serves
-- [The Harness Lifecycle](../explanation/the-harness-lifecycle.md)
-  — the Renewal stage where surface synchronisation fits
+- [How to: run a harness audit](run-a-harness-audit.md) — the
+  read-only diagnostic, same engine as sync.
+- [The Harness Lifecycle](../explanation/the-harness-lifecycle.md) —
+  the broader detect-heal-pull frame.
+- [How to: add a constraint](add-a-constraint.md) — the
+  `/harness-constrain` workflow.
+- [How to: upgrade your harness](upgrade-your-harness.md) — the
+  `/harness-upgrade` workflow.

--- a/docs/plugins/ai-literacy-superpowers/index.md
+++ b/docs/plugins/ai-literacy-superpowers/index.md
@@ -17,6 +17,11 @@ The flagship plugin in this marketplace — harness engineering, agent
 orchestration, literate programming, CUPID code review, compound
 learning, and the three enforcement loops.
 
+The everyday lifecycle entry is `/harness-sync` — it detects drift
+across every surface and applies the fixes you select. See
+[The Harness Lifecycle](explanation/the-harness-lifecycle.md) for the
+broader frame.
+
 The plugin's source lives at [`ai-literacy-superpowers/`](https://github.com/Habitat-Thinking/ai-literacy-superpowers/tree/main/ai-literacy-superpowers)
 in the repository.
 

--- a/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
@@ -371,7 +371,7 @@ Last audit: 2026-04-06 (0 days ago)
 
 ### Next Steps
 - Run /harness-constrain to add or promote constraints
-- Run /harness-audit for a full verification
+- Run /harness-sync to keep all surfaces in alignment, or /harness-audit for a read-only diagnostic
 - Run /harness-gc to run garbage collection checks
 ```
 

--- a/docs/superpowers/plans/2026-05-08-harness-sync-audit-driven.md
+++ b/docs/superpowers/plans/2026-05-08-harness-sync-audit-driven.md
@@ -1,0 +1,1731 @@
+# Audit-driven `/harness-sync` and Lifecycle Docs Simplification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewire `/harness-sync` to run `/harness-audit`'s detection logic internally via a shared audit-engine skill, presenting a unified drift table that includes audit findings beyond the current four push-direction surfaces. Simplify the lifecycle docs to converge on one canonical narrative ("detect drift → heal it; pull upstream when needed") with `/harness-sync` as the everyday entry point.
+
+**Architecture:** Extract a new internal `harness-audit-engine` skill that documents the shared drift-detection logic and report shape. Both `/harness-audit` (read-only inspection) and `/harness-sync` (read-then-fix) reference it. The `/harness-sync` command's process is restructured around this engine, with each drift row tagged `[auto]` or `[manual]` to distinguish mechanical fixes from judgement-required ones.
+
+**Tech Stack:** Markdown (skills, commands, docs), Bash (no new scripts in this PR — existing `/harness-sync` is purely conversational), MkDocs Material (for docs build verification), markdownlint (CI gate).
+
+---
+
+## File Structure
+
+**Create:**
+
+| Path | Responsibility |
+| --- | --- |
+| `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md` | The shared audit-engine contract: what to detect, the drift-report shape, the `[auto]`/`[manual]` classification rule, the per-finding action mapping. |
+
+**Modify:**
+
+| Path | Why |
+| --- | --- |
+| `ai-literacy-superpowers/commands/harness-audit.md` | Add reference to the new audit-engine skill at the top of the Process section. User-facing UX unchanged. |
+| `ai-literacy-superpowers/commands/harness-sync.md` | Rewrite the Process section to invoke audit-engine in Phase 2 (replacing the per-surface drift detection), expand the drift table in Phase 3 to include all audit findings with `[auto]`/`[manual]` tags, branch the apply step in Phase 5 between auto-fix and print-the-command. |
+| `docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md` | Substantive rewrite as the canonical lifecycle narrative. |
+| `docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md` | Trim to focus on the signal-capture → constraint-promotion sub-flow. |
+| `docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md` | Trim to the conceptual core; remove walkthroughs that duplicate how-tos. |
+| `docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` | Rewrite for the audit-driven flow. |
+| `docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md` | Clarify diagnostic role; route everyday users to `/harness-sync`. |
+| `docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md` | Touch-up: position `/harness-sync` as everyday command. |
+| `docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md` | Same touch-up. |
+| `docs/plugins/ai-literacy-superpowers/index.md` (plugin landing) | Touch-up: reflect simpler everyday flow. |
+| `CLAUDE.md` (root) | Quarterly/Monthly Operations sections: replace ad-hoc lists with `/harness-sync`. |
+| `ai-literacy-superpowers/templates/CLAUDE.md` | Same Operations update (shipped template). |
+| `README.md` | Plugin description; command tables. |
+| `ai-literacy-superpowers/.claude-plugin/plugin.json` | Version `0.34.1` → `0.35.0`. |
+| `.claude-plugin/marketplace.json` | `plugin_version` and `plugins[0].version` → `0.35.0`. |
+| `CHANGELOG.md` | New top heading `## 0.35.0 — 2026-05-08` with theme + bullets. |
+
+---
+
+## Task 1: Create the `harness-audit-engine` skill
+
+**Files:**
+- Create: `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md`
+
+The audit-engine is a new internal skill that both `/harness-audit` and `/harness-sync` reference. It defines the shared drift-detection logic so the two commands stay in sync as audit's surface coverage evolves.
+
+- [ ] **Step 1: Create the directory and SKILL.md**
+
+```bash
+mkdir -p ai-literacy-superpowers/skills/harness-audit-engine
+```
+
+Write `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md`:
+
+````markdown
+---
+name: harness-audit-engine
+description: Use when running the shared drift-detection logic that backs /harness-audit and /harness-sync — produces a structured drift report covering convention files, ONBOARDING.md, snapshot staleness, template drift, constraint regressions, recurring reflection patterns, and HARNESS.md Status section accuracy.
+---
+
+# Harness Audit Engine
+
+## Overview
+
+The harness audit-engine is the shared drift-detection layer that both
+`/harness-audit` and `/harness-sync` invoke. Audit is read-only; sync
+uses the same engine to drive its multi-select prompt. This skill
+defines the contract — what surfaces are scanned, the drift-report
+shape, and the per-finding `[auto]` / `[manual]` classification rule.
+
+`/harness-audit` and `/harness-sync` are the two callers. Their UX
+differs (audit prints, sync prompts), but the underlying findings are
+the same.
+
+## What the engine scans
+
+The engine evaluates every surface or fact that could be out of sync
+with `HARNESS.md`. The current scan covers:
+
+| Category | Finding | Auto-fixable? |
+| --- | --- | --- |
+| Convention files | `.cursor/rules/` matches HARNESS.md | yes — `/convention-sync` |
+| Convention files | `.github/copilot-instructions.md` matches HARNESS.md | yes — `/convention-sync` |
+| Convention files | `.windsurf/rules/` matches HARNESS.md | yes — `/convention-sync` |
+| Onboarding | `ONBOARDING.md` matches HARNESS.md + AGENTS.md + REFLECTION_LOG.md | yes — `/harness-onboarding` |
+| Observability | Most recent snapshot in `observability/snapshots/` is < 30 days old | yes — `/harness-health` |
+| Status section | `HARNESS.md` Status block matches actual constraint enforcement counts | yes — `/harness-audit` (audit updates Status as a side-effect) |
+| Template currency | `<!-- template-version: X -->` in HARNESS.md matches installed plugin version | manual — `/harness-upgrade` |
+| Constraint regression | Any constraint marked `deterministic` whose tool no longer succeeds | manual — `/harness-constrain` |
+| Reflection pattern | Recurring failure pattern in REFLECTION_LOG.md (2+ similar entries, not yet a constraint) | manual — `/harness-constrain` |
+| CI / CD | Constraint scope handled at runtime by harness-enforcer | informational — handled at runtime |
+
+New surfaces added to the engine appear in both commands automatically.
+
+## Drift-report shape
+
+The engine returns a list of findings. Each finding has:
+
+- `surface` — short label (e.g. `.cursor/rules/`, `Snapshot staleness`)
+- `status` — one of `drifted`, `missing`, `in sync`, `managed`, `candidate`
+- `details` — short string with the specific evidence (e.g. `last: 2026-04-15`, `HARNESS: 0.31, plugin: 0.34`)
+- `action_command` — the slash command that remediates this finding (e.g. `/convention-sync`, `/harness-upgrade`)
+- `auto_fixable` — `true` if the action runs without further user judgement; `false` if the action requires user input
+
+## State vocabulary
+
+- `drifted` — file or fact exists but does not match HARNESS.md / reality.
+- `missing` — file expected but not present.
+- `in sync` — matches HARNESS.md / reality.
+- `managed` — handled at runtime by other layers (CI/CD); informational only.
+- `candidate` — finding that is not strict drift but warrants review (recurring reflection patterns; deferred constraints).
+
+## Auto-fixable classification rule
+
+A finding is `auto_fixable: true` only when:
+
+1. There is a deterministic remediation (a specific command that, given the same HARNESS.md state, would always produce the same fix).
+2. The remediation writes to allow-listed paths (the four push-direction surfaces) OR mutates HARNESS.md only in defined ways (Status section regen via `/harness-audit`, snapshot creation via `/harness-health`).
+3. No user judgement is required between detection and remediation.
+
+Findings that need user input — choosing which constraint to add, deciding whether enforcement should be promoted, deciding when to take an upstream template upgrade — are `auto_fixable: false`. Sync surfaces them as `[manual]` rows; selecting them prints the suggested command without writing.
+
+## Caller contract
+
+Each caller is responsible for its own UX:
+
+- `/harness-audit` prints the findings in its existing format and updates `HARNESS.md` Status section.
+- `/harness-sync` builds its drift table from the findings, prompts for selection, and dispatches the action commands.
+
+The engine itself does not print or prompt. It returns the findings and exits.
+
+## Adding a new surface to the engine
+
+When a new check is added to the engine:
+
+1. Document the surface in the Categories table above.
+2. Decide its `auto_fixable` classification using the rule.
+3. Define the `action_command` it maps to.
+4. Both `/harness-audit` and `/harness-sync` pick up the new finding without further code changes.
+
+This is the value of factoring the engine: surface coverage evolves in one place.
+````
+
+- [ ] **Step 2: Run markdownlint**
+
+Run: `npx markdownlint-cli2 ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md`
+
+Expected: no warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md
+git commit -m "feat(skill): add harness-audit-engine shared skill
+
+Documents the shared drift-detection contract for /harness-audit and
+/harness-sync. Defines the surfaces scanned, the drift-report shape,
+the [auto]/[manual] classification rule, and the per-finding action
+mapping.
+
+The engine itself does not print or prompt — each caller handles its
+own UX. /harness-audit prints findings and updates HARNESS.md Status;
+/harness-sync builds its drift table and dispatches actions."
+```
+
+---
+
+## Task 2: Refactor `/harness-audit` to reference the audit-engine skill
+
+**Files:**
+- Modify: `ai-literacy-superpowers/commands/harness-audit.md` (top of Process section)
+
+`/harness-audit`'s user-facing behaviour does not change. The only edit is a new line at the top of the Process section that references the audit-engine skill, ensuring agents executing the command load it.
+
+- [ ] **Step 1: Read the current command**
+
+Run: `cat ai-literacy-superpowers/commands/harness-audit.md` to confirm the structure.
+
+- [ ] **Step 2: Insert the engine reference**
+
+Find the line near the top of the file that reads `## Process` (it will be roughly line 10).
+
+Immediately above the `## Process` heading, insert:
+
+```markdown
+Read the `harness-audit-engine` skill from this plugin before
+proceeding. The engine defines the shared drift-detection logic and
+the drift-report shape. This command is the read-only inspection
+caller; `/harness-sync` is the read-then-fix caller.
+
+```
+
+(Two newlines after the last sentence, then the existing `## Process` line.)
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 ai-literacy-superpowers/commands/harness-audit.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/harness-audit.md
+git commit -m "refactor(commands): point /harness-audit at audit-engine skill
+
+Adds a one-paragraph reference to the new harness-audit-engine skill
+at the top of the Process section. /harness-audit's user-facing UX is
+unchanged — it remains the read-only inspection caller. The engine
+reference ensures agents executing the command load the shared
+drift-detection contract."
+```
+
+---
+
+## Task 3: Rewrite `/harness-sync` to be audit-driven
+
+**Files:**
+- Modify: `ai-literacy-superpowers/commands/harness-sync.md` (Process section, drift table example)
+
+This is the load-bearing behavioural change. The current Process section has 8 numbered steps focused on the four push-direction surfaces. The new Process section keeps the 8-step shape but replaces the per-surface drift detection in step 3 with an audit-engine invocation, expands the drift table to include every audit finding tagged `[auto]` or `[manual]`, and branches the apply step between auto-fix and print-the-command.
+
+- [ ] **Step 1: Read the current command**
+
+Run: `cat ai-literacy-superpowers/commands/harness-sync.md` to confirm the current structure (8 numbered subsections under `## Process`, plus `## Error and Refusal Cases`, `## Idempotency`, `## Output Format`, `## Validation Checkpoint` sections).
+
+- [ ] **Step 2: Insert the engine reference**
+
+Find the line that reads `## Process` (currently line 29).
+
+Immediately above the `## Process` heading, insert:
+
+```markdown
+Read the `harness-audit-engine` skill from this plugin before
+proceeding. The engine defines the shared drift-detection logic and
+the drift-report shape. This command is the read-then-fix caller; it
+runs the engine, builds a unified drift table including every audit
+finding, and applies fixes via the existing primitives.
+
+```
+
+- [ ] **Step 3: Replace section "### 3. Phase 1 — Drift Scan"**
+
+Find the section heading `### 3. Phase 1 — Drift Scan` (currently line 83) and the next section heading `### 4. Phase 2 — Selection`.
+
+Replace EVERYTHING between them with:
+
+````markdown
+### 3. Phase 1 — Drift Scan via audit-engine
+
+**If invoked with `--check`, the command stops after this phase — see exit semantics at the end of this section.**
+
+Read `HARNESS.md` from the project root. If it does not exist, stop and tell
+the user:
+
+> No `HARNESS.md` found. Run `/harness-init` first, then re-run
+> `/harness-sync`.
+
+Invoke the `harness-audit-engine` skill to scan all surfaces. The engine
+returns a list of findings in the structured shape documented in the
+skill: each finding has `surface`, `status`, `details`, `action_command`,
+and `auto_fixable`.
+
+Surfaces the engine evaluates include (this list mirrors the table in the
+audit-engine skill — when surfaces are added there, they appear here
+automatically):
+
+- `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`
+- `ONBOARDING.md`
+- Most recent snapshot in `observability/snapshots/`
+- HARNESS.md Status section accuracy
+- Template version drift
+- Constraint regressions (deterministic constraints whose tool fails)
+- Recurring reflection patterns (the `Reflection-driven regression detection` GC rule's findings)
+- CI / CD (informational only)
+
+#### Drift scan output table
+
+Build and print this structured table from the findings. Each row's
+`Action on apply` column carries `[auto]` or `[manual]` based on the
+finding's `auto_fixable` field:
+
+```text
+Surface / Finding                              Status      Action on apply
+─────────────────────────────────────────────  ──────────  ────────────────────────
+.cursor/rules/                                 drifted     /convention-sync       [auto]
+.github/copilot-instructions.md                in sync     —
+.windsurf/rules/                               missing     /convention-sync       [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
+HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
+Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
+Constraint regression: ShellCheck unverified   drifted     /harness-constrain     [manual]
+Reflection pattern: Output validation x3       candidate   /harness-constrain     [manual]
+CI / CD (constraint scope)                     managed     handled at runtime
+─────────────────────────────────────────────────────────────────────────────────────
+N surfaces tracked · X drifted · Y missing · Z in sync · W managed · K candidates
+```
+
+State vocabulary:
+
+- `drifted` — file or fact exists but does not match HARNESS.md / reality.
+- `missing` — file is not present; would be created on apply.
+- `in sync` — matches HARNESS.md / reality.
+- `managed` — runtime-managed; surfaced for completeness, not actionable here.
+- `candidate` — not strict drift but warrants review (recurring reflection patterns; deferred constraints).
+
+If `--check` was passed, stop here and exit zero (or non-zero if any
+finding is `drifted`, `missing`, or `candidate`). Do not proceed to
+Phase 2.
+````
+
+- [ ] **Step 4: Replace section "### 4. Phase 2 — Selection"**
+
+Find `### 4. Phase 2 — Selection` (currently line 148) and the next section `### 5. Phase 3 — Apply`.
+
+Replace EVERYTHING between them with:
+
+````markdown
+### 4. Phase 2 — Selection
+
+If all findings are `in sync` or `managed`, tell the user:
+
+> All surfaces and audit checks are in sync. Nothing to apply.
+
+Exit cleanly with no changes.
+
+Otherwise, present a multi-select prompt. Use `AskUserQuestion` with
+`multiSelect: true`. List each `drifted`, `missing`, or `candidate`
+finding as a separate option, with the `[auto]` / `[manual]` tag from
+the table. Default selection is _all_ actionable findings.
+
+Group options visually so `[auto]` items appear before `[manual]`
+items. The `managed` row never appears as a selectable option.
+
+```json
+{
+  "type": "AskUserQuestion",
+  "multiSelect": true,
+  "question": "Select which findings to address. [auto] items run via existing primitives; [manual] items print the suggested command for you to run separately.",
+  "options": [
+    {
+      "id": "cursor",
+      "label": ".cursor/rules/  [auto: /convention-sync]",
+      "selected": true
+    },
+    {
+      "id": "windsurf",
+      "label": ".windsurf/rules/  [auto: /convention-sync (create)]",
+      "selected": true
+    },
+    {
+      "id": "onboarding",
+      "label": "ONBOARDING.md  [auto: /harness-onboarding]",
+      "selected": true
+    },
+    {
+      "id": "snapshot",
+      "label": "Snapshot staleness  [auto: /harness-health]",
+      "selected": true
+    },
+    {
+      "id": "status",
+      "label": "HARNESS.md Status accuracy  [auto: /harness-audit]",
+      "selected": true
+    },
+    {
+      "id": "template",
+      "label": "Template drift  [manual: /harness-upgrade]",
+      "selected": false
+    },
+    {
+      "id": "regression",
+      "label": "Constraint regression  [manual: /harness-constrain]",
+      "selected": false
+    },
+    {
+      "id": "none",
+      "label": "Apply nothing — exit without changes",
+      "selected": false
+    }
+  ]
+}
+```
+
+Construct the actual options list from the Phase 1 findings. `[auto]`
+items default to `selected: true`; `[manual]` items default to
+`selected: false` (the user must opt in to running judgement-required
+remediations, even via just printing the command).
+
+If the user selects "Apply nothing — exit without changes" (or
+deselects all surfaces), exit cleanly with no changes.
+````
+
+- [ ] **Step 5: Replace section "### 5. Phase 3 — Apply"**
+
+Find `### 5. Phase 3 — Apply` (currently line 201) and the next section `### 6. Verification Scan`.
+
+Replace EVERYTHING between them with:
+
+````markdown
+### 5. Phase 3 — Apply
+
+For each selected finding, branch on its `auto_fixable` classification:
+
+#### `[auto]` items — run the action command
+
+For each `[auto]` selected finding, invoke its `action_command` _in
+series_ (not in parallel — order matters for the verification scan):
+
+1. **`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`** — invoke `/convention-sync`. This handles all three convention-file surfaces in a single run; if multiple are selected they share the same invocation.
+2. **`ONBOARDING.md`** — invoke `/harness-onboarding`.
+3. **Snapshot staleness** — invoke `/harness-health`.
+4. **HARNESS.md Status section accuracy** — invoke `/harness-audit`. (Audit updates Status as a side-effect of running.)
+
+If an underlying command errors out for one finding:
+
+- Continue with the remaining selected `[auto]` findings.
+- Mark the errored finding as `still drifted (error)` in the verification
+  scan.
+- The overall run will exit non-zero (see step 6 below).
+
+#### `[manual]` items — print the suggested command
+
+For each `[manual]` selected finding, do NOT invoke the action command.
+Instead, print a "next step" line:
+
+```text
+Manual remediation suggested for: Template version drift
+Run: /harness-upgrade
+```
+
+The user runs these separately. `/harness-sync` does not invoke them
+to preserve the trust boundary — these commands require user judgement
+(which template content to adopt, which constraint to add).
+````
+
+- [ ] **Step 6: Replace section "### 6. Verification Scan"**
+
+Find `### 6. Verification Scan` (currently line 218) and the next section `### 7. Trust-Boundary Pre-Commit Guard`.
+
+Replace EVERYTHING between them with:
+
+````markdown
+### 6. Verification Scan
+
+After all selected `[auto]` items are applied, re-invoke the
+`harness-audit-engine` skill and build the delta table:
+
+```text
+Apply complete — verification scan:
+
+Surface / Finding                              Before      After
+─────────────────────────────────────────────  ──────────  ─────────────
+.cursor/rules/                                 drifted     in sync ✓
+.windsurf/rules/                               missing     in sync ✓
+ONBOARDING.md                                  drifted     in sync ✓
+Snapshot staleness                             drifted     in sync ✓
+HARNESS.md Status accuracy                     drifted     in sync ✓
+Template drift                                 drifted     drifted (manual — see suggestion above)
+```
+
+If any selected `[auto]` finding is _not_ now `in sync`, mark it as
+`still drifted (error)` in the After column. Do _not_ proceed to commit.
+Report the failed findings and exit non-zero.
+
+`[manual]` findings that the user selected are reported in the After
+column with the `(manual — see suggestion above)` note, not flagged
+as errors. They were not auto-applied.
+
+If all selected `[auto]` findings are now `in sync` (and any `[manual]`
+findings have their suggestions printed), proceed to the trust-boundary
+guard.
+````
+
+- [ ] **Step 7: Run markdownlint**
+
+Run: `npx markdownlint-cli2 ai-literacy-superpowers/commands/harness-sync.md`
+
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ai-literacy-superpowers/commands/harness-sync.md
+git commit -m "refactor(commands): /harness-sync is now audit-driven
+
+Replaces the per-surface drift detection in Phase 1 with an invocation
+of the new harness-audit-engine skill. The drift table now includes
+every audit finding tagged [auto] or [manual] based on whether the
+remediation runs without user judgement.
+
+Phase 3 (Apply) branches: [auto] findings run via existing primitives
+(/convention-sync, /harness-onboarding, /harness-health, /harness-audit);
+[manual] findings print 'Run: <command>' suggestions without writing,
+preserving the trust boundary.
+
+The trust-boundary pre-commit guard's allow-list is unchanged — the
+unified drift table includes additional rows but those rows either
+fix non-allow-listed paths via existing primitives (which have their
+own trust boundaries) or print suggestions without writing."
+```
+
+---
+
+## Task 4: Rewrite `the-harness-lifecycle.md` as canonical narrative
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md` (full body rewrite)
+
+The current page (290 lines) traces a six-stage tuning loop end-to-end. The new page is the canonical lifecycle narrative built around the simpler "detect drift → heal it; pull upstream when needed" frame, with `/harness-sync` as the everyday entry point.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md` to see the existing structure.
+
+- [ ] **Step 2: Replace the body (everything below the frontmatter)**
+
+Preserve the existing frontmatter (the first `---` block at the top of the file). Replace the body — everything from the first `# H1` heading down — with this content:
+
+````markdown
+# The Harness Lifecycle
+
+> The harness has a simple lifecycle: **detect drift, heal it, pull
+> upstream when needed**. Three commands cover it. Everything else is
+> a deeper or specialised version of one of those three.
+
+## The three states a harness is ever in
+
+A harness is always in one of three states:
+
+1. **In sync.** HARNESS.md matches reality. Convention files reflect
+   the current rules. Reflections are captured. The Status section
+   accurately describes enforcement.
+2. **Drifted.** Something has fallen out of alignment. A convention
+   file is stale, a snapshot has aged out, a constraint regressed,
+   or a recurring reflection pattern hasn't been promoted yet.
+3. **Behind upstream.** The plugin has shipped new template content
+   the project hasn't reviewed yet — new constraint defaults, new GC
+   rules, new conventions.
+
+Every command in the plugin moves the harness between these states.
+Most are specialisations; a few are the everyday entry points.
+
+## The everyday entry points
+
+Three commands cover most lifecycle activity:
+
+### `/harness-sync` — the everyday command
+
+Detects drift across every surface and lets you fix it in one pass.
+Internally runs `/harness-audit`'s detection logic, presents a unified
+drift table, and applies the fixes you select. Mechanical fixes
+(convention files, ONBOARDING.md, snapshots, HARNESS.md Status
+accuracy) run automatically. Judgement-required fixes (which
+constraint to add, whether to take a template upgrade) print the
+suggested command for you to run separately.
+
+When in doubt, run `/harness-sync`. It tells you everything that's out
+of alignment and either fixes it or tells you what to run.
+
+### `/harness-upgrade` — pull upstream changes
+
+When the plugin has shipped new template content, `/harness-upgrade`
+diffs your `HARNESS.md` against the current template and presents new
+items for review. You accept, skip, or customise each one.
+
+`/harness-sync` will tell you when this is needed (the "Template
+version drift" row in its drift table). `/harness-upgrade` is the
+remediation; it doesn't auto-run because choosing what to adopt is a
+judgement call.
+
+### `/harness-constrain` — capture or promote a constraint
+
+When you want to add a new constraint to HARNESS.md, or promote an
+existing one from `unverified` to `agent` or `deterministic`,
+`/harness-constrain` walks you through the authoring with the
+constraint-design skill loaded.
+
+`/harness-sync` will surface "Recurring reflection pattern" findings
+when REFLECTION_LOG.md shows the same surprise twice. That's the
+signal that a constraint should exist for that pattern. `/harness-
+constrain` is the authoring path.
+
+## The specialised commands
+
+Behind the everyday three, there are deeper or focused tools:
+
+- **`/harness-audit`** is the inspection-only deep-dive. Same engine
+  as `/harness-sync` but read-only — no prompts, just a report.
+  Useful when you want to inspect without committing to action, or
+  when scripting / scheduling. The cadence in `HARNESS.md`
+  Observability ("Harness audit: quarterly") refers to this command.
+- **`/harness-status`** is a quick-look summary — enforcement ratio,
+  drift indicator, GC state. Faster than `/harness-audit` for "is
+  everything roughly OK?"
+- **`/harness-health`** generates a full snapshot to
+  `observability/snapshots/`. The longitudinal record of the harness
+  over time, with trends.
+- **`/harness-gc`** manages the periodic garbage-collection rules
+  that fight slow drift between PR-level enforcement events.
+- **`/convention-sync`** and **`/harness-onboarding`** are the
+  primitives `/harness-sync` calls. You can invoke them directly when
+  you only want one surface refreshed.
+
+## When each lifecycle state happens
+
+- **You write a constraint** → run `/harness-constrain`. Then later,
+  next time you run `/harness-sync`, the new constraint propagates to
+  the convention files automatically (it shows up as a drifted
+  surface that auto-fixes).
+- **You merge a PR** → run `/harness-sync` if the PR changed
+  HARNESS.md content. Convention files and ONBOARDING.md regenerate.
+- **You see a build break** related to harness state → run
+  `/harness-audit` for the read-only diagnostic, or `/harness-sync`
+  to also fix.
+- **You install a new plugin version** → run `/harness-upgrade`. The
+  SessionStart hook nudges you when the template version has moved.
+- **You notice a pattern of failures** in REFLECTION_LOG.md → run
+  `/harness-constrain` to encode the lesson.
+
+## Why this lifecycle works
+
+The lifecycle is built around two truths.
+
+**Truth one: HARNESS.md is the single source of truth.** Everything
+else is derived. Convention files are derived from the Conventions
+and Constraints sections. ONBOARDING.md is derived from HARNESS.md +
+AGENTS.md + REFLECTION_LOG.md. The snapshot is derived from the
+current state. The Status section is derived from actual enforcement.
+When anything diverges, regeneration brings it back into alignment.
+
+**Truth two: not every drift is mechanical.** Some drift signals a
+real choice — should we take the upstream template? Should this
+recurring reflection become a constraint? Mechanical regeneration
+works for derived surfaces; choices need a human. The
+`[auto]` / `[manual]` distinction in `/harness-sync`'s drift table
+makes this explicit, and keeps the trust boundary clear: the command
+applies mechanical fixes; choices stay with you.
+
+## Related reading
+
+- [The Harness Tuning Loop](the-harness-tuning-loop.md) — the focused
+  sub-flow for promoting reflection patterns into constraints.
+- [The Self-Improving Harness](self-improving-harness.md) — why a
+  harness needs to evolve and how compound learning fits in.
+- [How to: sync the harness](../how-to/sync-harness.md) — the
+  step-by-step for `/harness-sync`.
+- [How to: run a harness audit](../how-to/run-a-harness-audit.md) —
+  the diagnostic workflow.
+````
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
+git commit -m "docs(explanation): rewrite the-harness-lifecycle as canonical narrative
+
+The page is now the single canonical lifecycle narrative for the
+plugin. Frame: 'detect drift → heal it; pull upstream when needed'.
+Three states (in sync, drifted, behind upstream) cover everything;
+three everyday commands (/harness-sync, /harness-upgrade,
+/harness-constrain) cover the transitions; everything else is a
+specialised tool.
+
+Drops the previous six-stage tuning-loop walkthrough — that content
+moves to the-harness-tuning-loop, which now focuses specifically on
+the signal-capture → constraint-promotion sub-flow."
+```
+
+---
+
+## Task 5: Trim `the-harness-tuning-loop.md` to its sub-flow
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md` (full body rewrite)
+
+The current page covers the broad lifecycle. With the lifecycle narrative now in `the-harness-lifecycle.md`, this page refocuses on the specific signal-capture → constraint-promotion sub-flow.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md` to see the existing structure.
+
+- [ ] **Step 2: Replace the body (everything below the frontmatter)**
+
+Preserve the existing frontmatter. Replace the body with:
+
+````markdown
+# The Harness Tuning Loop
+
+> A harness improves over time through a specific sub-flow: surprises
+> get captured as reflections, recurring patterns become candidate
+> constraints, candidate constraints get promoted via
+> `/harness-constrain`. This page is about that sub-flow.
+
+For the broader picture, see [The Harness Lifecycle](the-harness-lifecycle.md).
+This page goes deeper on the part of the lifecycle that turns
+*lessons* into *enforcement*.
+
+## The four stages
+
+### 1. Capture — write the reflection
+
+When a session ends with something surprising — a wrong assumption,
+an unexpected gotcha, a workflow hole — the integration agent (or you,
+running `/reflect`) appends an entry to `REFLECTION_LOG.md`. Each
+entry has:
+
+- A one-sentence task summary
+- The surprise — what went wrong or wasn't expected
+- A proposal — what could prevent this next time
+- A signal — `failure`, `workflow`, `context`, or `none`
+- An optional proposed constraint
+
+`failure` and `workflow` signals are the ones that feed this loop.
+
+### 2. Detect — let the GC rule find recurring patterns
+
+The `Reflection-driven regression detection` GC rule runs weekly. It
+scans `REFLECTION_LOG.md` for recurring failure patterns — the same
+type of surprise across two or more entries. When it finds one, it
+flags the pattern as a candidate constraint.
+
+`/harness-sync`'s drift table includes these candidates as
+`[manual]` rows. The action command suggested is `/harness-constrain`.
+
+### 3. Promote — author the constraint
+
+`/harness-constrain` is the authoring path. It loads the
+`constraint-design` skill, which walks through:
+
+- The rule itself (must be falsifiable)
+- The enforcement level (`unverified`, `agent`, `deterministic`)
+- The tool, if deterministic
+- The scope (`commit`, `pr`, `weekly`, `manual`)
+
+The constraint gets added to `HARNESS.md`. From that point forward
+it appears in `/harness-sync`'s convention-file drift detection
+(if it changes the conventions text) and in `/harness-audit`'s
+enforcement-ratio reporting.
+
+### 4. Verify — let the constraint catch real violations
+
+The newly authored constraint enters the active enforcement set. Its
+behaviour over the next few PRs is the test of whether the promotion
+was correct:
+
+- If it catches real instances of the original surprise, promotion
+  was right.
+- If it never fires, the underlying assumption may have been wrong —
+  the surprise was a one-off, or the constraint's rule isn't falsifiable
+  enough to detect the real pattern. Either way, future reflections
+  will say so.
+- If it fires on innocent code, the constraint is too strict; the
+  next reflection should propose softening it.
+
+## Why the loop is structured this way
+
+The loop deliberately separates *capture* from *promotion*. Reflections
+should be cheap — write them down without judgement. The judgement
+happens later, with the benefit of recurrence. A single failure isn't
+enough evidence to add a constraint; two related failures often is.
+
+This is also why the GC rule fires weekly rather than on every
+reflection. Reflection-time pattern matching would over-promote
+(every surprise becomes a constraint). Aggregated weekly review
+catches genuine recurrence.
+
+## Where this fits in the lifecycle
+
+This loop is one of the contributors to the "drifted → in sync"
+transition described in [The Harness Lifecycle](the-harness-lifecycle.md).
+A recurring pattern is a kind of drift between *what should be
+constrained* and *what is constrained*. `/harness-constrain` is the
+remediation; the GC rule and `/harness-sync` are the detection.
+
+## Related reading
+
+- [The Harness Lifecycle](the-harness-lifecycle.md) — the broader
+  detect-heal-pull frame.
+- [The Self-Improving Harness](self-improving-harness.md) — why
+  iteration matters and how compound learning fits in.
+- [How to: write a governance constraint](../how-to/write-a-governance-constraint.md)
+  — the deeper case for governance-flavoured constraints.
+- [How to: add a constraint](../how-to/add-a-constraint.md) — the
+  step-by-step for `/harness-constrain`.
+````
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
+git commit -m "docs(explanation): refocus the-harness-tuning-loop on its sub-flow
+
+The page no longer tries to cover the broader lifecycle (that lives
+in the-harness-lifecycle now). It focuses on the specific
+signal-capture → constraint-promotion sub-flow:
+
+  1. Capture — write the reflection
+  2. Detect — let the GC rule find recurring patterns
+  3. Promote — author the constraint via /harness-constrain
+  4. Verify — let the constraint catch real violations
+
+The 'Why the loop is structured this way' section explains the
+deliberate separation between cheap reflection capture and aggregated
+weekly promotion."
+```
+
+---
+
+## Task 6: Trim `self-improving-harness.md` to conceptual core
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md` (full body rewrite)
+
+The current page (262 lines) mixes conceptual content about *why* a harness must self-improve with command-level walkthroughs that duplicate how-to pages. The trim removes the duplicated walkthroughs and focuses the page on the conceptual core.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md` to see the existing structure.
+
+- [ ] **Step 2: Replace the body (everything below the frontmatter)**
+
+Preserve the existing frontmatter. Replace the body with:
+
+````markdown
+# The Self-Improving Harness
+
+> A harness that doesn't evolve becomes a museum exhibit. The
+> conventions that worked last quarter may not work this quarter.
+> The constraints that mattered when the team was small may be
+> ceremony when the team is large. The harness has to keep up — and
+> the cheapest way to do that is to make every session a contribution.
+
+## Why iteration matters
+
+The conventions captured in HARNESS.md were correct *when they were
+written*. The codebase changes; the team changes; tooling changes;
+expectations change. Without a path for the harness to evolve in
+response, three failure modes appear:
+
+- **Drift** — what's enforced no longer matches what should be enforced.
+  Either too strict (ceremony) or too lax (escape hatches). Either
+  way, trust in the harness erodes.
+- **Calcification** — the team stops pushing back on bad rules
+  because the rules are "what we do." Conventions become identity
+  rather than judgement.
+- **Stagnation** — patterns the team has actually learned in the
+  trenches never make it into the harness, because no one writes
+  them down. Knowledge stays in heads.
+
+The cure is to make every session a chance for the harness to
+update.
+
+## How sessions become contributions
+
+The plugin shapes sessions so that lessons accumulate without
+requiring a separate "process":
+
+- **`/reflect`** captures one session's surprise, classified by
+  signal (`failure`, `workflow`, `context`, `none`). Cheap to write,
+  cheap to merge via PR.
+- **`REFLECTION_LOG.md`** is the running journal. Most entries stay
+  there forever as historical record.
+- **The `Reflection-driven regression detection` GC rule** fires
+  weekly to find recurring patterns — the signal that a one-off
+  surprise has become a class of surprise.
+- **`/harness-sync`** surfaces those recurring patterns in its drift
+  table as `[manual]` candidate-constraint rows.
+- **`/harness-constrain`** authors the new constraint when the
+  pattern warrants it.
+- **`AGENTS.md`** is the curated subset — the lessons the team has
+  decided are part of the project's identity, not just the log.
+
+Every session contributes raw material. The aggregating mechanisms
+(GC rule, sync, constrain) turn that into structured, enforced
+knowledge over time.
+
+## The compound-learning principle
+
+Two ideas underlie this:
+
+**Lessons compound.** A team that captures lessons consistently is
+strictly better off than a team that doesn't, regardless of which
+specific lessons. The activation cost of `/reflect` (write three
+lines) is low enough that it's worth doing for every session — the
+compound effect over a year of sessions is large.
+
+**Curation is human.** The plugin captures aggressively (every
+reflection is appended) but promotes conservatively (only patterns
+recurring twice or more become constraints, only after the GC rule
+finds them, only after a human runs `/harness-constrain`). This
+asymmetry is deliberate. False captures cost nothing; false promotions
+add ceremony. The harness errs on the side of capturing too much and
+promoting too little.
+
+## What "self-improving" actually means
+
+It does not mean the harness rewrites itself autonomously. Every
+mutation is human-initiated:
+
+- A reflection is written by a human (or by an agent the human
+  reviews).
+- A constraint is promoted by a human running `/harness-constrain`.
+- A template upgrade is accepted by a human running `/harness-upgrade`.
+
+It means the harness has the *machinery* for evolution wired in: the
+journal, the recurrence detector, the promotion path, the curation
+target. Without that machinery, evolution requires a separate
+discipline that can be skipped under pressure. With it, evolution is
+a side effect of normal work.
+
+## Where this fits in the lifecycle
+
+The self-improving aspect is the long-arc view of the
+"drifted → in sync" transition described in
+[The Harness Lifecycle](the-harness-lifecycle.md). What looks like
+drift in one session is signal for the next session's improvement.
+
+## Related reading
+
+- [The Harness Lifecycle](the-harness-lifecycle.md) — the everyday
+  three-state model.
+- [The Harness Tuning Loop](the-harness-tuning-loop.md) — the focused
+  signal-capture → constraint-promotion sub-flow.
+- [Compound Learning](compound-learning.md) — the deeper conceptual
+  background on why lessons compound.
+````
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
+git commit -m "docs(explanation): trim self-improving-harness to conceptual core
+
+Removes command-level walkthroughs that duplicated content in the
+how-to pages. Keeps the conceptual content: why iteration matters
+(drift, calcification, stagnation), how sessions become contributions
+via the capture-aggregate-promote chain, the compound-learning
+principle (capture aggressively, promote conservatively), and what
+'self-improving' actually means (machinery for evolution, not
+autonomous mutation)."
+```
+
+---
+
+## Task 7: Rewrite `how-to/sync-harness.md` for new flow
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` (full body rewrite)
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` to see the existing structure.
+
+- [ ] **Step 2: Replace the body (everything below the frontmatter)**
+
+Preserve the existing frontmatter. Replace the body with:
+
+````markdown
+# Sync the harness
+
+> Run `/harness-sync` to bring every surface into alignment with
+> `HARNESS.md`. Same engine as `/harness-audit` (the read-only
+> diagnostic), but with a multi-select prompt that lets you apply
+> the fixes.
+
+## When to run it
+
+- After modifying `HARNESS.md` (new constraint, edited convention,
+  promoted enforcement level).
+- After merging a PR that touched `HARNESS.md` or any of the derived
+  surfaces.
+- When you suspect drift but want to see the full picture before
+  acting.
+- As a periodic check — once a sprint or whenever the SessionStart
+  hook nudges you.
+
+## What you'll see
+
+`/harness-sync` runs in three phases. Phase 1 is the drift scan via
+the shared audit-engine; it prints a unified drift table:
+
+```text
+Surface / Finding                              Status      Action on apply
+─────────────────────────────────────────────  ──────────  ────────────────────────
+.cursor/rules/                                 drifted     /convention-sync       [auto]
+.github/copilot-instructions.md                in sync     —
+.windsurf/rules/                               missing     /convention-sync       [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
+HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
+Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
+Reflection pattern: Output validation x3       candidate   /harness-constrain     [manual]
+CI / CD (constraint scope)                     managed     handled at runtime
+```
+
+The `Action on apply` column has two flavours:
+
+- **`[auto]`** — the fix is mechanical. `/harness-sync` will run it
+  for you when you select the row.
+- **`[manual]`** — the fix needs a judgement call (which constraint
+  to add, whether to take a template upgrade). `/harness-sync` will
+  print the suggested command but won't run it.
+
+## What you'll do
+
+After Phase 1 prints the drift table, Phase 2 prompts you with a
+multi-select. Every drifted, missing, or candidate finding appears
+as a checkbox. `[auto]` items default to checked; `[manual]` items
+default to unchecked.
+
+Pick which to address. Hit "Apply nothing — exit without changes" if
+you just wanted the diagnostic.
+
+Phase 3 applies the fixes. For each `[auto]` selection, `/harness-sync`
+invokes the underlying primitive (`/convention-sync`,
+`/harness-onboarding`, `/harness-health`, `/harness-audit`). For each
+`[manual]` selection, it prints a "next step" line:
+
+```text
+Manual remediation suggested for: Template version drift
+Run: /harness-upgrade
+```
+
+You run those separately.
+
+## Verification
+
+`/harness-sync` re-runs the audit-engine after applying and prints a
+delta table:
+
+```text
+Apply complete — verification scan:
+
+Surface / Finding                              Before      After
+─────────────────────────────────────────────  ──────────  ─────────────
+.cursor/rules/                                 drifted     in sync ✓
+.windsurf/rules/                               missing     in sync ✓
+ONBOARDING.md                                  drifted     in sync ✓
+Snapshot staleness                             drifted     in sync ✓
+HARNESS.md Status accuracy                     drifted     in sync ✓
+Template drift                                 drifted     drifted (manual — see suggestion above)
+```
+
+If any selected `[auto]` finding didn't reach `in sync`, the run exits
+non-zero and prints what failed. `[manual]` findings keep their
+"drifted" status with the suggestion note — they were never going to
+be auto-applied.
+
+## Branch and trust-boundary
+
+`/harness-sync` refuses to run on `main`. If you're on `main` it
+offers to create `chore/sync-surfaces-YYYY-MM-DD` for you. The
+trust-boundary pre-commit guard restricts what gets staged: only
+`.cursor/rules/**`, `.github/copilot-instructions.md`,
+`.windsurf/rules/**`, and `ONBOARDING.md` may be committed.
+`HARNESS.md`, `AGENTS.md`, and `REFLECTION_LOG.md` are off-limits to
+this command.
+
+If a `[auto]` action mutates HARNESS.md (the Status section update
+from `/harness-audit`, for example), that mutation lands as part of
+the action's own flow and is committed separately by the action's
+own logic. `/harness-sync`'s commit covers only the four push-direction
+surfaces.
+
+## `--check` mode
+
+`/harness-sync --check` runs Phase 1 only. Prints the drift table and
+exits. Useful from CI or scripts when you just want to know if drift
+exists. Exits non-zero if any finding is drifted, missing, or candidate;
+zero otherwise.
+
+## When `/harness-sync` isn't enough
+
+Some drift can't be `[auto]`-fixed:
+
+- **Template drift** — run `/harness-upgrade` and adjudicate the new
+  items.
+- **Constraint regression** — run `/harness-constrain` to either fix
+  the constraint or downgrade its enforcement level.
+- **Recurring reflection pattern** — run `/harness-constrain` to
+  promote the pattern into a constraint.
+
+`/harness-sync` will tell you which to run. You decide when.
+
+## Related
+
+- [How to: run a harness audit](run-a-harness-audit.md) — the
+  read-only diagnostic, same engine as sync.
+- [The Harness Lifecycle](../explanation/the-harness-lifecycle.md) —
+  the broader detect-heal-pull frame.
+- [How to: add a constraint](add-a-constraint.md) — the
+  `/harness-constrain` workflow.
+- [How to: upgrade your harness](upgrade-your-harness.md) — the
+  `/harness-upgrade` workflow.
+````
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
+git commit -m "docs(how-to): rewrite sync-harness for the audit-driven flow
+
+Documents the new /harness-sync behaviour: unified drift table from
+the shared audit-engine, [auto] vs [manual] action column, multi-select
+prompt with [auto] items pre-selected and [manual] items opt-in,
+verification scan, --check dry-run mode, trust-boundary preservation,
+and pointers to /harness-upgrade and /harness-constrain when sync
+can't auto-fix."
+```
+
+---
+
+## Task 8: Update `how-to/run-a-harness-audit.md` for diagnostic role
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md`
+
+The page already documents `/harness-audit`. The update positions it as the read-only diagnostic alternative to `/harness-sync` and routes everyday users to sync.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md` to see the existing structure.
+
+- [ ] **Step 2: Add a "When to use audit vs sync" section near the top**
+
+Find the first H2 heading after the page's introductory paragraph (likely `## When to run it` or similar). Immediately above that H2, insert:
+
+```markdown
+## Audit vs `/harness-sync`
+
+`/harness-audit` and `/harness-sync` use the same drift-detection
+engine. The difference is action:
+
+- **`/harness-audit`** is read-only. It prints findings and updates
+  the `HARNESS.md` Status section. It never prompts you to fix
+  anything. Useful when you want a clean diagnostic without
+  committing to action — for example from CI, or when scripting,
+  or when you suspect drift but aren't ready to deal with it yet.
+- **`/harness-sync`** runs the same engine but prompts you to apply
+  fixes. Mechanical fixes (convention files, ONBOARDING.md, snapshot,
+  Status section) auto-apply when selected. Judgement-required fixes
+  (template upgrade, constraint authoring) print suggested commands.
+
+**For everyday lifecycle hygiene, run `/harness-sync`.** Run
+`/harness-audit` when you specifically want the diagnostic without
+the action prompt.
+
+```
+
+- [ ] **Step 3: Update the page's opening paragraph if it overstates audit's role**
+
+If the page's intro says something like "audit is the everyday command for harness hygiene" or treats audit as the primary lifecycle entry, soften it. The intro should now position audit as a diagnostic tool that shares its engine with `/harness-sync`.
+
+A suggested opening (replace the first paragraph after the H1 heading if one exists):
+
+```markdown
+> `/harness-audit` is the read-only diagnostic. It runs the shared
+> drift-detection engine across every surface and prints findings,
+> without prompting you to fix anything. Use it when you want
+> visibility without action. For everyday hygiene, prefer
+> [`/harness-sync`](sync-harness.md), which uses the same engine and
+> applies fixes.
+
+```
+
+- [ ] **Step 4: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md`
+
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
+git commit -m "docs(how-to): clarify /harness-audit as diagnostic role
+
+Adds an 'Audit vs /harness-sync' section that explains the two
+commands share an engine. /harness-audit is read-only inspection;
+/harness-sync uses the same engine and applies fixes.
+
+Routes everyday users to /harness-sync for lifecycle hygiene; keeps
+/harness-audit positioned for diagnostic use cases (CI, scripting,
+inspection-without-commitment)."
+```
+
+---
+
+## Task 9: Touch-up tutorials (`getting-started.md` and `first-time-tour.md`)
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md`
+- Modify: `docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md`
+
+Both tutorials currently mention various harness commands. The touch-up positions `/harness-sync` as the everyday command in any lifecycle-related section.
+
+- [ ] **Step 1: Search both files for current command references**
+
+Run: `grep -n "harness-audit\|harness-sync\|convention-sync\|harness-onboarding" docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md`
+
+Look at the surrounding context for each match.
+
+- [ ] **Step 2: For each occurrence where the tutorial walks through "what to run periodically" or "after editing HARNESS.md", prefer `/harness-sync`**
+
+Replacement patterns:
+
+- "Run `/convention-sync` to push HARNESS.md to the AI tool rule files" → "Run `/harness-sync` to bring every surface into alignment with HARNESS.md (`/convention-sync` is one of the primitives it composes)"
+- "Run `/harness-audit` to see if anything has drifted" → "Run `/harness-sync` to see drift across every surface and apply the fixes you select; or `/harness-audit` for the read-only diagnostic"
+- Bare lists of "/convention-sync; /harness-onboarding; /harness-audit" as periodic actions → replace with "/harness-sync (everyday); /harness-audit (diagnostic only)"
+
+Apply these edits where they fit naturally; don't force the substitution if the surrounding tutorial text is doing something specific.
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
+git commit -m "docs(tutorials): position /harness-sync as the everyday command
+
+Updates getting-started.md and first-time-tour.md to mention
+/harness-sync where the tutorials previously listed individual
+primitives (/convention-sync, /harness-onboarding) or treated
+/harness-audit as the everyday entry. /harness-audit is mentioned
+as the diagnostic alternative."
+```
+
+---
+
+## Task 10: Touch-up plugin landing page
+
+**Files:**
+- Modify: `docs/plugins/ai-literacy-superpowers/index.md`
+
+The plugin landing currently has a "Where to start" section with quadrant links. The touch-up adds a one-line mention that `/harness-sync` is the everyday lifecycle command, in the appropriate section of the landing.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat docs/plugins/ai-literacy-superpowers/index.md`
+
+- [ ] **Step 2: Locate the "Where to start" or equivalent section**
+
+There should be a table or section listing the quadrants. If there's a paragraph that introduces the everyday workflow, add a sentence near the bottom of that paragraph (or just below the quadrant table):
+
+```markdown
+The everyday lifecycle entry is `/harness-sync` — it detects drift
+across every surface and applies the fixes you select. See
+[The Harness Lifecycle](explanation/the-harness-lifecycle.md) for the
+broader frame.
+```
+
+If there isn't a natural spot, add the sentence just above the
+"Where to start" table.
+
+- [ ] **Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 docs/plugins/ai-literacy-superpowers/index.md`
+
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/plugins/ai-literacy-superpowers/index.md
+git commit -m "docs(landing): mention /harness-sync as everyday lifecycle entry
+
+Adds a one-line pointer to /harness-sync and a link to the lifecycle
+explanation page on the plugin's landing page."
+```
+
+---
+
+## Task 11: Update CLAUDE.md (root + template) Operations sections
+
+**Files:**
+- Modify: `CLAUDE.md` (root)
+- Modify: `ai-literacy-superpowers/templates/CLAUDE.md`
+
+Both CLAUDE.md files have "Quarterly Operations" and "Monthly Operations" sections that list specific commands to run. Where these list ad-hoc combinations of `/convention-sync` + `/harness-onboarding` (or similar push-surface commands), replace with `/harness-sync`. Keep the cadence anchors (`/governance-audit`, `/cost-capture`, `/assess`, `/harness-audit`).
+
+- [ ] **Step 1: Search for the Operations sections**
+
+Run: `grep -n "Operations\|/harness-sync\|/convention-sync\|/harness-onboarding\|/harness-audit" CLAUDE.md ai-literacy-superpowers/templates/CLAUDE.md | head -30`
+
+- [ ] **Step 2: Update the Quarterly Operations section in both files**
+
+Find the section that currently reads roughly:
+
+```markdown
+## Quarterly Operations
+
+Aligned cadence (every 90 days, anchored to `/governance-audit`):
+
+1. `/governance-audit` — full governance review
+2. `/cost-capture` — capture spend snapshot from provider dashboards
+3. `/assess` — AI literacy re-assessment
+
+Run as a single sitting; one quarterly working block, not three scattered
+tasks.
+```
+
+Replace with the same content (it's already correct — the quarterly anchors don't include the surface-sync commands). If the file has additional bullets that mention `/convention-sync` or `/harness-onboarding`, swap those for `/harness-sync`.
+
+- [ ] **Step 3: Update the Monthly Operations section in both files**
+
+Find the section that reads roughly:
+
+```markdown
+## Monthly Operations
+
+Light-touch health check (every 30 days, between quarterly anchor weeks):
+
+1. `/governance-health` — governance constraint health snapshot
+2. Reflection review — scan `REFLECTION_LOG.md` for new entries worth
+   promoting to `AGENTS.md`
+```
+
+Add a third bullet for the everyday lifecycle entry:
+
+```markdown
+3. `/harness-sync` — bring every push-direction surface into alignment
+   with HARNESS.md (convention files, ONBOARDING.md, snapshot, Status
+   section). Surfaces template drift and recurring reflection patterns
+   as `[manual]` items for follow-up.
+```
+
+If the existing Monthly Operations section already has surface-related items, integrate `/harness-sync` and remove individual `/convention-sync` / `/harness-onboarding` mentions in favour of the unified entry.
+
+- [ ] **Step 4: Run markdownlint**
+
+Run: `npx markdownlint-cli2 CLAUDE.md ai-literacy-superpowers/templates/CLAUDE.md`
+
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md ai-literacy-superpowers/templates/CLAUDE.md
+git commit -m "docs(claude.md): /harness-sync is the everyday lifecycle entry
+
+Updates Monthly Operations sections in both CLAUDE.md (root) and
+templates/CLAUDE.md to list /harness-sync as the everyday
+lifecycle hygiene step. Quarterly Operations cadence anchors are
+unchanged.
+
+Lands in both root and shipped template so projects running
+/superpowers-init pick up the corrected guidance."
+```
+
+---
+
+## Task 12: Update README
+
+**Files:**
+- Modify: `README.md`
+
+The README has a Commands table that describes each lifecycle command. Update `/harness-sync`'s description to reflect the audit-driven flow; update `/harness-audit`'s description to clarify its diagnostic role.
+
+- [ ] **Step 1: Search for the Commands table**
+
+Run: `grep -nE "^\| ./harness-(sync|audit)" README.md`
+
+This should locate the rows for `/harness-sync` and `/harness-audit` in the Commands table.
+
+- [ ] **Step 2: Update the `/harness-sync` row**
+
+Find the row currently reading approximately:
+
+```markdown
+| `/harness-sync` | Multi-surface entry point — detects drift across convention files and ONBOARDING.md, applies fixes via the underlying primitives in one interactive pass |
+```
+
+Replace with:
+
+```markdown
+| `/harness-sync` | Everyday lifecycle entry. Runs the shared audit-engine to detect drift across every surface (convention files, ONBOARDING.md, snapshot, Status section, template, constraint regressions, recurring reflection patterns), presents a unified drift table tagged `[auto]`/`[manual]`, and applies the fixes you select. Mechanical fixes auto-apply via existing primitives; judgement-required fixes print suggested commands. |
+```
+
+- [ ] **Step 3: Update the `/harness-audit` row**
+
+Find the row currently reading approximately:
+
+```markdown
+| `/harness-audit` | Full meta-verification of the harness |
+```
+
+Replace with:
+
+```markdown
+| `/harness-audit` | Read-only diagnostic. Same engine as `/harness-sync` but prints findings without prompting to fix. Use for inspection-without-commitment, CI scripts, or the quarterly cadence anchor. |
+```
+
+- [ ] **Step 4: Run markdownlint**
+
+Run: `npx markdownlint-cli2 README.md`
+
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): update /harness-sync and /harness-audit descriptions
+
+The Commands table now reflects the audit-driven /harness-sync and
+the read-only diagnostic role of /harness-audit. Both descriptions
+emphasise that they share an engine."
+```
+
+---
+
+## Task 13: Bump plugin version 0.34.1 → 0.35.0
+
+**Files:**
+- Modify: `ai-literacy-superpowers/.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+Minor bump because `/harness-sync`'s behaviour materially changes.
+
+- [ ] **Step 1: Bump `plugin.json`**
+
+In `ai-literacy-superpowers/.claude-plugin/plugin.json`, change the `"version"` field from `"0.34.1"` to `"0.35.0"`.
+
+- [ ] **Step 2: Bump `marketplace.json`**
+
+In `.claude-plugin/marketplace.json`, change BOTH the top-level `"plugin_version"` and the entry inside the `plugins` array (the one with `"name": "ai-literacy-superpowers"`) from `"0.34.1"` to `"0.35.0"`.
+
+- [ ] **Step 3: Update README badge and marketplace plugin row**
+
+In `README.md`, update the `ai-literacy-superpowers` badge URL from `v0.34.1` to `v0.35.0`.
+
+Also update the marketplace plugin table row's version cell (the `| ai-literacy-superpowers | v0.34.1 |` row) from `v0.34.1` to `v0.35.0`.
+
+- [ ] **Step 4: Add the new CHANGELOG section**
+
+In `CHANGELOG.md`, insert a new top heading immediately above the existing top heading. Today's date is `2026-05-08`.
+
+```markdown
+## 0.35.0 — 2026-05-08
+
+### Feature — Audit-driven `/harness-sync`
+
+Restructures `/harness-sync` so it runs `/harness-audit`'s detection
+logic internally via a new shared `harness-audit-engine` skill. The
+unified drift table now includes every audit finding tagged `[auto]`
+or `[manual]`. Mechanical fixes (convention files, ONBOARDING.md,
+snapshot regen via `/harness-health`, HARNESS.md Status section regen
+via `/harness-audit`) auto-apply when selected. Judgement-required
+fixes (`/harness-upgrade`, `/harness-constrain`) print the suggested
+command without writing — preserving the trust boundary.
+
+`/harness-audit` keeps its standalone diagnostic role unchanged. Both
+commands now share the same engine; surface coverage evolves in one
+place.
+
+### Docs — Lifecycle simplification
+
+Three explanation pages are rewritten to converge on a single
+canonical narrative:
+
+- `the-harness-lifecycle` is now the everyday three-state model
+  (in sync, drifted, behind upstream) with `/harness-sync`,
+  `/harness-upgrade`, and `/harness-constrain` as the everyday entry
+  points.
+- `the-harness-tuning-loop` refocuses on the signal-capture →
+  constraint-promotion sub-flow specifically.
+- `self-improving-harness` trims to the conceptual core (why
+  iteration matters, the compound-learning principle).
+
+How-to pages for sync-harness and run-a-harness-audit are updated
+to reflect the audit-driven flow and the diagnostic-vs-everyday split.
+Touch-ups across tutorials, plugin landing, CLAUDE.md (root +
+template), and README align command descriptions.
+
+### Internal
+
+- New skill: `harness-audit-engine` documents the shared
+  drift-detection contract.
+```
+
+The existing `## 0.34.1 — 2026-05-08` heading stays unchanged below.
+
+- [ ] **Step 5: Verify the version locations agree**
+
+Run:
+
+```bash
+echo "plugin.json: $(jq -r .version ai-literacy-superpowers/.claude-plugin/plugin.json)"
+echo "marketplace.json plugin_version: $(jq -r .plugin_version .claude-plugin/marketplace.json)"
+echo "marketplace.json plugins[0].version: $(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
+echo "README badge: $(grep -oE 'ai--literacy--superpowers-v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1)"
+echo "README marketplace row: $(grep -E '\| \*\*\`ai-literacy-superpowers\`\*\* \| v' README.md | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+echo "CHANGELOG top: $(grep -m1 '^## ' CHANGELOG.md)"
+```
+
+Expected:
+
+```text
+plugin.json: 0.35.0
+marketplace.json plugin_version: 0.35.0
+marketplace.json plugins[0].version: 0.35.0
+README badge: ai--literacy--superpowers-v0.35.0
+README marketplace row: v0.35.0
+CHANGELOG top: ## 0.35.0 — 2026-05-08
+```
+
+- [ ] **Step 6: Run markdownlint**
+
+Run: `npx markdownlint-cli2 README.md CHANGELOG.md`
+
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ai-literacy-superpowers/.claude-plugin/plugin.json .claude-plugin/marketplace.json README.md CHANGELOG.md
+git commit -m "chore: bump ai-literacy-superpowers to v0.35.0
+
+Minor bump driven by the audit-driven /harness-sync rewrite. The
+shared audit-engine skill is new (inside the plugin directory);
+/harness-sync's command file changes meaningfully; templates/CLAUDE.md
+documentation updates land for new projects.
+
+Marketplace plugin_version, marketplace plugin entry version, README
+badge, and README marketplace plugin row all bumped together. New
+CHANGELOG section explains the feature and docs simplification."
+```
+
+---
+
+## Task 14: Local mkdocs build verification
+
+**Files:**
+- No file changes — this is verification only
+
+- [ ] **Step 1: Build the site locally**
+
+Run:
+
+```bash
+export PATH="$HOME/Library/Python/3.9/bin:$PATH"
+rm -rf site _site
+mkdocs build --strict
+```
+
+Expected: `Documentation built in N.NN seconds` with no `WARNING` lines (INFO lines about pre-existing anchor mismatches are acceptable).
+
+- [ ] **Step 2: Spot-check the rewritten pages render**
+
+Open or curl-grep `site/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle/index.html` and confirm:
+
+```bash
+grep -oE '<h[12][^>]*>[^<]+' site/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle/index.html | head -8
+```
+
+Expected: H1 "The Harness Lifecycle" plus the new H2 headings ("The three states a harness is ever in", "The everyday entry points", etc.).
+
+Repeat the check for the other rewritten pages:
+
+- `site/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop/index.html`
+- `site/plugins/ai-literacy-superpowers/explanation/self-improving-harness/index.html`
+- `site/plugins/ai-literacy-superpowers/how-to/sync-harness/index.html`
+- `site/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit/index.html`
+
+- [ ] **Step 3: No commit (verification only)**
+
+This task produces no file changes.
+
+---
+
+## Task 15: Open the chore PR and watch CI
+
+- [ ] **Step 1: Confirm the working tree is clean and pushed**
+
+Run:
+
+```bash
+git status
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean working tree; the commit list shows the 13 commits from Tasks 1–13 (Task 14 produced no commits).
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+
+```bash
+git push -u origin chore/harness-sync-audit-driven
+```
+
+- [ ] **Step 3: Open the PR with the chore label**
+
+Run:
+
+```bash
+gh pr create --label chore \
+  --title "chore: audit-driven /harness-sync and lifecycle docs simplification" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Rewires \`/harness-sync\` so it runs \`/harness-audit\`'s detection logic
+internally via a new shared \`harness-audit-engine\` skill. The drift
+table now covers every audit finding tagged \`[auto]\` or \`[manual]\`.
+\`/harness-audit\` stays as a callable read-only diagnostic with
+unchanged user-facing behaviour.
+
+Includes a docs simplification pass: rewrites the-harness-lifecycle,
+the-harness-tuning-loop, and self-improving-harness as the canonical
+narrative; updates how-to pages for sync-harness and run-a-harness-audit;
+touch-ups across tutorials, plugin landing, CLAUDE.md (root +
+template), and README.
+
+[Spec](docs/superpowers/specs/2026-05-08-harness-sync-audit-driven-design.md) ·
+[Plan](docs/superpowers/plans/2026-05-08-harness-sync-audit-driven.md)
+
+## What's in this PR
+
+- New skill \`ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md\`
+  documents the shared drift-detection contract.
+- \`/harness-sync\` and \`/harness-audit\` command files reference the
+  new skill. \`/harness-sync\`'s Process section is rewritten to call the
+  engine in Phase 1, build a unified drift table in Phase 1 with
+  \`[auto]\`/\`[manual]\` tags, and branch the apply step in Phase 3.
+- Three explanation page rewrites: \`the-harness-lifecycle\` becomes
+  the canonical narrative, \`the-harness-tuning-loop\` trims to the
+  signal-capture sub-flow, \`self-improving-harness\` trims to the
+  conceptual core.
+- How-to rewrites: \`sync-harness.md\` documents the new flow;
+  \`run-a-harness-audit.md\` clarifies the diagnostic role.
+- Touch-ups: tutorials (\`getting-started\`, \`first-time-tour\`),
+  plugin \`index.md\`, CLAUDE.md (root + template) Operations
+  sections, README Commands table.
+- Plugin version bump 0.34.1 → 0.35.0 with marketplace.json,
+  README badge + marketplace row, and CHANGELOG entry.
+
+## Why chore label
+
+Per AGENTS.md STYLE on reflection-driven amendments: implementation
+is conservatively bounded (single PR, 13 logical commits), version
+bump is honest (minor — \`/harness-sync\` behaviour change), and the
+work was brainstormed and specified in the linked spec.
+\`/diaboli\` and \`/choice-cartograph\` adjudications skipped on the
+same terms as the previous chore-labelled lifecycle PRs (#263, #265,
+#266).
+
+## Test plan
+
+- [x] markdownlint clean across all touched files.
+- [x] \`mkdocs build --strict\` succeeds locally with the rewritten docs.
+- [ ] CI green (markdownlint x2, spec-first ordering, version
+  consistency, Enforce PR constraints).
+- [ ] Pages deploy succeeds on merge.
+- [ ] Post-merge: run \`/harness-sync\` on the project itself; confirm
+  the unified drift table renders and \`[auto]\`/\`[manual]\` tags
+  appear correctly.
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+Run: `gh pr checks $(gh pr view --json number -q .number) --watch`
+
+Expected: all 5 checks (markdownlint x2, spec-first ordering, version consistency, Enforce PR constraints) pass.
+
+- [ ] **Step 5: Hand off to the user for merge**
+
+Once CI is green, report the PR URL. The user merges; this plan does not auto-merge. After merge:
+
+1. Pages workflow rebuilds the docs site with the rewritten lifecycle pages.
+2. Run `/harness-sync` on the project itself — first real-world exercise of the new flow.
+
+---
+
+## Self-Review
+
+Verifying coverage against the spec sections:
+
+- **Spec § 1 Summary**: Tasks 1–3 implement the audit-engine + /harness-sync rewrite + /harness-audit refactor. ✓
+- **Spec § 2 Why**: Captured in the explanation page rewrites (Tasks 4–6). ✓
+- **Spec § 3 Architecture**: Audit-engine skill (Task 1); both commands reference it (Tasks 2, 3). ✓
+- **Spec § 4 Unified drift table**: Specified in Task 3 (the rewritten Phase 1 section). ✓
+- **Spec § 5 Interactive flow**: Specified in Task 3 (Phases 1, 2, 3). ✓
+- **Spec § 6 /harness-audit standalone**: Task 2 (engine reference only, no UX change). ✓
+- **Spec § 7 Docs simplification**: Tasks 4–12 cover every page listed in the spec's docs table. ✓
+- **Spec § 8 Out of scope**: Honoured — no command-count reduction, no convention-sync/harness-onboarding standalone changes, no GC rule additions, no trust-boundary changes, no marketplace listing changes. ✓
+- **Spec § 9 Plan summary**: Tasks 1–15 mirror this with sufficient granularity. ✓
+- **Spec § 10 Verification**: Tasks 14–15 cover the build verification, CI, and post-merge testing. ✓
+
+Placeholder scan: clean. No "TBD", "TODO", "implement later", or vague requirements. Every step that mentions code shows the code.
+
+Type/path consistency: every file path is referenced consistently. The new skill is `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md` everywhere; the audit-engine is referenced by both commands; the version bump targets all four locations together.
+
+No issues found. Plan is ready.

--- a/docs/superpowers/specs/2026-05-08-harness-sync-audit-driven-design.md
+++ b/docs/superpowers/specs/2026-05-08-harness-sync-audit-driven-design.md
@@ -1,0 +1,237 @@
+# Audit-driven `/harness-sync` and lifecycle docs simplification — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-08 |
+| Status | Draft — pending user review |
+| Author | claude-opus-4-7[1m] (interactive session) |
+| Plugin version target | v0.35.0 (minor — `/harness-sync` behaviour change) |
+| PR ceremony | `chore`-labelled — diaboli and choice-cartograph deliberately skipped per AGENTS.md STYLE on reflection-driven amendments and project-owner judgement |
+| Related work | PR #257 (original /harness-sync), PR #259 (docs propagation constraint), PR #265 (MkDocs Material migration), PRs #263 + #266 (Diataxis reorg phases 1 + 2) |
+
+---
+
+## 1. Summary
+
+Restructure `/harness-sync` so it runs `/harness-audit`'s detection logic internally, presents a single unified drift table covering all surfaces (push-direction control surfaces, audit findings, recurring reflection patterns), and applies fixes through the existing primitives. The two commands become two interfaces over a shared internal **audit-engine**: `/harness-audit` is read-only inspection, `/harness-sync` is read-then-fix.
+
+`/harness-audit` stays callable as a standalone diagnostic command; its user-facing UX does not change. All other harness lifecycle commands (`/harness-init`, `/harness-status`, `/harness-health`, `/harness-constrain`, `/harness-gc`, `/harness-upgrade`, `/harness-onboarding`, `/convention-sync`) keep their current behaviour.
+
+The lifecycle docs are simplified in the same PR to converge on a single canonical narrative: **detect drift, heal it; pull upstream when needed**. Three explanation pages get substantive rewrites; several how-to pages and the plugin landing page get touch-ups.
+
+---
+
+## 2. Why
+
+### The accreted lifecycle
+
+The plugin currently ships 11 lifecycle commands across 6 categories: setup (`/harness-init`), inspection (`/harness-status`, `/harness-health`, `/harness-audit`), authoring (`/harness-constrain`, `/harness-gc`), pull (`/harness-upgrade`), push (`/harness-sync`, `/convention-sync`, `/harness-onboarding`), plus `/harness-affordance`. The categories accreted over time as new propagation paths were added. The seam that this spec targets is between **detection** and **remediation**:
+
+- `/harness-audit` finds drift everywhere (HARNESS.md vs reality, constraint enforcement levels, convention file sync, ONBOARDING staleness, snapshot age, template drift, recurring reflection patterns, …).
+- `/harness-sync` fixes drift in only **two** of those surfaces (convention files via `/convention-sync`, ONBOARDING.md via `/harness-onboarding`).
+
+A user wanting to bring the project into alignment with HARNESS.md must mentally map audit's findings to remediation commands and run each one separately. The mapping is implicit and easy to forget. The new `/harness-sync` makes the mapping explicit, presents the full picture, and applies the mechanical fixes in one pass.
+
+### The targeted scope
+
+This spec deliberately does not collapse the command count. Two reasons: (a) every existing command name is referenced from skills, GC rules, AGENTS.md, the docs site, the SessionStart hook nudges, and external user muscle memory; renaming or removing them is high-cost; (b) the conceptual simplification (everyday users use `/harness-sync`; experts can still use the underlying primitives) gets us most of the value at low cost. A more aggressive consolidation can be revisited later if this targeted change does not yield the perceived simplicity gain.
+
+---
+
+## 3. Architecture: shared engine, two interfaces
+
+```text
+audit-engine (internal)
+  └── scans HARNESS.md vs reality across all surfaces
+  └── returns a structured drift report
+
+/harness-audit (existing command, unchanged user-facing)
+  └── calls audit-engine
+  └── prints report
+  └── updates HARNESS.md Status section
+  └── exits
+
+/harness-sync (this PR's redesign)
+  └── calls audit-engine
+  └── presents unified drift table including ALL findings
+  └── multi-select prompt for which to apply
+  └── auto-fixes mechanical items via existing primitives
+  └── prints suggested commands for manual items
+  └── re-runs audit-engine to verify
+  └── commits + ships (existing flow)
+```
+
+The audit-engine is a new internal layer. It is **not** a separate command. It is the shared logic that both user-facing commands invoke. In implementation terms it can live as a sub-skill, a reference document plus prompt convention, or a shared procedural section — the spec leaves the implementation form to the plan as long as the contract holds: same drift report shape regardless of caller.
+
+---
+
+## 4. The unified drift table
+
+```text
+Surface / Finding                              Status      Action on apply
+─────────────────────────────────────────────  ──────────  ────────────────────────
+.cursor/rules/                                 drifted     /convention-sync       [auto]
+.github/copilot-instructions.md                in sync     —
+.windsurf/rules/                               missing     /convention-sync       [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
+Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
+Constraint regression: ShellCheck unverified   drifted     /harness-constrain     [manual]
+Reflection pattern: Output validation x3       candidate   /harness-constrain     [manual]
+HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
+CI / CD (constraint scope)                     managed     handled at runtime
+─────────────────────────────────────────────────────────────────────────────────────
+N surfaces tracked · X drifted · Y missing · Z in sync · W managed
+```
+
+### Vocabulary
+
+- `drifted` — file or fact exists but does not match HARNESS.md / reality.
+- `missing` — file expected but not present.
+- `in sync` — matches HARNESS.md / reality.
+- `managed` — handled at runtime by other layers (CI/CD); informational only.
+- `candidate` — **new state** for findings audit surfaces that are not strict drift but warrant review (recurring reflection patterns, deferred constraints).
+
+### Action column — `[auto]` vs `[manual]`
+
+- `[auto]` items have a deterministic remediation that the project trusts to apply without user judgement. The auto-fix runs via the existing primitive when the user selects the row in the multi-select prompt. The trust-boundary pre-commit guard's allow-list is unchanged.
+- `[manual]` items require user judgement (which constraint to add, whether enforcement should be promoted, whether a template upgrade is wanted). When selected, sync prints the suggested command and exits without applying it.
+
+### What audit-engine surfaces
+
+The drift report includes every check audit performs today. New rows added to the table relative to today's `/harness-sync`:
+
+- **Snapshot staleness** — auto-fix via `/harness-health`.
+- **Template version drift** — manual via `/harness-upgrade`.
+- **Constraint regression** — manual via `/harness-constrain`.
+- **Reflection pattern** (the GC rule's findings) — manual via `/harness-constrain`.
+- **Status section accuracy** — auto-fix via `/harness-audit` (which updates HARNESS.md Status as a side-effect).
+
+The full list lives in the existing audit logic; the spec does not enumerate further. Any future audit checks added via the audit-engine layer automatically appear in the sync table.
+
+---
+
+## 5. Interactive flow (deltas vs today)
+
+```text
+Phase 0: Branch enforcement              [unchanged]
+Phase 1: Working-tree-clean check        [unchanged]
+Phase 2: Run audit-engine                [NEW — replaces per-surface drift detection]
+Phase 3: Build unified drift table       [EXPANDED — see § 4]
+Phase 4: Multi-select prompt             [unchanged UX, more rows]
+Phase 5: Apply selected items
+         ├── [auto] items run via existing primitives  [unchanged]
+         └── [manual] items print "Run: <command>"     [NEW]
+Phase 6: Re-run audit-engine to verify   [REPLACES per-surface re-scan]
+Phase 7: Trust-boundary pre-commit guard [unchanged]
+Phase 8: Commit and ship                 [unchanged]
+```
+
+`--check` mode is unchanged: stops after Phase 3 with the drift table printed.
+
+`/harness-sync` continues to refuse running on `main`. The branch creation prompt and the working-tree-clean check are unchanged. The trust-boundary guard's allow-list is unchanged: the only paths that get committed are the four push-direction surfaces (`.cursor/rules/**`, `.github/copilot-instructions.md`, `.windsurf/rules/**`, `ONBOARDING.md`). Manual items emit suggestions, never writes.
+
+---
+
+## 6. `/harness-audit` standalone behaviour
+
+Unchanged. Still callable directly. Output format unchanged. Cadence reference in HARNESS.md Observability section ("Harness audit (/harness-audit): quarterly (90 days)") stays valid. The internal implementation calls audit-engine — but it would call the same logic anyway. No user-facing migration; no doc-link breakage; no GC-rule-name changes.
+
+---
+
+## 7. Docs simplification
+
+Three pages get substantive rewrites; several get touch-ups. The aim is one canonical lifecycle narrative that all the docs converge on, removing the current overlap between *the-harness-lifecycle*, *the-harness-tuning-loop*, and *self-improving-harness*.
+
+### Substantive rewrites
+
+| Page | Action |
+| --- | --- |
+| `docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md` | **Rewrite as the canonical lifecycle narrative.** Use the simpler "detect drift → heal it; pull upstream when needed" frame. Position `/harness-sync` as the everyday entry point. Reference `/harness-audit` only as the inspection-only deep-dive. The current six-stage tuning-loop narrative moves to the-harness-tuning-loop. |
+| `docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md` | **Trim and align.** Drop content that overlaps with the-harness-lifecycle. Refocus this page on the *signal capture → constraint promotion* sub-flow specifically: how reflections become candidate constraints, how `/harness-constrain` promotes them. No more end-to-end lifecycle narrative here. |
+| `docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md` | **Trim and align.** Position relative to the canonical lifecycle. Keep the conceptual content about why the harness needs to self-improve; remove command-level walkthroughs that duplicate the how-to pages. |
+
+### How-to rewrites
+
+| Page | Action |
+| --- | --- |
+| `docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md` | **Rewrite** to document the new audit-driven flow: the unified drift table, the `[auto]`/`[manual]` distinction, the multi-select prompt, the verification step. |
+| `docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md` | **Update** to clarify audit is the inspection-only deep-dive; route everyday users to `/harness-sync`. Keep audit's how-to content for users who want a focused diagnostic without the action prompt. |
+
+### Touch-ups
+
+| Page | Action |
+| --- | --- |
+| `docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md` | Mention `/harness-sync` as the everyday command; demote `/harness-audit` to "diagnostic if you want one." |
+| `docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md` | Same touch-up. |
+| `docs/plugins/ai-literacy-superpowers/index.md` (plugin landing) | Reflect the simpler everyday flow in the Where-to-start table or intro paragraph. |
+| `CLAUDE.md` (root) and `ai-literacy-superpowers/templates/CLAUDE.md` | Quarterly/Monthly Operations sections: replace ad-hoc lists of `/convention-sync` + `/harness-onboarding` invocations with `/harness-sync`. Keep the cadence anchors (`/governance-audit`, `/cost-capture`, `/assess`, `/harness-audit`). |
+| `README.md` | Plugin description and command tables: `/harness-sync` description updated; `/harness-audit` clarified as diagnostic. |
+
+### Out of scope for the docs pass
+
+- No reorganising of harness skills (harness-engineering, garbage-collection, constraint-design, …). Skill bodies stay; only `docs/` and root convention text change.
+- No restructuring of the four-quadrant Diataxis layout. Pages keep their current quadrants.
+- No changes to ONBOARDING.md or the convention files (`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`). Those are derived; they regenerate via `/harness-sync` after this PR ships.
+- No changes to AGENTS.md, REFLECTION_LOG.md, or HARNESS.md content beyond the small Status-section regen that audit performs.
+
+---
+
+## 8. Out of scope
+
+Explicitly deferred so the spec does not quietly grow:
+
+- **No reduction in command count.** Eleven lifecycle commands stay. Targeted simplification only.
+- **No change to `/harness-audit`'s standalone UX.**
+- **No change to `/convention-sync` or `/harness-onboarding`** as standalone commands.
+- **No new GC rules.** The existing GC rules continue to fire on their schedules; their findings will appear in audit-engine's drift report and therefore in `/harness-sync`'s table.
+- **No version/output-format changes** to the snapshot, audit report, ONBOARDING.md, or any constraint/GC entry shape.
+- **No change to the trust-boundary pre-commit guard's allow-list.** The unified drift table includes additional rows but those rows either fix non-allow-listed paths via existing primitives (which have their own trust boundaries) or print manual suggestions without writing.
+- **No HARNESS.md constraint additions or modifications.** The two existing PR-time constraints (`Docs site kept current`, `Docs propagation when shipping new commands`) cover the docs work already.
+- **No reorganising of harness skills.** SKILL.md files stay as authored.
+- **No changes to the marketplace listing's contract** (`marketplace.json` `version`).
+
+---
+
+## 9. Plan summary
+
+Single PR (`chore/harness-sync-audit-driven`):
+
+- New audit-engine layer (implementation form per the plan).
+- `/harness-sync` rewritten to call audit-engine, build unified drift table, distinguish `[auto]` vs `[manual]`.
+- `/harness-audit` refactored to also call audit-engine (no user-facing change).
+- Three explanation page rewrites (the-harness-lifecycle, the-harness-tuning-loop, self-improving-harness).
+- Two how-to page rewrites (sync-harness, run-a-harness-audit).
+- Touch-ups across tutorials, plugin landing, CLAUDE.md (root + template), README.
+- Plugin version bump 0.34.1 → 0.35.0 (minor — `/harness-sync` behaviour change).
+- CHANGELOG entry, marketplace.json `plugin_version`, README badge + marketplace row.
+
+### Spec-first / adjudication exemption
+
+The PR uses the `chore` label. Per CLAUDE.md's "Spec-First Exemptions" table, that label clears the spec-first-commit-ordering, `PRs have adjudicated objections`, and `PRs have adjudicated choice stories` constraints. Per AGENTS.md STYLE on reflection-driven amendments, chore-label-for-behavioural-change is acceptable when the implementation is conservatively bounded (single PR), the version bump is honest, and the work has been brainstormed and specified — all four conditions hold here.
+
+---
+
+## 10. Verification
+
+Before the PR opens:
+
+1. `/harness-sync` (interactive): the unified drift table renders with `[auto]`/`[manual]` columns; multi-select prompt offers all rows; selecting an `[auto]` row runs the existing primitive; selecting a `[manual]` row prints the suggested command without writing.
+2. `/harness-audit` (standalone): output unchanged from today's behaviour. Confirmed by running before and after on the same project state.
+3. The audit-engine's drift report shape is the same regardless of caller (asserted in implementation; verifiable by side-by-side running).
+4. `mkdocs build --strict` succeeds with the rewritten docs.
+5. markdownlint clean across all touched files.
+6. CI green: spec-first-check (chore exemption), version-check, markdownlint, Enforce PR constraints.
+
+After merge:
+
+7. Pages workflow rebuilds the docs site cleanly with the rewritten lifecycle pages.
+
+---
+
+## 11. Risks
+
+- **Audit-engine extraction may surface latent inconsistencies** between `/harness-audit`'s current behaviour and what's documented. Mitigation: implementation should preserve existing `/harness-audit` output exactly; any divergence is a separate fix.
+- **The unified drift table could overwhelm** users on large projects with many findings. Mitigation: the multi-select prompt's "Apply nothing" option remains the safe default; users can run `--check` to see the table without committing to action.
+- **Doc rewrites could lose detail** that some readers depend on. Mitigation: substantive rewrites of three pages should preserve the conceptually-load-bearing content (the three loops, the role of compound learning, the self-improvement principle); only the *narrative arrangement* changes.
+- **`[manual]` rows that appear repeatedly** could create alarm fatigue. Mitigation: those rows are exactly what `/harness-constrain` and `/harness-upgrade` are for; the user is being prompted to take action, which is the intended behaviour. If a particular finding is acceptable to leave, the user dispositions it via the existing constraint-or-skip mechanisms in those commands.


### PR DESCRIPTION
## Summary

Rewires `/harness-sync` so it runs `/harness-audit`'s detection logic internally via a new shared `harness-audit-engine` skill. The drift table now covers every audit finding tagged `[auto]` or `[manual]`. `/harness-audit` stays as a callable read-only diagnostic with unchanged user-facing behaviour.

Includes a docs simplification pass: rewrites the-harness-lifecycle, the-harness-tuning-loop, and self-improving-harness as the canonical narrative; updates how-to pages for sync-harness and run-a-harness-audit; touch-ups across tutorials, plugin landing, CLAUDE.md (root + template), and README.

[Spec](docs/superpowers/specs/2026-05-08-harness-sync-audit-driven-design.md) · [Plan](docs/superpowers/plans/2026-05-08-harness-sync-audit-driven.md)

## What's in this PR

- New skill `ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md` documents the shared drift-detection contract: surfaces scanned, drift-report shape, `[auto]`/`[manual]` classification rule, caller contract.
- `/harness-audit` and `/harness-sync` command files reference the new skill. `/harness-sync`'s Process section is rewritten: Phase 1 invokes the engine, builds a unified drift table with `[auto]`/`[manual]` tags; Phase 2's multi-select pre-selects `[auto]` and opt-ins `[manual]`; Phase 3 branches between auto-fix-via-primitive and print-suggestion-only; Phase 6 re-invokes the engine for verification.
- Three explanation page rewrites: `the-harness-lifecycle` becomes the canonical three-states narrative; `the-harness-tuning-loop` trims to the signal-capture sub-flow; `self-improving-harness` trims to the conceptual core.
- How-to rewrites: `sync-harness.md` documents the new flow; `run-a-harness-audit.md` adds an "Audit vs /harness-sync" section and reframes the opening to position audit as diagnostic.
- Touch-ups: `getting-started`, `first-time-tour`, plugin `index.md`, `CLAUDE.md` (root + template) Monthly Operations, README Commands table.
- Plugin version bump 0.34.1 → 0.35.0 (minor — `/harness-sync` behaviour change). Marketplace pointer, README badge + marketplace plugin row, CHANGELOG entry all aligned.

## Why chore label

Per AGENTS.md STYLE on reflection-driven amendments: implementation is conservatively bounded (single PR, 13 logical commits + spec + plan), version bump is honest (minor for `/harness-sync` behaviour), and the work was brainstormed and specified in the linked spec. `/diaboli` and `/choice-cartograph` adjudications skipped on the same terms as PRs #263, #265, #266.

## Verification

- [x] markdownlint clean across all touched files.
- [x] `mkdocs build --strict` succeeds locally.
- [x] All 5 rewritten pages render with expected new H1/H2 headings.
- [x] Unchanged sections of `/harness-sync` (Branch Enforcement, Working-Tree-Clean Check, Trust-Boundary Pre-Commit Guard, Commit and Ship, Error and Refusal Cases, Idempotency, Output Format, Validation Checkpoint) confirmed intact.
- [x] Trust-boundary allow-list unchanged.
- [ ] CI green.
- [ ] Pages deploy succeeds on merge.
- [ ] Post-merge: run `/harness-sync` on the project itself; confirm the unified drift table renders and `[auto]`/`[manual]` tags appear correctly.