### PR TITLE
Layer 2 expansion: trigger tests for 6 high-value skills

### DIFF
--- a/tdad_tests/README.md
+++ b/tdad_tests/README.md
@@ -147,7 +147,12 @@ dispatches via the Claude Agent SDK.
 | All shipped shell scripts | ✅ `bash -n` syntax check (every `.sh` in scripts/, scripts/lib/, hooks/scripts/) | n/a | n/a | n/a |
 | `hooks/hooks.json` | n/a | ✅ structural (manifest schema + every command script resolves) | n/a | n/a |
 | spec-writer | n/a | ✅ structural | n/a (agent, not skill) | ✅ implemented (gated on API key) |
-| cupid-code-review | n/a | ✅ structural | ✅ implemented (gated on API key) | ✅ implemented + LLM-as-judge rubric (gated on API key) |
+| cupid-code-review | n/a | ✅ structural | ✅ trigger tests | ✅ implemented + LLM-as-judge rubric (gated on API key) |
+| literate-programming | n/a | ✅ structural | ✅ trigger tests (4 queries) | not yet (case-by-case) |
+| secrets-detection | n/a | ✅ structural | ✅ trigger tests (4 queries) | not yet (case-by-case) |
+| dependency-vulnerability-audit | n/a | ✅ structural | ✅ trigger tests (4 queries) | not yet (case-by-case) |
+| github-actions-supply-chain | n/a | ✅ structural | ✅ trigger tests (4 queries) | not yet (case-by-case) |
+| docker-scout-audit | n/a | ✅ structural | ✅ trigger tests (4 queries) | not yet (case-by-case) |
 | All 25 commands | n/a | ✅ structural + wiring (Phase 1) | n/a | per-category strategy in spec — see [design](../docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md) |
 | 10 of 11 procedural commands | n/a | ✅ structural | n/a | ✅ Option C-direct test-stage helper per command |
 | `/worktree` (procedural, deliberate skip) | n/a | ✅ structural | n/a | helper would only wrap git; see `spike_helpers/__init__.py` |
@@ -158,7 +163,7 @@ dispatches via the Claude Agent SDK.
 
 | Component / area | Layer 0 | Layer 1 | Layer 2 | Layer 3 |
 | --- | --- | --- | --- | --- |
-| All components (1 agent, 1 skill, 1 command) | n/a | ✅ structural + wiring | n/a | not yet — plugin is small enough that matrices would be overkill |
+| All components (1 agent, 1 skill, 1 command) | n/a | ✅ structural + wiring | ✅ trigger tests on the model-cards skill (cross-plugin index) | not yet — plugin is small enough that matrices would be overkill |
 
 Layer 1 runs offline and passes against the real plugin. Layer 2 and
 Layer 3 are implemented and exercise the Claude Agent SDK. They run
@@ -172,7 +177,7 @@ Approximate per-run token cost based on Anthropic's published pricing
 
 - Layer 0 bash dispatcher: $0, ~3 seconds wall-clock
 - Layer 1 structural: $0, sub-second wall-clock
-- Layer 2 trigger tests: ~5 inferences against Haiku, ~$0.01 total
+- Layer 2 trigger tests: ~28 inferences against Haiku across 6 skills, ~$0.03 total
 - Layer 3 spec-writer: 1 multi-turn run against Sonnet, ~$0.05–$0.10
 - Layer 3 cupid-code-review: 1 review run + 1 judge run, ~$0.05
 

