### PR TITLE
Rename command-category abbreviations to full names

### DIFF
--- a/docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md
+++ b/docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md
@@ -13,9 +13,9 @@
 
 ## Amendment 1 — 2026-05-09: helpers stay test-stage (Option I)
 
-**Supersedes**: §4's framing of Option C-direct as "the markdown command becomes glue between the user and the helper", and §5's Phase 2 expansion line ("If the spike works, expand to the remaining 9 P commands in a single follow-up PR" — read as "and update the command markdowns to invoke the helpers").
+**Supersedes**: §4's framing of Option C-direct as "the markdown command becomes glue between the user and the helper", and §5's Phase 2 expansion line ("If the spike works, expand to the remaining 9 procedural commands in a single follow-up PR" — read as "and update the command markdowns to invoke the helpers").
 
-**Decision**: For all P commands, helpers stay in `tdad_tests/spike_helpers/`
+**Decision**: For all procedural commands, helpers stay in `tdad_tests/spike_helpers/`
 as test-stage code. Command markdowns continue as prose-driven instructions
 to the model. Tests verify the *documented behaviour*; drift between the
 helper and the command's prose is a test failure the author resolves
@@ -78,15 +78,15 @@ met case-by-case, not blanket.
 - Phases 1, 3, 4 (the wiring and matrix tests) — still cheap, still
   applied to every command.
 - Phase 2's spike helpers — they earned their keep by validating that
-  P-command logic *can* be tested. They stay in `tdad_tests/spike_helpers/`.
-- Per-skill Layer 3 tests for M commands — still case-by-case follow-up.
+  procedural-command logic *can* be tested. They stay in `tdad_tests/spike_helpers/`.
+- Per-skill Layer 3 tests for model-mediated commands — still case-by-case follow-up.
 
 ### What changes for the rollout from Phase 2
 
 The work previously framed as "Phase 3 rollout: promote helpers to
-scripts/, update command markdowns, expand to 9 more P commands" is
+scripts/, update command markdowns, expand to 9 more procedural commands" is
 now: "expand the test-stage helpers in `tdad_tests/spike_helpers/` to
-cover the remaining 9 P commands, *without* moving them into the plugin
+cover the remaining 9 procedural commands, *without* moving them into the plugin
 or changing the command markdowns."
 
 If a specific command has a side-effect severe enough to justify the
@@ -179,14 +179,14 @@ costs more than the value they return.
 
 ## 3. Inventory: 25 commands by category
 
-### Category P — Procedural-deterministic (11 commands)
+### Procedural-deterministic (11 commands)
 
 These are mostly mechanical: read files, transform, write files. The
 inferential work is minor (formatting the output, asking a single
 clarifying question). Their value is the side-effect on the file
 system.
 
-| Command | What it does | Why P |
+| Command | What it does | Why procedural |
 | --- | --- | --- |
 | `convention-sync` | Read HARNESS.md, generate Cursor/Copilot/Windsurf files | Pure transformation |
 | `harness-status` | Read HARNESS.md Status section, format and print | Read + format |
@@ -200,13 +200,13 @@ system.
 | `harness-health` (quick mode) | Read multiple data sources, aggregate, format | Read + aggregate |
 | `cost-capture` | Guide user through dashboards, write snapshot | Data entry with model formatting |
 
-### Category O — Orchestration (7 commands)
+### Orchestration (7 commands)
 
 These commands dispatch one or more existing agents and write the
 agents' output to a file. The command file is glue; the *agents* do
 the substantive work.
 
-| Command | Dispatches | Why O |
+| Command | Dispatches | Why orchestration |
 | --- | --- | --- |
 | `harness-audit` | harness-discoverer + harness-enforcer | Multi-agent dispatch |
 | `governance-audit` | governance-auditor | Single agent dispatch |
@@ -216,13 +216,13 @@ the substantive work.
 | `choice-cartograph` | choice-cartographer agent | Single agent dispatch |
 | `diaboli` | advocatus-diaboli agent | Single agent dispatch |
 
