### PR TITLE
chore(docs): strip vestigial Jekyll frontmatter across docs/plugins/

### DIFF
--- a/docs/plugins/ai-literacy-superpowers/explanation/adversarial-review.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/adversarial-review.md
@@ -1,14 +1,6 @@
 ---
 title: Adversarial Review
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 19
-redirect_from:
-  - /explanation/adversarial-review/
-  - /explanation/adversarial-review.html
 ---
-
 # Adversarial Review
 
 The advocatus-diaboli agent runs at two points in the pipeline: once before plan

--- a/docs/plugins/ai-literacy-superpowers/explanation/agent-orchestration.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/agent-orchestration.md
@@ -1,14 +1,6 @@
 ---
 title: Agent Orchestration
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 5
-redirect_from:
-  - /explanation/agent-orchestration/
-  - /explanation/agent-orchestration.html
 ---
-
 # Agent Orchestration
 
 Agent orchestration is the practice of distributing AI-assisted development work across multiple specialised agents, each with a defined role and bounded permissions, rather than funnelling all tasks through a single omniscient conversation. This page explains why that separation matters, how trust boundaries enforce it, and where the approach breaks down.

--- a/docs/plugins/ai-literacy-superpowers/explanation/codebase-entropy.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/codebase-entropy.md
@@ -1,14 +1,6 @@
 ---
 title: Codebase Entropy
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 4
-redirect_from:
-  - /explanation/codebase-entropy/
-  - /explanation/codebase-entropy.html
 ---
-
 # Codebase Entropy
 
 This page explains why codebases degrade and how AI accelerates the problem. For the mechanical details of fighting entropy, see [Garbage Collection](garbage-collection.md).

--- a/docs/plugins/ai-literacy-superpowers/explanation/compound-learning.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/compound-learning.md
@@ -1,14 +1,6 @@
 ---
 title: Compound Learning
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 6
-redirect_from:
-  - /explanation/compound-learning/
-  - /explanation/compound-learning.html
 ---
-
 # Compound Learning
 
 This page explains how AI development environments improve over time through captured learnings. For the detailed mechanics of self-improvement, see [The Self-Improving Harness](self-improving-harness.md).

--- a/docs/plugins/ai-literacy-superpowers/explanation/constraints-and-enforcement.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/constraints-and-enforcement.md
@@ -1,14 +1,6 @@
 ---
 title: Constraints and Enforcement
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 3
-redirect_from:
-  - /explanation/constraints-and-enforcement/
-  - /explanation/constraints-and-enforcement.html
 ---
-
 # Constraints and Enforcement
 
 This page introduces the concepts of constraint maturity and enforcement timing. For detailed mechanics, see [Progressive Hardening](progressive-hardening.md) and [The Three Enforcement Loops](three-enforcement-loops.md).

--- a/docs/plugins/ai-literacy-superpowers/explanation/context-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/context-engineering.md
@@ -1,14 +1,6 @@
 ---
 title: Context Engineering
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 2
-redirect_from:
-  - /explanation/context-engineering/
-  - /explanation/context-engineering.html
 ---
-
 # Context Engineering
 
 This page expands on the context engineering component introduced in [Harness Engineering](harness-engineering.md).

--- a/docs/plugins/ai-literacy-superpowers/explanation/decision-archaeology.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/decision-archaeology.md
@@ -1,14 +1,6 @@
 ---
 title: Decision Archaeology
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 20
-redirect_from:
-  - /explanation/decision-archaeology/
-  - /explanation/decision-archaeology.html
 ---
-
 # Decision Archaeology
 
 The Choice Cartographer agent runs after the spec-mode `/diaboli`

--- a/docs/plugins/ai-literacy-superpowers/explanation/determinacy-calibration.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/determinacy-calibration.md
@@ -1,14 +1,6 @@
 ---
 title: Determinacy Calibration
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 14
-redirect_from:
-  - /explanation/determinacy-calibration/
-  - /explanation/determinacy-calibration.html
 ---
-
 # Determinacy Calibration
 
 Progressive hardening describes the promotion ladder for constraints —

--- a/docs/plugins/ai-literacy-superpowers/explanation/fitness-functions.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/fitness-functions.md
@@ -1,14 +1,6 @@
 ---
 title: Fitness Functions
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 13
-redirect_from:
-  - /explanation/fitness-functions/
-  - /explanation/fitness-functions.html
 ---
-
 # Fitness Functions
 
 Fitness functions are periodic, objective measurements of architectural health — metrics and checks that tell you whether the codebase still conforms to properties that matter to the team: dependency boundaries, test coverage thresholds, security posture, module coupling, and similar structural qualities. Unlike constraint enforcement that runs at PR time, fitness functions are designed to track trends over time and surface slow degradation that no single change causes but that cumulative change produces.

--- a/docs/plugins/ai-literacy-superpowers/explanation/garbage-collection.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/garbage-collection.md
@@ -1,14 +1,6 @@
 ---
 title: Garbage Collection
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 12
-redirect_from:
-  - /explanation/garbage-collection/
-  - /explanation/garbage-collection.html
 ---
-
 # Garbage Collection
 
 Entropy accumulates in any codebase over time: dead code, stale dependencies, abandoned conventions, TODO comments that outlive their relevance. Garbage collection in the harness engineering sense is the scheduled practice of declaring what "clean" looks like and running periodic checks to measure how far the codebase has drifted from that standard. GC rules do not block individual merges; they produce reports that draw attention to accumulating problems before they become costly to unwind.

