### PR TITLE
TDAD Phase 2 spike: Option C helpers for /convention-sync and /observatory-verify

### DIFF
--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -49,6 +49,9 @@ tdad_tests/
 │   ├── plugin.py                          plugin component discovery
 │   ├── scenario.py                        markdown scenario parser
 │   └── sdk.py                             Claude Agent SDK helpers (L2/L3)
+├── spike_helpers/                         Phase 2 Option C helpers (test-stage)
+│   ├── convention_sync.py                 HARNESS.md → Cursor conventions.mdc
+│   └── observatory_verify.py              snapshot signal verification
 ├── scenarios/                             human-readable scenarios (L1-L3)
 │   ├── agents/spec-writer/
 │   ├── skills/cupid-code-review/
@@ -142,6 +145,8 @@ dispatches via the Claude Agent SDK.
 | spec-writer | n/a | ✅ structural | n/a (agent, not skill) | ✅ implemented (gated on API key) |
 | cupid-code-review | n/a | ✅ structural | ✅ implemented (gated on API key) | ✅ implemented + LLM-as-judge rubric (gated on API key) |
 | All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [#284 design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
+| convention-sync (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 8 tests |
+| observatory-verify (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 11 tests |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run

--- a/tdad_tests/fixtures/convention_sync/sample_harness.md
+++ b/tdad_tests/fixtures/convention_sync/sample_harness.md
@@ -1,0 +1,43 @@
+# HARNESS.md — Spike Phase 2 fixture
+
+This is a deliberately small but realistic HARNESS.md used as input
+to the convention-sync spike helper. It carries enough structure to
+exercise the parser and the renderer without becoming a maintenance
+burden.
+
+## Context
+
+### Stack
+
+- Primary languages: Python 3.12, Bash
+- Build system: uv + pyproject
+- Test framework: pytest
+- Container strategy: none in this fixture
+
+### Conventions
+
+- Naming: snake_case for files, PascalCase for classes
+- Docstrings on all public modules and functions
+- Use literate programming preamble for new source files
+
+## Constraints
+
+### Consistent formatting
+
+- Rule: All source files must pass the project's configured formatter
+  without changes
+- Enforcement: deterministic
+- Scope: commit
+
+### No secrets in source
+
+- Rule: No API keys, tokens, passwords, or private keys may appear
+  in committed source files
+- Enforcement: deterministic
+- Scope: commit
+
+## Garbage Collection
+
+This section is intentionally not covered by the spike helper —
+Garbage Collection is harness-internal and convention-sync skips it
+deliberately.

--- a/tdad_tests/fixtures/observatory_verify/complete_snapshot.md
+++ b/tdad_tests/fixtures/observatory_verify/complete_snapshot.md
@@ -1,0 +1,48 @@
+# Habitat Health Snapshot — 2026-05-09
+
+Spike Phase 2 fixture. Deliberately includes the headings and key
+fields the Snapshot signals expect, so a "happy path" verifier run
+returns every signal as PRESENT. Edit-with-care: removing a heading
+or renaming a key field will (correctly) flip its signal in tests.
+
+## Enforcement
+
+Constraints: 22/23 enforced (96%)
+Deterministic: 14 | Agent: 5 | Unverified: 4
+Drift detected: no
+
+## Enforcement Loop History
+
+Advisory (edit-time): active since 2026-04-15
+Strict (merge-time): active since 2026-04-15
+Investigative (scheduled): active since 2026-04-15
+
+## Garbage Collection
+
+Rules active: 14/14
+Findings since last snapshot: 3
+Cadence compliance: on schedule
+
+## Mutation Testing
+
+Kill rate per language or "not applicable"
+Trend: stable
+
+## Compound Learning
+
+REFLECTION_LOG entries: 27 (3 new)
+AGENTS.md entries: 12 (8 gotchas, 4 arch decisions)
+Promotions since last snapshot: 1
+
+## Session Quality
+
+Reflections with signal: 25/27 (93%)
+context: 8 | instruction: 4 | workflow: 11 | failure: 4
+Quality trend: stable
+
+## Operational Cadence
+
+Last /harness-audit: 2026-05-08 (1 days ago)
+Last /assess: 2026-04-29 (10 days ago)
+Last /reflect: 2026-05-09 (0 days ago)
+Outer loop overdue: no

--- a/tdad_tests/fixtures/observatory_verify/missing_enforcement_snapshot.md
+++ b/tdad_tests/fixtures/observatory_verify/missing_enforcement_snapshot.md
@@ -1,0 +1,23 @@
+# Habitat Health Snapshot — 2026-05-09
+
+Spike Phase 2 fixture. The Enforcement section is deliberately
+missing here so the verifier reports its signals as MISSING. The
+Mutation Testing section also has no body content, exercising the
+PARTIAL status (heading present, key fields absent).
+
+## Garbage Collection
+
+Rules active: 14/14
+Findings since last snapshot: 3
+Cadence compliance: on schedule
+
+## Mutation Testing
+
+(This section deliberately has no key field content to exercise
+the PARTIAL status.)
+
+## Compound Learning
+
+REFLECTION_LOG entries: 27 (3 new)
+AGENTS.md entries: 12 (8 gotchas, 4 arch decisions)
+Promotions since last snapshot: 1

--- a/tdad_tests/spike_helpers/__init__.py
+++ b/tdad_tests/spike_helpers/__init__.py
@@ -1,0 +1,25 @@
+"""Phase 2 spike helpers.
+
+These modules implement minimal Python versions of two procedural
+plugin commands (`/convention-sync` and `/observatory-verify`) so that
+their deterministic logic can be unit-tested. The spike's purpose is
+to validate the per-category strategy from the Phase-2 design spec
+(``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``):
+extracting P-category command logic into Python (Option C-direct) is
+testable, and the test scaffolding is cheap.
+
+Scope is deliberately narrow:
+
+- ``convention_sync`` handles only the Cursor ``.cursor/rules/
+  conventions.mdc`` output. Copilot and Windsurf are left for Phase 3.
+- ``observatory_verify`` handles only one signal source (Snapshot).
+  The remaining four sources (Governance, Reflection log, HARNESS.md,
+  Assessment) are left for Phase 3.
+
+The helpers live under ``tdad_tests/`` rather than the packaged plugin
+because they are spike-stage code: a follow-up Phase 3 PR is expected
+to either promote them to ``ai-literacy-superpowers/scripts/`` (where
+the command markdowns can invoke them) or refactor them based on what
+the spike teaches. Keeping them in test scaffolding for now avoids
+accidentally treating a spike artefact as production code.
+"""

--- a/tdad_tests/spike_helpers/convention_sync.py
+++ b/tdad_tests/spike_helpers/convention_sync.py
@@ -1,0 +1,176 @@
+"""Convention-sync helper: HARNESS.md → Cursor conventions.mdc.
+
+Extracts the Context section from a HARNESS.md and renders it in the
+Cursor ``.cursor/rules/conventions.mdc`` format documented in
+``ai-literacy-superpowers/skills/convention-sync/SKILL.md``. The
+helper does *only* this — Copilot and Windsurf outputs, plus the
+constraints.mdc file, are intentionally left for Phase 3.
+
+The point of the helper is to demonstrate that a procedural command's
+logic *can* be extracted into Python and tested with fixtures. Real
+production roll-out will likely move this code into
+``ai-literacy-superpowers/scripts/`` and update the slash command's
+markdown to invoke it (see the design spec at
+``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``).
+
+Three deliberate design choices worth recording:
+
+1. **Section parsing is line-based, not Markdown-AST-based.** HARNESS.md
+   uses a stable convention: ``## Context`` opens the section,
+   ``## Stack`` and ``## Conventions`` are subsections under it. A
+   line-based scanner that tracks heading levels is enough — pulling
+   in a markdown library would be more dependency surface than the
+   problem warrants for a spike.
+
+2. **The Cursor frontmatter is hard-coded.** ``description``, ``globs``,
+   and ``alwaysApply`` are the same for every project today. If/when
+   per-project frontmatter becomes a real requirement, this helper can
+   take a config arg.
+
+3. **Output is a string, not a file write.** The helper returns the
+   rendered text; the caller decides whether to write it to disk. This
+   makes tests trivial (assert on the string) and keeps the helper
+   pure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ContextSections:
+    """The Stack and Conventions subsections of HARNESS.md's Context.
+
+    ``stack`` and ``conventions`` are the *body* of each subsection —
+    the prose and bullet lists between the subsection heading and the
+    next heading at level ≤ 2. Empty list when the subsection is
+    absent or empty.
+    """
+
+    stack: list[str] = field(default_factory=list)
+    conventions: list[str] = field(default_factory=list)
+
+
+def parse_context(harness_text: str) -> ContextSections:
+    """Extract Stack and Conventions subsections from HARNESS.md text.
+
+    Walks the document line by line, tracking the current top-level
+    section (level-2 heading) and subsection (level-3 heading). When
+    in ``## Context`` and a level-3 heading matches Stack or
+    Conventions, the following lines are collected until the next
+    heading at level ≤ 3.
+    """
+    in_context = False
+    current_subsection: str | None = None
+    sections = ContextSections()
+
+    for line in harness_text.split("\n"):
+        # Level-2 heading: top-level section change.
+        if line.startswith("## ") and not line.startswith("###"):
+            heading = line[3:].strip()
+            in_context = heading.lower() == "context"
+            current_subsection = None
+            continue
+
+        # Level-3 heading: subsection change (only meaningful inside
+        # the Context section).
+        if line.startswith("### "):
+            if in_context:
+                sub = line[4:].strip().lower()
+                if sub == "stack":
+                    current_subsection = "stack"
+                elif sub == "conventions":
+                    current_subsection = "conventions"
+                else:
+                    current_subsection = None
+            else:
+                current_subsection = None
+            continue
+
+        # Body line. Append to the current subsection if we are in one.
+        if in_context and current_subsection is not None:
+            target = (
+                sections.stack
+                if current_subsection == "stack"
+                else sections.conventions
+            )
+            target.append(line)
+
+    # Trim leading and trailing blank lines from each subsection so the
+    # rendered output does not carry incidental whitespace.
+    sections.stack = _trim_blank_edges(sections.stack)
+    sections.conventions = _trim_blank_edges(sections.conventions)
+    return sections
+
+
+def _trim_blank_edges(lines: list[str]) -> list[str]:
+    """Strip blank lines from the start and end of a list."""
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    end = len(lines)
+    while end > start and not lines[end - 1].strip():
+        end -= 1
+    return lines[start:end]
+
+
+def render_cursor_conventions_mdc(context: ContextSections) -> str:
+    """Render the Cursor ``conventions.mdc`` content from a Context.
+
+    Format follows the Cursor reference in the convention-sync skill:
+    YAML frontmatter with ``description``, ``globs``, ``alwaysApply``,
+    then a ``# Project Conventions`` heading with ``## Stack`` and
+    ``## Conventions`` subsections in that order.
+    """
+    parts: list[str] = [
+        "---",
+        "description: Project conventions synced from HARNESS.md",
+        "globs: **/*",
+        "alwaysApply: true",
+        "---",
+        "",
+        "# Project Conventions",
+        "",
+        "## Stack",
+        "",
+    ]
+    if context.stack:
+        parts.extend(context.stack)
+    else:
+        parts.append("(No stack section found in HARNESS.md.)")
+    parts.append("")
+    parts.append("## Conventions")
+    parts.append("")
+    if context.conventions:
+        parts.extend(context.conventions)
+    else:
+        parts.append("(No conventions section found in HARNESS.md.)")
+    parts.append("")
+    return "\n".join(parts)
+
+
+def sync_cursor_conventions(harness_path: Path, output_path: Path) -> str:
+    """End-to-end: read HARNESS.md, render Cursor conventions, write file.
+
+    Convenience wrapper. The pure helpers (``parse_context`` and
+    ``render_cursor_conventions_mdc``) are what the tests primarily
+    cover; this function exercises the file-system path for the
+    happy-path integration test.
+
+    Returns the rendered text (also written to ``output_path``) so the
+    caller can assert on it without re-reading the file.
+    """
+    if not harness_path.exists():
+        raise FileNotFoundError(
+            f"HARNESS.md not found at {harness_path!r}. "
+            "convention-sync requires HARNESS.md as its single source "
+            "of truth. Run /harness-init first."
+        )
+    text = harness_path.read_text(encoding="utf-8")
+    context = parse_context(text)
+    rendered = render_cursor_conventions_mdc(context)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    return rendered

--- a/tdad_tests/spike_helpers/observatory_verify.py
+++ b/tdad_tests/spike_helpers/observatory_verify.py
@@ -1,0 +1,291 @@
+"""Observatory-verify helper: snapshot signal verification.
+
+Implements the deterministic core of ``/observatory-verify`` for one
+of its five signal sources — Snapshot — and leaves the other four
+sources for Phase 3. The intent is to demonstrate that the command's
+verification logic *can* be extracted and tested; the slice covered
+is enough to validate the pattern.
+
+Two pieces of logic are exposed:
+
+- ``parse_signal_checklist`` reads
+  ``ai-literacy-superpowers/skills/harness-observability/references/
+  observatory-signals.md`` and returns the structured list of
+  Snapshot signals (signal name, expected section heading, expected
+  key fields).
+- ``verify_snapshot`` reads a snapshot markdown file and returns
+  per-signal status (PRESENT / PARTIAL / MISSING / NO_OUTPUT) using
+  the same vocabulary the slash command does.
+
+Status values match the command's prose definitions:
+
+- ``PRESENT``: the expected section heading exists *and* every
+  declared key field is present in the section's body.
+- ``PARTIAL``: the section heading exists but at least one key field
+  is missing.
+- ``MISSING``: the section heading is not in the snapshot at all.
+- ``NO_OUTPUT``: the snapshot file does not exist.
+
+Why a partial-only check on key fields rather than full format
+validation? Because per-field format rules (regex of expected values)
+would couple the verifier tightly to the snapshot template's evolving
+shape. A presence check on the heading + each named key string is
+strict enough to catch the failure modes the command was designed for
+(missing section, renamed field) without becoming brittle to wording
+changes that don't change semantics.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class Status(str, Enum):
+    PRESENT = "PRESENT"
+    PARTIAL = "PARTIAL"
+    MISSING = "MISSING"
+    NO_OUTPUT = "NO_OUTPUT"
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One row from the Snapshot table in observatory-signals.md."""
+
+    name: str
+    """Human-readable signal name (e.g. ``Enforcement count``)."""
+
+    section_heading: str
+    """The level-2 heading the signal lives under (e.g. ``## Enforcement``)."""
+
+    key_fields: tuple[str, ...]
+    """Sub-strings the signal's row declared as key fields. Each must
+    appear in the section's body for the signal to be PRESENT."""
+
+
+@dataclass
+class SignalResult:
+    signal: Signal
+    status: Status
+    notes: str = ""
+
+
+# Match a level-2 heading line.
+_H2 = re.compile(r"^##\s+(?P<heading>.+?)\s*$")
+
+# Match a row in the snapshot section's signal table. The table looks
+# like ``| Signal | Section Heading | Key Fields |``. The exact column
+# ordering is fixed by the reference file's convention.
+_TABLE_ROW = re.compile(r"^\|\s*(?P<col>[^|]*?)\s*(?=\||$)")
+
+
+def parse_signal_checklist(checklist_path: Path) -> list[Signal]:
+    """Parse Snapshot-source signals from observatory-signals.md.
+
+    The reference file groups signals under ``## Source N: <name>``
+    headings. This helper picks out the Snapshot source specifically
+    (Source 1) and parses its table rows. Rows whose first column is
+    blank or starts with a separator (``---``) are skipped.
+
+    Other sources are intentionally ignored at this spike scope.
+    """
+    if not checklist_path.exists():
+        raise FileNotFoundError(
+            f"Signal checklist not found at {checklist_path!r}. "
+            "Without it the verifier has no contract to check against."
+        )
+
+    text = checklist_path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+
+    # Find the Snapshot source's bounds. Format:
+    #   ## Source 1: Snapshot ...
+    #   ... preamble ...
+    #   | Signal | Section Heading | Key Fields |
+    #   | --- | --- | --- |
+    #   | Enforcement count | `## Enforcement` | ... |
+    #   ...
+    #   ## Source 2: ...      <-- end of source 1
+    in_source_1 = False
+    table_lines: list[str] = []
+    for line in lines:
+        if line.startswith("## Source 1:"):
+            in_source_1 = True
+            continue
+        if line.startswith("## Source ") and "Source 1" not in line:
+            in_source_1 = False
+            continue
+        if in_source_1 and line.startswith("|"):
+            table_lines.append(line)
+
+    # The table rows have three columns. Skip header and separator
+    # rows; parse the rest.
+    signals: list[Signal] = []
+    for row in table_lines:
+        cols = _split_table_row(row)
+        if len(cols) < 3:
+            continue
+        if not cols[0] or cols[0].startswith("---"):
+            continue
+        if cols[0].lower() == "signal":  # header row
+            continue
+
+        name = cols[0]
+        heading = _strip_inline_code(cols[1])
+        key_fields = _parse_key_fields(cols[2])
+        signals.append(
+            Signal(
+                name=name,
+                section_heading=heading,
+                key_fields=tuple(key_fields),
+            )
+        )
+    return signals
+
+
+# Split a markdown table row on bare ``|`` separators, leaving ``\|``
+# (an escaped pipe inside a cell) intact. Negative lookbehind for
+# backslash is the cleanest way to express "pipe not preceded by
+# backslash". After splitting, each cell is stripped of leading and
+# trailing whitespace and any literal ``\|`` is restored to ``|``.
+_TABLE_SPLIT_RE = re.compile(r"(?<!\\)\|")
+
+
+def _split_table_row(row: str) -> list[str]:
+    raw = _TABLE_SPLIT_RE.split(row.strip().strip("|"))
+    return [cell.strip().replace(r"\|", "|") for cell in raw]
+
+
+def _strip_inline_code(text: str) -> str:
+    """Strip a single pair of surrounding backticks from a string.
+
+    The Section Heading column carries headings as backticked code
+    spans (``\\`## Enforcement\\```). Real snapshot files write the
+    heading without backticks, so the verifier needs the unquoted form
+    to compare against. Stripping is conservative: only one balanced
+    pair is removed; markdown that is already plain text passes through.
+    """
+    if text.startswith("`") and text.endswith("`") and len(text) >= 2:
+        return text[1:-1]
+    return text
+
+
+def _parse_key_fields(cell_text: str) -> list[str]:
+    """Split a 'Key Fields' table cell into individual field tokens.
+
+    Cell convention is one or more backtick-quoted phrases separated
+    by escaped pipes (``\\|``) which ``_split_table_row`` has already
+    restored to literal ``|``. Backticked spans become individual
+    fields; cells with no backticked spans return an empty list (some
+    reference rows describe their key fields as prose, which we treat
+    as 'no strict field check' rather than synthesising a field).
+    """
+    return re.findall(r"`([^`]+)`", cell_text)
+
+
+def _split_into_sections(snapshot_text: str) -> dict[str, list[str]]:
+    """Split snapshot text into ``heading → body lines``.
+
+    Headings are stored verbatim including the ``## `` prefix to match
+    how the signal checklist declares them.
+    """
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in snapshot_text.split("\n"):
+        match = _H2.match(line)
+        if match:
+            current = "## " + match.group("heading")
+            sections[current] = []
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return sections
+
+
+def verify_snapshot(
+    snapshot_path: Path | None,
+    signals: list[Signal],
+) -> list[SignalResult]:
+    """Check each signal against the snapshot and return per-signal status.
+
+    Pass ``None`` (or a non-existent path) for ``snapshot_path`` and
+    every signal returns ``NO_OUTPUT``.
+    """
+    if snapshot_path is None or not snapshot_path.exists():
+        return [
+            SignalResult(
+                signal=signal,
+                status=Status.NO_OUTPUT,
+                notes="Snapshot file not found.",
+            )
+            for signal in signals
+        ]
+
+    snapshot_text = snapshot_path.read_text(encoding="utf-8")
+    sections = _split_into_sections(snapshot_text)
+
+    results: list[SignalResult] = []
+    for signal in signals:
+        body_lines = sections.get(signal.section_heading)
+        if body_lines is None:
+            results.append(
+                SignalResult(
+                    signal=signal,
+                    status=Status.MISSING,
+                    notes=(
+                        f"Section {signal.section_heading!r} not "
+                        "found in snapshot."
+                    ),
+                )
+            )
+            continue
+
+        body = "\n".join(body_lines)
+        missing_fields = [
+            field
+            for field in signal.key_fields
+            if not _field_present(field, body)
+        ]
+        if not missing_fields:
+            results.append(
+                SignalResult(signal=signal, status=Status.PRESENT)
+            )
+        else:
+            results.append(
+                SignalResult(
+                    signal=signal,
+                    status=Status.PARTIAL,
+                    notes=(
+                        "Section present; missing key field(s): "
+                        + ", ".join(repr(f) for f in missing_fields)
+                    ),
+                )
+            )
+    return results
+
+
+def _field_present(field_pattern: str, body: str) -> bool:
+    """Decide whether a key-field pattern is present in the section body.
+
+    The signal checklist's Key Fields column declares patterns like
+    ``Constraints: N/M enforced (P%)`` where ``N``, ``M``, ``P`` are
+    placeholders for actual numbers. Real snapshots write
+    ``Constraints: 22/23 enforced (96%)`` — the prefix before the
+    first colon is stable; the values after vary. Matching on that
+    stable prefix is strict enough to catch field-rename regressions
+    without becoming brittle to value changes.
+
+    Two cases:
+
+    - Pattern contains a colon: require the part before-and-including
+      the colon to appear in the body.
+    - Pattern contains no colon: require the whole pattern as a
+      literal substring (rare; covers fields documented as prose).
+    """
+    colon_index = field_pattern.find(":")
+    if colon_index == -1:
+        return field_pattern in body
+    prefix = field_pattern[: colon_index + 1].strip()
+    return prefix in body

--- a/tdad_tests/tests/test_phase2_convention_sync.py
+++ b/tdad_tests/tests/test_phase2_convention_sync.py
@@ -1,0 +1,159 @@
+"""Phase 2 spike — convention-sync helper tests.
+
+Validates the per-category strategy from the design spec
+(``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``)
+for one P-category command. The helper at
+``tdad_tests/spike_helpers/convention_sync.py`` implements the Cursor
+``conventions.mdc`` slice of ``/convention-sync``; these tests cover
+its behaviour against fixture HARNESS.md inputs.
+
+Three cases earn their keep:
+
+- ``parse_context`` extracts Stack and Conventions correctly from a
+  fixture HARNESS.md with both subsections populated.
+- ``render_cursor_conventions_mdc`` produces output that matches the
+  format documented in
+  ``ai-literacy-superpowers/skills/convention-sync/SKILL.md`` —
+  frontmatter present, headings in order, body content preserved.
+- ``sync_cursor_conventions`` (end-to-end) writes to disk and raises
+  a clear error when HARNESS.md is missing.
+
+These are pure offline tests — no LLM, no SDK invocation. Cost: $0.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spike_helpers import convention_sync  # noqa: E402
+
+
+@pytest.fixture
+def harness_fixture(fixtures_dir: Path) -> Path:
+    """The sample HARNESS.md used by every test in this module."""
+    return fixtures_dir / "convention_sync" / "sample_harness.md"
+
+
+@pytest.mark.structural
+class TestParseContext:
+    """The HARNESS.md parser extracts the right subsections."""
+
+    def test_stack_subsection_parsed(self, harness_fixture: Path):
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        body = "\n".join(sections.stack)
+        assert "Python 3.12" in body
+        assert "pytest" in body
+        # Garbage Collection content is in a different top-level
+        # section and must not leak into Stack.
+        assert "Garbage Collection" not in body
+
+    def test_conventions_subsection_parsed(self, harness_fixture: Path):
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        body = "\n".join(sections.conventions)
+        assert "snake_case" in body
+        assert "literate programming" in body
+
+    def test_constraints_section_not_in_stack_or_conventions(
+        self, harness_fixture: Path
+    ):
+        """Stack and Conventions are subsections of Context. Other
+        top-level sections (Constraints, Garbage Collection) must not
+        leak into either."""
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        for body in (sections.stack, sections.conventions):
+            joined = "\n".join(body)
+            assert "Consistent formatting" not in joined
+            assert "No secrets in source" not in joined
+
+    def test_missing_context_returns_empty_sections(self):
+        """A HARNESS.md without a Context section yields empty bodies."""
+        text = "# Some other doc\n\n## Constraints\n\n- nothing here\n"
+        sections = convention_sync.parse_context(text)
+        assert sections.stack == []
+        assert sections.conventions == []
+
+
+@pytest.mark.structural
+class TestRenderCursorConventions:
+    """The Cursor renderer produces correctly-formatted output."""
+
+    def test_output_carries_frontmatter(self, harness_fixture: Path):
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        rendered = convention_sync.render_cursor_conventions_mdc(sections)
+        # Frontmatter is required by the Cursor format reference and
+        # by Cursor itself when interpreting the .mdc.
+        assert rendered.startswith("---\n")
+        assert "description: Project conventions synced from HARNESS.md" in rendered
+        assert "globs: **/*" in rendered
+        assert "alwaysApply: true" in rendered
+
+    def test_headings_in_documented_order(self, harness_fixture: Path):
+        """The format reference declares the heading order:
+        ``# Project Conventions`` → ``## Stack`` → ``## Conventions``.
+        Test that ordering is preserved."""
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        rendered = convention_sync.render_cursor_conventions_mdc(sections)
+        title_idx = rendered.index("# Project Conventions")
+        stack_idx = rendered.index("## Stack")
+        conv_idx = rendered.index("## Conventions")
+        assert title_idx < stack_idx < conv_idx
+
+    def test_body_content_preserved(self, harness_fixture: Path):
+        text = harness_fixture.read_text(encoding="utf-8")
+        sections = convention_sync.parse_context(text)
+        rendered = convention_sync.render_cursor_conventions_mdc(sections)
+        # Both subsection bodies should appear in the output.
+        assert "Python 3.12" in rendered
+        assert "snake_case" in rendered
+
+    def test_empty_subsections_render_a_placeholder(self):
+        """A fully-empty Context renders without crashing — the
+        renderer leaves a placeholder line so the output is still
+        well-formed Cursor mdc."""
+        empty = convention_sync.ContextSections()
+        rendered = convention_sync.render_cursor_conventions_mdc(empty)
+        assert "## Stack" in rendered
+        assert "## Conventions" in rendered
+        assert "(No stack section found in HARNESS.md.)" in rendered
+        assert "(No conventions section found in HARNESS.md.)" in rendered
+
+
+@pytest.mark.structural
+class TestSyncCursorConventionsEndToEnd:
+    """End-to-end: read HARNESS.md, render, write the output file."""
+
+    def test_happy_path_writes_expected_file(
+        self, harness_fixture: Path, tmp_path: Path
+    ):
+        output = tmp_path / ".cursor" / "rules" / "conventions.mdc"
+        rendered = convention_sync.sync_cursor_conventions(
+            harness_fixture, output
+        )
+        assert output.exists()
+        on_disk = output.read_text(encoding="utf-8")
+        # The function returns what it wrote — they must match.
+        assert on_disk == rendered
+        # And the disk content must carry the frontmatter and at least
+        # the Stack heading. Full-content checks live in the renderer
+        # tests above; this is the integration smoke.
+        assert on_disk.startswith("---\n")
+        assert "## Stack" in on_disk
+
+    def test_missing_harness_raises_clear_error(self, tmp_path: Path):
+        nonexistent = tmp_path / "no_such_harness.md"
+        output = tmp_path / "conventions.mdc"
+        with pytest.raises(FileNotFoundError) as excinfo:
+            convention_sync.sync_cursor_conventions(nonexistent, output)
+        message = str(excinfo.value)
+        assert "HARNESS.md" in message
+        assert str(nonexistent) in message

--- a/tdad_tests/tests/test_phase2_observatory_verify.py
+++ b/tdad_tests/tests/test_phase2_observatory_verify.py
@@ -1,0 +1,260 @@
+"""Phase 2 spike — observatory-verify helper tests.
+
+Validates the per-category strategy from the design spec for the
+second P-category command. The helper at
+``tdad_tests/spike_helpers/observatory_verify.py`` implements the
+Snapshot-source slice of ``/observatory-verify``; these tests cover
+its parser and per-signal verifier against fixture snapshot files.
+
+Three things earn coverage here:
+
+- ``parse_signal_checklist`` reads the real
+  ``observatory-signals.md`` from the plugin and extracts the
+  Snapshot-source signals (real reference; not a fixture). This
+  catches drift between the spike helper and the canonical signal
+  list.
+- ``verify_snapshot`` correctly classifies signals as PRESENT /
+  PARTIAL / MISSING / NO_OUTPUT against fixture snapshot files.
+- The ``NO_OUTPUT`` path triggers when the snapshot file does not
+  exist — the same shape ``/observatory-verify`` produces when no
+  snapshot has been generated yet.
+
+These are pure offline tests — no LLM, no SDK invocation. Cost: $0.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spike_helpers import observatory_verify  # noqa: E402
+from spike_helpers.observatory_verify import Status  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def signal_checklist_path(plugin_path: Path) -> Path:
+    """The real signal checklist shipped with the plugin."""
+    return (
+        plugin_path
+        / "skills"
+        / "harness-observability"
+        / "references"
+        / "observatory-signals.md"
+    )
+
+
+@pytest.fixture
+def snapshot_signals(signal_checklist_path: Path):
+    """Parsed Snapshot-source signals from the real reference doc."""
+    return observatory_verify.parse_signal_checklist(signal_checklist_path)
+
+
+@pytest.mark.structural
+class TestParseSignalChecklist:
+    """The signal-list parser reads the real checklist correctly."""
+
+    def test_at_least_some_signals_parsed(
+        self, snapshot_signals
+    ):
+        # The Snapshot source declares a substantial number of signals
+        # in the reference file — exact count drifts as observability
+        # evolves, so assert "more than a handful" rather than an
+        # exact number.
+        assert len(snapshot_signals) >= 10, (
+            f"Expected ≥10 Snapshot signals; got {len(snapshot_signals)}"
+        )
+
+    def test_signal_records_carry_name_and_heading(
+        self, snapshot_signals
+    ):
+        """Every parsed signal must have a non-empty name and a
+        section heading that starts with the markdown level-2 marker.
+
+        ``key_fields`` may legitimately be empty for some rows whose
+        Key Fields column is documented in prose rather than as
+        backticked tokens — those signals reduce to a "section
+        heading present" check, which is still useful contract."""
+        for signal in snapshot_signals:
+            assert signal.name, (
+                f"Signal record has empty name: {signal!r}"
+            )
+            assert signal.section_heading.startswith("## "), (
+                f"Section heading must start with '## ': "
+                f"{signal.section_heading!r}"
+            )
+
+    def test_known_signals_appear(self, snapshot_signals):
+        """Spot-check: signals that are stable parts of the contract
+        should be in the parsed list. Catches a regression where the
+        parser silently drops rows."""
+        names = {signal.name for signal in snapshot_signals}
+        for required in (
+            "Enforcement count",
+            "Tier breakdown",
+            "GC rules count",
+            "Reflection count",
+        ):
+            assert required in names, (
+                f"Expected signal {required!r} not parsed from "
+                "observatory-signals.md (parser drift suspected)"
+            )
+
+    def test_missing_checklist_raises(self, tmp_path: Path):
+        nonexistent = tmp_path / "no_signals.md"
+        with pytest.raises(FileNotFoundError):
+            observatory_verify.parse_signal_checklist(nonexistent)
+
+
+@pytest.mark.structural
+class TestVerifySnapshot:
+    """Per-signal status classification against fixture snapshots."""
+
+    def test_signals_whose_section_is_in_fixture_are_all_present(
+        self, snapshot_signals, fixtures_dir: Path
+    ):
+        """For every section the fixture covers, every signal targeting
+        that section should report PRESENT.
+
+        The fixture deliberately covers a representative subset of
+        snapshot sections — adding all 11+ sections would inflate the
+        fixture without strengthening the architectural validation.
+        Phase 3 (the rollout PR) is the right place to expand fixture
+        coverage to the full snapshot template."""
+        snapshot = (
+            fixtures_dir / "observatory_verify" / "complete_snapshot.md"
+        )
+        snapshot_text = snapshot.read_text(encoding="utf-8")
+        sections_in_fixture = {
+            "## " + line[3:].strip()
+            for line in snapshot_text.split("\n")
+            if line.startswith("## ") and not line.startswith("###")
+        }
+        assert sections_in_fixture, (
+            "Fixture has no level-2 sections; check it has not been "
+            "accidentally emptied"
+        )
+
+        results = observatory_verify.verify_snapshot(
+            snapshot, snapshot_signals
+        )
+        in_scope = [
+            r for r in results
+            if r.signal.section_heading in sections_in_fixture
+        ]
+        non_present = [
+            r for r in in_scope if r.status is not Status.PRESENT
+        ]
+        assert in_scope, (
+            "No signals had sections covered by the fixture; the "
+            "fixture and signal list have drifted apart"
+        )
+        assert not non_present, (
+            f"Among {len(in_scope)} in-scope signals, "
+            f"{len(non_present)} were not PRESENT: "
+            + ", ".join(
+                f"{r.signal.name}={r.status.value} ({r.notes})"
+                for r in non_present
+            )
+        )
+
+    def test_missing_section_yields_missing_status(
+        self, snapshot_signals, fixtures_dir: Path
+    ):
+        snapshot = (
+            fixtures_dir
+            / "observatory_verify"
+            / "missing_enforcement_snapshot.md"
+        )
+        results = observatory_verify.verify_snapshot(
+            snapshot, snapshot_signals
+        )
+        # Every signal whose section heading is "## Enforcement" should
+        # be MISSING (the section is removed from the fixture).
+        enforcement_signals = [
+            r
+            for r in results
+            if r.signal.section_heading == "## Enforcement"
+        ]
+        assert enforcement_signals, (
+            "Test fixture or signal list lost ## Enforcement signals"
+        )
+        for result in enforcement_signals:
+            assert result.status is Status.MISSING, (
+                f"Expected MISSING for {result.signal.name!r}, "
+                f"got {result.status.value}"
+            )
+
+    def test_section_with_no_key_fields_is_partial(
+        self, snapshot_signals, fixtures_dir: Path
+    ):
+        """The ``missing_enforcement_snapshot.md`` fixture deliberately
+        keeps the ``## Mutation Testing`` heading but has no key field
+        content. Mutation signals that *do* declare key fields should
+        be PARTIAL (heading found, fields absent). Mutation signals
+        that declare no key fields are PRESENT vacuously — that is
+        the documented semantics of an empty key_fields list."""
+        snapshot = (
+            fixtures_dir
+            / "observatory_verify"
+            / "missing_enforcement_snapshot.md"
+        )
+        results = observatory_verify.verify_snapshot(
+            snapshot, snapshot_signals
+        )
+        mutation_signals = [
+            r
+            for r in results
+            if r.signal.section_heading == "## Mutation Testing"
+        ]
+        assert mutation_signals, (
+            "Signal list lost ## Mutation Testing entries"
+        )
+        # At least one mutation signal must declare key fields and
+        # be reported as PARTIAL — that is the case the test cares
+        # about. Other mutation signals (with empty key_fields) are
+        # legitimately PRESENT and are not the failure mode the test
+        # is asserting.
+        partial_with_fields = [
+            r
+            for r in mutation_signals
+            if r.signal.key_fields and r.status is Status.PARTIAL
+        ]
+        assert partial_with_fields, (
+            "Expected at least one PARTIAL mutation signal that "
+            "declares key fields. Got: "
+            + ", ".join(
+                f"{r.signal.name}={r.status.value}"
+                f" (fields={len(r.signal.key_fields)})"
+                for r in mutation_signals
+            )
+        )
+
+    def test_no_snapshot_file_yields_no_output(
+        self, snapshot_signals, tmp_path: Path
+    ):
+        nonexistent = tmp_path / "no_snapshot.md"
+        results = observatory_verify.verify_snapshot(
+            nonexistent, snapshot_signals
+        )
+        assert results, (
+            "verify_snapshot returned no results at all; should still "
+            "produce one row per signal with NO_OUTPUT"
+        )
+        assert all(r.status is Status.NO_OUTPUT for r in results), (
+            "All signals should be NO_OUTPUT when snapshot file is "
+            "missing"
+        )
+
+    def test_none_snapshot_path_yields_no_output(
+        self, snapshot_signals
+    ):
+        """Passing ``None`` as the snapshot path is the explicit
+        'no snapshot exists yet' signal from the caller."""
+        results = observatory_verify.verify_snapshot(
+            None, snapshot_signals
+        )
+        assert all(r.status is Status.NO_OUTPUT for r in results)


### PR DESCRIPTION
## Summary

Implements Phase 2 from the command-tdad-testing-design spec (#293). Validates **Option C-direct** (extract deterministic command logic into Python, test the helper) against two P-category commands.

The helpers and tests answer the design's core question: *can a procedural slash command's logic be cleanly extracted into Python with testable side-effects?* The answer for both target commands is **yes**, with three real surface bugs surfaced and fixed during the spike.

## What was built

| Helper | Scope | Tests |
|---|---|---|
| `spike_helpers/convention_sync.py` | HARNESS.md → Cursor `conventions.mdc` (only) | 8 tests |
| `spike_helpers/observatory_verify.py` | Snapshot source only (1 of 5) | 11 tests |

Both helpers live under `tdad_tests/spike_helpers/` as **test-stage** code. Phase 3 is the right time to promote them to `ai-literacy-superpowers/scripts/` and update the command markdowns to invoke them — the spike's job is validation, not roll-out.

## Spike scope is deliberately narrow

The design spec said "1 hour design + 3 hours implementation per command." That estimate covers the slice each helper exercises:

- **convention-sync** handles only the Cursor output. Copilot, Windsurf, and the `constraints.mdc` file are left for Phase 3.
- **observatory-verify** handles only the Snapshot source (~21 of ~40 signals from the reference). The four other sources are left for Phase 3.

Each helper is small enough to read in one sitting (~150–290 lines) and exercises every architectural question the design spec asked.

## Real bugs the spike surfaced

Each would have hit Phase 3 across all 11 P commands; catching them early reduces rework risk.

| Bug | Fix |
|---|---|
| Markdown table parser broke on `\|` escaped pipes inside cells | Negative-lookbehind split regex; cells with embedded `\|` restore correctly |
| Section heading column uses backticked code spans (`` `## Enforcement` ``) but snapshot files write headings without backticks | Strip balanced surrounding backticks from the parsed heading |
| Key Fields use template placeholders (`N/M`, `YYYY-MM-DD`, `P%`) that real snapshots replace with actual values | Colon-prefix matching: the part before the first colon is stable, matching the real contract (*is the named field present?*) rather than the brittle one (*do values look like the template?*) |

The colon-prefix decision is worth highlighting separately — it accepts a slightly weaker contract in exchange for stability across snapshot value variations. See the docstring on `_field_present` in `observatory_verify.py`.

## Suite delta

| | Before | After |
|---|---|---|
| Passed | 57 | 76 |
| Skipped | 7 | 7 |
| Wall-clock | ~3.9s | ~4.5s |

Phase 2 added 19 tests (8 convention-sync + 11 observatory-verify). Full suite still completes in under 5 seconds offline.

## Validation outcome

The architecture works. C-direct is the right pattern for both target P commands. Specific findings worth carrying into Phase 3:

1. **Pure helpers (no I/O) test cleanest.** `parse_context` and `render_cursor_conventions_mdc` for convention-sync, and `parse_signal_checklist` and `verify_snapshot` for observatory-verify, are all pure functions. Tests are short and the helpers compose into integration tests trivially.
2. **End-to-end wrapper is a thin shim.** `sync_cursor_conventions` reads the file, calls the pure helpers, writes the file. That's the layer that handles `FileNotFoundError`. Production helpers should follow the same pure-core / thin-shim split.
3. **Fixture files for tests are real markdown, not mocks.** A real HARNESS.md fixture, real snapshot fixtures. They look identical to what production produces, which means the tests are exercising production code paths, not synthetic ones.

## What this PR does NOT do

- Doesn't update `/convention-sync` or `/observatory-verify` markdown to invoke the helpers (Phase 3)
- Doesn't add Copilot, Windsurf, or `constraints.mdc` outputs to the convention-sync helper (Phase 3)
- Doesn't add the four other observatory-verify signal sources (Phase 3)
- Doesn't change plugin behaviour — no version bump

## Test plan

- [x] `pytest tests/test_phase2_convention_sync.py` — 8 passed
- [x] `pytest tests/test_phase2_observatory_verify.py` — 11 passed
- [x] Full TDAD suite: 76 passed, 7 skipped (no API key)
- [x] `markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 9 files, all expected
- [ ] CI passes

## Related

- Design spec: PR #293
- Phase 1 (command wiring): PR #294
- Spike: PR #282