-### Category M — Model-mediated (7 commands)
+### Model-mediated (7 commands)
 
 These commands run a multi-turn interactive session. The model reasons
 across questions, user answers, and accumulating context. The value is
 the reasoning trajectory, not a single asserted output.
 
-| Command | What makes it M |
+| Command | What makes it model-mediated |
 | --- | --- |
 | `assess` | Multi-step assessment (scan, ask, score, recommend, badge update) |
 | `portfolio-assess` | Aggregation with model synthesis across many repos |
@@ -240,9 +240,9 @@ the reasoning trajectory, not a single asserted output.
 
 ## 4. Per-category testing strategy
 
-### P — Test side-effects (Option C from the spike)
+### Procedural — Test side-effects (Option C from the spike)
 
-**Approach.** For each P command, identify its observable side-effects
+**Approach.** For each procedural command, identify its observable side-effects
 on the file system or stdout. Write a Layer-3-equivalent test that:
 
 1. Sets up a fixture project state
@@ -266,9 +266,9 @@ on the file system or stdout. Write a Layer-3-equivalent test that:
 
 **Cost**: low. ~$0 per test (no LLM). Wall-clock seconds, not minutes.
 **Granularity**: per-command at first; per-side-effect over time.
-**Coverage target**: all 11 P commands.
+**Coverage target**: all 11 procedural commands.
 
-### O — Test the dispatched components, smoke the command
+### Orchestration — Test the dispatched components, smoke the command
 
 **Approach.** Orchestration commands inherit most of their value from
 the agents they dispatch. The framework already has Layer 3 TDAD for
@@ -286,15 +286,15 @@ test the *command* with a thin smoke check:
 
 The substantive testing — does the dispatched agent actually do the
 right thing? — lives at Layer 3 for the agent itself, not for the
-command. Each O command becomes a thin shell over already-tested
+command. Each orchestration command becomes a thin shell over already-tested
 agents.
 
 **Cost**: ~$0 per test (structural and grep). Wall-clock sub-second.
-**Coverage target**: all 7 O commands at the structural+wiring level;
+**Coverage target**: all 7 orchestration commands at the structural+wiring level;
 all 13 plugin agents at Layer 3 (4 of which are spike targets already
 or upcoming).
 
-### M — Acknowledge the cost; instrument lightly
+### Model-mediated — Acknowledge the cost; instrument lightly
 
 **Approach.** Genuinely model-mediated commands resist Layer-3 TDAD
 because the value is the multi-turn reasoning trajectory, not a single
@@ -311,22 +311,22 @@ asserted output. Three claims drive the recommendation:
   staying *unverified* or *agent-verified-via-its-skills* is a valid
   outcome. Not every component must reach Layer 3.
 
-For M commands, this spec recommends:
+For model-mediated commands, this spec recommends:
 
 1. **Layer 1 structural check** (covered by the universal pass below)
 2. **Skill-coverage check**: the command references its driving
    skill (`assess` ↔ `ai-literacy-assessment` skill, `extract-conventions`
    ↔ `convention-extraction` skill, etc.) and that skill exists. Most
-   M commands offload their substantive logic to a skill; the skill
+   model-mediated commands offload their substantive logic to a skill; the skill
    is the right unit of test.
 3. **No Layer 3** (deliberately). Skills get Layer 3 tests where
    feasible (the cupid-code-review pattern from PR #285 generalises
-   to several other skills); the M commands themselves remain
+   to several other skills); the model-mediated commands themselves remain
    structurally smoked but behaviourally unverified.
 
 **Cost**: ~$0 (structural + skill-coverage). Some skill Layer-3 tests
 already covered.
-**Coverage target**: all 7 M commands at structural + skill-coverage;
+**Coverage target**: all 7 model-mediated commands at structural + skill-coverage;
 some driving skills at Layer 3 in subsequent iterations.
 
 ---
@@ -358,9 +358,9 @@ failure class that the team has hit at least once before per the
 existing `Plugin-framework anchoring` GC rule history. The check is
 PR-time rather than weekly, so the failure is caught earlier.
 