--- a/docs/plugins/ai-literacy-superpowers/explanation/governance-as-meaning-alignment.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/governance-as-meaning-alignment.md
@@ -1,14 +1,6 @@
 ---
 title: Governance as meaning-alignment
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 16
-redirect_from:
-  - /explanation/governance-as-meaning-alignment/
-  - /explanation/governance-as-meaning-alignment.html
 ---
-
 # Governance as Meaning-Alignment
 
 Governance failures are not primarily technical failures. They are

--- a/docs/plugins/ai-literacy-superpowers/explanation/habitat-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/habitat-engineering.md
@@ -1,14 +1,6 @@
 ---
 title: Habitat Engineering
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 0
-redirect_from:
-  - /explanation/habitat-engineering/
-  - /explanation/habitat-engineering.html
 ---
-
 # Habitat Engineering
 
 Habitat engineering is the discipline of designing your entire development environment -- code, configuration, documentation, conventions, specifications, agents, and the feedback loops that bind them -- as a habitat for the combined intelligence of humans and AI working together. It is the central organising idea behind this plugin and the AI Literacy framework it implements.

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-engineering.md
@@ -1,14 +1,6 @@
 ---
 title: Harness Engineering
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 8
-redirect_from:
-  - /explanation/harness-engineering/
-  - /explanation/harness-engineering.html
 ---
-
 # Harness Engineering
 
 Harness engineering is the practice of surrounding AI-assisted code generation with deterministic tooling, agent-based review, and periodic entropy checks so that AI-generated code stays correct and coherent over time. This document explains where the idea came from, what it consists of, and how this plugin implements it.

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-md.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-md.md
@@ -1,14 +1,6 @@
 ---
 title: HARNESS.md, the Document
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 9
-redirect_from:
-  - /explanation/harness-md/
-  - /explanation/harness-md.html
 ---
-
 # HARNESS.md, the Document
 
 `HARNESS.md` is the human-readable, central description of how the

--- a/docs/plugins/ai-literacy-superpowers/explanation/progressive-hardening.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/progressive-hardening.md
@@ -1,14 +1,6 @@
 ---
 title: Progressive Hardening
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 10
-redirect_from:
-  - /explanation/progressive-hardening/
-  - /explanation/progressive-hardening.html
 ---
-
 # Progressive Hardening
 
 Progressive hardening is the constraint promotion ladder: constraints begin as unverified declarations in `HARNESS.md`, are promoted to agent-based review once you have a prompt that catches violations reliably, and are promoted again to deterministic enforcement once the constraint is understood precisely enough to express as a script or linter rule. Movement is always toward deterministic. Patterns of repeated agent catches are the signal that a constraint is ready to be promoted.

--- a/docs/plugins/ai-literacy-superpowers/explanation/regression-detection.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/regression-detection.md
@@ -1,14 +1,6 @@
 ---
 title: Regression Detection
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 17
-redirect_from:
-  - /explanation/regression-detection/
-  - /explanation/regression-detection.html
 ---
-
 # Regression Detection
 
 In harness engineering, regression means something different than it does in software testing. Code regression is a broken feature. Harness regression is a broken habit. When the practices that keep a harness alive stop happening -- when audits are skipped, when reflections dry up, when snapshots go stale -- the harness degrades silently. The constraints still fire. The rules still exist. But the human-in-the-loop activities that evolved and maintained the harness have stopped, and the harness slowly becomes cargo cult: a system that looks correct but is no longer serving the purpose it was designed for.

--- a/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/self-improving-harness.md
@@ -1,14 +1,6 @@
 ---
 title: The Self-Improving Harness
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 11
-redirect_from:
-  - /explanation/self-improving-harness/
-  - /explanation/self-improving-harness.html
 ---
-
 # The Self-Improving Harness
 
 > A harness that doesn't evolve becomes a museum exhibit. The

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-environment-hypothesis.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-environment-hypothesis.md
@@ -1,14 +1,6 @@
 ---
 title: The Environment Hypothesis
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 1
-redirect_from:
-  - /explanation/the-environment-hypothesis/
-  - /explanation/the-environment-hypothesis.html
 ---
-
 # The Environment Hypothesis
 
 The quality of AI-generated code is a function of the environment, not the model.

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md
@@ -1,14 +1,6 @@
 ---
 title: The Harness Lifecycle
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 19
-redirect_from:
-  - /explanation/the-harness-lifecycle/
-  - /explanation/the-harness-lifecycle.html
 ---
-
 # The Harness Lifecycle
 
 > The harness has a simple lifecycle: **detect drift, heal it, pull

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-harness-tuning-loop.md
@@ -1,14 +1,6 @@
 ---
 title: The Harness Tuning Loop
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 18
-redirect_from:
-  - /explanation/the-harness-tuning-loop/
-  - /explanation/the-harness-tuning-loop.html
 ---
-
 # The Harness Tuning Loop
 
 > A harness improves over time through a specific sub-flow: surprises

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-loops-that-learn.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-loops-that-learn.md
@@ -1,14 +1,6 @@
 ---
 title: The Loops That Learn
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 7
-redirect_from:
-  - /explanation/the-loops-that-learn/
-  - /explanation/the-loops-that-learn.html
 ---
-
 # The Loops That Learn
 
 Four practices, four timescales, one compounding system.

--- a/docs/plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md
@@ -1,14 +1,6 @@
 ---
 title: The Three Enforcement Loops
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 9
-redirect_from:
-  - /explanation/three-enforcement-loops/
-  - /explanation/three-enforcement-loops.html
 ---
