### PR TITLE
chore(docs): append .md to bare-filename markdown links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ engineering**, **agent orchestration**, **decision archaeology**,
 
 {: .fs-6 .fw-300 }
 
-[Get Started](plugins/ai-literacy-superpowers/getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Get Started](plugins/ai-literacy-superpowers/tutorials/getting-started.md){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Browse Plugins](plugins/index.md){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Quick Install](#add-the-marketplace){: .btn .fs-5 .mb-4 .mb-md-0 }
 

--- a/docs/plugins/ai-literacy-superpowers/how-to/build-a-governance-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/build-a-governance-dashboard.md
@@ -72,5 +72,5 @@ dependencies, showing health metrics, debt trends, and frame alignment.
 
 - Share the dashboard with your team for governance visibility
 - The governance data also feeds into the
-  [portfolio dashboard](build-portfolio-dashboard) when using
+  [portfolio dashboard](build-portfolio-dashboard.md) when using
   `/portfolio-assess`

--- a/docs/plugins/ai-literacy-superpowers/how-to/check-governance-health.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/check-governance-health.md
@@ -66,7 +66,7 @@ A current view of governance health without running a full audit.
 
 ## Next steps
 
-- [Run a governance audit](run-a-governance-audit) if any metric is
+- [Run a governance audit](run-a-governance-audit.md) if any metric is
   red
-- [Build a governance dashboard](build-a-governance-dashboard) for a
+- [Build a governance dashboard](build-a-governance-dashboard.md) for a
   visual overview

--- a/docs/plugins/ai-literacy-superpowers/how-to/detect-semantic-drift.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/detect-semantic-drift.md
@@ -76,7 +76,7 @@ a workflow for fixing drifted constraints.
 
 ## Next steps
 
-- [Run a governance audit](run-a-governance-audit) quarterly to catch
+- [Run a governance audit](run-a-governance-audit.md) quarterly to catch
   drift early
-- [Check governance health](check-governance-health) between audits
+- [Check governance health](check-governance-health.md) between audits
   for a quick pulse

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-governance-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-governance-audit.md
@@ -95,8 +95,8 @@ debt inventory, and prioritised recommendations.
 
 ## Next steps
 
-- [Check governance health](check-governance-health) for a quick
+- [Check governance health](check-governance-health.md) for a quick
   pulse between audits
-- [Build a governance dashboard](build-a-governance-dashboard) to
+- [Build a governance dashboard](build-a-governance-dashboard.md) to
   visualise trends
 - Add `/governance-audit` to your quarterly operating cadence

--- a/docs/plugins/ai-literacy-superpowers/how-to/write-a-governance-constraint.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/write-a-governance-constraint.md
@@ -94,7 +94,7 @@ three-frame alignment.
 
 ## Next steps
 
-- [Run a governance audit](run-a-governance-audit) to assess all your
+- [Run a governance audit](run-a-governance-audit.md) to assess all your
   governance constraints
-- [Detect semantic drift](detect-semantic-drift) to catch constraints
+- [Detect semantic drift](detect-semantic-drift.md) to catch constraints
   that have diverged from reality

--- a/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/first-time-tour.md
@@ -15,7 +15,7 @@ leaves the project in a coherent, better-off state than when you
 started.
 
 The tour assumes you have already completed
-[Getting Started](getting-started) — the plugin is installed and you
+[Getting Started](getting-started.md) — the plugin is installed and you
 have a project to try it against. If not, do that first.
 
 ---
@@ -603,12 +603,12 @@ before plan approval.
 
 ## Next Steps
 
-- [The Improvement Cycle](the-improvement-cycle) — a focused walk
+- [The Improvement Cycle](the-improvement-cycle.md) — a focused walk
   through one L2 → L3 cycle, if you want more depth on the
   assessment-driven path
-- [Governance for Your Harness](governance-for-your-harness) — a
+- [Governance for Your Harness](governance-for-your-harness.md) — a
   full walkthrough of the governance phase in isolation
-- [Harness for an Existing Codebase](harness-from-scratch) —
+- [Harness for an Existing Codebase](harness-from-scratch.md) —
   strategies for retrofitting a harness into a mature project
 - [Reference: Commands](../reference/commands.md) — the full
   specification for every command mentioned above

--- a/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
@@ -27,7 +27,7 @@ You need:
   or topic tag — optional if you are scanning a local directory
 
 If you haven't run a single-repo assessment yet, follow the
-[Getting Started](getting-started) tutorial first to install the
+[Getting Started](getting-started.md) tutorial first to install the
 plugin and run `/harness-init`, then use `/assess` to get an
 assessment document in at least one repo before continuing here.
 
@@ -453,7 +453,7 @@ After completing this tutorial you have:
 
 ## Next Steps
 
-- [The Improvement Cycle](the-improvement-cycle) — walk one repo from
+- [The Improvement Cycle](the-improvement-cycle.md) — walk one repo from
   L2 to L3 using the assessment's improvement plan
 - [How-to: Run a Portfolio Assessment](../how-to/run-portfolio-assessment.md)
   — flags, options, and edge cases for the `/portfolio-assess` command

--- a/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
@@ -396,12 +396,12 @@ run reflections, and discover patterns worth encoding.
 
 ## Next Steps
 
-- [A First-Time Tour of Every Capability](first-time-tour) — the full
+- [A First-Time Tour of Every Capability](first-time-tour.md) — the full
   tour of every command in the order it is most useful, with the reason
   each step comes where it does
-- [Creating Your First Skill](your-first-skill) — encode domain knowledge
+- [Creating Your First Skill](your-first-skill.md) — encode domain knowledge
   that agents will carry into every session
-- [Harness for an Existing Codebase](harness-from-scratch) — strategies for
+- [Harness for an Existing Codebase](harness-from-scratch.md) — strategies for
   retrofitting a harness into a project that already has conventions but no
   enforcement
 - [How-to Guides](../index.md) — specific tasks: adding a constraint, setting

--- a/docs/plugins/ai-literacy-superpowers/tutorials/governance-for-your-harness.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/governance-for-your-harness.md
@@ -17,9 +17,9 @@ It takes about twenty minutes.
 You need:
 
 - Claude Code installed with the ai-literacy-superpowers plugin
-  (see [Getting Started](getting-started))
+  (see [Getting Started](getting-started.md))
 - A project with a `HARNESS.md` — if you do not have one yet, run
-  through [Harness from Scratch](harness-from-scratch) first
+  through [Harness from Scratch](harness-from-scratch.md) first
 
 The tutorial works best if your `HARNESS.md` already has a few
 constraints. Most teams have at least one constraint that uses

--- a/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
@@ -24,7 +24,7 @@ are ready.
 Before starting, make sure you have:
 
 - Claude Code installed with the ai-literacy-superpowers plugin (see
-  [Getting Started](getting-started) if you haven't done this yet)
+  [Getting Started](getting-started.md) if you haven't done this yet)
 - An existing project with at least some CI in place
 - A few minutes to talk through your conventions — the extraction
   conversation is the most valuable part
@@ -389,7 +389,7 @@ not encoded.
 - [How-to: Set Up Secret Detection](../how-to/set-up-secret-detection.md) —
   promote the "no secrets in source" constraint from unverified to
   deterministic using gitleaks
-- [Creating Your First Skill](your-first-skill) — encode domain knowledge
+- [Creating Your First Skill](your-first-skill.md) — encode domain knowledge
   that agents carry into every session
 - [Reference: HARNESS.md Format](../reference/harness-md-format.md) — full
   specification of every field in HARNESS.md

--- a/docs/plugins/ai-literacy-superpowers/tutorials/surfacing-tacit-knowledge.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/surfacing-tacit-knowledge.md
@@ -57,7 +57,7 @@ the commands; the shape of the output is the same.
 You need:
 
 - Claude Code installed with the ai-literacy-superpowers plugin (see
-  [Getting Started](getting-started))
+  [Getting Started](getting-started.md))
 - A project repository the team works in — existing code, not a
   greenfield empty directory. Extraction depends on having artefacts
   to mine and a codebase to validate conventions against.
@@ -621,10 +621,10 @@ onboarding confusion, and scheduled quarterly revisits.
 
 ## Next Steps
 
-- [The Improvement Cycle](the-improvement-cycle) — run `/assess`
+- [The Improvement Cycle](the-improvement-cycle.md) — run `/assess`
   to measure where the habitat has moved you on the AI Literacy
   framework, and generate an improvement plan for the next level
-- [Governance for Your Harness](governance-for-your-harness) — for
+- [Governance for Your Harness](governance-for-your-harness.md) — for
   conventions that are important enough to audit quarterly,
   promote them to governance constraints with falsifiability
   checks and three-frame alignment

--- a/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
@@ -540,10 +540,10 @@ After completing this tutorial you have:
 
 ## Next Steps
 
-- [From Assessment to Dashboard](from-assessment-to-dashboard) — run
+- [From Assessment to Dashboard](from-assessment-to-dashboard.md) — run
   a portfolio assessment across multiple repos and generate a shareable
   dashboard
-- [Getting Started](getting-started) — back to basics if you haven't
+- [Getting Started](getting-started.md) — back to basics if you haven't
   set up the plugin yet
 - [How-to: Add a Constraint](../how-to/add-a-constraint.md) — add
   individual constraints without running the full init flow

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-assessment.md
@@ -28,7 +28,7 @@ is technically valid (it will return Level 0) but not very interesting.
 You also need:
 
 - Claude Code installed with the ai-literacy-superpowers plugin (see
-  [Getting Started](getting-started))
+  [Getting Started](getting-started.md))
 - Access to the project repository from your terminal
 
 The assessor can see everything Claude Code can see — files, CI