--- a/tdad_tests/runner/sdk.py
+++ b/tdad_tests/runner/sdk.py
@@ -222,7 +222,20 @@ async def match_skills(
         return []
     if not isinstance(parsed, list):
         return []
-    return [str(name) for name in parsed]
+    # Normalise: when the catalogue spans multiple plugins, the model
+    # sometimes ignores the "exactly as they appear" instruction and
+    # returns plugin-qualified forms like ``"model-cards:model-cards"``
+    # instead of the bare skill name. Strip any ``<prefix>:`` segment
+    # so the matcher's behaviour is the same in single-plugin and
+    # multi-plugin cases. Surfaced by a real Layer 2 run on the
+    # cross-plugin model-cards trigger test.
+    names: list[str] = []
+    for entry in parsed:
+        text = str(entry)
+        if ":" in text:
+            text = text.rsplit(":", 1)[-1]
+        names.append(text)
+    return names
 
 
 # ---------------------------------------------------------------------------

--- a/tdad_tests/scenarios/skills/dependency-vulnerability-audit/triggers-on-vulnerability-audit-query.md
+++ b/tdad_tests/scenarios/skills/dependency-vulnerability-audit/triggers-on-vulnerability-audit-query.md
@@ -1,0 +1,40 @@
+---
+component: dependency-vulnerability-audit
+component_type: skill
+tier: trigger
+---
+
+# Scenario: dependency-vulnerability-audit triggers on dependency-audit queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "Check this Go project for vulnerable dependencies"
+- "Audit our Maven dependencies for known CVEs"
+- "Set up govulncheck in our CI"
+- "What's the supply-chain risk in our project's dependency tree?"
+
+## Then
+
+For each query, the model should identify
+`dependency-vulnerability-audit` as a skill to invoke. The skill
+covers Go modules, Maven/JVM, and CI integration — all four queries
+fall within that surface.
+
+## Rubric
+
+Single-inference catalogue match. The skill must appear in the
+response.
+
+## Cross-skill collision risk
+
+`github-actions-supply-chain` and this skill could plausibly compete
+on the "CI integration / supply chain" framing. Both should ideally
+fire on the third query ("Set up govulncheck in our CI"); at minimum,
+this skill must fire. Cross-skill discrimination is exactly what the
+Layer 2 catalogue match exercises.

--- a/tdad_tests/scenarios/skills/docker-scout-audit/triggers-on-docker-cve-query.md
+++ b/tdad_tests/scenarios/skills/docker-scout-audit/triggers-on-docker-cve-query.md
@@ -1,0 +1,35 @@
+---
+component: docker-scout-audit
+component_type: skill
+tier: trigger
+---
+
+# Scenario: docker-scout-audit triggers on Docker-CVE queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "Scan our Docker image for CVEs"
+- "Check if our base image is stale"
+- "Audit Docker images for vulnerabilities"
+- "What CVEs are in our containers?"
+
+## Then
+
+For each query, the model should identify `docker-scout-audit` as a
+skill to invoke.
+
+## Rubric
+
+Single-inference catalogue match.
+
+## Failure-cost note
+
+Same security-class failure-cost as the `secrets-detection` and
+`dependency-vulnerability-audit` skills: missed image scans ship CVEs
+to production.

--- a/tdad_tests/scenarios/skills/github-actions-supply-chain/triggers-on-workflow-security-query.md
+++ b/tdad_tests/scenarios/skills/github-actions-supply-chain/triggers-on-workflow-security-query.md
@@ -1,0 +1,38 @@
+---
+component: github-actions-supply-chain
+component_type: skill
+tier: trigger
+---
+
+# Scenario: github-actions-supply-chain triggers on workflow-security queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "Review our GitHub Actions workflows for security issues"
+- "Harden our CI pipeline"
+- "Are our actions pinned to commit SHAs?"
+- "Audit this repo's GitHub Actions supply-chain risk"
+
+## Then
+
+For each query, the model should identify
+`github-actions-supply-chain` as a skill to invoke.
+
+## Rubric
+
+Single-inference catalogue match.
+
+## Distinction from `dependency-vulnerability-audit`
+
+This skill is specifically about *workflow file* security and
+*action* supply chain — pinning, permissions, third-party action
+trust. The `dependency-vulnerability-audit` skill is about
+*runtime* dependency CVEs (Go modules, Maven, etc.). The third
+query ("pinned to commit SHAs") is unambiguously this skill's
+territory.

--- a/tdad_tests/scenarios/skills/literate-programming/triggers-on-new-source-file-query.md
+++ b/tdad_tests/scenarios/skills/literate-programming/triggers-on-new-source-file-query.md
@@ -1,0 +1,41 @@
+---
+component: literate-programming
+component_type: skill
+tier: trigger
+---
+
+# Scenario: literate-programming triggers on source-file authoring queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded — so
+all skill descriptions, including `literate-programming`, are
+available for matching.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "I'm about to create a new module for parsing config files — what should it look like?"
+- "Write me a new helper class for handling user authentication"
+- "Create a new Python file that handles snapshot serialisation"
+- "I'm rewriting the renderer module from scratch"
+
+## Then
+
+For each query, the model should identify `literate-programming` as
+a skill to invoke. The skill's role is to ensure new code carries
+narrative preambles, reasoning-based documentation, and reader-first
+presentation.
+
+## Rubric
+
+A single inference per query: hand the model the plugin's skill
+descriptions and the query, ask "which skills would you invoke?",
+and parse the response. The skill must appear in the match list.
+
+## Implementation note
+
+Tests live in `tdad_tests/tests/test_layer2_triggers.py`. The
+extractor pattern is the same as the cupid-code-review trigger
+test from PR #285 (`runner.sdk.match_skills`).

--- a/tdad_tests/scenarios/skills/secrets-detection/triggers-on-secrets-audit-query.md
+++ b/tdad_tests/scenarios/skills/secrets-detection/triggers-on-secrets-audit-query.md
@@ -1,0 +1,37 @@
+---
+component: secrets-detection
+component_type: skill
+tier: trigger
+---
+
+# Scenario: secrets-detection triggers on secrets-audit queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "Audit this project for committed secrets"
+- "Set up gitleaks for this repository"
+- "Are there any API keys committed in our source?"
+- "Harden our 'no secrets in source' harness constraint"
+
+## Then
+
+For each query, the model should identify `secrets-detection` as a
+skill to invoke. The skill covers gitleaks setup, baselining, scanning,
+and CI integration — every query above falls within that surface.
+
+## Rubric
+
+Single-inference catalogue match. The skill must appear in the
+response.
+
+## Failure-cost note
+
+A description-drift miss here is a security-class failure: the user
+asks the right question, the right skill exists, and nothing fires.
+This is exactly the silent-degradation case Layer 2 was built for.

--- a/tdad_tests/tests/test_layer2_triggers.py
+++ b/tdad_tests/tests/test_layer2_triggers.py
@@ -135,3 +135,381 @@ class TestCupidCodeReviewTriggers:
                 "the description should mention 'composable' and "
                 "'predictable' explicitly."
             )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 expansion: five high-value skills (per the recommendation that
+# selected skills loaded primarily through description matching, with
+# clear trigger surfaces and security-class failure costs).
+#
+# Each class follows the same shape:
+# - A scenario fixture (loaded from tdad_tests/scenarios/skills/<name>/)
+# - Pre-flight (offline) — description contains expected trigger terms
+# - Parametrised explicit queries — each must fire the skill
+#
+# The single-inference catalogue match runs against Haiku; cost per
+# class is ~5 inferences ≈ $0.005. All five together stay well under
+# $0.05 per full Layer 2 run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestLiterateProgrammingTriggers:
+    """The literate-programming skill should fire when the user is
+    creating new source files, writing new functions/types, or
+    significantly rewriting existing code."""
+
+    @pytest.fixture
+    def scenario(self, scenarios_dir):
+        return parse_scenario(
+            scenarios_dir
+            / "skills"
+            / "literate-programming"
+            / "triggers-on-new-source-file-query.md"
+        )
+
+    TRIGGER_QUERIES = [
+        "I'm about to create a new module for parsing config files — what should it look like?",
+        "Write me a new helper class for handling user authentication",
+        "Create a new Python file that handles snapshot serialisation",
+        "I'm rewriting the renderer module from scratch",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, plugin_path, scenario
+    ):
+        skill = plugin_runner.find_component(
+            plugin_path,
+            name=scenario.component,
+            component_type=scenario.component_type,
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        # The description's whole point is to fire on source-file
+        # authoring queries. Any of these tokens individually is
+        # enough; absence of all four is a hard regression.
+        for token in ("source", "file", "function", "code"):
+            if token in description:
+                return
+        pytest.fail(
+            "literate-programming description does not mention any "
+            "of: source, file, function, code — model matching is "
+            "extremely unlikely to fire"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_source_file_query(
+        self, needs_api, plugin_path, query: str
+    ):
+        index = _skill_index(plugin_path)
+        matches = await match_skills(query, index)
+        assert "literate-programming" in matches, (
+            f"Query {query!r} did not match literate-programming. "
+            f"Model returned: {matches}. Description drift suspected."
+        )
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestSecretsDetectionTriggers:
+    """The secrets-detection skill should fire on secrets-audit
+    queries — gitleaks setup, scanning, baselining, CI integration."""
+
+    @pytest.fixture
+    def scenario(self, scenarios_dir):
+        return parse_scenario(
+            scenarios_dir
+            / "skills"
+            / "secrets-detection"
+            / "triggers-on-secrets-audit-query.md"
+        )
+
+    TRIGGER_QUERIES = [
+        "Audit this project for committed secrets",
+        "Set up gitleaks for this repository",
+        "Are there any API keys committed in our source?",
+        "Harden our 'no secrets in source' harness constraint",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, plugin_path, scenario
+    ):
+        skill = plugin_runner.find_component(
+            plugin_path,
+            name=scenario.component,
+            component_type=scenario.component_type,
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        assert "secret" in description, (
+            "secrets-detection description must mention 'secret(s)' "
+            "for the model to fire on secrets-audit queries"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_secrets_query(
+        self, needs_api, plugin_path, query: str
+    ):
+        index = _skill_index(plugin_path)
+        matches = await match_skills(query, index)
+        assert "secrets-detection" in matches, (
+            f"Query {query!r} did not match secrets-detection. "
+            f"Model returned: {matches}. Description drift suspected — "
+            "this is a security-class regression."
+        )
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestDependencyVulnerabilityAuditTriggers:
+    """The dependency-vulnerability-audit skill should fire on
+    dependency-audit queries (Go modules, Maven, supply-chain)."""
+
+    @pytest.fixture
+    def scenario(self, scenarios_dir):
+        return parse_scenario(
+            scenarios_dir
+            / "skills"
+            / "dependency-vulnerability-audit"
+            / "triggers-on-vulnerability-audit-query.md"
+        )
+
+    TRIGGER_QUERIES = [
+        "Check this Go project for vulnerable dependencies",
+        "Audit our Maven dependencies for known CVEs",
+        "Set up govulncheck in our CI",
+        "What's the supply-chain risk in our project's dependency tree?",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, plugin_path, scenario
+    ):
+        skill = plugin_runner.find_component(
+            plugin_path,
+            name=scenario.component,
+            component_type=scenario.component_type,
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        assert (
+            "vulnerab" in description or "dependenc" in description
+        ), (
+            "dependency-vulnerability-audit description must mention "
+            "vulnerabilities or dependencies"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_vulnerability_query(
+        self, needs_api, plugin_path, query: str
+    ):
+        index = _skill_index(plugin_path)
+        matches = await match_skills(query, index)
+        assert "dependency-vulnerability-audit" in matches, (
+            f"Query {query!r} did not match "
+            "dependency-vulnerability-audit. "
+            f"Model returned: {matches}. Description drift suspected."
+        )
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestGitHubActionsSupplyChainTriggers:
+    """The github-actions-supply-chain skill should fire on
+    workflow-security and CI-hardening queries."""
+
+    @pytest.fixture
+    def scenario(self, scenarios_dir):
+        return parse_scenario(
+            scenarios_dir
+            / "skills"
+            / "github-actions-supply-chain"
+            / "triggers-on-workflow-security-query.md"
+        )
+
+    TRIGGER_QUERIES = [
+        "Review our GitHub Actions workflows for security issues",
+        "Harden our CI pipeline",
+        "Are our actions pinned to commit SHAs?",
+        "Audit this repo's GitHub Actions supply-chain risk",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, plugin_path, scenario
+    ):
+        skill = plugin_runner.find_component(
+            plugin_path,
+            name=scenario.component,
+            component_type=scenario.component_type,
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        assert (
+            "github actions" in description or "workflow" in description
+        ), (
+            "github-actions-supply-chain description must mention "
+            "GitHub Actions or workflows"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_workflow_security_query(
+        self, needs_api, plugin_path, query: str
+    ):
+        index = _skill_index(plugin_path)
+        matches = await match_skills(query, index)
+        assert "github-actions-supply-chain" in matches, (
+            f"Query {query!r} did not match "
+            "github-actions-supply-chain. "
+            f"Model returned: {matches}. Description drift suspected."
+        )
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestDockerScoutAuditTriggers:
+    """The docker-scout-audit skill should fire on Docker-CVE and
+    base-image-staleness queries."""
+
+    @pytest.fixture
+    def scenario(self, scenarios_dir):
+        return parse_scenario(
+            scenarios_dir
+            / "skills"
+            / "docker-scout-audit"
+            / "triggers-on-docker-cve-query.md"
+        )
+
+    TRIGGER_QUERIES = [
+        "Scan our Docker image for CVEs",
+        "Check if our base image is stale",
+        "Audit Docker images for vulnerabilities",
+        "What CVEs are in our containers?",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, plugin_path, scenario
+    ):
+        skill = plugin_runner.find_component(
+            plugin_path,
+            name=scenario.component,
+            component_type=scenario.component_type,
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        assert "docker" in description, (
+            "docker-scout-audit description must mention Docker"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_docker_cve_query(
+        self, needs_api, plugin_path, query: str
+    ):
+        index = _skill_index(plugin_path)
+        matches = await match_skills(query, index)
+        assert "docker-scout-audit" in matches, (
+            f"Query {query!r} did not match docker-scout-audit. "
+            f"Model returned: {matches}. Description drift suspected."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-plugin Layer 2: model-cards skill from the model-cards plugin.
+#
+# Difference from the five tests above: the matching catalogue must
+# include skills from BOTH plugins. A real session a user runs with
+# both plugins installed sees both skill catalogues simultaneously,
+# and that combined catalogue is the realistic matching surface. A
+# single-plugin index for model-cards would test only one skill and
+# prove nothing about cross-plugin discrimination.
+#
+# The 5 tests above use single-plugin indexes because their target
+# skills' cross-plugin collision risk is low (no model-cards plugin
+# skill is about secrets, dependencies, Docker, or workflows). For
+# the model-cards skill, however, ai-literacy-superpowers'
+# `model-sovereignty` skill is a plausible competitor (both touch
+# "model" topics), so combined-index is the right test.
+# ---------------------------------------------------------------------------
+
+
+def _combined_skill_index(
+    *plugin_paths: Path,
+) -> list[tuple[str, str]]:
+    """Build a combined catalogue across multiple plugin paths.
+
+    Skills appear in plugin-discovery order; duplicates (same name in
+    two plugins) keep the first one encountered. The duplicate case
+    is unlikely today but worth a deterministic policy if it arises.
+    """
+    seen: set[str] = set()
+    pairs: list[tuple[str, str]] = []
+    for path in plugin_paths:
+        for skill in plugin_runner.list_skills(path):
+            if skill.name in seen:
+                continue
+            description = skill.frontmatter.get("description") or ""
+            if description:
+                pairs.append((skill.name, str(description)))
+                seen.add(skill.name)
+    return pairs
+
+
+@pytest.mark.trigger
+@pytest.mark.needs_api
+class TestModelCardsSkillTriggers:
+    """The model-cards skill (in the model-cards plugin) should fire
+    on model-card authoring queries — including in a session with the
+    ai-literacy-superpowers plugin also loaded."""
+
+    TRIGGER_QUERIES = [
+        "Create a model card for Claude Sonnet 4.6",
+        "Document this model's evals and benchmarks",
+        "Author a Mitchell-style model card for this model",
+        "What sections go into a model card?",
+    ]
+
+    def test_skill_metadata_includes_trigger_terms(
+        self, model_cards_path: Path
+    ):
+        skill = plugin_runner.find_component(
+            model_cards_path,
+            name="model-cards",
+            component_type="skill",
+        )
+        description = (
+            skill.frontmatter.get("description") or ""
+        ).lower()
+        assert "model card" in description, (
+            "model-cards skill description must mention 'model card' "
+            "for matching to fire on model-card queries"
+        )
+
+    @pytest.mark.parametrize("query", TRIGGER_QUERIES)
+    @pytest.mark.asyncio
+    async def test_skill_triggers_on_model_card_query(
+        self,
+        needs_api,
+        plugin_path: Path,
+        model_cards_path: Path,
+        query: str,
+    ):
+        # Combined index: both plugins' skills, so the test reflects
+        # a real user session with both installed.
+        index = _combined_skill_index(plugin_path, model_cards_path)
+        matches = await match_skills(query, index)
+        assert "model-cards" in matches, (
+            f"Query {query!r} did not match the model-cards skill. "
+            f"Model returned: {matches}. Likely cause: description "
+            "drift in model-cards/skills/model-cards/SKILL.md, or "
+            "ai-literacy-superpowers' model-sovereignty skill is "
+            "stealing matches that should go to model-cards."
+        )


### PR DESCRIPTION
## Summary

Adds Layer 2 (description-trigger) tests for the 6 skills identified as highest-value Layer 2 candidates — skills loaded primarily through description matching, with clear trigger surfaces and security-class or correctness-class failure costs.

## Skills covered

Each gets a scenario file under `scenarios/skills/<name>/` + a parametrised test class. 4 SDK queries per skill (Haiku, single inference each).

| Skill | Plugin | Trigger surface | Failure-cost class |
|---|---|---|---|
| `literate-programming` | ai-literacy-superpowers | new-source-file authoring | correctness |
| `secrets-detection` | ai-literacy-superpowers | secrets-audit | security |
| `dependency-vulnerability-audit` | ai-literacy-superpowers | dep-CVE / supply-chain | security |
| `github-actions-supply-chain` | ai-literacy-superpowers | workflow security | security |
| `docker-scout-audit` | ai-literacy-superpowers | Docker-CVE / base-image staleness | security |
| `model-cards` | model-cards | model-card authoring | correctness |

Each class:

- Pre-flight (offline) — skill description contains expected trigger terms; fails fast if a description rewrite drops the matching surface
- Parametrised SDK tests — single Haiku inference per query; asserts the target skill is in the catalogue match list

The `model-cards` class is **cross-plugin** — its matching catalogue spans both ai-literacy-superpowers and model-cards plugins, so the test reflects a real user session with both installed. The other 5 use a single-plugin index because cross-plugin collision risk is low for those skills.

## Real bug surfaced and fixed during the live run

The model occasionally ignores the prompt's "use exact catalogue names" instruction and returns plugin-qualified forms like `"model-cards:model-cards"` instead of `"model-cards"`. The `runner.sdk.match_skills` helper now strips `<prefix>:` segments so the matcher behaves consistently in single-plugin and multi-plugin contexts.

This is exactly the kind of finding the live-API discipline catches. The pre-flight tests would never have surfaced it; only the actual model invocation did.

## Live API run results

28 SDK trigger tests + 7 offline pre-flights, all green after the matcher fix:

| | |
|---|---|
| Passing | 35/35 (live) |
| Wall-clock | ~7 minutes (~14s per inference incl. SDK overhead) |
| Cost | ~$0.03 total (Haiku, 28 inferences) |

## Suite delta

- **Without API key**: 151 → 157 passed (+6 pre-flights), 7 → 31 skipped (+24 needs_api SDK tests)
- **With API key**: full Layer 2 catches all 28 trigger queries

## Test plan

- [x] Offline: 157 passed, 31 skipped (no API key)
- [x] Live API: 35/35 passed in ~7min (~$0.03)
- [x] `markdownlint-cli2` — clean
- [x] `git diff --cached --stat` — 8 files, all expected
- [ ] CI passes

## Related

- Layer 2 spike (cupid-code-review canonical pattern): PR #285
- Coverage expansion (hooks/scripts/model-cards): PR #300
- Procedural rollout: PR #301