-### Phase 2 — Spike Option C against 2 P commands
+### Phase 2 — Spike Option C against 2 procedural commands
 
-Pick 2 of the 11 P commands and validate Option C. Recommended:
+Pick 2 of the 11 procedural commands and validate Option C. Recommended:
 
 - `convention-sync` (cleanest case; pure transformation; HARNESS.md
   in → tool-rule files out)
@@ -374,27 +374,27 @@ behavioural tests with a fixture project, assert side-effects.
 **Output**: per-command test files in `tdad_tests/tests/`,
 fixtures in `tdad_tests/fixtures/`. Spike PR analogous to #282.
 
-If the spike works, expand to the remaining 9 P commands in a single
+If the spike works, expand to the remaining 9 procedural commands in a single
 follow-up PR. If it doesn't, the spike has surfaced what makes Option
 C harder than the design assumed — informative either way.
 
 ### Phase 3 — Orchestration command wiring
 
 Add `command-dispatches-existing-agents` parametrised tests across
-the 7 O commands. Each test parses the command body and asserts each
+the 7 orchestration commands. Each test parses the command body and asserts each
 named agent exists in `agents/`. ~$0, fast.
 
 This is essentially a tightening of Phase 1's wiring check, scoped
 explicitly to dispatch lines.
 
-### Phase 4 — Skill-driven M commands (only if cost/benefit holds)
+### Phase 4 — Skill-driven model-mediated commands (only if cost/benefit holds)
 
-The M commands' value lives in their driving skills. Inventory each
-M command's skill, write Layer-3 tests for the *skill* (per the
+The model-mediated commands' value lives in their driving skills. Inventory each
+model-mediated command's skill, write Layer-3 tests for the *skill* (per the
 existing PR #285 pattern for cupid-code-review), and call this
-sufficient. The M command itself stays at structural+skill-coverage.
+sufficient. The model-mediated command itself stays at structural+skill-coverage.
 
-If a particular M command has a side-effect worth asserting
+If a particular model-mediated command has a side-effect worth asserting
 (`assess` writes an assessment doc; `harness-onboarding` writes
 ONBOARDING.md), wrap that side-effect in a Phase-2-style Option C
 test — case by case.
@@ -408,7 +408,7 @@ architecture and the team has bandwidth to invest.
   from the spike). Listed as "deliberately not chosen": the
   CI-environment cost and subprocess fragility are too high for the
   return.
-- Per-command behavioural tests for every M command. Acknowledged as
+- Per-command behavioural tests for every model-mediated command. Acknowledged as
   expensive; deliberately not pursued unless Phase 4 proves
   worthwhile per command.
 
@@ -418,7 +418,7 @@ architecture and the team has bandwidth to invest.
 
 ### Trade-off — Option C-direct vs C-subprocess
 
-For P commands, the choice between extracting logic into Python and
+For procedural commands, the choice between extracting logic into Python and
 running existing bash blocks as subprocesses is a per-command call.
 C-direct produces cleaner, faster, more parametrisable tests; the
 extraction work is cost upfront. C-subprocess works with what already
@@ -441,7 +441,7 @@ extract code-fenced blocks and prose mentions, and validate against
 a structured allowlist. That's more work; the simple grep is fine
 until it breaks.
 
-### Open question — should M commands ever reach Layer 3?
+### Open question — should model-mediated commands ever reach Layer 3?
 
 This spec says "no, by default; case by case if there's a clear
 side-effect." That position deserves to be revisited if/when M
@@ -466,7 +466,7 @@ in a future plugin), the pattern should be promoted from
 Adopt the per-category strategy. Sequence the phases as listed.
 Phase 1 (universal structural pass) is the cheapest and highest-
 leverage; do it first regardless of subsequent decisions. Phase 2
-validates the architecture for P commands before scaling. Phase 3
+validates the architecture for procedural commands before scaling. Phase 3
 tightens orchestration wiring. Phase 4 is opt-in per command.
 
 Issue #284 closes once this spec is reviewed and approved. The
