### PR TITLE
fix: /harness-sync no longer auto-invokes /harness-onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.3.0",
-  "plugin_version": "0.35.0",
+  "plugin_version": "0.35.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.35.0"
+      "version": "0.35.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.35.1 — 2026-05-08
+
+### Refinement — `/harness-sync` no longer auto-invokes `/harness-onboarding`
+
+Removes the auto-invocation of `/harness-onboarding` from
+`/harness-sync`'s Phase 3 apply step. ONBOARDING.md staleness still
+appears in the unified drift table (audit-engine continues to detect
+it), but it now appears as a `[manual]` row instead of `[auto]` —
+sync prints "Run: /harness-onboarding" and exits without writing.
+
+Rationale: ONBOARDING.md regen is a heavier mutation than
+convention-file regen and benefits from the user's deliberate trigger.
+Convention-file sync is a tight derive-from-HARNESS.md operation;
+onboarding regen also pulls in AGENTS.md and REFLECTION_LOG.md and
+produces a substantial human-facing document. Same-shape change as
+template-drift and constraint-regression: surface the staleness, let
+the user act.
+
+The trust-boundary pre-commit guard's allow-list drops `ONBOARDING.md`
+accordingly — sync never writes to it now.
+
+Updates `/harness-sync`'s command file, the audit-engine skill's
+classification table, the sync-harness how-to, the run-a-harness-audit
+how-to, the-harness-lifecycle explanation, CLAUDE.md (root + template)
+Monthly Operations, and the README Commands table.
+
 ## 0.35.0 — 2026-05-08
 
 ### Feature — Audit-driven `/harness-sync`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,9 +210,10 @@ Light-touch health check (every 30 days, between quarterly anchor weeks):
 2. Reflection review — scan `REFLECTION_LOG.md` for new entries worth
    promoting to `AGENTS.md`
 3. `/harness-sync` — bring every push-direction surface into alignment
-   with HARNESS.md (convention files, ONBOARDING.md, snapshot, Status
-   section). Surfaces template drift and recurring reflection patterns
-   as `[manual]` items for follow-up.
+   with HARNESS.md (convention files, snapshot, Status section).
+   Surfaces ONBOARDING.md staleness, template drift, and recurring
+   reflection patterns as `[manual]` items for follow-up; sync prints
+   the suggested command but does not invoke them.
 
 ## Sync from Source
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.3.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.35.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.35.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)
@@ -27,7 +27,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.35.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **30 skills, 13 agents, 25 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.35.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **30 skills, 13 agents, 25 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 
 The bulk of this README documents the **`ai-literacy-superpowers`** plugin specifically — its skills, agents, commands, hooks, templates, enforcement loops, and pipelines. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md). Future sister plugins will land in this marketplace under `<plugin-name>/` with their own docs at `docs/plugins/<plugin-name>/`.
@@ -228,7 +228,7 @@ A coordinated team that handles the full development lifecycle.
 | `/assess` | AI literacy assessment with immediate fixes, workflow recommendations, and prioritised improvement plans |
 | `/harness-health` | Harness health snapshot — enforcement ratio, trends, meta-observability checks |
 | `/extract-conventions` | Guided session — surfaces tacit team conventions and maps them to CLAUDE.md and HARNESS.md |
-| `/harness-sync` | Everyday lifecycle entry. Runs the shared audit-engine to detect drift across every surface (convention files, ONBOARDING.md, snapshot, Status section, template, constraint regressions, recurring reflection patterns), presents a unified drift table tagged `[auto]`/`[manual]`, and applies the fixes you select. Mechanical fixes auto-apply via existing primitives; judgement-required fixes print suggested commands. |
+| `/harness-sync` | Everyday lifecycle entry. Runs the shared audit-engine to detect drift across every surface (convention files, snapshot, Status section accuracy, ONBOARDING.md staleness, template, constraint regressions, recurring reflection patterns), presents a unified drift table tagged `[auto]`/`[manual]`, and applies the fixes you select. Mechanical fixes (convention files, snapshot, Status) auto-apply via existing primitives; judgement-required fixes (ONBOARDING regen, template upgrade, constraint authoring) print suggested commands. |
 | `/convention-sync` | Sync HARNESS.md conventions to Cursor, Copilot, and Windsurf convention files |
 | `/portfolio-assess` | Multi-repo AI literacy assessment — aggregate across local repos, GitHub orgs, or topic tags |
 | `/cost-capture` | Capture AI tool cost data — record spend, compare to previous snapshot, update model routing |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-sync.md