@@ -325,9 +325,9 @@ and what gaps you have closed.
 
 ## Next Steps
 
-- [Harness for an Existing Codebase](harness-from-scratch) — if the
+- [Harness for an Existing Codebase](harness-from-scratch.md) — if the
   assessment revealed gaps in your harness, start here
-- [Creating Your First Skill](your-first-skill) — encode domain knowledge
+- [Creating Your First Skill](your-first-skill.md) — encode domain knowledge
   the assessor found was missing
 - [How-to: Set Up Secret Detection](../how-to/set-up-secret-detection.md) —
   a common Level 2 → Level 3 gap

--- a/docs/plugins/ai-literacy-superpowers/tutorials/your-first-skill.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/your-first-skill.md
@@ -20,7 +20,7 @@ skill is active. It takes about twenty minutes.
 You need:
 
 - Claude Code installed with the ai-literacy-superpowers plugin (see
-  [Getting Started](getting-started) if you haven't done this yet)
+  [Getting Started](getting-started.md) if you haven't done this yet)
 - A project with at least a `.claude/` directory — run `/superpowers-init`
   if you don't have one
 
@@ -332,7 +332,7 @@ for freshness periodically.
 
 ## Next Steps
 
-- [Harness for an Existing Codebase](harness-from-scratch) — encode more
+- [Harness for an Existing Codebase](harness-from-scratch.md) — encode more
   of your conventions in HARNESS.md and promote them to enforcement
 - [Reference: Commands](../reference/commands.md) — `/harness-gc` for
   managing skill freshness over time

--- a/docs/plugins/model-cards/explanation/index.md
+++ b/docs/plugins/model-cards/explanation/index.md
@@ -5,6 +5,6 @@ title: Concepts
 
 Conceptual background for the `model-cards` plugin.
 
-- [Mitchell-Extended Cards](mitchell-extended-cards) — why the cards
+- [Mitchell-Extended Cards](mitchell-extended-cards.md) — why the cards
   are shaped the way they are; the consumer-evaluator audience the
   Operational Details section serves.

--- a/docs/plugins/model-cards/how-to/index.md
+++ b/docs/plugins/model-cards/how-to/index.md
@@ -6,7 +6,7 @@ title: How-to Guides
 Task-oriented guides for the `model-cards` plugin. Pick the page that
 matches what you want to do.
 
-- [Research a Model Card](research-a-model-card) — author a single
+- [Research a Model Card](research-a-model-card.md) — author a single
   Mitchell-extended card from a model name.
-- [Seed Your Library](seed-your-library) — bulk-populate cards for a
+- [Seed Your Library](seed-your-library.md) — bulk-populate cards for a
   set of frontier models from the shipped seed list.

--- a/docs/plugins/model-cards/index.md
+++ b/docs/plugins/model-cards/index.md
@@ -18,8 +18,8 @@ in the repository.
 
 | If you want to… | Go to |
 | --- | --- |
-| Do a specific task (research a card, seed your library) | [How-to Guides](how-to/) |
-| Look up an agent, command, skill, or the card schema | [Reference](reference/) |
-| Understand why the cards are shaped the way they are | [Concepts](explanation/) |
+| Do a specific task (research a card, seed your library) | [How-to Guides](how-to/index.md) |
+| Look up an agent, command, skill, or the card schema | [Reference](reference/index.md) |
+| Understand why the cards are shaped the way they are | [Concepts](explanation/index.md) |
 
 End-to-end tutorials are not yet shipped for this plugin.

--- a/docs/plugins/model-cards/reference/index.md
+++ b/docs/plugins/model-cards/reference/index.md
@@ -6,8 +6,8 @@ title: Reference
 Lookup material for the `model-cards` plugin's components and
 artefacts.
 
-- [Agents](agents) — the `model-card-researcher` agent.
-- [Skills](skills) — the `model-cards` skill that grounds the agent.
-- [Commands](commands) — the `/model-card` slash command.
-- [Card Template](card-template) — structure of a Mitchell-extended
+- [Agents](agents.md) — the `model-card-researcher` agent.
+- [Skills](skills.md) — the `model-cards` skill that grounds the agent.
+- [Commands](commands.md) — the `/model-card` slash command.
+- [Card Template](card-template.md) — structure of a Mitchell-extended
   model card (the 9 canonical sections plus Operational Details).

--- a/scripts/migrations/fix-bare-filename-links.py
+++ b/scripts/migrations/fix-bare-filename-links.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+fix-bare-filename-links.py — append .md to bare-filename markdown links.
+
+Jekyll's link resolver (and just-the-docs's permalinks) auto-strip the
+`.md` extension from links, so writing `[X](getting-started)` works.
+mkdocs is stricter — bare-filename links don't resolve and silently
+404 on the deployed site (mkdocs logs them as INFO during build but
+does not fail).
+
+This script runs `mkdocs build` once, parses every "unrecognized
+relative link" INFO line, and rewrites each link to add the `.md`
+extension.
+
+Handles:
+- Bare slug:        `[X](getting-started)` → `[X](getting-started.md)`
+- Path-style:       `[X](plugins/foo/getting-started)` → `[X](plugins/foo/getting-started.md)`
+- With anchor:      `[X](getting-started#section)` → `[X](getting-started.md#section)`
+
+Skips links that already end in `.md` or have a recognised file
+extension.
+
+Usage:
+    python3 scripts/migrations/fix-bare-filename-links.py [--apply]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+DOCS_DIR = Path("docs")
+
+INFO_LINE = re.compile(
+    r"Doc file '(?P<source>.+?\.md)' contains an unrecognized relative link "
+    r"'(?P<target>[^']+?)', it was left as is\."
+)
+
+
+def collect_fixes() -> dict[Path, set[str]]:
+    """Run mkdocs build and parse INFO lines into {source_path: {bare_target, ...}}."""
+    env = os.environ.copy()
+    # macOS/local: ensure mkdocs is on PATH
+    env["PATH"] = f"{os.path.expanduser('~/Library/Python/3.9/bin')}:{env.get('PATH', '')}"
+    result = subprocess.run(
+        ["mkdocs", "build"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    output = (result.stderr or "") + (result.stdout or "")
+
+    fixes: dict[Path, set[str]] = defaultdict(set)
+    for line in output.splitlines():
+        m = INFO_LINE.search(line)
+        if not m:
+            continue
+        source = DOCS_DIR / m.group("source")
+        target = m.group("target")
+        if target.endswith(".md") or "." in target.rsplit("/", 1)[-1]:
+            # Already has an extension — skip (avoid clobbering .html, .png, etc.)
+            continue
+        fixes[source].add(target)
+    return fixes
+
+
+def apply_fixes(fixes: dict[Path, set[str]], apply: bool) -> tuple[int, int]:
+    """Returns (links_rewritten, files_modified)."""
+    total = 0
+    files_modified = 0
+
+    for source, targets in fixes.items():
+        if not source.exists():
+            print(f"  SKIP (not found): {source}", file=sys.stderr)
+            continue
+        content = source.read_text()
+        new_content = content
+        per_file = 0
+
+        for target in sorted(targets, key=len, reverse=True):
+            # Match `[label](target)` or `[label](target#anchor)` exactly
+            pattern = re.compile(
+                r"\]\(" + re.escape(target) + r"(?P<tail>\)|#[^)]*\))",
+                re.MULTILINE,
+            )
+            new_content, n = pattern.subn(
+                lambda m: f"]({target}.md{m.group('tail')[0:0]}{m.group('tail')[:1] if m.group('tail') == ')' else m.group('tail')}"
+                if False else f"]({target}.md{m.group('tail') if m.group('tail') != ')' else ')'}",
+                new_content,
+            )
+            # Fallback: simpler subn that handles both cases unambiguously
+            if n == 0:
+                # Try variant: target with /
+                pattern2 = re.compile(
+                    r"\]\(" + re.escape(target) + r"/?\)"
+                )
+                new_content, n = pattern2.subn(f"]({target}.md)", new_content)
+            per_file += n
+
+        if per_file > 0:
+            total += per_file
+            files_modified += 1
+            if apply:
+                source.write_text(new_content)
+            else:
+                print(f"  WOULD FIX {per_file:>2} link(s) in {source}", file=sys.stderr)
+
+    return total, files_modified
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="write changes in place")
+    args = parser.parse_args()
+
+    fixes = collect_fixes()
+    total, files_modified = apply_fixes(fixes, args.apply)
+
+    verb = "would rewrite" if not args.apply else "rewrote"
+    print(
+        f"{verb} {total} bare-filename link(s) across {files_modified} file(s)",
+        file=sys.stderr,
+    )
+    if not args.apply:
+        print("(re-run with --apply to write changes)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the last MkDocs migration follow-up. 43 bare-filename links across 19 files were silently 404-ing on the deployed site. Jekyll's link resolver auto-stripped `.md`; mkdocs requires it.

| Form | Before | After |
| --- | --- | --- |
| Bare slug | `[X](getting-started)` | `[X](getting-started.md)` |
| Path-style | `[X](plugins/foo/X)` | `[X](plugins/foo/X.md)` |
| With anchor | `[X](getting-started#section)` | `[X](getting-started.md#section)` |

## Two manual corrections

- **`docs/plugins/model-cards/index.md`** — three folder-style links (`[How-to Guides](how-to/)`) had `.md` appended by the script (`how-to/.md` — broken). Manually corrected to `<folder>/index.md` form.
- **`docs/index.md`** — the "Get Started" button link was `[Get Started](plugins/ai-literacy-superpowers/getting-started)` (bare). Phase 2 moved `getting-started.md` into the `tutorials/` quadrant. The bare-filename rewriter wasn't smart enough to know about the Phase 2 move (it just appended `.md`). Fixed manually to point at `plugins/ai-literacy-superpowers/tutorials/getting-started.md`.

## How

`scripts/migrations/fix-bare-filename-links.py` — one-shot tool committed for reproducibility. Runs `mkdocs build`, parses INFO-level "unrecognized relative link" diagnostics, applies `.md` suffix per file.

## Verification

- [x] `mkdocs build --strict` now succeeds.
- [x] Five remaining INFO-level diagnostics are all "anchor not found" (links to non-existent `#section` anchors on target pages — pre-existing, scope of this PR is bare-filename only).
- [ ] CI green.
- [ ] Pages deploy: deployed links resolve correctly.

## Why chore label

Pure docs polish. Outside the plugin directory (no version bump). One-off mechanical cleanup driven by mkdocs's own diagnostic output.

## All four deferred follow-ups now closed

This PR is the fourth in today's deferred-follow-up sweep alongside #271 (friendly nav labels), #272 (Node 24 actions), and #273 (vestigial Jekyll frontmatter cleanup).