### PR TITLE
chore(ci): bump pages.yml actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -45,7 +45,7 @@ jobs:
           MKDOCS_BASE_URL: ${{ steps.pages.outputs.base_url }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 


### PR DESCRIPTION
## Summary

The Pages deploy workflow logs Node 20 deprecation warnings on every run. Bumps two actions to their current Node 24-compatible versions ahead of the September 2026 cutoff.

## Bumps

- `actions/setup-python` v5 → **v6** (Node 24)
- `actions/upload-pages-artifact` v4 → **v5** (uses `upload-artifact` v7 internally, Node 24)

## Already on Node 24

- `actions/checkout@v6`
- `actions/configure-pages@v6`
- `actions/deploy-pages@v5`

## Why chore label

Maintenance bump, no behavioural change. Outside the plugin directory (no version bump). Preventive — Node 20 deprecation deadline is 2026-09-16; this isn't currently breaking, just noisy.