### PR TITLE
Strip Jekyll/Just-the-Docs Kramdown attributes from docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,9 @@ opinionated tools for the AI Literacy framework — **harness
 engineering**, **agent orchestration**, **decision archaeology**,
 **governance**, and **model evaluation**.
 
-{: .fs-6 .fw-300 }
-
-[Get Started](plugins/ai-literacy-superpowers/tutorials/getting-started.md){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[Browse Plugins](plugins/index.md){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[Quick Install](#add-the-marketplace){: .btn .fs-5 .mb-4 .mb-md-0 }
+[Get Started](plugins/ai-literacy-superpowers/tutorials/getting-started.md)
+· [Browse Plugins](plugins/index.md)
+· [Quick Install](#add-the-marketplace)
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/explanation/agent-orchestration.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/agent-orchestration.md
@@ -13,7 +13,6 @@ Most teams use AI coding assistants in a single loop: describe what you want, re
 
 This is the single-agent bottleneck. As the work grows, the constraint is not the AI's ability to generate code. The constraint is your ability to review it. The AI scales; you do not.
 
-{: .note }
 > **Try this:** Think about the last time you used an AI assistant for a substantial task. How long did you spend *generating* the code versus *reviewing and fixing* the code? If the ratio surprises you, you have found the bottleneck.
 
 ---
@@ -78,7 +77,6 @@ This is **bounded trust** — the principle of least privilege applied to AI age
 
 The boundary that matters most — the one people violate first — is between the implementer and the tests. If the implementer can edit test files, it can make the tests match the implementation instead of the other way around. TDD collapses. The tests were written before the implementer existed. They define correctness. The implementer does not get to redefine it.
 
-{: .warning }
 > Here is what happens without trust boundaries: you set up an agent that can write code, review its own code, approve its own review, and merge its own PR. You have built an automated system with zero quality gates. Every mistake goes straight to production. This is not a hypothetical. People build this. It goes badly.
 
 The temptation to give every agent full permissions — just to make things easier, just this once — is strong. Resist it. "Just this once" is how every trust boundary dies.
@@ -141,7 +139,6 @@ Three things matter here.
 
 **The cycle limit.** When the reviewer rejects and the implementer fixes, there is a maximum of three cycles. Without a limit, you get agent ping-pong: the reviewer keeps finding issues, the implementer keeps introducing new ones, and the token cost keeps climbing. Three cycles is enough for genuine iteration. If it is not resolved in three, a human needs to look — and the problem is usually in the spec, not the code.
 
-{: .note }
 > **Try this:** Imagine you are building an agent pipeline for a different domain — say, writing documentation instead of code. What agents would you create? What would each one's trust boundary be? Where would you put the human gates? Sketch it before reading on. Designing trust boundaries is the skill this section teaches.
 
 ---

--- a/docs/plugins/ai-literacy-superpowers/explanation/codebase-entropy.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/codebase-entropy.md
@@ -4,7 +4,6 @@ title: Codebase Entropy
 # Codebase Entropy
 
 This page explains why codebases degrade and how AI accelerates the problem. For the mechanical details of fighting entropy, see [Garbage Collection](garbage-collection.md).
-{: .note }
 
 ---
 
@@ -44,7 +43,6 @@ Your codebase follows the same pattern. Not literally -- the metaphor is borrowe
 
 This is not a failure of discipline. It is a force. You can fight it, but you cannot ignore it. And if you think you are ignoring it successfully, you are not measuring.
 
-{: .note }
 > **Try this:** How many TODOs are in your current project right now? Not a rough guess -- actually run a search. Now: how many of those TODOs are older than six months? How many reference a deadline that has already passed? The gap between what you guessed and what you found is the entropy you cannot see.
 
 ---
@@ -117,7 +115,6 @@ You set up a linting rule. Someone disables it for one file with a comment that 
 
 A disabled check does not announce itself. It just stops catching things. And you will not notice until the thing it was catching gets through.
 
-{: .note }
 > **Try this:** Think about the last three bugs your team encountered. For each one, ask: which type of entropy caused it? Was it stale docs that led someone astray? A convention that was not followed? Dead code that obscured the real logic? A dependency that aged badly? A constraint that was not enforced? Most teams have never asked this question. The answer tells you where your entropy rate is highest.
 
 ---
@@ -195,7 +192,6 @@ That person is doing some of the most valuable work on the team.
 
 Your environment is not a thing you build once. It is a thing you maintain forever. The building is the easy part. The maintenance is the work.
 
-{: .warning }
 > The teams that treat garbage collection as infrastructure -- not chores -- will have environments that compound in value. Everyone else's will quietly fall apart, and they will blame the AI for producing inconsistent output when the real problem is what they are feeding it.
 
 ---

--- a/docs/plugins/ai-literacy-superpowers/explanation/compound-learning.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/compound-learning.md
@@ -4,7 +4,6 @@ title: Compound Learning
 # Compound Learning
 
 This page explains how AI development environments improve over time through captured learnings. For the detailed mechanics of self-improvement, see [The Self-Improving Harness](self-improving-harness.md).
-{: .note }
 
 ---
 
@@ -40,7 +39,6 @@ Without a learning loop, all of that evaporates. Session ends. Corrections disap
 
 Two minutes at the end of a session. Maybe less.
 
-{: .note }
 > **Try this:** Think about your last AI coding session. What did you correct? What would you tell a colleague who was about to start the same task? Write that down in two sentences. You have just written your first reflection.
 
 These reflections are not documentation. They are raw material — ore, not steel. The valuable step comes next.
@@ -59,7 +57,6 @@ A gotcha that showed up once is an anecdote. A gotcha that showed up three times
 
 This is where human judgement meets AI volume. The AI generates code at a pace you cannot match. You generate *insight* at a pace it cannot match. The learning loop combines both.
 
-{: .warning }
 > Skipping curation is the most common failure mode. Without it, reflections accumulate as noise and the learning loop stalls. The human review step is not optional — it is the mechanism that separates signal from noise.
 
 ---
@@ -178,7 +175,6 @@ Yes. When reflections are captured in a shared location and conventions live in 
 
 ---
 
-{: .note }
 > **Try this:** What is the one thing your AI keeps getting wrong? The correction you have made so many times you could type it in your sleep? Write it down. Be specific — not "better error handling" but "catch exceptions in service methods, wrap them in AppError with a code and message, and let the controller handle the HTTP response." Now put it where your AI can read it. A `CONVENTIONS.md` file. A `CLAUDE.md` file. A system prompt. Whatever your tool uses. That is your first reflection promoted to a convention. Your first learning loop, running.
 
 One convention. One fewer correction tomorrow. Then another. The flywheel does not ask permission to start turning.

--- a/docs/plugins/ai-literacy-superpowers/explanation/constraints-and-enforcement.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/constraints-and-enforcement.md
@@ -98,7 +98,7 @@ Some rules should never be promoted. "Functions should be small enough to unders
 >
 > Start with three rules. Just three. Write them precisely. Make them specific enough to be checkable. Run them past your team. That is your declared layer. Next week, pick the one you are most confident about and add it to your AI review step. That is your first promotion. The deterministic layer can wait.
 
-{: .warning }
+<!-- markdownlint-disable-next-line MD028 -->
 > **The over-constraining trap.** It is tempting to look at the promotion ladder and think "let's just make everything deterministic from day one." Do not do this. Rules you have not battle-tested will have edge cases you have not imagined. A deterministic rule with bad edge cases blocks your team, generates workarounds, and erodes trust in the entire constraint system. Start soft. Harden with evidence.
 
 ---
@@ -115,7 +115,6 @@ When a constraint fires matters as much as how strict it is.
 
 A common mistake: putting a new, untested constraint directly into the merge loop. Your team hits it on a Friday afternoon deploy, cannot figure out why it is failing, and overrides it. Now the override is the convention. You have made enforcement *weaker* by making it too strict too soon.
 
-{: .note }
 > **Try this:** Think about one rule your team has right now. What level is it? What loop is it in? Could it be in a different one?
 
 ---

--- a/docs/plugins/ai-literacy-superpowers/explanation/context-engineering.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/context-engineering.md
@@ -4,7 +4,6 @@ title: Context Engineering
 # Context Engineering
 
 This page expands on the context engineering component introduced in [Harness Engineering](harness-engineering.md).
-{: .fs-5 }
 
 Context engineering is the discipline of taking the tacit knowledge trapped in your team's heads and making it explicit, precise, and machine-readable. It is the difference between an AI that generates plausible code and an AI that generates *your team's* code.
 
@@ -30,7 +29,6 @@ When a new human joins, they absorb this through osmosis -- code reviews, pairin
 
 Your AI gets none of it. Every session starts from absolute zero. No memory of yesterday's review comments. No awareness of the architectural decision records. It is not a new joiner who is slowly getting up to speed. It is a new joiner whose memory gets wiped every morning.
 
-{: .note }
 > **Try this:** Pick one convention from your current project -- something "everyone knows" but that is not written down anywhere. Now try to write it down in a single sentence, precisely enough that someone who has never seen your codebase could follow it. Harder than you expected, isn't it?
 
 ---
@@ -120,7 +118,6 @@ That last question is particularly revealing. It turns every AI interaction into
 
 Ask three senior developers "what separates a clean refactoring from an over-engineered one?" and you will get three different answers. Those disagreements are conventions that have not been resolved yet. Surfacing them is one of the most valuable side effects of context engineering: it forces your team to confront things they assumed they already agreed about.
 
-{: .note }
 > **Try this:** Think of a project you work on. What triggers an immediate rejection in review? Write down your answer. Now imagine asking two other people on your team the same question. Would they give the same answer? If you are not sure, that is a convention that needs extracting and encoding.
 
 ---
@@ -131,7 +128,6 @@ Context rots.
 
 Your conventions reference functions that get renamed. Your stack declaration lists framework versions that get upgraded. Your architectural decisions describe constraints that get relaxed. If your context documents do not evolve with the code, they become actively harmful -- the AI follows outdated rules that produce code that *used to be* correct.
 
-{: .warning }
 > Context documents must be versioned alongside the code they describe. They live in the repository, not in a wiki. They get reviewed in pull requests. When someone changes a convention, the context document changes in the same commit. The moment your context files live in a wiki, they are dead. They will be accurate for about two sprints. After that, they will be worse than having no context at all, because the AI will follow them confidently in the wrong direction.
 
 This is what separates context engineering from documentation. Documentation lives adjacent to the workflow. Context lives *inside* the workflow. It is checked in, reviewed, and maintained with the same rigour as the code itself.

--- a/docs/plugins/ai-literacy-superpowers/explanation/the-environment-hypothesis.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/the-environment-hypothesis.md
@@ -23,7 +23,6 @@ AI assistants deserve the same analysis. They are pattern-completion engines tha
 
 The fix is not a longer prompt. Prompts are single-use. A great prompt helps one interaction. A great environment helps every interaction. One compounds. The other doesn't.
 
-{: .note }
 > **Try this: the two-minute audit.** Open the root of your main project. Pretend you are an AI assistant dropped into this codebase for the first time. What do you know? What conventions are written down? What architectural decisions are documented? What constraints are enforced automatically versus relying on human reviewers to catch? If the answer is "not much," you have just diagnosed why your AI output is not great.
 
 ## What "environment" means
@@ -60,7 +59,6 @@ Your codebase is a kitchen. Your AI assistant is a cook. When the AI writes code
 
 The AI cannot read your mind. But it can read your environment.
 
-{: .warning }
 > Documenting conventions without enforcing them is not enough. Documentation that is not enforced is a suggestion. The environment must include enforcement -- constraints that catch violations automatically, feedback loops that learn from mistakes, and context structured so the AI can actually use it. A wiki page about naming conventions is documentation. A pre-commit hook that rejects bad names is environment.
 
 ### A dialogue: The Model vs The Environment

--- a/docs/plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/three-enforcement-loops.md
@@ -35,7 +35,6 @@ The inner loop operates during the creative phase of work. Strict blocking at ed
 
 This is a deliberate design trade-off. The inner loop accepts a higher rate of missed violations in exchange for lower friction. The middle loop exists precisely to catch what the inner loop surfaces but does not enforce.
 
-{: .note }
 > The inner loop is also the cheapest place to catch problems. A violation detected at edit time costs seconds to fix. The same violation detected at PR time costs minutes of CI pipeline and context-switching. The inner loop's value is not in its enforcement power but in its proximity to the moment of creation.
 
 ---
@@ -61,7 +60,6 @@ Deterministic checks â€” linters, formatters, type checkers, structural tests â€
 
 Agent-based reviews produce findings that the orchestrator must resolve. The orchestrator dispatches fixes and re-runs the review. If three cycles do not resolve the findings, the orchestrator escalates to the human rather than forcing the merge or looping indefinitely. This bounded-trust design prevents agent disagreements from deadlocking the pipeline while keeping humans as the final authority.
 
-{: .warning }
 > A common mistake is putting a new, untested constraint directly into the middle loop. The first developer to hit it on a Friday afternoon will override it, and that override becomes the new convention. New constraints should start in the inner loop (advisory) and graduate to the middle loop only after they have proven their value and precision. This is the [progressive hardening](progressive-hardening.md) principle.
 
 ### The orchestrator's role

--- a/docs/plugins/ai-literacy-superpowers/how-to/build-portfolio-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/build-portfolio-dashboard.md
@@ -6,7 +6,6 @@ title: Build an AI Literacy Portfolio Dashboard
 Turn your portfolio assessment data into a shareable HTML dashboard
 showing AI literacy levels across your repos.
 
-{: .note }
 > The plugin includes a `portfolio-dashboard` skill that knows how to
 > generate this dashboard. You can ask Claude directly — "build me a
 > dashboard from my portfolio assessments" — and the skill handles

--- a/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/from-assessment-to-dashboard.md
@@ -429,7 +429,6 @@ the median level is rising, and which repos are improving fastest.
 This is the evidence that turns AI literacy work from an assertion
 into a measurable outcome.
 
-{: .note }
 > **Stale assessments.** Repos whose most recent assessment is older
 > than 90 days are flagged in the portfolio view. Re-run `/assess` in
 > those repos before the next portfolio run to keep the data current.

--- a/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/getting-started.md
@@ -115,7 +115,6 @@ For your first time, accepting all defaults is a good choice. If you want
 to start smaller — say, just context and constraints — deselect the others.
 The command only asks questions about the features you selected.
 
-{: .note }
 > **Re-running is additive.** If you run `/harness-init` again later, it
 > detects which features are already configured and defaults them to off.
 > Unconfigured features default to on. Your existing configuration is

--- a/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/harness-from-scratch.md
@@ -81,7 +81,6 @@ Answer concretely. After each answer the agent restates it, asks one
 follow-up to sharpen the wording, and proposes a category. You confirm
 before it writes anything.
 
-{: .note }
 > **"It depends" is a signal, not a failure.** If an answer keeps landing
 > on "it depends on context," that convention needs decomposition into
 > specific, observable cases before it can be encoded. The agent will
@@ -264,7 +263,6 @@ Update each constraint's enforcement field to reflect reality:
 - **Scope**: commit
 ```
 
-{: .note }
 > **The harness does not need to own every constraint.** If golangci-lint
 > already enforces naming conventions, you can omit that constraint from
 > HARNESS.md entirely, or note it in a comment. The harness tracks what
@@ -353,7 +351,6 @@ A ratio below 1.0 means some constraints are declared but not yet
 automated. That is expected when retrofitting — use this number as a
 target to improve over time rather than a pass/fail score.
 
-{: .note }
 > **Re-run `/harness-init` to add features later.** If you skipped CI
 > configuration this time, you can run `/harness-init` again to add it.
 > The command detects which sections are already configured and only

--- a/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
+++ b/docs/plugins/ai-literacy-superpowers/tutorials/the-improvement-cycle.md
@@ -122,7 +122,6 @@ The command writes a timestamped document to
 discipline scores, strengths, gaps, and recommendations. This document
 drives the improvement plan.
 
-{: .note }
 > **Immediate adjustments.** After producing the assessment document,
 > the command identifies habitat hygiene fixes it can apply right now
 > without requiring discussion — updating a stale badge count, adding


### PR DESCRIPTION
## Summary

You noticed an odd `{: .fs-6 .fw-300 }` rendered as literal text on the docs site homepage. That syntax is **Jekyll/Just-the-Docs Kramdown attribute lists** — leftover from a previous static-site setup. The docs site now uses mkdocs-material, which doesn't process this syntax, so the markers render as literal text on every affected page.

A `grep -rn '{: \.' docs/` turned up **18 instances across 13 files** — far more than the one on the homepage. Stripped them all in one sweep.

## What was on each surface

- **`docs/index.md`** (4): the `{: .fs-6 .fw-300 }` you saw on the marketplace tagline, plus three `{: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }` annotations attached to the Get Started / Browse Plugins / Quick Install button links
- **Explanation pages** (7 files, 12 instances): `{: .note }` and `{: .warning }` annotations on blockquotes — meant to render styled callouts in Just-the-Docs
- **How-to and tutorial pages** (5 files, 1 instance each): same `{: .note }` pattern

## What renders now

- The three homepage CTAs render as plain links separated by `·` — equivalent navigational function, no literal-text noise
- Previously-styled blockquotes render as standard mkdocs-material blockquotes (readable, no noise)
- `mkdocs build --strict` passes locally with all changes; only pre-existing INFO items remain

## Optional follow-up (not in this PR)

The mkdocs-material `admonition` extension is enabled in `mkdocs.yml`. If you want the styled-callout effect back on the previously-`{: .note }`/`{: .warning }`-flagged blockquotes, individual blocks can be converted to `!!! note` / `!!! warning` admonitions in a follow-up PR. That's beyond the scope of "remove the noise" — the user-visible bug is fixed by stripping; restoring the visual emphasis is an enhancement.

Same goes for the homepage CTA buttons — the `attr_list` extension is enabled, so the three links could be promoted to `[Get Started](...){: .md-button .md-button--primary }` to render as material-buttons. Out of scope here.

## One MD028 fix

Stripping the Kramdown markers in `constraints-and-enforcement.md` left two previously-styled blockquotes adjacent (separated only by a blank line). Markdownlint MD028 flags this as ambiguous. Resolved with a single `<!-- markdownlint-disable-next-line MD028 -->` comment above the second blockquote — preserves visual separation, satisfies the lint.

## Why `chore`

Pure docs cleanup outside the plugin directory. No plugin behaviour change, no version bump, no AGENTS.md edit.

## Test plan

- [x] `grep -rn '{: \.' docs/` returns zero matches across the entire `docs/` tree
- [x] `mkdocs build --strict` passes locally (only pre-existing INFO items, no new warnings or errors)
- [x] `markdownlint-cli2` clean across all 13 modified files
- [ ] CI green on this PR — including `docs-build-check` (mkdocs --strict in CI on docs PRs from PR #308)
- [ ] Pages deploy after merge renders cleanly without literal `{: .* }` text on the homepage or any other affected page