-
 # The Three Enforcement Loops
 
 The plugin structures verification into three loops — inner, middle, and outer — that operate at different timescales and with different tolerances for friction. The inner loop runs at edit time and is advisory, surfacing issues as suggestions without blocking work. The middle loop runs at PR time and is strict, with the authority to block a merge until failures are addressed. The outer loop runs on a schedule and is investigative, producing reports that feed back into the harness rather than blocking any single piece of work.

--- a/docs/plugins/ai-literacy-superpowers/explanation/understand-harness-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/understand-harness-engineering.md
@@ -1,14 +1,6 @@
 ---
 title: Understand Harness Engineering
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 24
-redirect_from:
-  - /how-to/understand-harness-engineering/
-  - /how-to/understand-harness-engineering.html
 ---
-
 # Understand Harness Engineering
 
 Apply the harness engineering framework to your project — understand the

--- a/docs/plugins/ai-literacy-superpowers/how-to/add-a-constraint.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/add-a-constraint.md
@@ -1,14 +1,6 @@
 ---
 title: Add a Constraint
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 2
-redirect_from:
-  - /how-to/add-a-constraint/
-  - /how-to/add-a-constraint.html
 ---
-
 # Add a Constraint
 
 Add or promote a constraint in HARNESS.md using `/harness-constrain` to capture the rule,

--- a/docs/plugins/ai-literacy-superpowers/how-to/add-fitness-functions.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/add-fitness-functions.md
@@ -1,14 +1,6 @@
 ---
 title: Add Fitness Functions
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 3
-redirect_from:
-  - /how-to/add-fitness-functions/
-  - /how-to/add-fitness-functions.html
 ---
-
 # Add Fitness Functions
 
 Add architectural fitness functions to HARNESS.md as weekly GC rules that detect system-wide

--- a/docs/plugins/ai-literacy-superpowers/how-to/audit-dependencies.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/audit-dependencies.md
@@ -1,14 +1,6 @@
 ---
 title: Audit Dependencies
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 13
-redirect_from:
-  - /how-to/audit-dependencies/
-  - /how-to/audit-dependencies.html
 ---
-
 # Audit Dependencies
 
 This guide walks you through auditing your project dependencies for known vulnerabilities, supply chain risk, and staleness — covering Go modules and Maven/JVM projects.

--- a/docs/plugins/ai-literacy-superpowers/how-to/audit-docker-images.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/audit-docker-images.md
@@ -1,14 +1,6 @@
 ---
 title: Audit Docker Images
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 14
-redirect_from:
-  - /how-to/audit-docker-images/
-  - /how-to/audit-docker-images.html
 ---
-
 # Audit Docker Images
 
 This guide walks you through using Docker Scout to audit your Docker images for CVEs, assess base image staleness, and apply hardening recommendations.

--- a/docs/plugins/ai-literacy-superpowers/how-to/build-a-governance-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/build-a-governance-dashboard.md
@@ -1,14 +1,6 @@
 ---
 title: Build a Governance Dashboard
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 33
-redirect_from:
-  - /how-to/build-a-governance-dashboard/
-  - /how-to/build-a-governance-dashboard.html
 ---
-
 # Build a Governance Dashboard
 
 Generate an HTML dashboard visualising governance health, constraint

--- a/docs/plugins/ai-literacy-superpowers/how-to/build-portfolio-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/build-portfolio-dashboard.md
@@ -1,14 +1,6 @@
 ---
 title: Build an AI Literacy Portfolio Dashboard
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 8
-redirect_from:
-  - /how-to/build-portfolio-dashboard/
-  - /how-to/build-portfolio-dashboard.html
 ---
-
 # Build an AI Literacy Portfolio Dashboard
 
 Turn your portfolio assessment data into a shareable HTML dashboard

--- a/docs/plugins/ai-literacy-superpowers/how-to/check-governance-health.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/check-governance-health.md
@@ -1,14 +1,6 @@
 ---
 title: Check Governance Health
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 31
-redirect_from:
-  - /how-to/check-governance-health/
-  - /how-to/check-governance-health.html
 ---
-
 # Check Governance Health
 
 Quick governance pulse check between quarterly audits.

--- a/docs/plugins/ai-literacy-superpowers/how-to/configure-observability.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/configure-observability.md
@@ -1,14 +1,6 @@
 ---
 title: Configure Observability
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 35
-redirect_from:
-  - /how-to/configure-observability/
-  - /how-to/configure-observability.html
 ---
-
 # Configure Observability
 
 Set snapshot cadence, operating targets, health thresholds, and regression detection in HARNESS.md.

--- a/docs/plugins/ai-literacy-superpowers/how-to/create-team-api.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/create-team-api.md
@@ -1,14 +1,6 @@
 ---
 title: Create a Team API
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 23
-redirect_from:
-  - /how-to/create-team-api/
-  - /how-to/create-team-api.html
 ---
-
 # Create a Team API
 
 Generate or update a Team Topologies Team API document populated with AI

--- a/docs/plugins/ai-literacy-superpowers/how-to/detect-semantic-drift.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/detect-semantic-drift.md
@@ -1,14 +1,6 @@
 ---
 title: Detect Semantic Drift
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 32
-redirect_from:
-  - /how-to/detect-semantic-drift/
-  - /how-to/detect-semantic-drift.html
 ---
-
 # Detect Semantic Drift in Your Constraints
 
 Find governance constraints whose meaning has diverged from the

--- a/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
@@ -1,14 +1,6 @@
 ---
 title: Discover Affordances
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 39
-redirect_from:
-  - /how-to/discover-affordances/
-  - /how-to/discover-affordances.html
 ---
-
 # Discover Affordances
 
 Run the affordance discovery scanner against your project's existing