+++ b/ai-literacy-superpowers/commands/harness-sync.md
@@ -1,13 +1,13 @@
 ---
 name: harness-sync
-description: Detect drift across all push-direction control surfaces, present the full picture, and apply the user's selected fixes via the existing primitives — single human-instigated entry point for keeping convention files and ONBOARDING.md in sync with HARNESS.md.
+description: Detect drift across all push-direction control surfaces, present the full picture, and apply the user's selected fixes via the existing primitives — single human-instigated entry point for keeping convention files in sync with HARNESS.md. ONBOARDING.md staleness is surfaced but not auto-fixed; users run /harness-onboarding deliberately when they want it regenerated.
 ---
 
 # /harness-sync
 
 Detect drift across every push-direction surface, present the full picture as
 a structured table, and apply the selected fixes via the existing primitives
-(`/convention-sync`, `/harness-onboarding`). This command is a multiplexer —
+(`/convention-sync`). This command is a multiplexer —
 it composes existing commands and does not introduce new propagation logic.
 
 **What this command does NOT do:**
@@ -126,7 +126,7 @@ Surface / Finding                              Status      Action on apply
 .cursor/rules/                                 drifted     /convention-sync       [auto]
 .github/copilot-instructions.md                in sync     —
 .windsurf/rules/                               missing     /convention-sync       [auto]
-ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [manual]
 Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
 HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
 Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
@@ -182,11 +182,6 @@ items. The `managed` row never appears as a selectable option.
       "selected": true
     },
     {
-      "id": "onboarding",
-      "label": "ONBOARDING.md  [auto: /harness-onboarding]",
-      "selected": true
-    },
-    {
       "id": "snapshot",
       "label": "Snapshot staleness  [auto: /harness-health]",
       "selected": true
@@ -195,6 +190,11 @@ items. The `managed` row never appears as a selectable option.
       "id": "status",
       "label": "HARNESS.md Status accuracy  [auto: /harness-audit]",
       "selected": true
+    },
+    {
+      "id": "onboarding",
+      "label": "ONBOARDING.md  [manual: /harness-onboarding]",
+      "selected": false
     },
     {
       "id": "template",
@@ -233,9 +233,10 @@ For each `[auto]` selected finding, invoke its `action_command` _in
 series_ (not in parallel — order matters for the verification scan):
 
 1. **`.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`** — invoke `/convention-sync`. This handles all three convention-file surfaces in a single run; if multiple are selected they share the same invocation.
-2. **`ONBOARDING.md`** — invoke `/harness-onboarding`.
-3. **Snapshot staleness** — invoke `/harness-health`.
-4. **HARNESS.md Status section accuracy** — invoke `/harness-audit`. (Audit updates Status as a side-effect of running.)
+2. **Snapshot staleness** — invoke `/harness-health`.
+3. **HARNESS.md Status section accuracy** — invoke `/harness-audit`. (Audit updates Status as a side-effect of running.)
+
+`ONBOARDING.md` is **not** auto-invoked. Sync surfaces its staleness as a `[manual]` finding so users see the drift, but `/harness-onboarding` is run separately by the user — onboarding regen is a heavier mutation than convention-file regen and benefits from the user's deliberate trigger.
 
 If an underlying command errors out for one finding:
 
@@ -270,7 +271,7 @@ Surface / Finding                              Before      After
 ─────────────────────────────────────────────  ──────────  ─────────────
 .cursor/rules/                                 drifted     in sync ✓
 .windsurf/rules/                               missing     in sync ✓
-ONBOARDING.md                                  drifted     in sync ✓
+ONBOARDING.md                                  drifted     drifted (manual — see suggestion above)
 Snapshot staleness                             drifted     in sync ✓
 HARNESS.md Status accuracy                     drifted     in sync ✓
 Template drift                                 drifted     drifted (manual — see suggestion above)
@@ -303,10 +304,11 @@ Verify every modified path matches the allow-list:
 - `.cursor/rules/**`
 - `.github/copilot-instructions.md`
 - `.windsurf/rules/**`
-- `ONBOARDING.md`
 
 If any path falls _outside_ the allow-list (including `HARNESS.md`,
-`AGENTS.md`, or `REFLECTION_LOG.md`), refuse to commit. Tell the user:
+`AGENTS.md`, `REFLECTION_LOG.md`, or `ONBOARDING.md` — which sync
+surfaces as a `[manual]` finding but never writes to), refuse to
+commit. Tell the user:
 
 > Trust-boundary violation: the underlying primitive modified a file outside
 > the allowed set. This is a bug in the underlying command, not a
