### PR TITLE
Fix tdad_tests editable install + ignore Python build artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@
 .claude/affordance-discovery-*.md
 _site/
 site/
+
+# Python build artefacts (tdad_tests/ test suite). The venv, pytest
+# cache, byte-compiled modules, and editable-install metadata are all
+# per-developer and should not be committed.
+**/.venv/
+**/__pycache__/
+**/.pytest_cache/
+**/*.egg-info/

--- a/tdad_tests/pyproject.toml
+++ b/tdad_tests/pyproject.toml
@@ -30,6 +30,15 @@ dependencies = [
     "claude-agent-sdk>=0.1.0",
 ]
 
+# Tell setuptools exactly what to package. Without this, auto-discovery
+# sees three top-level directories with Python/data files (``runner/``,
+# ``fixtures/``, ``scenarios/``) and refuses to guess which is the
+# package. ``runner`` is the only directory that is actually Python
+# code intended for import; ``fixtures/`` and ``scenarios/`` are
+# data-shaped and should not be installed.
+[tool.setuptools]
+packages = ["runner"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"


### PR DESCRIPTION
## Summary

Two small fixes surfaced by the first live run of the TDAD suite (issue #281, PR #282):

1. **`pyproject.toml`** — declare `packages = ["runner"]` under `[tool.setuptools]`. Without this, setuptools auto-discovery sees three top-level directories with Python or data files (`runner/`, `fixtures/`, `scenarios/`) and refuses to guess which is the package. The README documents `pip install -e .` as the install path; this makes that command actually work.

2. **`.gitignore`** — add `**/.venv/`, `**/__pycache__/`, `**/.pytest_cache/`, `**/*.egg-info/` so per-developer Python build artefacts under `tdad_tests/` never accumulate in commits.

## Methodological note

The spike's structural tests (Layer 1) could not catch either of these — they're properties of the install process, not the source files. The first live install with Python 3.12 surfaced both. This is exactly the pattern the spike's three-tier architecture predicts: each layer catches a different class of failure. Worth recording as evidence that the architecture is doing what it was designed to do.

## Live run results

Using Sonnet 4.6 for generation, Haiku 4.5 for classification:

| Layer | Result |
| --- | --- |
| 1 (structural) | 13 passed, 1 skipped (frontmatter strictness finding) |
| 2 (trigger) | 6 passed (all 4 explicit + 1 implicit CUPID queries) |
| 3 (behavioural) | 7 passed (spec-writer + cupid review + judge) |

**Total: 26 passed, 1 skipped, 0 failures.**

Wall-clock: ~68s for Layer 2 (5 Haiku inferences), ~130s for Layer 3 (2 Sonnet agent runs + 1 Haiku judge).

## Test plan

- [x] `pip install -e .` succeeds with the fix
- [x] `pytest tests/test_layer1_structural.py` — 13 passed, 1 skipped
- [x] `pytest tests/test_layer2_triggers.py` (with `ANTHROPIC_API_KEY`) — 6 passed
- [x] `pytest tests/test_layer3_behavioural.py` (with `ANTHROPIC_API_KEY`) — 7 passed
- [ ] CI markdownlint passes