### PR TITLE
Fix Layer 0 bash script paths (recovery from PR #289 merge gap)

### DIFF
--- a/tdad_tests/layer0_deterministic/test-archive-promoted-reflections.sh
+++ b/tdad_tests/layer0_deterministic/test-archive-promoted-reflections.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT="$SCRIPT_DIR/../scripts/archive-promoted-reflections.sh"
+# Tests live in tdad_tests/layer0_deterministic/; the script under
+# test ships inside the packaged plugin two levels up.
+SCRIPT="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/archive-promoted-reflections.sh"
 FIXTURES="$SCRIPT_DIR/fixtures"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/tdad_tests/layer0_deterministic/test-migrate-reflection-log.sh
+++ b/tdad_tests/layer0_deterministic/test-migrate-reflection-log.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT="$SCRIPT_DIR/../scripts/migrate-reflection-log.sh"
+# Tests live in tdad_tests/layer0_deterministic/; the script under
+# test ships inside the packaged plugin two levels up.
+SCRIPT="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/migrate-reflection-log.sh"
 FIXTURES="$SCRIPT_DIR/fixtures"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
+++ b/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 # Test harness for reflection-log-helpers.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LIB_PATH="$SCRIPT_DIR/../scripts/lib/reflection-log-helpers.sh"
+# Tests live in tdad_tests/layer0_deterministic/; the library under
+# test ships inside the packaged plugin two levels up.
+LIB_PATH="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh"
 FIXTURES_DIR="$SCRIPT_DIR/fixtures"
 
 # shellcheck source=/dev/null


### PR DESCRIPTION
## Summary

PR #289 moved the bash test scripts from `ai-literacy-superpowers/tests/` to `tdad_tests/layer0_deterministic/`, but only the explicitly-staged files made it into the merge commit. The path-update edits to the moved bash scripts (changing `SCRIPT="$SCRIPT_DIR/../scripts/..."` → `"$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/..."`) were left as unstaged working-tree changes.

Result: on main, the bash scripts try to find their targets at `tdad_tests/layer0_deterministic/../scripts/<name>.sh` — a path that does not exist. **Layer 0 has been effectively broken on main since #289 merged.**

This PR lands the path fixes that should have been in #289.

## Verification

- `pytest tests/test_layer0_deterministic.py` — 3 passed in 3.01s (covers all 23 underlying bash test cases)
- `bash tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh` — exits 0
- `bash tdad_tests/layer0_deterministic/test-archive-promoted-reflections.sh` — exits 0
- `bash tdad_tests/layer0_deterministic/test-migrate-reflection-log.sh` — exits 0

## Root cause (worth recording)

Same class of mistake as the rename-and-cleanup pair (#286 / #287): `git mv` followed by in-file edits, then `git commit` on a narrowly-staged set, drops the in-file edits. Two ways to avoid this in future:

- Always `git add -A` before `git commit` for rename+edit changes
- Or do `git diff --stat HEAD` after staging and verify all expected modifications are listed

I'll capture this as a reflection so it lands in REFLECTION_LOG.md and isn't forgotten.

## Test plan

- [x] All three bash scripts run from new location and exit 0
- [x] Pytest dispatcher reports 3 passed
- [ ] CI passes