### PR TITLE
TDAD Phase 1: command wiring tests for all 25 commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.3.0",
-  "plugin_version": "0.35.4",
+  "plugin_version": "0.35.5",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.35.4"
+      "version": "0.35.5"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.35.5 — 2026-05-09
+
+### Fix — `/harness-sync` consistently references `harness-audit-engine`
+
+Three places in `harness-sync.md` referenced the skill informally as
+`audit-engine` when its actual name is `harness-audit-engine`. The
+prose was understandable to a human reader but failed strict
+component-name resolution.
+
+Surfaced by **TDAD Phase 1** (the new command-wiring test in
+`tdad_tests/tests/test_command_wiring.py`), which parses every
+command's body for `Dispatch the X agent` and `Read the X skill`
+patterns and asserts each referenced component exists. This is
+exactly the rename-without-callsite-update failure class Phase 1 was
+designed to catch — and it did, on its first run, against three
+commands (the other two — `assess` and `harness-init` — were false
+positives in the regex's handling of `gh repo edit --add-topic
+agent-harness-enabled`, fixed by adding a `(?!-)` negative lookahead
+on the trailing keyword).
+
+No functional behaviour change — the loader uses the `harness-audit-engine`
+skill correctly today. Patch bump for the prose-consistency edit
+that the new test required.
+
 ## 0.35.4 — 2026-05-09
 
 ### Fix — agent frontmatter now strict-YAML compliant (resolves #283)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.3.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.35.4-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.35.5-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-sync.md
+++ b/ai-literacy-superpowers/commands/harness-sync.md
@@ -18,7 +18,7 @@ it composes existing commands and does not introduce new propagation logic.
 - It does _not_ rewrite the body of `HARNESS.md`. The only allowed mutation
   is the Status block — the four lines under the
   `<!-- Auto-updated by /harness-audit — do not edit manually -->` marker —
-  which sync regenerates as the audit-engine's narrowly-scoped Status auto-fix.
+  which sync regenerates as the `harness-audit-engine`'s narrowly-scoped Status auto-fix.
   Everything above the Status block (Context, Constraints, Garbage Collection,
   Observability, Read-side filtering) is off-limits to this command.
 - It does _not_ pull upstream template changes into `HARNESS.md` — that is
@@ -92,7 +92,7 @@ the user:
 
 Exit without making any changes.
 
-### 3. Phase 1 — Drift Scan via audit-engine
+### 3. Phase 1 — Drift Scan via `harness-audit-engine`
 
 **If invoked with `--check`, the command stops after this phase — see exit semantics at the end of this section.**
 
@@ -108,7 +108,7 @@ skill: each finding has `surface`, `status`, `details`, `action_command`,
 and `auto_fixable`.
 
 Surfaces the engine evaluates include (this list mirrors the table in the
-audit-engine skill — when surfaces are added there, they appear here
+`harness-audit-engine` skill — when surfaces are added there, they appear here
 automatically):
 
 - `.cursor/rules/`, `.github/copilot-instructions.md`, `.windsurf/rules/`

--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -141,7 +141,7 @@ dispatches via the Claude Agent SDK.
 | reflection-log plumbing | ✅ 23 bash tests via dispatcher | n/a | n/a | n/a |
 | spec-writer | n/a | ✅ structural | n/a (agent, not skill) | ✅ implemented (gated on API key) |
 | cupid-code-review | n/a | ✅ structural | ✅ implemented (gated on API key) | ✅ implemented + LLM-as-judge rubric (gated on API key) |
-| harness-init | n/a | ✅ structural | n/a (command) | **architectural gap — see issue #284** |
+| All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [#284 design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run

--- a/tdad_tests/tests/test_command_wiring.py
+++ b/tdad_tests/tests/test_command_wiring.py
@@ -1,0 +1,274 @@
+"""Phase 1: command wiring tests.
+
+Every slash command file in the plugin tells the model what to do —
+typically by referencing other plugin components. ``/harness-init``
+says "Dispatch the harness-discoverer agent." ``/assess`` says "Read
+the ai-literacy-assessment skill before proceeding." These prose
+references are how the command's behaviour is wired to the rest of
+the plugin.
+
+When a referenced agent or skill is renamed or removed, the
+referencing command silently breaks. The model reads the prose, looks
+for the named component, fails to find it, and falls back to whatever
+guess it can construct. This is the rename-without-callsite-update
+failure class — it is invisible to schema-style frontmatter checks
+because the *frontmatter* is fine; the rot is in the body.
+
+This test catches that failure at PR time. It walks every command
+body, extracts the prose references that follow the project's
+conventional shapes, and asserts each referent exists.
+
+Why patterns rather than a parser? Because the references are written
+in English. ``Dispatch the X agent`` is human prose, not structured
+markup. Capturing the conventions the team actually uses (backticked
+names; "and" lists for multi-skill references; path-style references
+to ``skills/<name>``) catches the references most commands actually
+make. False negatives — a reference written in some unconventional
+phrasing — are acceptable: that is just an uncovered surface, not a
+silent regression. False positives (matching "the agent" as if "the"
+were an agent name) are worse, so the patterns are tight: backticked
+names always count; un-backticked names must contain at least one
+hyphen (the project's actual agent and skill names overwhelmingly do).
+
+Phase 1 is one of the cheapest, highest-leverage tests in the suite.
+It runs offline, in milliseconds, parametrised per command — failures
+point at the specific command and the specific missing reference.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+# The plugin path is fixed for parametrisation at collection time.
+# Tests that need a fixture-resolved path use the ``plugin_path``
+# fixture instead; this constant is purely for parametrize() ids.
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "ai-literacy-superpowers"
+)
+
+
+# Reference-extraction patterns. The patterns are layered so the
+# multi-name forms run first — otherwise the single-name patterns
+# would consume just the trailing name in "X and Y skills" and miss
+# the leading one.
+#
+# Pattern shapes:
+# - backticked name immediately before agent/agents/skill/skills
+# - un-backticked hyphenated name immediately before the same words
+# - "X and Y skills" form (captures both names from one match)
+# - "skills/<name>" path-style reference
+#
+# Two correctness invariants the patterns enforce:
+#
+# 1. The hyphen requirement on un-backticked names stops "the agent"
+#    and "any skill" from matching — common English words don't
+#    contain hyphens, but every plugin agent and most plugin skills do.
+#
+# 2. The trailing keyword (agent / agents / skill / skills) must NOT
+#    be followed by another hyphen. Without this, ``--add-topic
+#    agent-harness-enabled`` matches as if "add-topic" were an agent
+#    name, because ``agent-harness-enabled`` starts with the literal
+#    token "agent" with hyphens being word boundaries. The negative
+#    lookahead ``(?!-)`` on the trailing keyword rejects this case.
+_PATTERNS_PER_KIND: dict[str, list[re.Pattern]] = {
+    "skill": [
+        # X and Y form must run before the single-name forms.
+        re.compile(
+            r"`([a-z][a-z0-9-]+)`\s+and\s+`([a-z][a-z0-9-]+)`\s+skills?\b(?!-)"
+        ),
+        re.compile(r"`([a-z][a-z0-9-]+)`\s+skills?\b(?!-)"),
+        re.compile(r"\b([a-z][a-z0-9]*-[a-z][a-z0-9-]*)\s+skills?\b(?!-)"),
+        re.compile(r"\bskills/([a-z][a-z0-9-]+)\b"),
+    ],
+    "agent": [
+        re.compile(r"`([a-z][a-z0-9-]+)`\s+agents?\b(?!-)"),
+        re.compile(r"\b([a-z][a-z0-9]*-[a-z][a-z0-9-]*)\s+agents?\b(?!-)"),
+    ],
+}
+
+
+# Names that match the lexical patterns but are not real plugin
+# components. The list is empty by intent — every entry would be a
+# real false positive worth understanding before suppressing — and
+# kept here as the documented escape hatch for genuine ambiguity if
+# it surfaces. Today nothing needs to live here.
+_KNOWN_FALSE_POSITIVES: dict[str, set[str]] = {
+    "agent": set(),
+    "skill": set(),
+}
+
+
+def extract_references(body: str) -> dict[str, set[str]]:
+    """Extract agent and skill references from a command body.
+
+    Returns a mapping ``{"agent": {name, ...}, "skill": {name, ...}}``.
+    The returned set is the *deduplicated* set of names the command
+    body claims to reference. Filtering against the plugin's actual
+    component listing happens at the test layer, not here.
+    """
+    references: dict[str, set[str]] = {"agent": set(), "skill": set()}
+    for kind, patterns in _PATTERNS_PER_KIND.items():
+        for pattern in patterns:
+            for match in pattern.finditer(body):
+                for name in match.groups():
+                    if name and name not in _KNOWN_FALSE_POSITIVES[kind]:
+                        references[kind].add(name)
+    return references
+
+
+# Materialise the command list at collection time so pytest can
+# generate one parametrised case per command. Falling back to a
+# single failed case if discovery fails — preferable to silent
+# zero-test runs.
+def _commands_for_parametrize() -> list[plugin_runner.Component]:
+    if not _PLUGIN_PATH.is_dir():
+        return []
+    return list(plugin_runner.list_commands(_PLUGIN_PATH))
+
+
+_ALL_COMMANDS = _commands_for_parametrize()
+
+
+@pytest.mark.structural
+class TestCommandWiring:
+    """Every command body must reference only real plugin components.
+
+    These are pure structural / wiring checks — no LLM, no fixtures,
+    no per-command setup beyond reading the file. They catch the
+    rename-without-callsite-update class of failure at PR time, before
+    the referencing command silently breaks for users.
+    """
+
+    def test_at_least_one_command_discovered(self):
+        assert _ALL_COMMANDS, (
+            "No commands discovered for parametrisation. "
+            f"Plugin path searched: {_PLUGIN_PATH!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        _ALL_COMMANDS,
+        ids=lambda command: command.name,
+    )
+    def test_command_references_resolve(
+        self,
+        command: plugin_runner.Component,
+        plugin_path: Path,
+    ):
+        """Every agent/skill the command references must exist."""
+        body = plugin_runner.read_component_body(command.path)
+        refs = extract_references(body)
+
+        agent_names = {c.name for c in plugin_runner.list_agents(plugin_path)}
+        skill_names = {c.name for c in plugin_runner.list_skills(plugin_path)}
+
+        missing_agents = refs["agent"] - agent_names
+        missing_skills = refs["skill"] - skill_names
+
+        if missing_agents or missing_skills:
+            details: list[str] = []
+            if missing_agents:
+                details.append(
+                    f"missing agents: {sorted(missing_agents)}"
+                )
+            if missing_skills:
+                details.append(
+                    f"missing skills: {sorted(missing_skills)}"
+                )
+            pytest.fail(
+                f"Command /{command.name} references components that "
+                f"do not exist. {'; '.join(details)}.\n"
+                "Either the referenced component was renamed or removed "
+                "without updating this command's callsite, or the "
+                "command's prose phrasing falls outside the wiring "
+                "test's pattern set (see _KNOWN_FALSE_POSITIVES in "
+                "this file)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Self-tests: confirm the extractor catches the conventional shapes and
+# rejects the adversarial ones. These run regardless of plugin state and
+# protect the wiring check itself from regressing if patterns are tuned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestExtractor:
+    """The wiring check is only as good as its extractor; verify it."""
+
+    def test_backticked_agent_reference(self):
+        body = "Dispatch the `harness-discoverer` agent to scan."
+        refs = extract_references(body)
+        assert refs["agent"] == {"harness-discoverer"}
+
+    def test_unbackticked_hyphenated_agent_reference(self):
+        body = "Run the choice-cartographer agent against the spec."
+        refs = extract_references(body)
+        assert refs["agent"] == {"choice-cartographer"}
+
+    def test_backticked_skill_reference(self):
+        body = "Read the `convention-sync` skill from this plugin."
+        refs = extract_references(body)
+        assert refs["skill"] == {"convention-sync"}
+
+    def test_x_and_y_skills_reference(self):
+        body = (
+            "Read the `harness-engineering` and `context-engineering` "
+            "skills from this plugin before proceeding."
+        )
+        refs = extract_references(body)
+        assert refs["skill"] == {
+            "harness-engineering",
+            "context-engineering",
+        }
+
+    def test_path_style_skill_reference(self):
+        body = (
+            "Read `${CLAUDE_PLUGIN_ROOT}/skills/convention-extraction/"
+            "SKILL.md` for the full guidance."
+        )
+        refs = extract_references(body)
+        assert "convention-extraction" in refs["skill"]
+
+    def test_common_words_are_not_captured(self):
+        # "the agent" and "any skill" appear in prose; the un-backticked
+        # patterns require a hyphen, so common English words don't match.
+        body = (
+            "The agent reads the file. Any skill could in principle "
+            "be loaded here."
+        )
+        refs = extract_references(body)
+        assert refs["agent"] == set()
+        assert refs["skill"] == set()
+
+    def test_hyphenated_compound_starting_with_agent_is_rejected(self):
+        # ``gh repo edit --add-topic agent-harness-enabled`` is the
+        # canonical case from assess.md and harness-init.md. Before
+        # the negative-lookahead invariant, the pattern matched
+        # "add-topic" as if it were an agent name. With ``(?!-)`` on
+        # the trailing keyword, it does not.
+        body = "gh repo edit --add-topic agent-harness-enabled 2>/dev/null"
+        refs = extract_references(body)
+        assert refs["agent"] == set()
+        assert refs["skill"] == set()
+
+    def test_words_not_followed_by_agent_or_skill_are_ignored(self):
+        # The patterns require the trailing token to be "agent",
+        # "agents", "skill", or "skills". Hyphenated names followed by
+        # any other word are ignored, which is the desired behaviour:
+        # we only care about *references* to plugin components, not
+        # mentions of hyphenated terms in general.
+        body = "The architecture-decision pattern guides our choices."
+        refs = extract_references(body)
+        assert refs["agent"] == set()
+        assert refs["skill"] == set()


