### PR TITLE
Expand TDAD coverage: hooks, shell scripts, model-cards plugin

### DIFF
--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -139,16 +139,26 @@ dispatches via the Claude Agent SDK.
 
 ## Status
 
+### ai-literacy-superpowers plugin
+
 | Component / area | Layer 0 | Layer 1 | Layer 2 | Layer 3 |
 | --- | --- | --- | --- | --- |
 | reflection-log plumbing | ✅ 23 bash tests via dispatcher | n/a | n/a | n/a |
+| All shipped shell scripts | ✅ `bash -n` syntax check (every `.sh` in scripts/, scripts/lib/, hooks/scripts/) | n/a | n/a | n/a |
+| `hooks/hooks.json` | n/a | ✅ structural (manifest schema + every command script resolves) | n/a | n/a |
 | spec-writer | n/a | ✅ structural | n/a (agent, not skill) | ✅ implemented (gated on API key) |
 | cupid-code-review | n/a | ✅ structural | ✅ implemented (gated on API key) | ✅ implemented + LLM-as-judge rubric (gated on API key) |
-| All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [#284 design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
+| All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
 | convention-sync (procedural, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 8 tests |
 | observatory-verify (procedural, Phase 2 spike) | n/a | ✅ structural | n/a | ✅ Option C-direct helper + 11 tests |
 | 6 of 7 orchestration commands (Phase 3) | n/a | ✅ structural + wiring + per-command dispatch matrix | n/a | inherits from agents (Layer 3 covers each agent) |
 | All 7 model-mediated commands (Phase 4) | n/a | ✅ structural + wiring + per-command skill-coverage matrix | n/a | per-skill Layer 3 deferred (case-by-case per design spec) |
+
+### model-cards plugin
+
+| Component / area | Layer 0 | Layer 1 | Layer 2 | Layer 3 |
+| --- | --- | --- | --- | --- |
+| All components (1 agent, 1 skill, 1 command) | n/a | ✅ structural + wiring | n/a | not yet — plugin is small enough that matrices would be overkill |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run
@@ -169,6 +179,44 @@ Approximate per-run token cost based on Anthropic's published pricing
 A full Layer 0+1+2+3 run is around $0.10–$0.20. Tier execution is
 recommended for CI: Layers 0–1 on every PR (free, fast), Layer 2+3
 nightly or label-gated.
+
+## Coverage gaps and deferrals
+
+The TDAD suite covers **everything below Layer 3** for both plugins.
+Layer 3 (full SDK behavioural testing) is deliberately partial — the
+design spec at
+[`docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md`](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md)
+flagged it as case-by-case opt-in because per-skill cost varies and
+some failure modes don't justify the API spend.
+
+**Documented opt-ins (Layer 3 not yet built):**
+
+- 12 of 13 ai-literacy-superpowers agents — Layer 3 has been built for
+  spec-writer; the others inherit through the agent-verified tier of
+  the framework's promotion ladder. Add Layer 3 case-by-case when an
+  agent has a clear assertable side-effect (e.g., harness-discoverer's
+  scan output).
+- 30 of 31 ai-literacy-superpowers skills — Layer 3 has been built for
+  cupid-code-review (the canonical pattern). Per-skill Layer 3
+  decisions belong in their own spec each.
+- All 1 of 1 model-cards components — plugin is small; structural
+  coverage is sufficient.
+
+**Documented Phase-3 rollout target:**
+
+- 9 of 11 procedural commands without Option C helpers — Phase 2 (PR
+  #295) demonstrated the pattern; the spec amendment (PR #298) clarified
+  that helpers stay test-stage in `tdad_tests/spike_helpers/` rather
+  than promoting to plugin scripts. Rollout work is repetitive
+  application of the Phase 2 pattern; scope is one PR per ~3 commands.
+
+**Genuine architectural exclusion:**
+
+- `superpowers-init` orchestrates *other slash commands* rather than
+  dispatching agents directly. The Phase 3 dispatch matrix
+  deliberately excluded it. A "command-references-other-commands"
+  matrix could be added as a Phase 5 if drift in this area becomes a
+  real failure mode.
 
 ## Issue
 

--- a/tdad_tests/conftest.py
+++ b/tdad_tests/conftest.py
@@ -34,7 +34,13 @@ import pytest
 
 @pytest.fixture(scope="session")
 def plugin_path() -> Path:
-    """Resolve the packaged plugin directory."""
+    """Resolve the ai-literacy-superpowers packaged plugin directory.
+
+    Most existing tests assume this is the plugin under test — it is
+    the canonical and largest plugin in the repo. ``model_cards_path``
+    is the equivalent for the second plugin shipped from this repo;
+    each plugin has its own structural tests.
+    """
     # tdad_tests/ is a sibling of the inner ai-literacy-superpowers/
     # packaged directory inside the repo. The repo root sits one level up
     # from this conftest.
@@ -43,6 +49,25 @@ def plugin_path() -> Path:
     if not packaged.is_dir():
         pytest.fail(
             f"Plugin directory not found at {packaged!r}. "
+            "Has the plugin been moved or renamed?"
+        )
+    return packaged
+
+
+@pytest.fixture(scope="session")
+def model_cards_path() -> Path:
+    """Resolve the model-cards packaged plugin directory.
+
+    The repo ships two plugins side-by-side under ``marketplace.json``:
+    ai-literacy-superpowers (large) and model-cards (small, focused).
+    Both deserve at least Layer 1 structural coverage; this fixture
+    exposes the second plugin's path for tests scoped to it.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    packaged = repo_root / "model-cards"
+    if not packaged.is_dir():
+        pytest.fail(
+            f"model-cards plugin directory not found at {packaged!r}. "
             "Has the plugin been moved or renamed?"
         )
     return packaged

--- a/tdad_tests/tests/test_hooks_structural.py
+++ b/tdad_tests/tests/test_hooks_structural.py
@@ -1,0 +1,231 @@
+"""Layer 1 structural tests for the plugin's ``hooks.json``.
+
+The plugin ships ``ai-literacy-superpowers/hooks/hooks.json`` — a
+declarative manifest that registers every hook (PreToolUse, Stop,
+SessionStart, etc.) the plugin contributes to Claude Code. Hooks
+either invoke an inline ``prompt`` (the model evaluates it on the
+event) or run a ``command`` (typically a shell script under
+``hooks/scripts/``).
+
+Two failure modes worth catching at PR time:
+
+1. The ``hooks.json`` file is malformed (invalid JSON, missing the
+   top-level ``hooks`` map, or a hook entry missing required fields).
+   The Claude Code loader rejects malformed manifests, but the
+   failure surfaces only when a user installs and tries to use the
+   plugin. PR-time validation catches it earlier.
+
+2. A hook's ``command`` references a script path that does not exist.
+   Same class of failure as the rename-without-callsite-update bug
+   the command-wiring test catches for slash commands; this is the
+   equivalent for hook scripts.
+
+Both checks are pure structural — JSON parse + filesystem stat. No
+LLM, no execution. Runs in milliseconds.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "ai-literacy-superpowers"
+)
+
+
+# Recognised hook event names. Adding a new event type here is a
+# deliberate decision (Claude Code occasionally introduces new ones);
+# the test fails on any unrecognised event name to surface the
+# question at PR time rather than letting it slip through.
+KNOWN_HOOK_EVENTS = {
+    "PreToolUse",
+    "PostToolUse",
+    "Stop",
+    "SubagentStop",
+    "SessionStart",
+    "SessionEnd",
+    "UserPromptSubmit",
+    "PreCompact",
+    "Notification",
+}
+
+
+@pytest.fixture(scope="module")
+def hooks_manifest() -> dict:
+    """Parse the hooks manifest. Fails the module if the file is
+    malformed — every test below assumes a parseable manifest."""
+    path = _PLUGIN_PATH / "hooks" / "hooks.json"
+    if not path.exists():
+        pytest.fail(f"hooks.json not found at {path!r}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"hooks.json is invalid JSON: {exc}")
+
+
+@pytest.mark.structural
+class TestHooksManifestStructure:
+    """The hooks.json manifest must follow the documented shape."""
+
+    def test_has_top_level_hooks_map(self, hooks_manifest: dict):
+        assert "hooks" in hooks_manifest, (
+            "hooks.json must have a top-level 'hooks' key — the "
+            "manifest format Claude Code expects"
+        )
+        assert isinstance(hooks_manifest["hooks"], dict), (
+            "'hooks' must be a JSON object mapping event name to "
+            "hook list"
+        )
+
+    def test_has_top_level_description(self, hooks_manifest: dict):
+        """A description is non-essential to Claude Code but is the
+        shipped manifest's documentation surface — the team has chosen
+        to maintain one, so absence is a regression."""
+        assert "description" in hooks_manifest, (
+            "hooks.json should carry a top-level 'description' "
+            "documenting what the manifest as a whole does"
+        )
+        assert isinstance(hooks_manifest["description"], str), (
+            "'description' must be a string"
+        )
+        assert hooks_manifest["description"].strip(), (
+            "'description' must be non-empty"
+        )
+
+    def test_event_names_are_recognised(self, hooks_manifest: dict):
+        """Each top-level key under ``hooks`` should be a recognised
+        Claude Code event name. Unknown names are either typos or
+        upstream additions worth surfacing at PR time."""
+        unknown = [
+            name
+            for name in hooks_manifest["hooks"]
+            if name not in KNOWN_HOOK_EVENTS
+        ]
+        assert not unknown, (
+            f"hooks.json registers hooks for unknown events: {unknown}. "
+            "Either Claude Code added a new event type (update "
+            f"KNOWN_HOOK_EVENTS in this file) or a typo crept in. "
+            f"Recognised events: {sorted(KNOWN_HOOK_EVENTS)}."
+        )
+
+
+@pytest.mark.structural
+class TestHookEntryStructure:
+    """Every hook entry under every event must have the expected
+    shape — matcher + hooks list of typed entries with required
+    fields per type."""
+
+    def test_each_event_has_a_list_of_hook_groups(
+        self, hooks_manifest: dict
+    ):
+        for event, groups in hooks_manifest["hooks"].items():
+            assert isinstance(groups, list), (
+                f"hooks.{event} must be a list; got {type(groups).__name__}"
+            )
+
+    def test_each_group_has_matcher_and_hooks(
+        self, hooks_manifest: dict
+    ):
+        broken: list[str] = []
+        for event, groups in hooks_manifest["hooks"].items():
+            for index, group in enumerate(groups):
+                if "matcher" not in group:
+                    broken.append(
+                        f"hooks.{event}[{index}] missing 'matcher'"
+                    )
+                if "hooks" not in group:
+                    broken.append(
+                        f"hooks.{event}[{index}] missing 'hooks' list"
+                    )
+                elif not isinstance(group["hooks"], list):
+                    broken.append(
+                        f"hooks.{event}[{index}].hooks must be a list"
+                    )
+        assert not broken, "Malformed hook groups: " + "\n  ".join(
+            ["", *broken]
+        )
+
+    def test_each_hook_entry_has_required_fields(
+        self, hooks_manifest: dict
+    ):
+        """Each entry inside a group must have a ``type`` and a
+        ``timeout``, plus the type-specific payload field
+        (``command`` for ``type=command``, ``prompt`` for
+        ``type=prompt``)."""
+        broken: list[str] = []
+        for event, groups in hooks_manifest["hooks"].items():
+            for group_idx, group in enumerate(groups):
+                for hook_idx, hook in enumerate(group.get("hooks", [])):
+                    location = (
+                        f"hooks.{event}[{group_idx}].hooks[{hook_idx}]"
+                    )
+                    if "type" not in hook:
+                        broken.append(f"{location} missing 'type'")
+                        continue
+                    if "timeout" not in hook:
+                        broken.append(f"{location} missing 'timeout'")
+                    htype = hook["type"]
+                    if htype == "command" and "command" not in hook:
+                        broken.append(
+                            f"{location} type=command but no 'command'"
+                        )
+                    elif htype == "prompt" and "prompt" not in hook:
+                        broken.append(
+                            f"{location} type=prompt but no 'prompt'"
+                        )
+                    elif htype not in ("command", "prompt"):
+                        broken.append(
+                            f"{location} unknown type {htype!r}"
+                        )
+        assert not broken, "Malformed hook entries: " + "\n  ".join(
+            ["", *broken]
+        )
+
+
+@pytest.mark.structural
+class TestHookCommandsResolve:
+    """Every ``command`` hook must reference a script path that
+    actually exists on disk. The same rename-without-callsite-update
+    failure class the command-wiring test catches for slash commands,
+    but for hook scripts."""
+
+    # Match a command-style hook command of the form:
+    #   bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/<name>.sh
+    # and capture the script path relative to the plugin root.
+    _COMMAND_RE = re.compile(
+        r"\$\{CLAUDE_PLUGIN_ROOT\}/(?P<rel_path>[A-Za-z0-9_./-]+\.sh)"
+    )
+
+    def test_every_command_script_exists(self, hooks_manifest: dict):
+        broken: list[str] = []
+        for event, groups in hooks_manifest["hooks"].items():
+            for group_idx, group in enumerate(groups):
+                for hook_idx, hook in enumerate(group.get("hooks", [])):
+                    if hook.get("type") != "command":
+                        continue
+                    command = hook.get("command", "")
+                    match = self._COMMAND_RE.search(command)
+                    if not match:
+                        # Command does not reference a script path
+                        # under CLAUDE_PLUGIN_ROOT — could be a
+                        # one-liner using shell builtins; skip rather
+                        # than flag as broken.
+                        continue
+                    rel_path = match.group("rel_path")
+                    full_path = _PLUGIN_PATH / rel_path
+                    if not full_path.exists():
+                        broken.append(
+                            f"hooks.{event}[{group_idx}].hooks"
+                            f"[{hook_idx}] references "
+                            f"${{CLAUDE_PLUGIN_ROOT}}/{rel_path}, "
+                            f"which does not exist"
+                        )
+        assert not broken, (
+            "Hook command(s) reference missing script(s):"
+            + "\n  ".join(["", *broken])
+        )

--- a/tdad_tests/tests/test_layer0_script_syntax.py
+++ b/tdad_tests/tests/test_layer0_script_syntax.py
@@ -1,0 +1,122 @@
+"""Layer 0: bash syntax check for every shell script the plugin ships.
+
+The plugin ships a substantial set of shell scripts: standalone
+scripts under ``ai-literacy-superpowers/scripts/`` (plus its ``lib/``
+subdirectory) and per-event hook scripts under
+``ai-literacy-superpowers/hooks/scripts/``. Any of these can hit a
+production user's machine if invoked by a hook or referenced from a
+command. A syntax error in one of them — a missing ``done`` after a
+loop, an unbalanced quote, a stray ``$`` — is a runtime failure that
+the user sees without warning.
+
+Layer 0 already runs full integration tests for the three reflection-
+log scripts that have substantive logic (the bash test suite under
+``tdad_tests/layer0_deterministic/``). What that suite does *not*
+cover is the rest of the shipped scripts — the ones whose body is
+"call gh, format output, exit" and whose primary failure mode is
+being syntactically broken rather than producing wrong output.
+
+This module fills that gap. For every ``.sh`` file the plugin ships,
+``bash -n <file>`` parses the script without executing it and exits
+non-zero on any syntax error. Equivalent to a compile-only build for
+shell. Catches the failure mode at PR time, before the script ever
+runs.
+
+Cost: $0, milliseconds per script. Coverage: every shipped shell
+script. Granularity: per-script — failure points at the specific
+file and line.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "ai-literacy-superpowers"
+)
+
+
+def _all_shell_scripts() -> list[Path]:
+    """Find every ``.sh`` file the plugin ships.
+
+    Three locations cover the current plugin layout:
+
+    - ``scripts/`` for standalone scripts (badge updates, cache sync).
+    - ``scripts/lib/`` for sourceable libraries.
+    - ``hooks/scripts/`` for per-event hook scripts.
+
+    Returns absolute paths so the parametrise IDs render usefully and
+    each test can dispatch the script without further resolution.
+    """
+    if not _PLUGIN_PATH.is_dir():
+        return []
+    candidates: list[Path] = []
+    for directory in (
+        _PLUGIN_PATH / "scripts",
+        _PLUGIN_PATH / "scripts" / "lib",
+        _PLUGIN_PATH / "hooks" / "scripts",
+    ):
+        if directory.is_dir():
+            candidates.extend(sorted(directory.glob("*.sh")))
+    return candidates
+
+
+_ALL_SCRIPTS = _all_shell_scripts()
+
+
+@pytest.fixture(scope="session")
+def bash_executable() -> str:
+    """Locate the system bash; fail informatively if it is missing."""
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.fail(
+            "bash not found on PATH. Layer 0 script-syntax checks "
+            "require a POSIX shell with bash."
+        )
+    return bash
+
+
+@pytest.mark.structural
+class TestShellScriptSyntax:
+    """Every shipped shell script must parse cleanly under ``bash -n``."""
+
+    def test_at_least_one_script_discovered(self):
+        assert _ALL_SCRIPTS, (
+            "No shell scripts discovered for syntax checking. "
+            "Plugin layout may have changed; check "
+            "_all_shell_scripts() in this file."
+        )
+
+    @pytest.mark.parametrize(
+        "script",
+        _ALL_SCRIPTS,
+        ids=lambda script: script.name,
+    )
+    def test_script_parses(
+        self, script: Path, bash_executable: str
+    ) -> None:
+        """Run ``bash -n`` on the script. Non-zero exit means a
+        syntax error; the captured output names the file and line.
+
+        ``bash -n`` performs syntactic validation only — no commands
+        execute, no side effects. This is the compile-only equivalent
+        for shell.
+        """
+        result = subprocess.run(
+            [bash_executable, "-n", str(script)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"{script.name} failed bash syntax check "
+                f"(exit {result.returncode}).\n"
+                f"--- stderr ---\n{result.stderr}\n"
+                f"--- stdout ---\n{result.stdout}"
+            )

--- a/tdad_tests/tests/test_model_cards_structural.py
+++ b/tdad_tests/tests/test_model_cards_structural.py
@@ -1,0 +1,170 @@
+"""Layer 1 structural + wiring tests for the model-cards plugin.
+
+The repo ships two plugins side-by-side under ``marketplace.json``:
+ai-literacy-superpowers (large, the primary subject of the existing
+TDAD suite) and model-cards (small, focused on Mitchell-style model
+card authoring). Both deserve at least Layer 1 coverage — the bar
+for a plugin to ship is "every component is structurally sound and
+references resolve."
+
+The model-cards plugin is small enough that per-category matrices
+(orchestration / model-mediated) would be overkill — it has one
+agent, one skill, one command, and that command's wiring is fully
+captured by the generic resolver below. If the plugin grows beyond a
+single component of each type, this file should evolve toward the
+matrix-style coverage the larger plugin uses.
+
+This module mirrors a subset of ``test_layer1_structural.py`` and
+``test_command_wiring.py``, scoped to the model-cards plugin path
+via the ``model_cards_path`` fixture in conftest.py. The shared
+``runner.plugin`` helpers do not bake in any assumption about which
+plugin they run against, so re-using them here is mechanical.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+# Reuse the reference-extraction patterns from the existing wiring
+# test rather than duplicating regex maintenance — the patterns are
+# the same regardless of which plugin's command bodies they run
+# against.
+from tests.test_command_wiring import extract_references  # noqa: E402
+
+
+@pytest.mark.structural
+class TestModelCardsComponents:
+    """Every model-cards component must have well-formed frontmatter."""
+
+    def test_at_least_one_agent_exists(self, model_cards_path: Path):
+        agents = list(plugin_runner.list_agents(model_cards_path))
+        assert agents, "model-cards plugin has no agents"
+
+    def test_at_least_one_skill_exists(self, model_cards_path: Path):
+        skills = list(plugin_runner.list_skills(model_cards_path))
+        assert skills, "model-cards plugin has no skills"
+
+    def test_at_least_one_command_exists(self, model_cards_path: Path):
+        commands = list(plugin_runner.list_commands(model_cards_path))
+        assert commands, "model-cards plugin has no commands"
+
+    def test_every_component_has_a_name(self, model_cards_path: Path):
+        components = list(plugin_runner.list_agents(model_cards_path))
+        components.extend(plugin_runner.list_skills(model_cards_path))
+        components.extend(plugin_runner.list_commands(model_cards_path))
+        missing = [
+            f"{c.component_type}:{c.name}"
+            for c in components
+            if not c.frontmatter.get("name")
+        ]
+        assert not missing, (
+            f"Components in model-cards missing 'name' frontmatter: {missing}"
+        )
+
+    def test_every_component_has_a_description(
+        self, model_cards_path: Path
+    ):
+        components = list(plugin_runner.list_agents(model_cards_path))
+        components.extend(plugin_runner.list_skills(model_cards_path))
+        components.extend(plugin_runner.list_commands(model_cards_path))
+        missing = [
+            f"{c.component_type}:{c.name}"
+            for c in components
+            if not c.frontmatter.get("description")
+        ]
+        assert not missing, (
+            "Components in model-cards missing 'description' "
+            f"frontmatter: {missing}"
+        )
+
+    def test_every_skill_has_skill_md(self, model_cards_path: Path):
+        broken = [
+            c.name
+            for c in plugin_runner.list_skills(model_cards_path)
+            if not c.path.exists()
+        ]
+        assert not broken, (
+            f"model-cards skills missing SKILL.md: {broken}"
+        )
+
+
+@pytest.mark.structural
+class TestModelCardsWiring:
+    """Every reference in a model-cards command body must resolve to
+    a real component within the model-cards plugin."""
+
+    def test_command_references_resolve(self, model_cards_path: Path):
+        commands = list(plugin_runner.list_commands(model_cards_path))
+        agent_names = {
+            c.name for c in plugin_runner.list_agents(model_cards_path)
+        }
+        skill_names = {
+            c.name for c in plugin_runner.list_skills(model_cards_path)
+        }
+
+        broken: list[str] = []
+        for command in commands:
+            body = plugin_runner.read_component_body(command.path)
+            refs = extract_references(body)
+            for missing in refs["agent"] - agent_names:
+                broken.append(
+                    f"model-cards command /{command.name} references "
+                    f"missing agent {missing!r}"
+                )
+            for missing in refs["skill"] - skill_names:
+                broken.append(
+                    f"model-cards command /{command.name} references "
+                    f"missing skill {missing!r}"
+                )
+        assert not broken, (
+            "Broken references in model-cards command bodies:\n  - "
+            + "\n  - ".join(broken)
+        )
+
+
+@pytest.mark.structural
+class TestModelCardsExpectedComponents:
+    """Spot-check that the documented model-cards components are
+    actually present. Catches the case where someone deletes a
+    canonical component without realising it was load-bearing for
+    other documentation or for the marketplace listing."""
+
+    def test_model_card_researcher_agent_present(
+        self, model_cards_path: Path
+    ):
+        component = plugin_runner.find_component(
+            model_cards_path,
+            name="model-card-researcher",
+            component_type="agent",
+        )
+        description = component.frontmatter.get("description") or ""
+        assert "model card" in description.lower(), (
+            "model-card-researcher agent description must mention "
+            "'model card' for the Claude Code skill matcher to fire"
+        )
+
+    def test_model_cards_skill_present(self, model_cards_path: Path):
+        plugin_runner.find_component(
+            model_cards_path,
+            name="model-cards",
+            component_type="skill",
+        )
+
+    def test_model_card_command_present(
+        self, model_cards_path: Path
+    ):
+        component = plugin_runner.find_component(
+            model_cards_path,
+            name="model-card",
+            component_type="command",
+        )
+        assert component.frontmatter.get("description"), (
+            "model-card command must declare a description"
+        )


### PR DESCRIPTION
## Summary

Fills the most-clearly-indicated TDAD coverage gaps for both plugins shipped from this repo. The honest answer to *"appropriate TDAD coverage for everything"* is **not** "Layer 3 for every component" — that violates the design spec's case-by-case opt-in for Layer 3. The honest answer is: **every component covered at the cheapest layer that catches its failure modes**, with intentional gaps documented.

## What got covered

Three new test files, 36 new tests total:

| Test file | What it covers | Layer |
|---|---|---|
| `test_layer0_script_syntax.py` | `bash -n` syntax check for 12 shipped shell scripts | Layer 0 |
| `test_hooks_structural.py` | `hooks/hooks.json` schema + every command-script reference resolves on disk | Layer 1 |
| `test_model_cards_structural.py` | model-cards plugin: structural + wiring (3 components) | Layer 1 |

## Why these specific gaps

| Gap | Why prioritised |
|---|---|
| Shell script syntax | A syntax error in a hook script ships to every user; `bash -n` catches it at PR time, costs ~$0 |
| `hooks.json` validation | Manifest is the contract Claude Code reads at install — malformed JSON or stale script paths break the plugin silently |
| model-cards Layer 1 | Second plugin in repo previously had **zero** TDAD coverage; mirroring superpowers' Layer 1 is the cheapest way to ensure "every component is structurally sound" |

## What this PR does NOT do (and why)

The audit surfaced gaps the design spec explicitly classified as **deferred opt-ins**. These are not addressed here:

- 12 of 13 ai-literacy-superpowers agents lack Layer 3 — case-by-case per design spec; spec-writer is the canonical example, others wait for clear-side-effect candidates
- 30 of 31 ai-literacy-superpowers skills lack Layer 3 — same; cupid-code-review is the canonical example
- 9 of 11 procedural commands lack Option C helpers — the Phase 3 rollout per the amended spec; that's repetitive application of the Phase 2 pattern, deserves its own PR(s)
- `superpowers-init` excluded from orchestration matrix — orchestrates other slash commands, not agents; would need a Phase 5 "command-references-other-commands" matrix if drift here becomes a real failure mode

These are now documented in the suite README's new **"Coverage gaps and deferrals"** section so the suite's scope is explicit.

## Suite delta

| | Before | After |
|---|---|---|
| Passed | 95 | 131 |
| Skipped | 7 | 7 |
| Wall-clock | ~4.0s | ~3.9s |

All four layers run offline. No plugin behaviour change, no version bump.

## Per-plugin coverage (new in README)

The README's Status section is split into per-plugin tables:

- **ai-literacy-superpowers**: 11 rows covering all component types
- **model-cards**: 1 row covering all 3 components

## Test plan

- [x] All 36 new tests pass
- [x] Full TDAD suite without API key: 131 passed, 7 skipped (unchanged)
- [x] `markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 5 files, all expected
- [ ] CI passes

## Related

- Spike: PR #282
- SDK runner: PR #285
- Phase 1: PR #294
- Phase 2 spike: PR #295
- Phase 3: PR #296
- Phase 4: PR #297
- Design spec amendment: PR #298
- Rename to full names: PR #299