@@ -325,21 +327,16 @@ If the guard passes, proceed to step 8 to commit and ship.
 Stage the surface files only:
 
 ```bash
-git add .cursor/rules/ .github/copilot-instructions.md .windsurf/rules/ ONBOARDING.md
+git add .cursor/rules/ .github/copilot-instructions.md .windsurf/rules/
 ```
 
 Git will only stage files with actual changes; paths that were not touched are
 safe to include in the `git add` list.
 
-Parameterise the commit message based on which surfaces were applied:
-
-- Both convention files and `ONBOARDING.md`:
-  `"chore: sync convention files and ONBOARDING.md to HARNESS.md"`
-- Convention files only: `"chore: sync convention files to HARNESS.md"`
-- `ONBOARDING.md` only: `"chore: sync ONBOARDING.md to HARNESS.md"`
+Commit message: `"chore: sync convention files to HARNESS.md"`.
 
 ```bash
-git commit -m "chore: <parameterised message above>"
+git commit -m "chore: sync convention files to HARNESS.md"
 ```
 
 Push the branch:
@@ -368,17 +365,9 @@ Report the PR URL and the verification delta.
 Stage and commit only — do _not_ push and do _not_ open a PR:
 
 ```bash
-git add .cursor/rules/ .github/copilot-instructions.md .windsurf/rules/ ONBOARDING.md
-git commit -m "chore: <parameterised message — use the same parameterisation as Path A>"
+git add .cursor/rules/ .github/copilot-instructions.md .windsurf/rules/
+git commit -m "chore: sync convention files to HARNESS.md"
 ```
-
-Use the same parameterised commit message as Path A — derived from which
-surfaces were applied:
-
-- Both convention files and `ONBOARDING.md`:
-  `"chore: sync convention files and ONBOARDING.md to HARNESS.md"`
-- Convention files only: `"chore: sync convention files to HARNESS.md"`
-- `ONBOARDING.md` only: `"chore: sync ONBOARDING.md to HARNESS.md"`
 
 Report the commit hash and tell the user:
 
@@ -413,10 +402,10 @@ Verification:
   .cursor/rules/                  drifted → in sync ✓
   .github/copilot-instructions.md drifted → in sync ✓
   .windsurf/rules/                missing → in sync ✓ (created)
-  ONBOARDING.md                   drifted → in sync ✓
+  ONBOARDING.md                   drifted → drifted (manual — run /harness-onboarding)
 
 Branch:   chore/sync-surfaces-2026-05-07
-Commit:   a1b2c3d  chore: sync convention files and ONBOARDING.md to HARNESS.md
+Commit:   a1b2c3d  chore: sync convention files to HARNESS.md
 Pushed:   origin/chore/sync-surfaces-2026-05-07
 PR:       https://github.com/Habitat-Thinking/ai-literacy-superpowers/pull/N
 ```
@@ -428,9 +417,9 @@ Harness Sync complete.
 
 Verification:
   .cursor/rules/                  drifted → in sync ✓
-  ONBOARDING.md                   drifted → in sync ✓
+  ONBOARDING.md                   drifted → drifted (manual — run /harness-onboarding)
 
-Commit:   a1b2c3d  chore: sync convention files and ONBOARDING.md to HARNESS.md
+Commit:   a1b2c3d  chore: sync convention files to HARNESS.md
 Push when ready: git push -u origin <branch-name>
 ```
 