### PR DESCRIPTION
## Summary

First implementation of the per-category command testing strategy from
the design spec at
`docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md`
(merged in #293). Phase 1 is the universal structural+wiring pass —
zero cost, sub-second wall-clock, applies to every command.

## What it does

`tdad_tests/tests/test_command_wiring.py` parametrises across all 25
commands. For each command, it extracts agent and skill references
from the body using four pattern shapes:

- `` `<name>` agent`` (backticked, most common)
- `` `<name>` and `<name2>` skills`` (multi-name form)
- `<hyphenated-name> agent` (un-backticked, must contain a hyphen)
- `skills/<name>` (path-style)

Every captured name must resolve to a real component in `agents/` or
`skills/`. Failures point at the specific command and the specific
missing component.

## What it caught on first run

Three failures, all worth keeping:

| Command | Issue | Resolution |
| --- | --- | --- |
| `assess` | `--add-topic agent-harness-enabled` looked like a reference | False positive. Pattern fix: `(?!-)` negative lookahead |
| `harness-init` | Same `--add-topic` issue | Same pattern fix |
| `harness-sync` | Three places said `audit-engine` instead of `harness-audit-engine` | **Real prose imprecision**. Updated to use full skill name. |

The pattern fix is documented inline in the test file as the second
correctness invariant. A new self-test
(`test_hyphenated_compound_starting_with_agent_is_rejected`) covers
the case explicitly so the negative lookahead can't silently regress.

## Suite delta

| | Before | After |
| --- | --- | --- |
| Passed | 23 | 57 |
| Skipped | 7 | 7 |
| Wall-clock | ~3.7s | ~3.9s |

The +34 = 25 parametrised command tests + 8 extractor self-tests + 1
discovery sanity check.

## Why per-command granularity

Pytest reports each command's wiring as its own test result. When
a command fails, the failure message names the specific command and
the specific missing component — no decoding required. Adding a new
command means it auto-appears in the parametrised set; no test code
needs updating.

## Version bump

Patch bump 0.35.4 → 0.35.5 for the `harness-sync.md` prose
consistency edit. No functional behaviour change — Claude Code's
loader works correctly with the previous prose. This is documentation
precision tightening that the new test required.

## Test plan

- [x] `pytest tests/test_command_wiring.py` — 33 passed (25 commands + 8 self-tests)
- [x] `pytest tests/` — 57 passed, 7 skipped (full suite, no API key)
- [x] `npx markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 7 files staged, all expected (lesson from #291)
- [ ] CI passes

## Related

- Design spec: PR #293 / `docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md`
- Spike: PR #282
- Original finding: `tdad_tests/scenarios/commands/harness-init/FINDING-command-tdab-gap.md`

## What this PR does NOT do

- Phase 2 (Option C spike against 2 P commands) — separate PR
- Phase 3 (broader rollout) — separate PR
- Phase 4 (skill-driven M command Layer 3) — separate PR