--- a/docs/plugins/ai-literacy-superpowers/how-to/enforce-human-pace.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/enforce-human-pace.md
@@ -1,14 +1,6 @@
 ---
 title: Enforce Human Pace
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 26
-redirect_from:
-  - /how-to/enforce-human-pace/
-  - /how-to/enforce-human-pace.html
 ---
-
 # Enforce Human Pace
 
 Add the Human Pace constraint and cadence drift GC rule to keep

--- a/docs/plugins/ai-literacy-superpowers/how-to/extract-conventions.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/extract-conventions.md
@@ -1,14 +1,6 @@
 ---
 title: Extract Conventions
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 10
-redirect_from:
-  - /how-to/extract-conventions/
-  - /how-to/extract-conventions.html
 ---
-
 # Extract Conventions
 
 Run a guided convention extraction session to surface tacit team knowledge and encode

--- a/docs/plugins/ai-literacy-superpowers/how-to/generate-improvement-plan.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/generate-improvement-plan.md
@@ -1,14 +1,6 @@
 ---
 title: Generate an Improvement Plan
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 21
-redirect_from:
-  - /how-to/generate-improvement-plan/
-  - /how-to/generate-improvement-plan.html
 ---
-
 # Generate an Improvement Plan
 
 Generate a prioritised improvement plan from assessment gaps and work

--- a/docs/plugins/ai-literacy-superpowers/how-to/generate-onboarding.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/generate-onboarding.md
@@ -1,14 +1,6 @@
 ---
 title: Generate an Onboarding Guide
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 36
-redirect_from:
-  - /how-to/generate-onboarding/
-  - /how-to/generate-onboarding.html
 ---
-
 # Generate an Onboarding Guide
 
 `/harness-onboarding` is one of the underlying primitives that

--- a/docs/plugins/ai-literacy-superpowers/how-to/harden-github-actions.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/harden-github-actions.md
@@ -1,14 +1,6 @@
 ---
 title: Harden GitHub Actions
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 15
-redirect_from:
-  - /how-to/harden-github-actions/
-  - /how-to/harden-github-actions.html
 ---
-
 # Harden GitHub Actions
 
 This guide walks you through reviewing and hardening your GitHub Actions workflows against supply chain attacks — covering SHA pinning, permissions scoping, and automated update configuration.

--- a/docs/plugins/ai-literacy-superpowers/how-to/orchestrate-across-repos.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/orchestrate-across-repos.md
@@ -1,14 +1,6 @@
 ---
 title: Orchestrate Changes Across Repos
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 22
-redirect_from:
-  - /how-to/orchestrate-across-repos/
-  - /how-to/orchestrate-across-repos.html
 ---
-
 # Orchestrate Changes Across Repos
 
 Coordinate changes — skills, templates, hooks, and harness policies —

--- a/docs/plugins/ai-literacy-superpowers/how-to/review-a-spec-adversarially.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/review-a-spec-adversarially.md
@@ -1,14 +1,6 @@
 ---
 title: Review a Spec Adversarially
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 38
-redirect_from:
-  - /how-to/review-a-spec-adversarially/
-  - /how-to/review-a-spec-adversarially.html
 ---
-
 # Review a Spec Adversarially
 
 Run `/diaboli` to get an adversarial review of a spec (before plan approval) or an

--- a/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
@@ -1,14 +1,6 @@
 ---
 title: Review Code with CUPID
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 12
-redirect_from:
-  - /how-to/review-code-with-cupid/
-  - /how-to/review-code-with-cupid.html
 ---
-
 # Review Code with CUPID
 
 This guide walks you through reviewing code using the five CUPID properties — Composable, Unix philosophy, Predictable, Idiomatic, Domain-based — as a structured lens for surfacing improvement opportunities.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-calibration-review.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-calibration-review.md
@@ -1,14 +1,6 @@
 ---
 title: Run a Determinacy Calibration Review
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 40
-redirect_from:
-  - /how-to/run-a-calibration-review/
-  - /how-to/run-a-calibration-review.html
 ---
-
 # Run a Determinacy Calibration Review
 
 Run a periodic calibration review to interpret the signal from

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-governance-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-governance-audit.md
@@ -1,14 +1,6 @@
 ---
 title: Run a Governance Audit
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 30
-redirect_from:
-  - /how-to/run-a-governance-audit/
-  - /how-to/run-a-governance-audit.html
 ---
-
 # Run a Governance Audit
 
 Investigate governance health — falsifiability, semantic drift,

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
@@ -1,14 +1,6 @@
 ---
 title: Run a Harness Audit
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 4
-redirect_from:
-  - /how-to/run-a-harness-audit/
-  - /how-to/run-a-harness-audit.html
 ---
-
 # Run a Harness Audit
 
 > `/harness-audit` is the read-only diagnostic. It runs the shared

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
@@ -1,14 +1,6 @@
 ---
 title: Run an Assessment
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 9
-redirect_from:
-  - /how-to/run-an-assessment/
-  - /how-to/run-an-assessment.html
 ---
-
 # Run an Assessment
 
 Run an AI literacy assessment to determine where your team sits on the ALCI framework,

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-choice-cartograph.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-choice-cartograph.md
@@ -1,14 +1,6 @@
 ---
 title: Run the Choice Cartographer
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 39
-redirect_from:
-  - /how-to/run-choice-cartograph/
-  - /how-to/run-choice-cartograph.html
 ---
-
 # Run the Choice Cartographer
 
 Run `/choice-cartograph` to map the implicit decisions a spec has made — the

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-portfolio-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-portfolio-assessment.md
@@ -1,14 +1,6 @@
 ---
 title: Run a Portfolio Assessment
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 20
-redirect_from:
-  - /how-to/run-portfolio-assessment/
-  - /how-to/run-portfolio-assessment.html
 ---