--- a/ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md
+++ b/ai-literacy-superpowers/skills/harness-audit-engine/SKILL.md
@@ -27,7 +27,7 @@ with `HARNESS.md`. The current scan covers:
 | Convention files | `.cursor/rules/` matches HARNESS.md | yes — `/convention-sync` |
 | Convention files | `.github/copilot-instructions.md` matches HARNESS.md | yes — `/convention-sync` |
 | Convention files | `.windsurf/rules/` matches HARNESS.md | yes — `/convention-sync` |
-| Onboarding | `ONBOARDING.md` matches HARNESS.md + AGENTS.md + REFLECTION_LOG.md | yes — `/harness-onboarding` |
+| Onboarding | `ONBOARDING.md` matches HARNESS.md + AGENTS.md + REFLECTION_LOG.md | manual — `/harness-onboarding` |
 | Observability | Most recent snapshot in `observability/snapshots/` is < 30 days old | yes — `/harness-health` |
 | Status section | `HARNESS.md` Status block matches actual constraint enforcement counts | yes — `/harness-audit` (audit updates Status as a side-effect) |
 | Template currency | `<!-- template-version: X -->` in HARNESS.md matches installed plugin version | manual — `/harness-upgrade` |

--- a/ai-literacy-superpowers/templates/CLAUDE.md
+++ b/ai-literacy-superpowers/templates/CLAUDE.md
@@ -201,9 +201,10 @@ Light-touch health check (every 30 days, between quarterly anchor weeks):
 2. Reflection review — scan `REFLECTION_LOG.md` for new entries worth
    promoting to `AGENTS.md`
 3. `/harness-sync` — bring every push-direction surface into alignment
-   with HARNESS.md (convention files, ONBOARDING.md, snapshot, Status
-   section). Surfaces template drift and recurring reflection patterns
-   as `[manual]` items for follow-up.
+   with HARNESS.md (convention files, snapshot, Status section).
+   Surfaces ONBOARDING.md staleness, template drift, and recurring
+   reflection patterns as `[manual]` items for follow-up; sync prints
+   the suggested command but does not invoke them.
 
 ## Project Constraints
 

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
@@ -41,10 +41,11 @@ Three commands cover most lifecycle activity:
 Detects drift across every surface and lets you fix it in one pass.
 Internally runs `/harness-audit`'s detection logic, presents a unified
 drift table, and applies the fixes you select. Mechanical fixes
