### PR TITLE
docs: friendly nav labels via awesome-pages .pages files

### DIFF
--- a/docs/plugins/ai-literacy-superpowers/.pages
+++ b/docs/plugins/ai-literacy-superpowers/.pages
@@ -1,0 +1,1 @@
+title: ai-literacy-superpowers

--- a/docs/plugins/ai-literacy-superpowers/explanation/.pages
+++ b/docs/plugins/ai-literacy-superpowers/explanation/.pages
@@ -1,0 +1,1 @@
+title: Concepts

--- a/docs/plugins/ai-literacy-superpowers/how-to/.pages
+++ b/docs/plugins/ai-literacy-superpowers/how-to/.pages
@@ -1,0 +1,1 @@
+title: How-to Guides

--- a/docs/plugins/ai-literacy-superpowers/reference/.pages
+++ b/docs/plugins/ai-literacy-superpowers/reference/.pages
@@ -1,0 +1,1 @@
+title: Reference

--- a/docs/plugins/ai-literacy-superpowers/tutorials/.pages
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/.pages
@@ -1,0 +1,1 @@
+title: Getting Started

--- a/docs/plugins/model-cards/.pages
+++ b/docs/plugins/model-cards/.pages
@@ -1,0 +1,1 @@
+title: model-cards

--- a/docs/plugins/model-cards/explanation/.pages
+++ b/docs/plugins/model-cards/explanation/.pages
@@ -1,0 +1,1 @@
+title: Concepts

--- a/docs/plugins/model-cards/how-to/.pages
+++ b/docs/plugins/model-cards/how-to/.pages
@@ -1,0 +1,1 @@
+title: How-to Guides

--- a/docs/plugins/model-cards/reference/.pages
+++ b/docs/plugins/model-cards/reference/.pages
@@ -1,0 +1,1 @@
+title: Reference


### PR DESCRIPTION
## Summary

Closes the Phase 2 follow-up on nav labels. The deployed sidebar previously rendered folder names as Title Case ("Ai literacy superpowers", "Model cards", "How to", "Concepts", "Getting started") because `mkdocs-awesome-pages` defaults to that transformation when no `.pages` override exists.

## What changed

Adds 9 `.pages` files — the awesome-pages idiomatic mechanism for customising per-directory nav titles. Two layers of overrides:

**Plugin sections (preserve kebab-case)**:
- `docs/plugins/ai-literacy-superpowers/.pages` → `ai-literacy-superpowers`
- `docs/plugins/model-cards/.pages` → `model-cards`

**Quadrant labels (Diataxis friendly names)**:
- `tutorials/.pages` → `Getting Started`
- `how-to/.pages` → `How-to Guides`
- `reference/.pages` → `Reference`
- `explanation/.pages` → `Concepts`

Both plugins get their full set of quadrant `.pages` files so the labelling is consistent.

## Why chore label

Pure docs polish. Outside the plugin directory (no version bump). One-line `.pages` files per directory — mechanically correct, no design decisions.

## Test plan

- [x] `mkdocs build --strict` succeeds.
- [x] Built nav verified to show new labels in correct positions (parsed the rendered HTML).
- [ ] CI green.
- [ ] Pages deploy succeeds; deployed nav verified.