-
 # Run a Portfolio Assessment
 
 Aggregate AI literacy assessments across multiple repositories into an

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-auto-enforcer.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-auto-enforcer.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Auto-Enforcer
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 5
-redirect_from:
-  - /how-to/set-up-auto-enforcer/
-  - /how-to/set-up-auto-enforcer.html
 ---
-
 # Set Up Auto-Enforcer
 
 Wire the auto-enforcer GitHub Action to check every PR against the constraints in

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-context-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-context-engineering.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Context Engineering
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 11
-redirect_from:
-  - /how-to/set-up-context-engineering/
-  - /how-to/set-up-context-engineering.html
 ---
-
 # Set Up Context Engineering
 
 This guide walks you through writing enforceable conventions for the Context section of your `HARNESS.md` so that LLMs and new team members work from the same shared understanding of your codebase.

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-garbage-collection.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-garbage-collection.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Garbage Collection
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 16
-redirect_from:
-  - /how-to/set-up-garbage-collection/
-  - /how-to/set-up-garbage-collection.html
 ---
-
 # Set Up Garbage Collection
 
 This guide walks you through designing and adding garbage collection (GC) rules to your `HARNESS.md` — periodic checks that fight the entropy that real-time hooks and PR gates cannot catch.

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-model-routing.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-model-routing.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Model Routing
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 19
-redirect_from:
-  - /how-to/set-up-model-routing/
-  - /how-to/set-up-model-routing.html
 ---
-
 # Set Up Model Routing
 
 Decide which models handle which workloads, document those routing rules

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-secret-detection.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-secret-detection.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Secret Detection
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 1
-redirect_from:
-  - /how-to/set-up-secret-detection/
-  - /how-to/set-up-secret-detection.html
 ---
-
 # Set Up Secret Detection
 
 This guide walks you through adding gitleaks-based secret detection to your project and wiring it into the harness so it runs automatically at commit time and in CI.

--- a/docs/plugins/ai-literacy-superpowers/how-to/set-up-verification-slots.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/set-up-verification-slots.md
@@ -1,14 +1,6 @@
 ---
 title: Set Up Verification Slots
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 18
-redirect_from:
-  - /how-to/set-up-verification-slots/
-  - /how-to/set-up-verification-slots.html
 ---
-
 # Set Up Verification Slots
 
 Integrate a deterministic tool into a harness constraint so the enforcer

--- a/docs/plugins/ai-literacy-superpowers/how-to/sync-conventions.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/sync-conventions.md
@@ -1,14 +1,6 @@
 ---
 title: Sync Conventions
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 6
-redirect_from:
-  - /how-to/sync-conventions/
-  - /how-to/sync-conventions.html
 ---
-
 # Sync Conventions
 
 `/convention-sync` is one of the underlying primitives that

--- a/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/sync-harness.md
@@ -1,14 +1,6 @@
 ---
 title: Sync Harness Surfaces
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 7
-redirect_from:
-  - /how-to/sync-harness/
-  - /how-to/sync-harness.html
 ---
-
 # Sync the harness
 
 > Run `/harness-sync` to bring every surface into alignment with

--- a/docs/plugins/ai-literacy-superpowers/how-to/track-ai-costs.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/track-ai-costs.md
@@ -1,14 +1,6 @@
 ---
 title: Track AI Costs
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 25
-redirect_from:
-  - /how-to/track-ai-costs/
-  - /how-to/track-ai-costs.html
 ---
-
 # Track AI Costs
 
 Capture AI tool spending data and integrate it into your health

--- a/docs/plugins/ai-literacy-superpowers/how-to/update-the-plugin.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/update-the-plugin.md
@@ -1,14 +1,6 @@
 ---
 title: Update the Plugin
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 27
-redirect_from:
-  - /how-to/update-the-plugin/
-  - /how-to/update-the-plugin.html
 ---
-
 # Update the Plugin
 
 Keep the plugin current when new versions are released, and adopt new

--- a/docs/plugins/ai-literacy-superpowers/how-to/upgrade-your-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/upgrade-your-harness.md
@@ -1,14 +1,6 @@
 ---
 title: Upgrade Your Harness
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 34
-redirect_from:
-  - /how-to/upgrade-your-harness/
-  - /how-to/upgrade-your-harness.html
 ---
-
 # Upgrade Your Harness
 
 Run `/harness-upgrade` to adopt new template content after updating the plugin.

--- a/docs/plugins/ai-literacy-superpowers/how-to/verify-observatory-signals.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/verify-observatory-signals.md
@@ -1,14 +1,6 @@
 ---
 title: Verify Observatory Signals
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 37
-redirect_from:
-  - /how-to/verify-observatory-signals/
-  - /how-to/verify-observatory-signals.html
 ---
-
 # Verify Observatory Signals
 
 Run `/observatory-verify` to check that all data signals the Habitat

--- a/docs/plugins/ai-literacy-superpowers/how-to/write-a-governance-constraint.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/write-a-governance-constraint.md
@@ -1,14 +1,6 @@
 ---
 title: Write a Governance Constraint
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 29
-redirect_from:
-  - /how-to/write-a-governance-constraint/
-  - /how-to/write-a-governance-constraint.html
 ---
-
 # Write a Governance Constraint
 
 Translate a governance requirement into a falsifiable HARNESS.md

--- a/docs/plugins/ai-literacy-superpowers/how-to/write-literate-code.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/write-literate-code.md
@@ -1,14 +1,6 @@
 ---
 title: Write Literate Code
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 17
-redirect_from:
-  - /how-to/write-literate-code/
-  - /how-to/write-literate-code.html
 ---