-(convention files, ONBOARDING.md, snapshots, HARNESS.md Status
-accuracy) run automatically. Judgement-required fixes (which
-constraint to add, whether to take a template upgrade) print the
-suggested command for you to run separately.
+(convention files, snapshots, HARNESS.md Status accuracy) run
+automatically. Judgement-required fixes (which constraint to add,
+whether to take a template upgrade, regenerating ONBOARDING.md when
+it's heavier and worth your deliberate trigger) print the suggested
+command for you to run separately.
 
 When in doubt, run `/harness-sync`. It tells you everything that's out
 of alignment and either fixes it or tells you what to run.
@@ -89,9 +90,16 @@ Behind the everyday three, there are deeper or focused tools:
   over time, with trends.
 - **`/harness-gc`** manages the periodic garbage-collection rules
   that fight slow drift between PR-level enforcement events.
-- **`/convention-sync`** and **`/harness-onboarding`** are the
-  primitives `/harness-sync` calls. You can invoke them directly when
-  you only want one surface refreshed.
+- **`/convention-sync`** is the primitive `/harness-sync` calls for
+  the convention files (`.cursor/rules/`, `.github/copilot-instructions.md`,
+  `.windsurf/rules/`). You can invoke it directly when you only want
+  those surfaces refreshed.
+- **`/harness-onboarding`** regenerates `ONBOARDING.md` from
+  `HARNESS.md` + `AGENTS.md` + `REFLECTION_LOG.md`. `/harness-sync`
+  surfaces ONBOARDING staleness in its drift table but does **not**
+  invoke this command — onboarding regen is heavier than convention-
+  file regen and benefits from your deliberate trigger. Run it
+  separately when sync flags ONBOARDING as drifted.
 
 ## When each lifecycle state happens
 
@@ -100,7 +108,9 @@ Behind the everyday three, there are deeper or focused tools:
   the convention files automatically (it shows up as a drifted
   surface that auto-fixes).
 - **You merge a PR** → run `/harness-sync` if the PR changed
-  HARNESS.md content. Convention files and ONBOARDING.md regenerate.
+  HARNESS.md content. Convention files regenerate automatically; if
+  ONBOARDING is flagged as drifted, run `/harness-onboarding`
+  separately.
 - **You see a build break** related to harness state → run
   `/harness-audit` for the read-only diagnostic, or `/harness-sync`
   to also fix.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
@@ -29,9 +29,10 @@ engine. The difference is action:
   committing to action — for example from CI, or when scripting,
   or when you suspect drift but aren't ready to deal with it yet.
 - **`/harness-sync`** runs the same engine but prompts you to apply
-  fixes. Mechanical fixes (convention files, ONBOARDING.md, snapshot,
-  Status section) auto-apply when selected. Judgement-required fixes
-  (template upgrade, constraint authoring) print suggested commands.
+  fixes. Mechanical fixes (convention files, snapshot, Status section)
+  auto-apply when selected. Judgement-required fixes (ONBOARDING
+  regen, template upgrade, constraint authoring) print suggested
+  commands.
 
 **For everyday lifecycle hygiene, run `/harness-sync`.** Run
 `/harness-audit` when you specifically want the diagnostic without

--- a/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
@@ -38,7 +38,7 @@ Surface / Finding                              Status      Action on apply
 .cursor/rules/                                 drifted     /convention-sync       [auto]
 .github/copilot-instructions.md                in sync     —
 .windsurf/rules/                               missing     /convention-sync       [auto]
-ONBOARDING.md                                  drifted     /harness-onboarding    [auto]
+ONBOARDING.md                                  drifted     /harness-onboarding    [manual]
 Snapshot staleness (last: 2026-04-15)          drifted     /harness-health        [auto]
 HARNESS.md Status section accuracy             drifted     /harness-audit         [auto]
 Template version (HARNESS: 0.31, plugin: 0.34) drifted     /harness-upgrade       [manual]
@@ -65,9 +65,9 @@ Pick which to address. Hit "Apply nothing — exit without changes" if
 you just wanted the diagnostic.
 
 Phase 3 applies the fixes. For each `[auto]` selection, `/harness-sync`
-invokes the underlying primitive (`/convention-sync`,
-`/harness-onboarding`, `/harness-health`, `/harness-audit`). For each
-`[manual]` selection, it prints a "next step" line:
+invokes the underlying primitive (`/convention-sync`, `/harness-health`,
+`/harness-audit`). For each `[manual]` selection — including
+`ONBOARDING.md` staleness — it prints a "next step" line:
 
 ```text
 Manual remediation suggested for: Template version drift
@@ -88,7 +88,7 @@ Surface / Finding                              Before      After
 ─────────────────────────────────────────────  ──────────  ─────────────
 .cursor/rules/                                 drifted     in sync ✓
 .windsurf/rules/                               missing     in sync ✓
-ONBOARDING.md                                  drifted     in sync ✓
+ONBOARDING.md                                  drifted     drifted (manual — run /harness-onboarding)
 Snapshot staleness                             drifted     in sync ✓
 HARNESS.md Status accuracy                     drifted     in sync ✓
 Template drift                                 drifted     drifted (manual — see suggestion above)
@@ -104,10 +104,12 @@ be auto-applied.
 `/harness-sync` refuses to run on `main`. If you're on `main` it
 offers to create `chore/sync-surfaces-YYYY-MM-DD` for you. The
 trust-boundary pre-commit guard restricts what gets staged: only
-`.cursor/rules/**`, `.github/copilot-instructions.md`,
-`.windsurf/rules/**`, and `ONBOARDING.md` may be committed.
-`HARNESS.md`, `AGENTS.md`, and `REFLECTION_LOG.md` are off-limits to
-this command.
+`.cursor/rules/**`, `.github/copilot-instructions.md`, and
+`.windsurf/rules/**` may be committed. `HARNESS.md`, `AGENTS.md`,
+`REFLECTION_LOG.md`, and `ONBOARDING.md` are off-limits to this
+command. `ONBOARDING.md` shows in the drift table as a `[manual]`
+finding so you can see when it's stale, but `/harness-onboarding`
+runs separately under your deliberate trigger.
 
 If a `[auto]` action mutates HARNESS.md (the Status section update
 from `/harness-audit`, for example), that mutation lands as part of


### PR DESCRIPTION
## Summary

Per design feedback on PR #267 (just-shipped audit-driven `/harness-sync`): remove `/harness-onboarding` from sync's `[auto]` remediation list. ONBOARDING.md staleness still appears in the unified drift table — it's still a real surface the audit-engine detects — but it's now a `[manual]` row alongside template-drift and constraint-regression. Sync prints "Run: /harness-onboarding" and exits without writing.

## Why

ONBOARDING.md regen is a heavier mutation than convention-file regen and benefits from the user's deliberate trigger:

- Convention-file sync is a tight derive-from-HARNESS.md operation. The output is a small set of structured rule files mechanically derived from one source.
- ONBOARDING.md regen pulls in HARNESS.md + AGENTS.md + REFLECTION_LOG.md and produces a substantial human-facing document. Worth the user's awareness, not their automation.

This matches how template-drift and constraint-regression are already handled: surface the staleness, let the user act.

## What changed

- **`/harness-sync` command file**: drift table example shows ONBOARDING.md as `[manual]`; multi-select JSON moves the `onboarding` option from `[auto]` defaults to `[manual]` with `selected: false`; Phase 3 `[auto]` action list drops the onboarding bullet; new explanation paragraph in Phase 3; Output Format examples updated; commit-message parameterisation simplified (no more "ONBOARDING-only" or "convention-files-and-ONBOARDING" variants — sync only commits convention files).
- **Trust-boundary pre-commit guard's allow-list drops `ONBOARDING.md`** — sync never writes to it now. Off-limits explicitly alongside HARNESS.md, AGENTS.md, REFLECTION_LOG.md.
- **`harness-audit-engine` skill**: ONBOARDING.md row in the Categories table changes from `yes — /harness-onboarding` to `manual — /harness-onboarding`. Engine still detects the staleness; only the auto-fixable classification flips.
- **Docs synchronised**: `sync-harness.md` how-to, `run-a-harness-audit.md` how-to, `the-harness-lifecycle.md` explanation (specialised-commands list now distinguishes `/convention-sync` as a primitive sync calls vs `/harness-onboarding` which sync surfaces but does not invoke), CLAUDE.md (root + template) Monthly Operations bullet, README Commands table.
- **Plugin version 0.35.0 → 0.35.1** (patch — refinement of the v0.35.0 feature, no new behaviour added).

## Test plan

- [x] markdownlint clean across all 9 modified files.
- [x] `mkdocs build --strict` succeeds.
- [x] All five version locations agree on 0.35.1.
- [x] No remaining `[auto]` references to ONBOARDING.md anywhere in the docs.
- [ ] CI green.
- [ ] Pages deploy succeeds on merge.

## Why fix label

This is a corrective behaviour change to a feature shipped earlier today (PR #267, v0.35.0). No design work needed — the rationale is documented inline in CHANGELOG and commit message. Patch-level bump reflects the refinement nature.