### PR TITLE
TDAD Phase 3: orchestration command dispatch matrix

### DIFF
--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -147,6 +147,7 @@ dispatches via the Claude Agent SDK.
 | All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [#284 design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
 | convention-sync (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 8 tests |
 | observatory-verify (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 11 tests |
+| 6 of 7 O commands (Phase 3) | n/a | ✅ structural + wiring + per-command dispatch matrix | n/a | inherits from agents (Layer 3 covers each agent) |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run

--- a/tdad_tests/tests/test_command_dispatch_matrix.py
+++ b/tdad_tests/tests/test_command_dispatch_matrix.py
@@ -1,0 +1,223 @@
+"""Phase 3 — orchestration command dispatch matrix.
+
+Phase 1 catches the failure mode "command references X, X doesn't
+exist" — the rename-without-callsite-update class. Phase 3 catches
+the inverse: "command was supposed to dispatch Y and doesn't anymore."
+The two tests have orthogonal coverage.
+
+Phase 3's contribution is a *matrix*: each of the 7 orchestration (O)
+commands declares the agents and skills it must dispatch. The test
+parametrises across the matrix and asserts each declared dispatch is
+present in the command body. If a future refactor removes a dispatch
+without updating its callers, the test fails — naming the specific
+command and the specific missing dispatch.
+
+Why per-command expected-dispatches rather than a generic check?
+Because an orchestration command's *value* is the specific agents it
+chains together. ``/harness-audit`` is supposed to dispatch
+harness-discoverer, harness-enforcer, *and* harness-auditor. If a
+refactor accidentally removes the third, Phase 1 stays green (every
+remaining reference resolves) but the command's behaviour silently
+degrades. The matrix locks in the contract.
+
+The matrix is hand-authored from the current command bodies. Adding
+a new dispatch to an O command means the agent gets a new entry; the
+matrix follows the prose. Both directions of drift (prose loses a
+dispatch, prose gains one) are caught — the former by failing
+assertions, the latter by reading the test alongside any PR that
+adds dispatches.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+# Each entry is ``(command_name, expected_agents, expected_skills)``.
+#
+# - ``expected_agents`` lists the *agents* the command must dispatch
+#   somewhere in its body. The match is on backticked or
+#   un-backticked agent name immediately before the word "agent".
+# - ``expected_skills`` lists the *skills* the command must invoke or
+#   reference as load-bearing. Some O commands (notably
+#   ``/harness-sync``) use a skill rather than an agent as their
+#   primary work-horse; this captures those.
+#
+# Commands intentionally absent from the matrix:
+#
+# - ``/superpowers-init`` — orchestrates other slash commands rather
+#   than dispatching agents directly. Its dispatches are commands; the
+#   command-to-command wiring is a different surface (Phase 1's
+#   generic check catches missing skill references; per-command
+#   command-call expectations would be a Phase 3.5 if we ever need
+#   them).
+DISPATCH_MATRIX: list[tuple[str, list[str], list[str]]] = [
+    # /harness-audit chains three agents to verify harness state.
+    # Removing any of them silently weakens the audit.
+    (
+        "harness-audit",
+        ["harness-discoverer", "harness-enforcer", "harness-auditor"],
+        [],
+    ),
+    # /governance-audit is a single-agent dispatcher.
+    ("governance-audit", ["governance-auditor"], []),
+    # /harness-init dispatches the discoverer up front; the guided
+    # init flow that follows is conversational and doesn't dispatch
+    # further agents directly.
+    ("harness-init", ["harness-discoverer"], []),
+    # /harness-sync is the special case — its primary work-horse is
+    # the harness-audit-engine *skill*, not an agent. The matrix
+    # captures that.
+    ("harness-sync", [], ["harness-audit-engine"]),
+    # /choice-cartograph and /diaboli are single-agent dispatchers.
+    ("choice-cartograph", ["choice-cartographer"], []),
+    ("diaboli", ["advocatus-diaboli"], []),
+]
+
+
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "ai-literacy-superpowers"
+)
+
+
+def _command_body(command_name: str) -> str:
+    """Read the body of an O command for matching."""
+    component = plugin_runner.find_component(
+        _PLUGIN_PATH, name=command_name, component_type="command"
+    )
+    return plugin_runner.read_component_body(component.path)
+
+
+def _agent_dispatch_present(body: str, agent_name: str) -> bool:
+    """Whether the body contains a dispatch for ``agent_name``.
+
+    Accepts both backticked and un-backticked forms, both
+    ``Dispatch the X agent`` and ``Run the X agent`` shapes. The
+    matching is deliberately lenient on the verb (the project uses
+    several) but strict on the named-agent + " agent" structure.
+    """
+    backticked = re.compile(
+        rf"`{re.escape(agent_name)}`\s+agents?\b(?!-)"
+    )
+    plain = re.compile(
+        rf"\b{re.escape(agent_name)}\s+agents?\b(?!-)"
+    )
+    return bool(backticked.search(body) or plain.search(body))
+
+
+def _skill_dispatch_present(body: str, skill_name: str) -> bool:
+    """Whether the body contains a load-bearing reference to a skill.
+
+    The reference can be backticked + " skill" or path-style
+    ``skills/<name>``. Both forms appear in current commands; both
+    count as the command exercising the skill.
+    """
+    backticked = re.compile(
+        rf"`{re.escape(skill_name)}`\s+skills?\b(?!-)"
+    )
+    path_style = re.compile(
+        rf"\bskills/{re.escape(skill_name)}\b"
+    )
+    return bool(backticked.search(body) or path_style.search(body))
+
+
+@pytest.mark.structural
+class TestOrchestrationDispatchMatrix:
+    """Each O command must dispatch the specific agents/skills it
+    declares as load-bearing."""
+
+    @pytest.mark.parametrize(
+        "command_name,expected_agents,expected_skills",
+        DISPATCH_MATRIX,
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_command_dispatches_expected_components(
+        self,
+        command_name: str,
+        expected_agents: list[str],
+        expected_skills: list[str],
+    ):
+        body = _command_body(command_name)
+
+        missing_agents = [
+            agent
+            for agent in expected_agents
+            if not _agent_dispatch_present(body, agent)
+        ]
+        missing_skills = [
+            skill
+            for skill in expected_skills
+            if not _skill_dispatch_present(body, skill)
+        ]
+
+        if missing_agents or missing_skills:
+            details: list[str] = []
+            if missing_agents:
+                details.append(
+                    f"missing agent dispatches: {missing_agents}"
+                )
+            if missing_skills:
+                details.append(
+                    f"missing skill invocations: {missing_skills}"
+                )
+            pytest.fail(
+                f"Command /{command_name} no longer dispatches "
+                f"components it is expected to. {'; '.join(details)}.\n"
+                "Either the dispatch line was removed in a refactor "
+                "and not replaced (a regression), or the matrix in "
+                "this test file is out of date and should be updated "
+                "alongside the prose change."
+            )
+
+
+@pytest.mark.structural
+class TestMatrixCoverage:
+    """The matrix itself must be coherent — agents and skills it
+    references must exist, every named command must exist, and the
+    matrix should cover every O-category command except the
+    deliberate exclusions documented inline."""
+
+    def test_every_referenced_agent_exists(self):
+        agent_names = {
+            c.name for c in plugin_runner.list_agents(_PLUGIN_PATH)
+        }
+        broken = []
+        for cmd, agents, _ in DISPATCH_MATRIX:
+            for agent in agents:
+                if agent not in agent_names:
+                    broken.append(
+                        f"{cmd} expects nonexistent agent {agent!r}"
+                    )
+        assert not broken, "Matrix references missing agents: " + str(broken)
+
+    def test_every_referenced_skill_exists(self):
+        skill_names = {
+            c.name for c in plugin_runner.list_skills(_PLUGIN_PATH)
+        }
+        broken = []
+        for cmd, _, skills in DISPATCH_MATRIX:
+            for skill in skills:
+                if skill not in skill_names:
+                    broken.append(
+                        f"{cmd} expects nonexistent skill {skill!r}"
+                    )
+        assert not broken, "Matrix references missing skills: " + str(broken)
+
+    def test_every_named_command_exists(self):
+        command_names = {
+            c.name for c in plugin_runner.list_commands(_PLUGIN_PATH)
+        }
+        missing = [
+            cmd for cmd, _, _ in DISPATCH_MATRIX if cmd not in command_names
+        ]
+        assert not missing, (
+            f"Matrix names commands that no longer exist: {missing}"
+        )


### PR DESCRIPTION
## Summary

Implements Phase 3 from the command-tdad-testing-design spec (#293). Adds a per-O-command dispatch matrix that asserts each orchestration command references the specific agents (or skills) it is supposed to dispatch.

**Phase 1 catches** "command references X, X does not exist" (the rename-without-callsite-update class).
**Phase 3 catches** the inverse — "command was supposed to dispatch Y and does not anymore."

The two checks have orthogonal coverage; Phase 3 only fails when an expected dispatch is *removed* without replacement.

## Matrix coverage (6 of 7 O commands)

| Command | Expected dispatches |
|---|---|
| `/harness-audit` | `harness-discoverer` + `harness-enforcer` + `harness-auditor` |
| `/governance-audit` | `governance-auditor` |
| `/harness-init` | `harness-discoverer` |
| `/harness-sync` | `harness-audit-engine` **skill** (special case — its work-horse is a skill, not an agent) |
| `/choice-cartograph` | `choice-cartographer` |
| `/diaboli` | `advocatus-diaboli` |

**Deliberate exclusion**: `/superpowers-init` orchestrates via *other slash commands* rather than dispatching agents directly. Per-command command-call expectations would be a Phase 3.5 if it ever proves useful; Phase 1's generic check already catches missing skill references.

## Test shape

Parametrised over the matrix — each row produces an independent test result. Failures name the specific command and the specific missing dispatch. Three additional matrix-coherence tests verify every named agent, skill, and command in the matrix actually exists, protecting the test from drifting into stale expectations.

## Suite delta

| | Before | After |
|---|---|---|
| Passed | 76 | 85 |
| Skipped | 7 | 7 |
| Wall-clock | ~4.5s | ~5.4s |

The +9 = 6 parametrised dispatch checks + 3 matrix-coherence checks.

## What this PR does NOT do

- Doesn't add Phase 4 (M command skill-coverage) — separate follow-up
- Doesn't promote the Phase 2 spike helpers to production scripts — separate follow-up
- Doesn't change plugin behaviour — no version bump

## Test plan

- [x] `pytest tests/test_command_dispatch_matrix.py` — 9 passed
- [x] Full TDAD suite without API key: 85 passed, 7 skipped
- [x] `markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 2 files (test + README), all expected
- [ ] CI passes

## Related

- Design spec: PR #293
- Phase 1 (command wiring): PR #294
- Phase 2 spike (Option C helpers): PR #295