-
 # Write Literate Code
 
 This guide walks you through applying the literate programming discipline to your code — writing files whose structure and documentation make the reasoning visible to the next reader.

--- a/docs/plugins/ai-literacy-superpowers/index.md
+++ b/docs/plugins/ai-literacy-superpowers/index.md
@@ -1,16 +1,6 @@
 ---
 title: ai-literacy-superpowers
-layout: default
-parent: Plugins
-nav_order: 2
-has_children: true
-redirect_from:
-  - /tutorials/
-  - /how-to/
-  - /reference/
-  - /explanation/
 ---
-
 # ai-literacy-superpowers
 
 The flagship plugin in this marketplace — harness engineering, agent

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -1,14 +1,6 @@
 ---
 title: Agents
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 2
-redirect_from:
-  - /reference/agents/
-  - /reference/agents.html
 ---
-
 # Agents
 
 The plugin ships 13 agents organised into three groups: the

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -1,14 +1,6 @@
 ---
 title: Commands
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 3
-redirect_from:
-  - /reference/commands/
-  - /reference/commands.html
 ---
-
 # Commands
 
 All 24 slash commands registered in `commands/`. Each command is

--- a/docs/plugins/ai-literacy-superpowers/reference/governance-summary-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/governance-summary-format.md
@@ -1,14 +1,6 @@
 ---
 title: Governance Summary Format
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 8
-redirect_from:
-  - /reference/governance-summary-format/
-  - /reference/governance-summary-format.html
 ---
-
 # Governance Summary Format
 
 The machine-readable section in governance audit reports that the

--- a/docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md
@@ -1,14 +1,6 @@
 ---
 title: HARNESS.md Format
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 5
-redirect_from:
-  - /reference/harness-md-format/
-  - /reference/harness-md-format.html
 ---
-
 # HARNESS.md Format
 
 Section-by-section reference for the `HARNESS.md` file. This file is

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -1,14 +1,6 @@
 ---
 title: Hooks
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 4
-redirect_from:
-  - /reference/hooks/
-  - /reference/hooks.html
 ---
-
 # Hooks
 
 All hooks are registered in `hooks/hooks.json` and active in every

--- a/docs/plugins/ai-literacy-superpowers/reference/output-validation.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/output-validation.md
@@ -1,14 +1,6 @@
 ---
 title: Output Validation
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 7
-redirect_from:
-  - /reference/output-validation/
-  - /reference/output-validation.html
 ---
-
 # Output Validation
 
 Output validation checkpoints verify that structured output matches expected formats before committing or proceeding. Eight commands implement this pattern to catch format deviations early.

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -1,14 +1,6 @@
 ---
 title: Skills
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 1
-redirect_from:
-  - /reference/skills/
-  - /reference/skills.html
 ---
-
 # Skills
 
 The plugin ships 30 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.

--- a/docs/plugins/ai-literacy-superpowers/reference/templates.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/templates.md
@@ -1,14 +1,6 @@
 ---
 title: Templates
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 6
-redirect_from:
-  - /reference/templates/
-  - /reference/templates.html
 ---
-
 # Templates
 
 The plugin ships 11 template files in `templates/`. Commands like

--- a/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
@@ -1,14 +1,6 @@
 ---
 title: A First-Time Tour of Every Capability
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 7
-redirect_from:
-  - /tutorials/first-time-tour/
-  - /tutorials/first-time-tour.html
 ---
-
 # A First-Time Tour of Every Capability
 
 The plugin ships with twenty-two slash commands, a dozen agents, and

--- a/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
@@ -1,14 +1,6 @@
 ---
 title: From Assessment to Dashboard
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 5
-redirect_from:
-  - /tutorials/from-assessment-to-dashboard/
-  - /tutorials/from-assessment-to-dashboard.html
 ---
-
 # From Assessment to Dashboard
 
 This tutorial walks you through running a portfolio assessment across

--- a/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
@@ -1,14 +1,6 @@
 ---
 title: Getting Started
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 1
-redirect_from:
-  - /tutorials/getting-started/
-  - /tutorials/getting-started.html
 ---
-
 # Getting Started
 
 This tutorial walks you through installing the ai-literacy-superpowers plugin,

--- a/docs/plugins/ai-literacy-superpowers/tutorials/governance-for-your-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/governance-for-your-harness.md
@@ -1,14 +1,6 @@
 ---
 title: Governance for Your Harness
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 8
-redirect_from:
-  - /tutorials/governance-for-your-harness/
-  - /tutorials/governance-for-your-harness.html
 ---
-
 # Governance for Your Harness
 
 Take your harness from "governance language without operational meaning"

--- a/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
@@ -1,14 +1,6 @@
 ---
 title: Harness for an Existing Codebase
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 3
-redirect_from:
-  - /tutorials/harness-from-scratch/
-  - /tutorials/harness-from-scratch.html
 ---
-
 # Harness for an Existing Codebase
 
 Most projects already have conventions — they just aren't written down

--- a/docs/plugins/ai-literacy-superpowers/tutorials/surfacing-tacit-knowledge.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/surfacing-tacit-knowledge.md
@@ -1,14 +1,6 @@
 ---
 title: Surfacing Tacit Knowledge
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 9
-redirect_from:
-  - /tutorials/surfacing-tacit-knowledge/
-  - /tutorials/surfacing-tacit-knowledge.html
 ---
-
 # Surfacing Tacit Knowledge
 
 Most of what makes a team effective in a complex domain is not

--- a/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
@@ -1,14 +1,6 @@
 ---
 title: The Improvement Cycle
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 6
-redirect_from:
-  - /tutorials/the-improvement-cycle/
-  - /tutorials/the-improvement-cycle.html
 ---
