### PR TITLE
chore: bump HARNESS.md template-version marker to 0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.35.1 — 2026-05-08
 
+### Chore — Bump HARNESS.md template-version marker to 0.35.1
+
+Brings the project's HARNESS.md `template-version` comment in line with
+the current plugin release. `/harness-upgrade` confirmed no new template
+constraints, GC rules, or sections to surface — every active and
+commented item from the cached template (baseline `0.29.0`) is already
+present in this project's HARNESS.md, often customised with project-
+specific content. The bump records that the upgrade was reviewed for
+0.34.x and 0.35.x; no semantic change to the harness itself.
+
 ### Refinement — `/harness-sync` no longer auto-invokes `/harness-onboarding`
 
 Removes the auto-invocation of `/harness-onboarding` from

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.33.0 -->
+<!-- template-version: 0.35.1 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- `/harness-upgrade` ran against the cached template (baseline `0.29.0`) at plugin version `0.35.1` and found no new constraints, GC rules, or sections to surface — every template item is already present in this project's HARNESS.md, many of them customised with project-specific extensions.
- Bumps the `<!-- template-version: ... -->` marker in `HARNESS.md` from `0.33.0` to `0.35.1` to record that 0.34.x and 0.35.x were reviewed.
- Adds a Chore entry under the existing `0.35.1 — 2026-05-08` heading.

No plugin file changes — version-check should pass without a bump (no diff inside `ai-literacy-superpowers/`). The local `.claude/.harness-upgrade-dismissed` file (gitignored) was also bumped to silence the SessionStart hook.

## Test plan

- [ ] CI: markdownlint passes
- [ ] CI: spec-first-check passes (chore exemption via label + branch prefix)
- [ ] CI: version-check passes (no plugin file changes)