### PR TITLE
Fix relative links in Contributing page (broken main)

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -8,12 +8,12 @@ This page is the docs-site projection of the project's
 [`ONBOARDING.md`](https://github.com/Habitat-Thinking/ai-literacy-superpowers/blob/main/ONBOARDING.md).
 The source of truth lives in the repo and is regenerated from
 `HARNESS.md`, `AGENTS.md`, and `REFLECTION_LOG.md` by the
-[`/harness-onboarding`](plugins/ai-literacy-superpowers/how-to/generate-onboarding.md)
+[`/harness-onboarding`](../plugins/ai-literacy-superpowers/how-to/generate-onboarding.md)
 command. When ONBOARDING.md is regenerated, this page should be
 updated to mirror it.
 
 If you are setting up your environment for the first time, start with
-the [Getting Started tutorial](plugins/ai-literacy-superpowers/tutorials/getting-started.md).
+the [Getting Started tutorial](../plugins/ai-literacy-superpowers/tutorials/getting-started.md).
 The page below picks up where that tutorial leaves off, covering the
 day-to-day conventions and discipline a contributor needs to ship a
 PR against this repo.
@@ -133,7 +133,7 @@ they pass.
   a code-mode objection record at
   `docs/superpowers/objections/<spec-slug>.md` and
   `<spec-slug>-code.md`, with all dispositions resolved. Run
-  [`/diaboli`](plugins/ai-literacy-superpowers/how-to/review-a-spec-adversarially.md)
+  [`/diaboli`](../plugins/ai-literacy-superpowers/how-to/review-a-spec-adversarially.md)
   after the spec is written and again after the implementation is
   complete.
 - **Adjudicated choice stories** — every non-exempt feature PR needs
@@ -182,7 +182,7 @@ Periodic checks run weekly or monthly to catch slow drift.
 - **Change cadence drift** — watches whether PR sizes or cycle times
   are increasing, which can signal that AI-speed production is
   outpacing human review. See
-  [Enforce the human pace](plugins/ai-literacy-superpowers/how-to/enforce-human-pace.md)
+  [Enforce the human pace](../plugins/ai-literacy-superpowers/how-to/enforce-human-pace.md)
   for the rationale.
 - **Plugin manifest currency** — checks whether `plugin.json` counts
   still match actual skills, agents, and commands.
@@ -478,9 +478,9 @@ at different timescales:
 
 For the conceptual background on each loop, see:
 
-- [Three enforcement loops](plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md)
-- [The harness lifecycle](plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md)
-- [Garbage collection](plugins/ai-literacy-superpowers/explanation/garbage-collection.md)
+- [Three enforcement loops](../plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md)
+- [The harness lifecycle](../plugins/ai-literacy-superpowers/explanation/the-harness-lifecycle.md)
+- [Garbage collection](../plugins/ai-literacy-superpowers/explanation/garbage-collection.md)
 
 The project runs on a monthly observability cadence:
 
@@ -557,5 +557,5 @@ The project runs on a monthly observability cadence:
 - [Command-TDAD-testing design spec](https://github.com/Habitat-Thinking/ai-literacy-superpowers/blob/main/docs/superpowers/specs/2026-05-09-command-tdad-testing-design.md)
   — per-category strategy for testing commands, including the
   Option I amendment that keeps helpers test-stage
-- [Generate an Onboarding Guide](plugins/ai-literacy-superpowers/how-to/generate-onboarding.md)
+- [Generate an Onboarding Guide](../plugins/ai-literacy-superpowers/how-to/generate-onboarding.md)
   — how to regenerate `ONBOARDING.md` (the source of this page)


### PR DESCRIPTION
## Summary

Recovery PR for #306. The Pages deploy after #306 merged aborted in
`mkdocs build --strict` mode because the docs-internal links in
`docs/contributing/index.md` were written relative to `docs/`,
not relative to the source file's directory (`docs/contributing/`).

Eight links of the form `plugins/ai-literacy-superpowers/...` were
being resolved by MkDocs at `contributing/plugins/ai-literacy-superpowers/...`
which doesn't exist. All eight now use `../plugins/...`.

The PR-time CI suite (markdownlint, version-check, spec-first,
enforce-PR-constraints) does not include a `mkdocs build --strict`
step, so the breakage was only caught by the post-merge Pages
workflow. Adding strict-build at PR time is a candidate follow-up,
but is out of scope for this recovery PR.

## Verification

Local strict build:

```text
$ python3 -m mkdocs build --strict --site-dir /tmp/_site_check
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /tmp/_site_check
INFO    -  ... (all pre-existing INFO items, none from contributing/)
INFO    -  Documentation built in 2.33 seconds
```

No "Aborted with N warnings in strict mode!" line.

## Test plan

- [x] Local `mkdocs build --strict` passes
- [x] All 8 links in `docs/contributing/index.md` now prefixed
      with `../`
- [ ] CI green on this PR
- [ ] Pages deploy succeeds after merge — verify at
      [habitat-thinking.github.io/ai-literacy-superpowers/contributing/](https://habitat-thinking.github.io/ai-literacy-superpowers/contributing/)

## Why `fix`

Recovery from a regression on `main` — the `fix` exemption is the
right label per CLAUDE.md's Spec-First Exemptions table for
"targeted bug fix or correction where no design work is needed".