-
 # The Improvement Cycle
 
 This tutorial walks you through one complete improvement cycle: a

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-assessment.md
@@ -1,14 +1,6 @@
 ---
 title: Your First Assessment
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 4
-redirect_from:
-  - /tutorials/your-first-assessment/
-  - /tutorials/your-first-assessment.html
 ---
-
 # Your First Assessment
 
 An AI literacy assessment tells you where your team stands in its AI

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-skill.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-skill.md
@@ -1,14 +1,6 @@
 ---
 title: Creating Your First Skill
-layout: default
-parent: ai-literacy-superpowers
-grand_parent: Plugins
-nav_order: 2
-redirect_from:
-  - /tutorials/your-first-skill/
-  - /tutorials/your-first-skill.html
 ---
-
 # Creating Your First Skill
 
 A skill is a Markdown file that agents read when working. It encodes

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,10 +1,6 @@
 ---
 title: Plugins
-layout: default
-nav_order: 6
-has_children: true
 ---
-
 # Plugins
 
 The `ai-literacy-superpowers` marketplace ships more than one plugin.

--- a/docs/plugins/model-cards/explanation/index.md
+++ b/docs/plugins/model-cards/explanation/index.md
@@ -1,12 +1,6 @@
 ---
 title: Concepts
-nav_label: Concepts
-parent: model-cards
-grand_parent: Plugins
-has_children: true
-nav_order: 4
 ---
-
 # Concepts
 
 Conceptual background for the `model-cards` plugin.

--- a/docs/plugins/model-cards/explanation/mitchell-extended-cards.md
+++ b/docs/plugins/model-cards/explanation/mitchell-extended-cards.md
@@ -1,14 +1,6 @@
 ---
 title: Mitchell-Extended Model Cards
-layout: default
-parent: Concepts
-grand_parent: model-cards
-nav_order: 1
-redirect_from:
-  - /plugins/model-cards/mitchell-extended-cards/
-  - /plugins/model-cards/mitchell-extended-cards.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Mitchell-Extended Model Cards

--- a/docs/plugins/model-cards/how-to/index.md
+++ b/docs/plugins/model-cards/how-to/index.md
@@ -1,12 +1,6 @@
 ---
 title: How-to Guides
-nav_label: How-to Guides
-parent: model-cards
-grand_parent: Plugins
-has_children: true
-nav_order: 2
 ---
-
 # How-to Guides
 
 Task-oriented guides for the `model-cards` plugin. Pick the page that

--- a/docs/plugins/model-cards/how-to/research-a-model-card.md
+++ b/docs/plugins/model-cards/how-to/research-a-model-card.md
@@ -1,14 +1,6 @@
 ---
 title: Research a Model Card
-layout: default
-parent: How-to Guides
-grand_parent: model-cards
-nav_order: 1
-redirect_from:
-  - /plugins/model-cards/research-a-model-card/
-  - /plugins/model-cards/research-a-model-card.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Research a Model Card

--- a/docs/plugins/model-cards/how-to/seed-your-library.md
+++ b/docs/plugins/model-cards/how-to/seed-your-library.md
@@ -1,14 +1,6 @@
 ---
 title: Seed Your Library
-layout: default
-parent: How-to Guides
-grand_parent: model-cards
-nav_order: 2
-redirect_from:
-  - /plugins/model-cards/seed-your-library/
-  - /plugins/model-cards/seed-your-library.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Seed Your Model Card Library

--- a/docs/plugins/model-cards/index.md
+++ b/docs/plugins/model-cards/index.md
@@ -1,11 +1,6 @@
 ---
 title: model-cards
-layout: default
-parent: Plugins
-nav_order: 1
-has_children: true
 ---
-
 # model-cards
 
 Research and author Mitchell-extended model cards from a model name.

--- a/docs/plugins/model-cards/reference/agents.md
+++ b/docs/plugins/model-cards/reference/agents.md
@@ -1,14 +1,6 @@
 ---
 title: Agent — model-card-researcher
-layout: default
-parent: Reference
-grand_parent: model-cards
-nav_order: 1
-redirect_from:
-  - /plugins/model-cards/agents/
-  - /plugins/model-cards/agents.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Agent: model-card-researcher

--- a/docs/plugins/model-cards/reference/card-template.md
+++ b/docs/plugins/model-cards/reference/card-template.md
@@ -1,14 +1,6 @@
 ---
 title: Card Template
-layout: default
-parent: Reference
-grand_parent: model-cards
-nav_order: 2
-redirect_from:
-  - /plugins/model-cards/card-template/
-  - /plugins/model-cards/card-template.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Card Template

--- a/docs/plugins/model-cards/reference/commands.md
+++ b/docs/plugins/model-cards/reference/commands.md
@@ -1,14 +1,6 @@
 ---
 title: Commands
-layout: default
-parent: Reference
-grand_parent: model-cards
-nav_order: 3
-redirect_from:
-  - /plugins/model-cards/commands/
-  - /plugins/model-cards/commands.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Commands

--- a/docs/plugins/model-cards/reference/index.md
+++ b/docs/plugins/model-cards/reference/index.md
@@ -1,12 +1,6 @@
 ---
 title: Reference
-nav_label: Reference
-parent: model-cards
-grand_parent: Plugins
-has_children: true
-nav_order: 3
 ---
-
 # Reference
 
 Lookup material for the `model-cards` plugin's components and

--- a/docs/plugins/model-cards/reference/skills.md
+++ b/docs/plugins/model-cards/reference/skills.md
@@ -1,14 +1,6 @@
 ---
 title: Skill — model-cards
