### PR TITLE
Add TDAD fast-suite (Layers 0+1) as PR-time CI gate

### DIFF
--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -1,0 +1,62 @@
+# TDAD Layers 0 + 1 — fast deterministic suite — PR-time gate.
+#
+# Runs the two free, deterministic layers of the TDAD test suite on
+# every PR:
+#
+# - Layer 0: bash plumbing tests for reflection-log helpers, archive
+#            scripts, and the migration helper. Dispatched by the
+#            pytest test_layer0_deterministic.py module which shells
+#            out to bash test scripts.
+# - Layer 1: structural tests for the plugin's own components and
+#            scenario corpus. Frontmatter well-formed, components
+#            exist, scenarios resolve.
+#
+# Both layers run offline (no API key required) and complete in under
+# ten seconds on a stock GitHub-hosted runner. Layers 2 (trigger) and
+# Layer 3 (behavioural) are NOT run here — they require ANTHROPIC_API_KEY
+# and per-run cost ($0.03 per Layer 2 trigger run; $0.05–$0.20 per
+# Layer 3 behavioural run). A separate workflow can be added if the
+# project decides to gate Layer 2/3 nightly or behind a label.
+#
+# This is a hard gate — Layer 0 or Layer 1 failures block the PR.
+
+name: TDAD fast suite (Layers 0 + 1)
+
+on:
+  pull_request:
+    paths:
+      - 'ai-literacy-superpowers/**'
+      - 'tdad_tests/**'
+      - 'HARNESS.md'
+      - 'AGENTS.md'
+      - '.github/workflows/tdad-tests-fast.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fast-suite:
+    name: Run TDAD Layers 0 + 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: tdad_tests/pyproject.toml
+
+      - name: Install tdad_tests
+        working-directory: tdad_tests
+        run: pip install -e .
+
+      - name: Run Layer 0 (deterministic plumbing)
+        working-directory: tdad_tests
+        run: pytest tests/test_layer0_deterministic.py -v
+
+      - name: Run Layer 1 (structural)
+        working-directory: tdad_tests
+        run: pytest tests/test_layer1_structural.py -v

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -298,6 +298,23 @@
 - **Tool**: `.github/workflows/spec-redaction-marker-check.yml`
 - **Scope**: pr
 
+### TDAD fast-suite passes (Layers 0 + 1)
+
+- **Rule**: Layer 0 (deterministic bash plumbing tests) and Layer 1
+  (structural tests for plugin components and scenario corpus) of the
+  TDAD test suite must pass on every PR that touches plugin code,
+  `tdad_tests/`, `HARNESS.md`, or `AGENTS.md`. Layer 0 covers bash
+  helpers (reflection-log archival, parser library, migration
+  scripts). Layer 1 covers frontmatter well-formedness, component
+  existence, and scenario-target resolution. Both layers run offline
+  (no API key required) and complete in under ten seconds. Layers 2
+  (trigger) and 3 (behavioural) are NOT covered by this gate — they
+  require API key + per-run cost and are deferred to a separate
+  workflow if/when the project decides cadence.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/tdad-tests-fast.yml`
+- **Scope**: pr
+
 ### New plugin components must ship with a TDAD scenario
 
 - **Rule**: When a PR adds a new file matching one of
@@ -717,6 +734,6 @@ the per-reader policy table.
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
 Last audit: 2026-05-08
-Constraints enforced: 22/23
+Constraints enforced: 23/24
 Garbage collection active: 18/18
 Drift detected: no (ONBOARDING.md regenerated 2026-05-09)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Skills](https://img.shields.io/badge/Skills-30-2E8B57?style=flat-square)](#skills-30)
 [![Agents](https://img.shields.io/badge/Agents-13-2E8B57?style=flat-square)](#agents-13)
 [![Commands](https://img.shields.io/badge/Commands-25-2E8B57?style=flat-square)](#commands-25)
-[![Harness](https://img.shields.io/badge/Harness-22%2F23_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-23%2F24_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-09-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)


### PR DESCRIPTION
## Summary

The TDAD test suite at `tdad_tests/` has been live and locally testable since v0.35.5 but was never gated in CI. This PR closes the gap for the two free, deterministic layers and runs them on every PR that touches plugin code, the test suite, HARNESS, or AGENTS.

| Layer | Tests | Wall-clock | Cost |
|---|---|---|---|
| **0 — bash plumbing** | 3 | ~2.5s | $0 |
| **1 — structural** | 14 | ~0.3s | $0 |
| **Total** | **17** | **~3s** | **$0** |

Layers 2 (trigger, ~$0.03/run) and 3 (behavioural, $0.05–$0.20/run) require `ANTHROPIC_API_KEY` and per-run cost design. Deferred to a separate workflow with explicit cadence and budget decisions.

## Why now

The rename+edit gotcha that bit `main` twice this week (PRs #286 → #287, #289 → #290) would have been caught pre-merge by Layer 0 had it been a PR-time gate. Both reflections in REFLECTION_LOG.md record this as a verification gap. The Layer 0 dispatcher tests the bash plumbing — exactly the surface that broke both times.

This continues the day's pattern of closing post-merge verification gaps with PR-time gates: `docs-build-check.yml` (#308), `tdad-scenario-check.yml` (#309), `spec-redaction-marker-check.yml` (#310), and now `tdad-tests-fast.yml`.

## Pre-flight

Ran both layers locally against current `main`:

```text
Layer 0: 3 passed in 2.45s
Layer 1: 14 passed in 0.32s
```

The workflow ports the same `pytest` invocations. Pip 23+ (which `actions/setup-python@v6` provides) supports the PEP 660 editable-install pattern that `tdad_tests/pyproject.toml` declares.

## New HARNESS constraint

`TDAD fast-suite passes (Layers 0 + 1)` — deterministic, scope `pr`, tool `tdad-tests-fast.yml`. Triggers on changes to `ai-literacy-superpowers/**`, `tdad_tests/**`, `HARNESS.md`, `AGENTS.md`, or the workflow file itself.

## Bumps

- HARNESS.md Status: **22/23 → 23/24 enforced**
- README badge: matches

## Why `chore`

New CI infrastructure that runs existing tests in a new place. No plugin behaviour change, no version bump, no AGENTS.md edit. Same shape as PR #308 (docs-build-check), PR #309 (tdad-scenario-check), and PR #310 (spec-redaction-marker-check).

## Test plan

- [x] Layer 0 + Layer 1 pass locally on `main`
- [x] Workflow YAML parses cleanly
- [x] Markdownlint clean on HARNESS.md, README.md
- [ ] CI green on this PR — including the new `Run TDAD Layers 0 + 1` job (the workflow's path filter includes the workflow file itself, so it self-tests on this PR)
- [ ] Layer 0 + 1 pass against the same `main` snapshot in CI as they did locally