### PR TITLE
Bump HARNESS.md template-version marker to 0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ accepted:
 
 ### Habitat hygiene
 
+- HARNESS.md template-version marker bumped from `0.35.1` to `0.38.0`
+  after `/harness-upgrade` confirmed the project's harness already
+  contains every active and commented-out item present in the current
+  template (24 constraints + 18 GC rules vs the template's 5 + 14).
 - README Skills badge: 31 → 32 (catches the
   `component-design-with-tdad` skill added in v0.37.0)
 - README marketplace table and Skills heading anchor: same

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.35.1 -->
+<!-- template-version: 0.38.0 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

- `/harness-upgrade` ran against the 0.38.0 template and confirmed the project's harness already contains every active and commented-out item present in the template (24 constraints + 18 GC rules locally vs the template's 5 + 14).
- Bumps the `<!-- template-version: ... -->` marker in `HARNESS.md` from `0.35.1` to `0.38.0` so the staleness signal stays accurate.
- Adds a one-line note under the existing `0.38.0` CHANGELOG section's "Habitat hygiene" group — no plugin version bump because nothing inside `ai-literacy-superpowers/` changed.

## Test plan

- [x] `/harness-upgrade` reported "Your harness already contains all current template content."
- [x] `git diff` shows only the marker line and a CHANGELOG bullet
- [ ] CI green (spec-first exempted via `chore` label; markdownlint; version-check)