-layout: default
-parent: Reference
-grand_parent: model-cards
-nav_order: 4
-redirect_from:
-  - /plugins/model-cards/skills/
-  - /plugins/model-cards/skills.html
 ---
-
 <!-- redirect-sunset: 2027-05-08 -->
 
 # Skill: model-cards

--- a/scripts/migrations/strip-jekyll-frontmatter.py
+++ b/scripts/migrations/strip-jekyll-frontmatter.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+strip-jekyll-frontmatter.py — one-shot cleanup of Jekyll-only frontmatter fields.
+
+After the Jekyll → MkDocs Material migration, the following frontmatter
+fields are dead weight (mkdocs ignores them) but remain in 90+ docs files:
+
+  layout, parent, grand_parent, nav_order, nav_label, has_children,
+  redirect_from
+
+The redirect_from values were already migrated to mkdocs.yml's
+redirect_maps by an earlier migration script (jekyll-to-mkdocs.py).
+This cleanup removes the now-vestigial frontmatter.
+
+Preserves: title (mkdocs uses it), and any non-Jekyll fields.
+
+Usage:
+    python3 scripts/migrations/strip-jekyll-frontmatter.py [--apply]
+
+Without --apply the script reports what it would change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path("docs/plugins")
+
+JEKYLL_FIELDS = {
+    "layout",
+    "parent",
+    "grand_parent",
+    "nav_order",
+    "nav_label",
+    "has_children",
+    "redirect_from",
+}
+
+FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def strip_jekyll_fields(frontmatter: str) -> tuple[str, int]:
+    """Return (cleaned_frontmatter, fields_removed_count)."""
+    lines = frontmatter.split("\n")
+    out: list[str] = []
+    skipping = False  # True while we're inside a multi-line block (e.g. redirect_from list)
+    removed = 0
+
+    for line in lines:
+        stripped = line.lstrip()
+        # Top-level key (no indentation, ends with colon)
+        key_match = re.match(r"^([A-Za-z_]\S*):", line)
+        if key_match:
+            key = key_match.group(1)
+            if key in JEKYLL_FIELDS:
+                skipping = True
+                removed += 1
+                continue
+            else:
+                skipping = False
+                out.append(line)
+        elif skipping and (line.startswith(" ") or line.startswith("\t") or stripped.startswith("-")):
+            # Continuation line of a multi-line YAML block we're dropping
+            continue
+        else:
+            skipping = False
+            out.append(line)
+
+    return "\n".join(out).rstrip(), removed
+
+
+def process_file(path: Path, apply: bool) -> int:
+    """Returns number of frontmatter fields removed."""
+    content = path.read_text()
+    m = FRONTMATTER.match(content)
+    if not m:
+        return 0
+
+    fm = m.group(1)
+    rest = content[m.end():]
+
+    new_fm, removed = strip_jekyll_fields(fm)
+    if removed == 0:
+        return 0
+
+    if not new_fm.strip():
+        # All frontmatter fields were Jekyll-only; remove the frontmatter block entirely
+        new_content = rest.lstrip("\n")
+    else:
+        new_content = f"---\n{new_fm}\n---\n{rest}"
+
+    if apply:
+        path.write_text(new_content)
+
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="write changes in place")
+    args = parser.parse_args()
+
+    files = sorted(DOCS_DIR.rglob("*.md"))
+    total_removed = 0
+    files_modified = 0
+
+    for path in files:
+        n = process_file(path, args.apply)
+        if n > 0:
+            total_removed += n
+            files_modified += 1
+
+    verb = "would remove" if not args.apply else "removed"
+    print(
+        f"{verb} {total_removed} Jekyll frontmatter field(s) across {files_modified} file(s)",
+        file=sys.stderr,
+    )
+    if not args.apply:
+        print("(re-run with --apply to write changes)", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Cleanup pass: removes 457 Jekyll-only frontmatter fields across 92 files. The user's deferred follow-up was nominally "Phase 1 model-cards frontmatter cleanup", but the same vestigial fields exist across all 92 docs/plugins/ pages — easier to clean in one sweep than to leave the rest as ongoing tech debt.

## What's removed

mkdocs ignores all of these; they were misleading clutter:

| Field | Origin | Replacement |
| --- | --- | --- |
| `layout: default` | Jekyll layout selector | n/a in mkdocs |
| `parent`, `grand_parent` | just-the-docs nav hierarchy | mkdocs-awesome-pages folder structure |
| `nav_order`, `nav_label`, `has_children` | just-the-docs nav controls | `.pages` files (PR #271) |
| `redirect_from` | Jekyll redirect plugin | Already migrated to `mkdocs.yml` `redirect_maps` (PR #265) |

Preserved: `title` (mkdocs uses it).

## How

`scripts/migrations/strip-jekyll-frontmatter.py` — one-shot Python script committed for reproducibility (alongside the existing `jekyll-to-mkdocs.py` and `rewrite-relative-links.py` migration tools).

## Verification

- [x] `mkdocs build --strict` succeeds.
- [x] Sample page renders with correct title (Research a Model Card).
- [x] Sidebar nav still renders correctly — folder structure + `.pages` files (added in PR #271) drive nav now, not frontmatter.
- [x] Redirect coverage preserved — sample lookup confirms mkdocs.yml has the corresponding entry for the stripped redirect_from.
- [ ] CI green.
- [ ] Pages deploy: spot-check that no nav regression appears live.

## Why chore label

Pure cleanup. Outside the plugin directory (no version bump). Net `-597` lines (725 removed, 128 added) — most of the additions are the new migration script.