@@ -484,8 +484,8 @@ phase can be picked up independently.
 - **A single right answer for command testing.** The premise of this
   spec is that there isn't one; the right answer is per category, and
   pretending otherwise leads to either over-engineering (testing P
-  commands the same heavyweight way M commands need) or
-  under-engineering (using P-style tests on M commands that need
+  commands the same heavyweight way model-mediated commands need) or
+  under-engineering (using procedural-style tests on model-mediated commands that need
   more).
 - **Removal of any existing tests.** Layer 0 (deterministic plumbing),
   Layer 1, Layer 2, Layer 3 all stand as built. This is a *new

--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -145,10 +145,10 @@ dispatches via the Claude Agent SDK.
 | spec-writer | n/a | ✅ structural | n/a (agent, not skill) | ✅ implemented (gated on API key) |
 | cupid-code-review | n/a | ✅ structural | ✅ implemented (gated on API key) | ✅ implemented + LLM-as-judge rubric (gated on API key) |
 | All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [#284 design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
-| convention-sync (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 8 tests |
-| observatory-verify (P, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 11 tests |
-| 6 of 7 O commands (Phase 3) | n/a | ✅ structural + wiring + per-command dispatch matrix | n/a | inherits from agents (Layer 3 covers each agent) |
-| All 7 M commands (Phase 4) | n/a | ✅ structural + wiring + per-command skill-coverage matrix | n/a | per-skill Layer 3 deferred (case-by-case per design spec) |
+| convention-sync (procedural, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 8 tests |
+| observatory-verify (procedural, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 11 tests |
+| 6 of 7 orchestration commands (Phase 3) | n/a | ✅ structural + wiring + per-command dispatch matrix | n/a | inherits from agents (Layer 3 covers each agent) |
+| All 7 model-mediated commands (Phase 4) | n/a | ✅ structural + wiring + per-command skill-coverage matrix | n/a | per-skill Layer 3 deferred (case-by-case per design spec) |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run

--- a/tdad_tests/scenarios/commands/harness-init/FINDING-command-tdab-gap.md
+++ b/tdad_tests/scenarios/commands/harness-init/FINDING-command-tdab-gap.md
@@ -108,12 +108,12 @@ answer:
   smoke test that asserts each command references agents that exist.
 - **M (model-mediated, 7 commands)** — Layer 3 testing is high-cost
   and high-fragility; this spec recommends staying at structural +
-  skill-coverage. Skills get Layer 3 where feasible; the M commands
+  skill-coverage. Skills get Layer 3 where feasible; the model-mediated commands
   themselves stay agent-verified-via-skills.
 
 The spec phases roll-out so cost grows monotonically: Phase 1 is a
 universal structural pass (~$0, all 25 commands); Phase 2 is an
-Option C spike on 2 P commands; Phases 3 and 4 follow.
+Option C spike on 2 procedural commands; Phases 3 and 4 follow.
 
 This finding remains as the canonical design-question record for
 posterity. The decision is captured in the spec; the phases are

--- a/tdad_tests/spike_helpers/__init__.py
+++ b/tdad_tests/spike_helpers/__init__.py
@@ -5,7 +5,7 @@ plugin commands (`/convention-sync` and `/observatory-verify`) so that
 their deterministic logic can be unit-tested. The spike's purpose is
 to validate the per-category strategy from the Phase-2 design spec
 (``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``):
-extracting P-category command logic into Python (Option C-direct) is
+extracting procedural command logic into Python (Option C-direct) is
 testable, and the test scaffolding is cheap.
 
 Scope is deliberately narrow:

--- a/tdad_tests/tests/test_command_dispatch_matrix.py
+++ b/tdad_tests/tests/test_command_dispatch_matrix.py
@@ -5,7 +5,7 @@ exist" — the rename-without-callsite-update class. Phase 3 catches
 the inverse: "command was supposed to dispatch Y and doesn't anymore."
 The two tests have orthogonal coverage.
 
-Phase 3's contribution is a *matrix*: each of the 7 orchestration (O)
+Phase 3's contribution is a *matrix*: each of the 7 orchestration
 commands declares the agents and skills it must dispatch. The test
 parametrises across the matrix and asserts each declared dispatch is
 present in the command body. If a future refactor removes a dispatch
@@ -21,7 +21,7 @@ remaining reference resolves) but the command's behaviour silently
 degrades. The matrix locks in the contract.
 
 The matrix is hand-authored from the current command bodies. Adding
-a new dispatch to an O command means the agent gets a new entry; the
+a new dispatch to an orchestration command means the agent gets a new entry; the
 matrix follows the prose. Both directions of drift (prose loses a
 dispatch, prose gains one) are caught — the former by failing
 assertions, the latter by reading the test alongside any PR that
@@ -47,7 +47,7 @@ from runner import plugin as plugin_runner  # noqa: E402
 #   somewhere in its body. The match is on backticked or
 #   un-backticked agent name immediately before the word "agent".
 # - ``expected_skills`` lists the *skills* the command must invoke or
-#   reference as load-bearing. Some O commands (notably
+#   reference as load-bearing. Some orchestration commands (notably
 #   ``/harness-sync``) use a skill rather than an agent as their
 #   primary work-horse; this captures those.
 #
@@ -89,7 +89,7 @@ _PLUGIN_PATH = (
 
 
 def _command_body(command_name: str) -> str:
-    """Read the body of an O command for matching."""
+    """Read the body of an orchestration command for matching."""
     component = plugin_runner.find_component(
         _PLUGIN_PATH, name=command_name, component_type="command"
     )
@@ -131,7 +131,7 @@ def _skill_dispatch_present(body: str, skill_name: str) -> bool:
 
 @pytest.mark.structural
 class TestOrchestrationDispatchMatrix:
-    """Each O command must dispatch the specific agents/skills it
+    """Each orchestration command must dispatch the specific agents/skills it
     declares as load-bearing."""
 
     @pytest.mark.parametrize(
@@ -182,7 +182,7 @@ class TestOrchestrationDispatchMatrix:
 class TestMatrixCoverage:
     """The matrix itself must be coherent — agents and skills it
     references must exist, every named command must exist, and the
-    matrix should cover every O-category command except the
+    matrix should cover every orchestration command except the
     deliberate exclusions documented inline."""
 
     def test_every_referenced_agent_exists(self):

--- a/tdad_tests/tests/test_command_skill_coverage.py
+++ b/tdad_tests/tests/test_command_skill_coverage.py
@@ -1,6 +1,6 @@
-"""Phase 4 — M-command skill-coverage matrix.
+"""Phase 4 — model-mediated-command skill-coverage matrix.
 
-Model-mediated (M) commands derive their substantive behaviour from
+Model-mediated commands derive their substantive behaviour from
 their driving skill. ``/assess`` reads the ``ai-literacy-assessment``
 skill before proceeding; ``/extract-conventions`` reads the
 ``convention-extraction`` skill; ``/governance-constrain`` reads the
@@ -8,7 +8,7 @@ skill before proceeding; ``/extract-conventions`` reads the
 methodology; the command's prose is the conversational shell that
 loads the skill at the right time.
 
-This makes M commands fragile in a specific way: if the driving
+This makes model-mediated commands fragile in a specific way: if the driving
 skill is renamed, refactored, or split without updating the
 referencing command, the command's prose still reads (Phase 1 may
 not catch it if the rename split into two skills, both of which
@@ -21,14 +21,14 @@ for the skill-driven layer:
 
 - Phase 1 catches "skill reference is broken" (passive — fails when
   the named skill no longer exists).
-- Phase 4 catches "M command was supposed to load Y skill and no
+- Phase 4 catches "model-mediated command was supposed to load Y skill and no
   longer does" (active — fails when an expected reference is
   missing, even if the command's prose still parses cleanly).
 
 The two tests have orthogonal coverage. Both belong.
 
 Per the design spec (`docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md`),
-Layer 3 behavioural tests of M-command driving skills are the
+Layer 3 behavioural tests of model-mediated-command driving skills are the
 high-cost, case-by-case follow-up — only worth investing in for
 specific skills with assertable side-effects (the ``cupid-code-review``
 test in PR #285 is the canonical pattern; ``harness-onboarding`` is a
@@ -59,7 +59,7 @@ from runner import plugin as plugin_runner  # noqa: E402
 # 2026-05-09. When a command's prose adds or removes a skill load,
 # this matrix must be updated alongside the prose change — that is
 # the contract this test enforces.
-M_COMMAND_SKILL_MATRIX: list[tuple[str, list[str]]] = [
+MODEL_MEDIATED_COMMAND_SKILLS: list[tuple[str, list[str]]] = [
     # /assess uses two skills: the assessment methodology, and the
     # literacy-improvements skill that turns a level into a
     # prioritised improvement plan.
@@ -94,7 +94,7 @@ _PLUGIN_PATH = (
 
 
 def _command_body(command_name: str) -> str:
-    """Read the body of an M command for matching."""
+    """Read the body of an model-mediated command for matching."""
     component = plugin_runner.find_component(
         _PLUGIN_PATH, name=command_name, component_type="command"
     )
@@ -105,7 +105,7 @@ def _skill_load_present(body: str, skill_name: str) -> bool:
     """Whether the body contains a load-bearing reference to a skill.
 
     Accepts both backticked and path-style references — the project
-    uses both forms across M commands. ``\\b`` word-boundary anchors
+    uses both forms across model-mediated commands. ``\\b`` word-boundary anchors
     plus a negative lookahead on hyphen prevent false positives like
     ``foo`` matching ``foo-bar`` because ``-`` is a regex word
     boundary.
@@ -133,13 +133,13 @@ def _skill_load_present(body: str, skill_name: str) -> bool:
 
 
 @pytest.mark.structural
-class TestMCommandSkillCoverage:
-    """Each M command must load the specific skills it declares as
+class TestModelMediatedCommandSkillCoverage:
+    """Each model-mediated command must load the specific skills it declares as
     its driving methodology."""
 
     @pytest.mark.parametrize(
         "command_name,expected_skills",
-        M_COMMAND_SKILL_MATRIX,
+        MODEL_MEDIATED_COMMAND_SKILLS,
         ids=lambda v: v if isinstance(v, str) else "",
     )
     def test_command_loads_expected_skills(
@@ -176,7 +176,7 @@ class TestMatrixCoverage:
             c.name for c in plugin_runner.list_skills(_PLUGIN_PATH)
         }
         broken: list[str] = []
-        for cmd, skills in M_COMMAND_SKILL_MATRIX:
+        for cmd, skills in MODEL_MEDIATED_COMMAND_SKILLS:
             for skill in skills:
                 if skill not in skill_names:
                     broken.append(
@@ -192,7 +192,7 @@ class TestMatrixCoverage:
         }
         missing = [
             cmd
-            for cmd, _ in M_COMMAND_SKILL_MATRIX
+            for cmd, _ in MODEL_MEDIATED_COMMAND_SKILLS
             if cmd not in command_names
         ]
         assert not missing, (
@@ -200,9 +200,9 @@ class TestMatrixCoverage:
         )
 
     def test_matrix_covers_every_m_command(self):
-        """The 7 M commands documented in the design spec
+        """The 7 model-mediated commands documented in the design spec
         (``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``)
-        should all appear in the matrix. If a new M command lands or
+        should all appear in the matrix. If a new model-mediated command lands or
         an existing one is reclassified, the matrix should be updated
         deliberately — this test surfaces the drift if it isn't.
 
@@ -219,11 +219,11 @@ class TestMatrixCoverage:
             "harness-gc",
             "harness-onboarding",
         }
-        matrix_commands = {cmd for cmd, _ in M_COMMAND_SKILL_MATRIX}
+        matrix_commands = {cmd for cmd, _ in MODEL_MEDIATED_COMMAND_SKILLS}
         missing_from_matrix = expected_m_commands - matrix_commands
         unexpected_in_matrix = matrix_commands - expected_m_commands
         assert not missing_from_matrix, (
-            "M commands missing from skill-coverage matrix: "
+            "model-mediated commands missing from skill-coverage matrix: "
             f"{sorted(missing_from_matrix)}"
         )
         assert not unexpected_in_matrix, (

--- a/tdad_tests/tests/test_phase2_convention_sync.py
+++ b/tdad_tests/tests/test_phase2_convention_sync.py
@@ -2,7 +2,7 @@
 
 Validates the per-category strategy from the design spec
 (``docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md``)
-for one P-category command. The helper at
+for one procedural command. The helper at
 ``tdad_tests/spike_helpers/convention_sync.py`` implements the Cursor
 ``conventions.mdc`` slice of ``/convention-sync``; these tests cover
 its behaviour against fixture HARNESS.md inputs.

--- a/tdad_tests/tests/test_phase2_observatory_verify.py
+++ b/tdad_tests/tests/test_phase2_observatory_verify.py
@@ -1,7 +1,7 @@
 """Phase 2 spike — observatory-verify helper tests.
 
 Validates the per-category strategy from the design spec for the
-second P-category command. The helper at
+second procedural command. The helper at
 ``tdad_tests/spike_helpers/observatory_verify.py`` implements the
 Snapshot-source slice of ``/observatory-verify``; these tests cover
 its parser and per-signal verifier against fixture snapshot files.


### PR DESCRIPTION
## Summary

Replaces the P / M / O command-category abbreviations introduced in the design spec (#293) with their full names — **procedural**, **model-mediated**, **orchestration** — throughout forward-looking files.

## Why

The abbreviations were terse but not self-explanatory. A reader hitting "P command" or "M-category" in the codebase had to chase the design spec's §3 to decode either. Spelling them out makes every file readable in isolation, which matters more than the few characters saved.

## What changed

60 substitutions across 8 files (no record-of-the-past files were rewritten — see "What did NOT change" below):

| File | Substitutions |
|---|---|
| `docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md` | 30 + section heading + table column header rewrites |
| `tdad_tests/README.md` | 4 |
| `tdad_tests/scenarios/commands/harness-init/FINDING-command-tdab-gap.md` | 2 |
| `tdad_tests/spike_helpers/__init__.py` | 1 |
| `tdad_tests/tests/test_command_dispatch_matrix.py` | 6 |
| `tdad_tests/tests/test_command_skill_coverage.py` | 17 (incl. variable + class rename) |
| `tdad_tests/tests/test_phase2_convention_sync.py` | 1 |
| `tdad_tests/tests/test_phase2_observatory_verify.py` | 1 |

Code identifier renames (the only non-prose changes):

- `M_COMMAND_SKILL_MATRIX` → `MODEL_MEDIATED_COMMAND_SKILLS`
- `TestMCommandSkillCoverage` → `TestModelMediatedCommandSkillCoverage`

## What did NOT change

- **`REFLECTION_LOG.md`** — append-only history; rewriting prior entries would falsify the record. Past entries reference "P-command" etc. as the language of their moment.
- **`CHANGELOG.md` historical entries** — same reason.
- **Prior PR descriptions** — historical artefacts on GitHub.

## Verification

- [x] `pytest tests/` — 95 passed, 7 skipped (unchanged from before rename — confirms the variable + class rename didn't break anything)
- [x] `markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 8 files, all expected
- [x] No remaining occurrences of `\b[PMO][- ](command|commands|category|categories)\b` in forward-looking files
- [ ] CI passes

## Mass-rename mechanics

A small one-shot Python script (not committed) applied the substitutions consistently. Long-form patterns ran before short-form to avoid double-substitution. The script printed a per-file report of what changed; spot-checks confirmed the substitutions read naturally in context.

## Related

- Design spec where the abbreviations were introduced: PR #293
- Spec amendment that surfaced the readability concern: PR #298
- Phases 1–4 (the work that propagated the abbreviations): PRs #294, #295, #296, #297