### PR TITLE
Diagnostic Legibility — LegibilityElement schema (v0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "diagnostic-legibility",
       "source": "./diagnostic-legibility",
       "description": "Agents accountable for helping to maintain human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope.",
-      "version": "0.1.0"
+      "version": "0.2.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
 [![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.39.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
-[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.1.0-4682B4?style=flat-square)](diagnostic-legibility/)
+[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.2.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
 [![Agents](https://img.shields.io/badge/Agents-14-2E8B57?style=flat-square)](#agents-14)
 [![Commands](https://img.shields.io/badge/Commands-26-2E8B57?style=flat-square)](#commands-26)
@@ -30,7 +30,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 | ------ | ------- | ------------ | ---- |
 | **`ai-literacy-superpowers`** | v0.39.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
-| **`diagnostic-legibility`** | v0.1.0 | Scaffold-only. Will host agents accountable for maintaining human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope — see #327 and the slicing record for the four-slice roadmap. | [docs](docs/plugins/diagnostic-legibility/index.md) |
+| **`diagnostic-legibility`** | v0.2.0 | Scaffold-only. Will host agents accountable for maintaining human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope — see #327 and the slicing record for the four-slice roadmap. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
 The bulk of this README documents the **`ai-literacy-superpowers`** plugin specifically — its skills, agents, commands, hooks, templates, enforcement loops, and pipelines. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md). Future sister plugins will land in this marketplace under `<plugin-name>/` with their own docs at `docs/plugins/<plugin-name>/`.
 

--- a/diagnostic-legibility/.claude-plugin/plugin.json
+++ b/diagnostic-legibility/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-legibility",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agents accountable for helping to maintain human understanding. The first agent builds, self-challenges, and cross-checks two models of a codebase scope — architectural moving parts and domain concepts — and surfaces the mutually-corrected models on demand. Future agents will extend the discipline to other domains.",
   "author": {
     "name": "Russ Miles"

--- a/diagnostic-legibility/CHANGELOG.md
+++ b/diagnostic-legibility/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.2.0 — 2026-05-26
+
+### LegibilityElement schema
+
+Adds the `LegibilityElement` schema artefact at
+`templates/legibility-element.md`. The schema covers both the
+architectural and domain dimensions of the diagnostic-legibility
+agent (built in sub-S2b, issue #335) under a single flat record type;
+the dimensions are typed by the collection wrapper `LegibilityModel`,
+not by the record itself. Carries `name`, `description`, `evidence`
+(list of `{path, excerpt?}`), `confidence` (low/medium/high), and
+`challenge_notes`. Wrapper adds `scope`, `generated_at`,
+`generated_by`, and the two collections.
+
+Replaces the `templates/.gitkeep` placeholder from v0.1.0.
+
+Validation is enforced by the agent during construction; no runtime
+validator ships at this version.
+
+Sub-S1 of the meta-iteration recorded at
+`docs/superpowers/slices/dl-s2-two-model-agent.md`. Tracks parent
+issue #331. Sub-S2b (challenge protocol + working agent) is deferred
+to issue #335.
+
 ## 0.1.0 — 2026-05-26
 
 ### Scaffold

--- a/diagnostic-legibility/templates/legibility-element.md
+++ b/diagnostic-legibility/templates/legibility-element.md
@@ -1,0 +1,124 @@
+# LegibilityElement
+
+The unit of legibility produced by the diagnostic-legibility agent. A
+single record type used for both architectural and domain dimensions —
+the two collections (`architectural[]` and `domain[]` inside the
+`LegibilityModel` wrapper) carry the type distinction; the record
+itself is uniform.
+
+Dimension-specific framing (e.g. architectural boundaries and
+collaborators, or domain ubiquitous-language and aliases) lives in the
+free-text `description` field rather than in dedicated fields. This
+keeps prompt construction symmetric across dimensions and makes the
+cross-check (issue #332) and surfacing (issue #333) work mechanically
+simpler.
+
+## Fields
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `name` | string | yes | Short identifier for the element. For architectural: a component, service, or module name. For domain: a concept term. |
+| `description` | string | yes | Free-text explanation. Carries dimension-specific framing: for architectural, what the element does and how it is bounded; for domain, what the term means and how it is used. Multi-paragraph is fine. |
+| `evidence` | list of objects | yes | Citations grounding the element. Each entry has `path` (string) and optional `excerpt` (string). At least one entry per element when confidence is `medium` or `high`. |
+| `confidence` | enum | yes | One of `low`, `medium`, `high`. Indicates the agent's confidence in the element. `low` means "candidate, included for completeness"; `high` means "well-evidenced and challenged". |
+| `challenge_notes` | list of strings | yes | What the challenge-refine step surfaced and how it was resolved. May be empty when the challenge protocol has not yet run. |
+
+Equivalent type signature (for documentation only — not a committed type):
+
+```
+LegibilityElement = {
+  name: string,
+  description: string,
+  evidence: [{ path: string, excerpt?: string }],
+  confidence: "low" | "medium" | "high",
+  challenge_notes: [string]
+}
+```
+
+## Validation rules
+
+The agent enforces these rules during construction (no runtime
+validator ships at v0.2.0):
+
+- `name` must be non-empty.
+- `description` must be non-empty.
+- `evidence` must have at least one entry when `confidence` is
+  `medium` or `high`. `low`-confidence elements may have empty
+  evidence (the agent flagged a candidate without ground).
+- `confidence` must be one of the three enum values.
+- `challenge_notes` may be empty.
+
+## LegibilityModel
+
+The top-level structure the agent emits. Wraps two collections of
+`LegibilityElement`.
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `scope` | string | yes | A path or description of what was modelled (e.g. `"./src/auth/"` or `"the checkout flow across services A and B"`). |
+| `generated_at` | string (ISO 8601) | yes | Timestamp the model pair was produced. |
+| `generated_by` | string | yes | Agent name + model identifier (e.g. `"diagnostic-legibility-agent / claude-sonnet-4-6"`). |
+| `architectural` | list of `LegibilityElement` | yes | The architectural-dimension elements. May be empty if scope yielded no architecture-level findings. |
+| `domain` | list of `LegibilityElement` | yes | The domain-dimension elements. May be empty if scope yielded no domain concepts. |
+
+### LegibilityModel validation rules
+
+- At least one of `architectural` or `domain` must be non-empty. An
+  empty pair on both sides is a degenerate output and the agent should
+  surface a `low`-confidence placeholder rather than emit two empty
+  lists.
+- The two lists may have different lengths; symmetric size is not
+  required.
+
+## Examples
+
+### Architectural example
+
+```yaml
+name: AuthenticationService
+description: |
+  The HTTP-level entry point for credential validation. Bounded by
+  the login endpoint and the session-issuance endpoint. Collaborates
+  with the credentials store (read-only) and the session-token issuer
+  (write). The service owns the credential-validation policy but not
+  the storage of credentials themselves.
+evidence:
+  - path: src/auth/service.py
+    excerpt: "class AuthenticationService:\n    def authenticate(self, credentials):"
+  - path: src/auth/README.md
+    excerpt: "AuthenticationService is the only entry point that writes session tokens."
+confidence: high
+challenge_notes:
+  - "Initial draft included session storage as a responsibility; challenge clarified the service issues but does not store, and the description was revised."
+```
+
+### Domain example
+
+```yaml
+name: Order
+description: |
+  In this codebase, "Order" is a finalised purchase intent that has
+  cleared cart and inventory checks but has not yet been fulfilled.
+  Distinct from "Cart" (mutable, pre-checkout) and from "Shipment"
+  (post-fulfilment). The ubiquitous-language canonical term is "Order";
+  the codebase uses "PurchaseOrder" in some legacy modules as an alias.
+evidence:
+  - path: src/domain/order.py
+    excerpt: "class Order:  # canonical name; PurchaseOrder is deprecated"
+  - path: docs/glossary.md
+    excerpt: "Order: a finalised purchase intent..."
+confidence: high
+challenge_notes:
+  - "Initial draft conflated Order with Cart; challenge surfaced the cart→order transition as the boundary and the description was refined."
+```
+
+## Why this schema
+
+The design rationale lives in the spec at
+[`docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md`](../../docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md).
+The short version: a single flat schema is the simplest path that
+keeps prompting, cross-checking (issue #332), and surfacing
+(issue #333) mechanically uniform. The trade-off accepted is that
+dimension-specific affordances (boundaries, ubiquitous-language
+canonicals, etc.) live in the free-text `description` field rather
+than dedicated columns.

--- a/docs/superpowers/plans/2026-05-26-dl-s2a-legibility-element-schema.md
+++ b/docs/superpowers/plans/2026-05-26-dl-s2a-legibility-element-schema.md
@@ -1,0 +1,482 @@
+# Diagnostic Legibility — sub-S2a `LegibilityElement` schema — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship sub-S2a — the `LegibilityElement` schema artefact for the `diagnostic-legibility` plugin. One markdown file at `diagnostic-legibility/templates/legibility-element.md` describes the schema, the `LegibilityModel` wrapper, validation rules, and worked examples for both architectural and domain dimensions. Plugin version bumps `0.1.0 → 0.2.0`.
+
+**Architecture:** No code added. The artefact is a markdown spec page that future sub-S2b agent prompts will reference by path. The schema is enforced by the agent during construction, not by a runtime validator.
+
+**Tech Stack:** Markdown + JSON. No new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md`
+
+---
+
+## File structure
+
+```
+diagnostic-legibility/
+├── .claude-plugin/plugin.json                # MODIFIED: 0.1.0 → 0.2.0
+├── CHANGELOG.md                              # MODIFIED: new 0.2.0 entry
+└── templates/
+    ├── .gitkeep                              # REMOVED
+    └── legibility-element.md                 # NEW
+
+.claude-plugin/marketplace.json               # MODIFIED: plugins[].version 0.1.0 → 0.2.0 for diagnostic-legibility
+README.md                                     # MODIFIED: badge + table row version bumps
+```
+
+Top-level `version` in marketplace.json stays at `0.4.0`. `plugin_version` stays at `0.39.0`. No `ai-literacy-superpowers/` files touched.
+
+---
+
+## Phase 1 — The schema template
+
+### Task 1: Write the schema template
+
+**Files:**
+- Create: `diagnostic-legibility/templates/legibility-element.md`
+- Delete: `diagnostic-legibility/templates/.gitkeep`
+
+- [ ] **Step 1: Remove the placeholder**
+
+```bash
+git rm diagnostic-legibility/templates/.gitkeep
+```
+
+- [ ] **Step 2: Write the template**
+
+Write `diagnostic-legibility/templates/legibility-element.md` with EXACTLY this content:
+
+````markdown
+# LegibilityElement
+
+The unit of legibility produced by the diagnostic-legibility agent. A
+single record type used for both architectural and domain dimensions —
+the two collections (`architectural[]` and `domain[]` inside the
+`LegibilityModel` wrapper) carry the type distinction; the record
+itself is uniform.
+
+Dimension-specific framing (e.g. architectural boundaries and
+collaborators, or domain ubiquitous-language and aliases) lives in the
+free-text `description` field rather than in dedicated fields. This
+keeps prompt construction symmetric across dimensions and makes the
+cross-check (issue #332) and surfacing (issue #333) work mechanically
+simpler.
+
+## Fields
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `name` | string | yes | Short identifier for the element. For architectural: a component, service, or module name. For domain: a concept term. |
+| `description` | string | yes | Free-text explanation. Carries dimension-specific framing: for architectural, what the element does and how it is bounded; for domain, what the term means and how it is used. Multi-paragraph is fine. |
+| `evidence` | list of objects | yes | Citations grounding the element. Each entry has `path` (string) and optional `excerpt` (string). At least one entry per element when confidence is `medium` or `high`. |
+| `confidence` | enum | yes | One of `low`, `medium`, `high`. Indicates the agent's confidence in the element. `low` means "candidate, included for completeness"; `high` means "well-evidenced and challenged". |
+| `challenge_notes` | list of strings | yes | What the challenge-refine step surfaced and how it was resolved. May be empty when the challenge protocol has not yet run. |
+
+Equivalent type signature (for documentation only — not a committed type):
+
+```
+LegibilityElement = {
+  name: string,
+  description: string,
+  evidence: [{ path: string, excerpt?: string }],
+  confidence: "low" | "medium" | "high",
+  challenge_notes: [string]
+}
+```
+
+## Validation rules
+
+The agent enforces these rules during construction (no runtime
+validator ships at v0.2.0):
+
+- `name` must be non-empty.
+- `description` must be non-empty.
+- `evidence` must have at least one entry when `confidence` is
+  `medium` or `high`. `low`-confidence elements may have empty
+  evidence (the agent flagged a candidate without ground).
+- `confidence` must be one of the three enum values.
+- `challenge_notes` may be empty.
+
+## LegibilityModel
+
+The top-level structure the agent emits. Wraps two collections of
+`LegibilityElement`.
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `scope` | string | yes | A path or description of what was modelled (e.g. `"./src/auth/"` or `"the checkout flow across services A and B"`). |
+| `generated_at` | string (ISO 8601) | yes | Timestamp the model pair was produced. |
+| `generated_by` | string | yes | Agent name + model identifier (e.g. `"diagnostic-legibility-agent / claude-sonnet-4-6"`). |
+| `architectural` | list of `LegibilityElement` | yes | The architectural-dimension elements. May be empty if scope yielded no architecture-level findings. |
+| `domain` | list of `LegibilityElement` | yes | The domain-dimension elements. May be empty if scope yielded no domain concepts. |
+
+### LegibilityModel validation rules
+
+- At least one of `architectural` or `domain` must be non-empty. An
+  empty pair on both sides is a degenerate output and the agent should
+  surface a `low`-confidence placeholder rather than emit two empty
+  lists.
+- The two lists may have different lengths; symmetric size is not
+  required.
+
+## Examples
+
+### Architectural example
+
+```yaml
+name: AuthenticationService
+description: |
+  The HTTP-level entry point for credential validation. Bounded by
+  the login endpoint and the session-issuance endpoint. Collaborates
+  with the credentials store (read-only) and the session-token issuer
+  (write). The service owns the credential-validation policy but not
+  the storage of credentials themselves.
+evidence:
+  - path: src/auth/service.py
+    excerpt: "class AuthenticationService:\n    def authenticate(self, credentials):"
+  - path: src/auth/README.md
+    excerpt: "AuthenticationService is the only entry point that writes session tokens."
+confidence: high
+challenge_notes:
+  - "Initial draft included session storage as a responsibility; challenge clarified the service issues but does not store, and the description was revised."
+```
+
+### Domain example
+
+```yaml
+name: Order
+description: |
+  In this codebase, "Order" is a finalised purchase intent that has
+  cleared cart and inventory checks but has not yet been fulfilled.
+  Distinct from "Cart" (mutable, pre-checkout) and from "Shipment"
+  (post-fulfilment). The ubiquitous-language canonical term is "Order";
+  the codebase uses "PurchaseOrder" in some legacy modules as an alias.
+evidence:
+  - path: src/domain/order.py
+    excerpt: "class Order:  # canonical name; PurchaseOrder is deprecated"
+  - path: docs/glossary.md
+    excerpt: "Order: a finalised purchase intent..."
+confidence: high
+challenge_notes:
+  - "Initial draft conflated Order with Cart; challenge surfaced the cart→order transition as the boundary and the description was refined."
+```
+
+## Why this schema
+
+The design rationale lives in the spec at
+[`docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md`](../../docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md).
+The short version: a single flat schema is the simplest path that
+keeps prompting, cross-checking (issue #332), and surfacing
+(issue #333) mechanically uniform. The trade-off accepted is that
+dimension-specific affordances (boundaries, ubiquitous-language
+canonicals, etc.) live in the free-text `description` field rather
+than dedicated columns.
+````
+
+- [ ] **Step 3: Verify the file exists**
+
+```bash
+ls -la diagnostic-legibility/templates/legibility-element.md && ! ls diagnostic-legibility/templates/.gitkeep 2>/dev/null
+```
+
+Expected: the new file exists; the old `.gitkeep` does not.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add diagnostic-legibility/templates/legibility-element.md diagnostic-legibility/templates/.gitkeep
+git commit -m "Diagnostic Legibility — LegibilityElement schema template"
+```
+
+(`git add` on the deleted `.gitkeep` records the removal; `git rm` in step 1 already staged it but re-adding via path is harmless.)
+
+---
+
+## Phase 2 — Version bumps
+
+### Task 2: Plugin manifest version bump
+
+**Files:**
+- Modify: `diagnostic-legibility/.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Edit the version**
+
+Change `"version": "0.1.0"` to `"version": "0.2.0"` in `diagnostic-legibility/.claude-plugin/plugin.json`.
+
+- [ ] **Step 2: Verify**
+
+```bash
+python3 -c "import json; d=json.load(open('diagnostic-legibility/.claude-plugin/plugin.json')); assert d['version']=='0.2.0'; print('OK')"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add diagnostic-legibility/.claude-plugin/plugin.json
+git commit -m "Diagnostic Legibility — plugin.json bump 0.1.0 -> 0.2.0"
+```
+
+### Task 3: CHANGELOG entry
+
+**Files:**
+- Modify: `diagnostic-legibility/CHANGELOG.md`
+
+- [ ] **Step 1: Insert a new top-level section**
+
+Insert immediately after `# Changelog` and before the existing `## 0.1.0 — 2026-05-26` heading:
+
+```markdown
+## 0.2.0 — 2026-05-26
+
+### LegibilityElement schema
+
+Adds the `LegibilityElement` schema artefact at
+`templates/legibility-element.md`. The schema covers both the
+architectural and domain dimensions of the diagnostic-legibility
+agent (built in sub-S2b, issue #335) under a single flat record type;
+the dimensions are typed by the collection wrapper `LegibilityModel`,
+not by the record itself. Carries `name`, `description`, `evidence`
+(list of `{path, excerpt?}`), `confidence` (low/medium/high), and
+`challenge_notes`. Wrapper adds `scope`, `generated_at`,
+`generated_by`, and the two collections.
+
+Replaces the `templates/.gitkeep` placeholder from v0.1.0.
+
+Validation is enforced by the agent during construction; no runtime
+validator ships at this version.
+
+Sub-S1 of the meta-iteration recorded at
+`docs/superpowers/slices/dl-s2-two-model-agent.md`. Tracks parent
+issue #331. Sub-S2b (challenge protocol + working agent) is deferred
+to issue #335.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+head -10 diagnostic-legibility/CHANGELOG.md
+```
+
+Expected: the new section is at the top, immediately after `# Changelog`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add diagnostic-legibility/CHANGELOG.md
+git commit -m "Diagnostic Legibility — CHANGELOG 0.2.0 entry"
+```
+
+### Task 4: Marketplace entry version bump
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Edit the diagnostic-legibility entry's version**
+
+Find the `diagnostic-legibility` entry in `plugins[]` and change its `"version": "0.1.0"` to `"version": "0.2.0"`. The top-level `"version": "0.4.0"` and `"plugin_version": "0.39.0"` stay unchanged.
+
+- [ ] **Step 2: Verify**
+
+```bash
+python3 -c "
+import json
+d = json.load(open('.claude-plugin/marketplace.json'))
+assert d['version'] == '0.4.0', f'top-level: {d[\"version\"]}'
+assert d['plugin_version'] == '0.39.0', f'plugin_version: {d[\"plugin_version\"]}'
+dl = next(p for p in d['plugins'] if p['name'] == 'diagnostic-legibility')
+assert dl['version'] == '0.2.0', f'dl entry: {dl[\"version\"]}'
+print('marketplace.json OK')
+"
+```
+
+Expected: `marketplace.json OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "Marketplace — diagnostic-legibility entry 0.1.0 -> 0.2.0"
+```
+
+### Task 5: Root README badge + table row version bumps
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Bump the per-plugin badge**
+
+Change:
+```
+[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.1.0-4682B4?style=flat-square)](diagnostic-legibility/)
+```
+to:
+```
+[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.2.0-4682B4?style=flat-square)](diagnostic-legibility/)
+```
+
+- [ ] **Step 2: Bump the table row's version column**
+
+In the marketplace table, find the row that begins:
+```
+| **`diagnostic-legibility`** | v0.1.0 |
+```
+and change to:
+```
+| **`diagnostic-legibility`** | v0.2.0 |
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -nE "diagnostic--legibility-v0\.[12]\.0|\\*\\*\`diagnostic-legibility\`\\*\\* \\| v0\\.[12]\\.0" README.md
+```
+
+Expected: hits for `v0.2.0` only; no `v0.1.0` for diagnostic-legibility.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "Root README — diagnostic-legibility badge and table row 0.1.0 -> 0.2.0"
+```
+
+---
+
+## Phase 3 — Verify and ship
+
+### Task 6: Local CI gate checks
+
+- [ ] **Step 1: Spec-first ordering**
+
+```bash
+git log main..HEAD --reverse --oneline | head -1
+```
+
+Expected: the first commit is the spec.
+
+- [ ] **Step 2: Per-plugin version sync**
+
+```bash
+python3 -c "
+import json
+m = json.load(open('.claude-plugin/marketplace.json'))
+for p in m['plugins']:
+    pj = json.load(open(p['source'] + '/.claude-plugin/plugin.json'))
+    assert p['version'] == pj['version'], f'{p[\"name\"]}: marketplace={p[\"version\"]} plugin.json={pj[\"version\"]}'
+    print(f'{p[\"name\"]}: {pj[\"version\"]} OK')
+"
+```
+
+Expected: each plugin reports its version followed by `OK`. diagnostic-legibility should now show 0.2.0.
+
+- [ ] **Step 3: ai-literacy-superpowers untouched**
+
+```bash
+git diff --name-only main..HEAD -- ai-literacy-superpowers/ | head -1
+```
+
+Expected: empty.
+
+- [ ] **Step 4: TDAD + docs-reference parity checks are no-ops**
+
+```bash
+git diff --name-only main..HEAD --diff-filter=A | grep -E '^ai-literacy-superpowers/(agents|skills|commands)/' || echo "no component file additions — both checks are no-ops"
+```
+
+Expected: `no component file additions — both checks are no-ops`.
+
+### Task 7: Push, PR, CI, merge
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin dl-s2-two-model-agent
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "Diagnostic Legibility — LegibilityElement schema (v0.2.0)" --body "$(cat <<'EOF'
+## Summary
+
+Sub-S2a of the meta-iteration slicing at \`docs/superpowers/slices/dl-s2-two-model-agent.md\`, which itself slices parent S2 (issue #331) of the diagnostic-legibility roadmap. Ships the \`LegibilityElement\` schema artefact at \`diagnostic-legibility/templates/legibility-element.md\` and bumps the plugin to v0.2.0.
+
+The sub-S1 (this PR) and sub-S2b (issue #335) split came from carpaccio's meta-iteration on issue #331: the schema decision is a branching gate that propagates into every subsequent prompt, the cross-check (issue #332), and the surfacing (issue #333). Splitting it out keeps the schema-revision cost bounded.
+
+Spec: \`docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md\`
+Plan: \`docs/superpowers/plans/2026-05-26-dl-s2a-legibility-element-schema.md\`
+
+## What's in the PR
+
+- New schema template at \`diagnostic-legibility/templates/legibility-element.md\` (one record type, \`LegibilityElement\`, used for both architectural and domain dimensions; \`LegibilityModel\` wrapper for the agent's top-level output).
+- The \`templates/.gitkeep\` placeholder from v0.1.0 is removed.
+- diagnostic-legibility plugin.json and CHANGELOG bump from 0.1.0 → 0.2.0.
+- marketplace.json: only the diagnostic-legibility entry's version bumps. Top-level \`version\` (0.4.0) and \`plugin_version\` (0.39.0) are unchanged.
+- Root README badge + table row bump for diagnostic-legibility.
+
+## What's NOT in the PR
+
+- No agent file (sub-S2b, #335).
+- No challenge-refine protocol (sub-S2b, #335).
+- No runtime validator (deferred; validation is enforced by the agent during construction at v0.2.0).
+- No machine-readable JSON Schema file (deferred; markdown is the canonical artefact).
+
+## Test plan
+
+- [ ] Spec-first ordering passes (spec is first commit on branch).
+- [ ] Per-plugin version sync passes: diagnostic-legibility plugin.json (0.2.0) matches marketplace entry (0.2.0).
+- [ ] marketplace.json top-level \`version\` (0.4.0) and \`plugin_version\` (0.39.0) unchanged.
+- [ ] TDAD scenario presence check is a no-op (no agents/skills/commands files added).
+- [ ] Docs reference parity check is a no-op (no agents/skills/commands files added).
+- [ ] Markdown lint passes.
+- [ ] Docs build check passes.
+
+Tracks parent issue #331. Does **not** close it — sub-S2b (#335) closes #331 when the agent ships.
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks $(gh pr view --json number --jq .number) --watch
+```
+
+Wait for all checks green. If anything fails, fetch the failure log (`gh run view <run-id> --log-failed`) and fix at root cause.
+
+- [ ] **Step 4: Merge**
+
+```bash
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --squash --delete-branch
+```
+
+- [ ] **Step 5: Verify parent issue #331 stays OPEN**
+
+```bash
+gh issue view 331 --json state --jq .state
+```
+
+Expected: `OPEN`. Closed by sub-S2b (#335), not by this PR.
+
+- [ ] **Step 6: Sync marketplace cache**
+
+```bash
+bash ai-literacy-superpowers/scripts/sync-marketplace-cache.sh
+CACHE="${HOME}/.claude/plugins/marketplaces/ai-literacy-superpowers"
+git -C "${CACHE}" fetch -q origin && git -C "${CACHE}" pull --ff-only origin main 2>&1 | tail -3
+```
+
+---
+
+## Out of scope (deferred)
+
+- Agent file under `diagnostic-legibility/agents/` (sub-S2b, #335).
+- Challenge-refine protocol design (sub-S2b, #335).
+- Runtime validator that checks `LegibilityElement` instances at agent-output time.
+- Machine-readable JSON Schema file alongside the markdown template.
+- TDAD scenarios (no agent file added; the constraint does not fire).
+- Cross-check protocol (parent S3, #332).
+- Surfacing interface (parent S4, #333).

--- a/docs/superpowers/slices/dl-s2-two-model-agent.md
+++ b/docs/superpowers/slices/dl-s2-two-model-agent.md
@@ -1,0 +1,144 @@
+---
+task: "Diagnostic Legibility — S2: Two-model agent with per-model self-challenge"
+task_slug: dl-s2-two-model-agent
+date: 2026-05-26
+carpaccio_model: claude-sonnet-4-6
+inseparable: false
+progressed_slice: S1
+slices:
+  - id: S1
+    title: Schema decision — same or distinct data structures for the two model types
+    scope: >
+      Decide whether the architectural-model and domain-concepts-model are
+      the same data structure (parameterised) or genuinely distinct schemas.
+      Produce the schema definition(s) — field names, types, and descriptions —
+      for each model type as the deliverable. No agent implementation yet;
+      the deliverable is the schema artefact (markdown or inline spec section)
+      that S2 can build directly on.
+    decision_focus: >
+      Are "big moving parts" and "domain concepts" the same record type (one
+      schema, two instances) or distinct record types with different fields?
+      This is a branching gate: if same, a single parameterised type suffices
+      and S2b builds one construction path; if distinct, S2b needs two
+      construction paths with different prompting targets. The wrong answer here
+      propagates into every prompt the agent sends, into the cross-check
+      (S3 of the parent), and into the surfacing format (S4 of the parent).
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: null
+    file_as_issue: false
+    issue_url: null
+    merged_into: null
+
+  - id: S2
+    title: Challenge protocol and working agent — per-model self-challenge and refined output
+    scope: >
+      Design the challenge-refine cycle for each model type (given the schemas
+      from S1) and implement the agent. Decisions include: single-pass vs.
+      iterative challenge, what constitutes "good enough" refinement, and whether
+      the agent self-challenges in one multi-turn context or dispatches a second
+      pass. The deliverable is a working agent file in
+      diagnostic-legibility/agents/ that accepts a scope, constructs both
+      models, refines each through its challenge protocol, and emits the two
+      refined models as structured output. Does not cross-check models against
+      each other (that is S3 of the parent).
+    decision_focus: >
+      What is the challenge-refine cycle for each model type? Options range
+      from: (a) a single critique-and-revise in one prompt, (b) a separate
+      challenge dispatch that critiques and returns to the constructor, or
+      (c) an iterative loop with a stopping condition (token budget, stability
+      threshold, fixed count). The choice affects the agent's architecture
+      (one pass vs. pipeline), its testability (where does the challenge output
+      live?), its token cost, and what "refined" means in S3's cross-check
+      inputs. This decision also determines whether there is one challenge
+      protocol shared across both model types or two distinct protocols matched
+      to each schema.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: null
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/335
+    merged_into: null
+---
+
+## S1 — Schema decision — same or distinct data structures for the two model types — decision-boundary
+
+**Context**
+
+The parent issue (#331) names the central question of S2 explicitly: "Are the 'big moving parts' model and the 'domain concepts' model the same data structure processed twice, or do they have distinct structure, prompting strategies, and challenge criteria?" The parent slicing record treated the entire schema + challenge + implementation as one slice, with the rationale that it was separable from cross-check (S3) and surfacing (S4). At meta-iteration granularity — slicing S2 itself — this schema question is a genuine gate. It is not merely a design preference; it determines the branching structure of every subsequent step.
+
+The model-card-researcher agent (pattern anchor) shows what a well-defined agent schema looks like: the agent produces a single record type (the model card), driven by a single template. The diagnostic legibility agent is distinctive in that it produces *two* records in one pass, which makes the schema question non-trivial. If the architectural model has fields like `component_name`, `boundary_description`, `dependency_surface` and the domain model has fields like `concept_name`, `definition`, `ubiquitous_language_term`, then the schemas differ fundamentally — neither field set is a renaming of the other. If both models have fields like `name`, `description`, `confidence_score`, `challenge_notes` then one schema suffices and the difference is only in the prompting target and challenge criteria.
+
+**Decision content**
+
+The schema decision is the branching gate for S2. Two materially different outcomes:
+
+1. **Same schema, different prompting target**: One `LegibilityModel` type with fields `name`, `description`, `confidence`, `challenge_notes`. The architectural-model instance uses a prompt targeting components, boundaries, and data flows; the domain-model instance uses a prompt targeting concepts, definitions, and ubiquitous language. The challenge criteria differ only in their content, not their structure.
+
+2. **Distinct schemas**: `ArchitecturalModel` has fields specific to structural concerns (e.g. `moving_parts[]`, `interface_boundaries[]`, `coupling_points[]`); `DomainModel` has fields specific to semantic concerns (e.g. `ubiquitous_terms[]`, `aggregates[]`, `context_boundaries[]`). Different fields, different validation rules, and different challenge questions.
+
+The difference propagates directly into S2's challenge protocol (what a good challenge question looks like for each type), into S3's cross-check (what it means for an architectural concept to challenge a domain concept, and vice versa), and into S4's surfacing format (how the two models are presented side by side). The schema artefact from this slice is the input specification for S2.
+
+**Dependencies**
+
+S1 of the parent (the plugin scaffold) must exist — the schema artefact will be committed as part of the diagnostic-legibility plugin's design documentation, and the directory structure (agents/, templates/) must be in place. S1 of the parent is shipped (PR #334 merged).
+
+**Rationale**
+
+The schema decision is genuinely separable from the challenge-protocol decision (S2 of this record). You can define the schema fields without deciding whether the challenge cycle is a single-pass critique or an iterative loop. The reverse is not true: you cannot write challenge criteria or challenge prompts without knowing what the fields being challenged are. Establishing the schema first is therefore not just an ordering preference — it is a dependency that the challenge-protocol design must respect. Gating on it separately preserves the human's ability to redirect at a low-cost moment: if the human decides during disposition that a shared schema is preferable, the challenge-protocol design (S2) adjusts accordingly without any agent code needing rewrite.
+
+---
+
+## S2 — Challenge protocol and working agent — per-model self-challenge and refined output — decision-boundary
+
+**Context**
+
+Once the schemas are settled (S1 of this record), the agent needs a challenge-refine cycle for each model. The parent issue says the agent "subjects each model to a challenge-refine cycle" — but leaves the cycle mechanics open. The model-card-researcher provides a partial pattern: it runs a tiered source strategy and produces refined content, but it does not have an explicit self-challenge step. The carpaccio and advocatus-diaboli agents are read-only emitters; neither provides a pattern for iterative refinement within a single agent pass.
+
+The challenge-refine cycle is where the anti-hallucination value of the agent lives. A single critique-and-revise step is simpler but may miss persistent errors; an iterative loop with a convergence criterion is more thorough but has variable token cost and needs a stopping condition. The choice is architecturally material for both quality and cost.
+
+**Decision content**
+
+Three candidate challenge-protocol architectures:
+
+1. **Single-pass critique-revise**: The agent constructs the model, then sends a challenge prompt ("What is wrong or under-specified in this model?"), then sends a revise prompt ("Revise the model to address the challenge"). One round. Fixed cost. Observable output: the revised model. Challenge output is an intermediate artifact, not retained in the final output.
+
+2. **Retained-challenge single-pass**: Same as above, but the challenge questions and their resolutions are retained in the output alongside the revised model. The challenge output becomes part of the deliverable, available for S3's cross-check to use as diagnostic context.
+
+3. **Iterative loop with stopping condition**: The agent runs challenge-revise cycles until the model stabilises (e.g. challenge produces no material changes, or a fixed iteration count is reached). Higher quality ceiling but variable cost. Stopping condition is a design decision in its own right.
+
+The choice among these three also determines whether both model types share a challenge protocol (structure is identical, just applied to different schemas) or whether each type has a bespoke challenge protocol matching its schema's domain-specific concerns.
+
+The deliverable of this slice is a working agent file at `diagnostic-legibility/agents/<name>.agent.md` that: accepts a scope, constructs the two models (per the schemas from S1), applies the challenge protocol to each, and emits both refined models as structured output.
+
+**Dependencies**
+
+S1 of this record (schema definitions must be settled before challenge criteria can be written). The diagnostic-legibility scaffold (S1 of parent, shipped in PR #334).
+
+**Rationale**
+
+The challenge protocol is architecturally independent from the schema question — it is the design of *how* the agent improves each model, not *what* the model contains. Separating them allows the human to engage with the challenge-mechanics question on its own merits after the schema is established. It also makes the working agent the first observable, runnable deliverable of the S2 track — this slice satisfies the end-to-end filter (a human can invoke the agent against a real codebase scope and observe two refined model outputs). Sequencing S1 first keeps the cost of a schema revision bounded to updating the challenge prompts rather than reconstructing a completed agent.
+
+---
+
+## Sequencing recommendation
+
+S1 → S2. The schema definition (S1) is a hard dependency for the challenge-protocol design and implementation (S2). The challenge criteria, challenge prompts, and the agent's internal structure all reference the schema fields by name. Writing the challenge protocol without settled schemas produces work that is likely to require partial rewrite when the schema is revised.
+
+There is no case for interleaving these two slices. S2 should not begin until S1's schema artefact is in place and the disposition has confirmed the same-or-distinct choice.
+
+---
+
+## Explicitly not slicing on
+
+- **Scope ingestion mechanism.** How the agent reads the target codebase (filesystem walk, context-window injection, LSP query, incremental summarisation) is an implementation choice inside the agent, not a design gate. The parent slicing record correctly excluded this, and the exclusion holds at meta-iteration. It would only become a slice if the context-window constraint for large codebases is identified as a binding architectural constraint — but the issue does not surface that.
+
+- **Convergence stopping condition as a standalone slice.** The iterative-loop option for the challenge protocol has a nested decision (what is the stopping condition?). This is not sliced out separately because the stopping condition is a parameter inside the challenge-protocol design, not an independently disposable gate. If the human picks the iterative-loop option in S2 disposition, the stopping condition is specified in the same spec.
+
+- **Output format of the refined model pair.** The parent slicing record assigned the output format decision to S4 (surfacing interface). S2's deliverable is "structured output" — the format decision belongs to S4 because the output format is the contract between the agent pipeline and the human-facing surface. Pre-deciding format here would create a forward dependency on S4's interface decision.
+
+- **Per-model bespoke challenge prompts vs. parameterised prompts.** Whether the architectural challenge prompt and domain challenge prompt are written as two separate prompt strings or as one parameterised template is an implementation choice within S2, not a design gate. The decision follows from the schema decision (same schema → parameterisable; distinct schemas → likely bespoke) and does not need its own slice.
+
+- **Slicing on the two model types separately.** Constructing the architectural model and constructing the domain model could have been treated as two slices. This would be slicing on semantic content rather than on decisions — both constructions live inside the same agent, share the same execution context, and are designed in the same spec session. Treating them as separate slices would pad the count without adding cognitive-engagement value.
+
+- **TDAD scenarios as a separate slice.** The project convention (CLAUDE.md) requires TDAD scenarios alongside each agent file. Writing the scenarios is an obligation that follows from S2's agent deliverable, not an independent design decision. It is implementation ceremony, not a design gate.

--- a/docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md
+++ b/docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md
@@ -1,0 +1,339 @@
+# Diagnostic Legibility — sub-S2a — `LegibilityElement` schema — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-26 |
+| Status | Draft |
+| Author | claude-opus-4-7[1m] (interactive session with russmiles) |
+| Slice | sub-S1 of the meta-iteration record at `docs/superpowers/slices/dl-s2-two-model-agent.md` (which is itself S2 of the parent record `docs/superpowers/slices/diagnostic-legibility-plugin.md`) |
+| Parent issue | #331 (Diagnostic Legibility S2) |
+| Deferred sibling issue | #335 (sub-S2b: challenge protocol + working agent) |
+| Plugin version target | `diagnostic-legibility` v0.1.0 → v0.2.0 |
+| Marketplace listing | Unchanged at v0.4.0; `plugin_version` unchanged at v0.39.0 |
+| PR ceremony | feature — full `/diaboli` (spec + code) and `/choice-cartograph` |
+| Related work | S1 of parent (PR #334 merged, scaffold shipped); sibling slicing of `model-cards/templates/` as a pattern anchor |
+
+---
+
+## 1. Premise
+
+Issue #331 commissions the two-model agent for the diagnostic-legibility
+plugin. Carpaccio's meta-iteration on that issue (recorded at
+`docs/superpowers/slices/dl-s2-two-model-agent.md`) surfaced a sub-gate
+the parent slicing did not show: the schema-shape decision for the two
+models is a branching gate that should be settled before any agent
+code is written. The wrong answer propagates into every prompt the
+agent sends, into the cross-check (parent S3 / issue #332), and into
+the surfacing format (parent S4 / issue #333).
+
+This spec covers sub-S1 of that meta-iteration only: the
+`LegibilityElement` schema artefact. The agent implementation,
+challenge protocol, and refined-output mechanics live in the deferred
+sibling issue #335 (sub-S2b).
+
+## 2. The schema decision
+
+The chosen shape (settled in brainstorming above this spec): **same
+flat schema for both dimensions** — `LegibilityElement`. The
+architectural-model and domain-model instances are typed by their
+*collection*, not by their *record*. Dimension-specific framing
+(boundaries, collaborators, ubiquitous language, aliases) collapses
+into the free-text `description` field.
+
+This is the simplest path. Three consequences worth naming:
+
+- **Prompting**: one prompt template targets both dimensions, with
+  the dimension passed as a parameter and the target description
+  varying accordingly. Sub-S2b designs the prompt's structure.
+- **Cross-check (parent S3, #332)**: comparing two collections of
+  the same record type is mechanically simpler than comparing
+  records of different types. The cross-check protocol can iterate
+  the two lists symmetrically.
+- **Surfacing (parent S4, #333)**: the human-facing presentation
+  can use the same row template for both lists, with section headings
+  distinguishing the dimensions.
+
+The trade-off accepted: the schema does not carry
+dimension-specific affordances. Whether an architectural element
+has explicit `responsibility` and `boundary` fields, or whether a
+domain concept has explicit `ubiquitous_language_canonical` and
+`aliases` fields, those concerns live inside the free-text
+`description` field. A later iteration may revisit this if it
+turns out the descriptions become a junk drawer.
+
+## 3. `LegibilityElement` schema
+
+### 3.1 Fields
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `name` | string | yes | Short identifier for the element. For architectural: a component, service, or module name. For domain: a concept term. |
+| `description` | string | yes | Free-text explanation. Carries dimension-specific framing: for architectural, what the element does and how it is bounded; for domain, what the term means and how it is used. Multi-paragraph is fine. |
+| `evidence` | list of objects | yes | Citations grounding the element. Each entry has `path` (string) and optional `excerpt` (string). At least one entry per element when confidence is `medium` or `high`. |
+| `confidence` | enum | yes | One of `low`, `medium`, `high`. Indicates the agent's confidence in the element. `low` means "candidate, included for completeness"; `high` means "well-evidenced and challenged". |
+| `challenge_notes` | list of strings | yes | What the challenge-refine step surfaced and how it was resolved. Empty list permitted only when challenge protocol is not yet run (sub-S2b will populate this). |
+
+### 3.2 Type definition
+
+The schema is described in prose with a field table in the template
+file (per §4); no machine-readable schema file (JSON Schema or
+similar) ships at this version. The agent reads the template as
+prose and embeds it into its system prompt.
+
+Equivalent type signature in pseudocode (for documentation only,
+not committed as code):
+
+```
+LegibilityElement = {
+  name: string,
+  description: string,
+  evidence: [{ path: string, excerpt?: string }],
+  confidence: "low" | "medium" | "high",
+  challenge_notes: [string]
+}
+```
+
+### 3.3 Validation rules
+
+- `name` must be non-empty.
+- `description` must be non-empty.
+- `evidence` must have at least one entry when `confidence` is
+  `medium` or `high`. `low`-confidence elements may have empty
+  evidence (the agent flagged a candidate without ground).
+- `confidence` must be one of the three enum values.
+- `challenge_notes` may be empty (sub-S2b's agent will not always
+  populate it; the cross-check in parent S3 may).
+
+The validation rules are enforced *by the agent*, not by a runtime
+validator. Sub-S2b's agent file references this template and applies
+the rules as part of its construction protocol. A later slice may
+ship a deterministic validator if it earns its keep.
+
+## 4. `LegibilityModel` collection wrapper
+
+The two dimensions are gathered into a `LegibilityModel` wrapper
+that the agent emits as its top-level output.
+
+### 4.1 Fields
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `scope` | string | yes | A path or description of what was modelled (e.g. `"./src/auth/"` or `"the checkout flow across services A and B"`). |
+| `generated_at` | string (ISO 8601) | yes | Timestamp the model pair was produced. |
+| `generated_by` | string | yes | Agent name + model identifier (e.g. `"diagnostic-legibility-agent / claude-sonnet-4-6"`). |
+| `architectural` | list of `LegibilityElement` | yes | The architectural-dimension elements. May be empty if scope yielded no architecture-level findings. |
+| `domain` | list of `LegibilityElement` | yes | The domain-dimension elements. May be empty if scope yielded no domain concepts. |
+
+### 4.2 Validation rules
+
+- At least one of `architectural` or `domain` must be non-empty.
+  An empty pair on both sides is a degenerate output and the agent
+  should surface a `low`-confidence placeholder rather than emit
+  two empty lists.
+- The two lists may have different lengths; symmetric size is not
+  required.
+
+## 5. The schema artefact
+
+### 5.1 Path
+
+`diagnostic-legibility/templates/legibility-element.md`
+
+Same `templates/` directory pattern that `model-cards/templates/`
+uses. The template is referenced by sub-S2b's agent file via its
+relative path.
+
+### 5.2 Format
+
+A single markdown file. Sections:
+
+- `# LegibilityElement` — heading and one-paragraph charter.
+- `## Fields` — the field table from §3.1.
+- `## Validation rules` — from §3.3.
+- `## LegibilityModel` — the wrapper from §4.
+- `## Examples` — two worked examples, one architectural and one
+  domain, each as a YAML block showing a `LegibilityElement`
+  instance. The examples are illustrative; they ground the agent's
+  prompt in concrete shape.
+- `## Why this schema` — short pointer to this spec (§2) so a
+  reader landing on the template file can find the design
+  rationale.
+
+### 5.3 Worked examples (content for the template)
+
+The architectural example shows an element naming a service:
+
+```yaml
+name: AuthenticationService
+description: |
+  The HTTP-level entry point for credential validation. Bounded by
+  the login endpoint and the session-issuance endpoint. Collaborates
+  with the credentials store (read-only) and the session-token issuer
+  (write). The service owns the credential-validation policy but not
+  the storage of credentials themselves.
+evidence:
+  - path: src/auth/service.py
+    excerpt: "class AuthenticationService:\n    def authenticate(self, credentials):"
+  - path: src/auth/README.md
+    excerpt: "AuthenticationService is the only entry point that writes session tokens."
+confidence: high
+challenge_notes:
+  - "Initial draft included session storage as a responsibility; challenge clarified the service issues but does not store, and the description was revised."
+```
+
+The domain example shows an element naming a concept:
+
+```yaml
+name: Order
+description: |
+  In this codebase, "Order" is a finalised purchase intent that has
+  cleared cart and inventory checks but has not yet been fulfilled.
+  Distinct from "Cart" (mutable, pre-checkout) and from "Shipment"
+  (post-fulfilment). The ubiquitous-language canonical term is "Order";
+  the codebase uses "PurchaseOrder" in some legacy modules as an alias.
+evidence:
+  - path: src/domain/order.py
+    excerpt: "class Order:  # canonical name; PurchaseOrder is deprecated"
+  - path: docs/glossary.md
+    excerpt: "Order: a finalised purchase intent..."
+confidence: high
+challenge_notes:
+  - "Initial draft conflated Order with Cart; challenge surfaced the cart→order transition as the boundary and the description was refined."
+```
+
+## 6. User stories and acceptance scenarios
+
+### 6.1 Story — sub-S2b can build the agent against the schema
+
+**As** a developer implementing sub-S2b (the two-model agent and its
+challenge protocol)
+**I want** to find the `LegibilityElement` schema as a committed
+template in the plugin
+**So that** my agent's prompts can reference it by path and embed
+its prose directly into the system message.
+
+```gherkin
+Given the merged main on this PR
+When I look at diagnostic-legibility/templates/legibility-element.md
+Then the file exists
+And it contains a field table for LegibilityElement
+And it contains the LegibilityModel wrapper definition
+And it contains at least one architectural example and one domain example
+And it contains a link back to this spec for the design rationale
+```
+
+### 6.2 Story — the schema is human-readable as documentation
+
+**As** a future reader trying to understand what the diagnostic
+legibility plugin produces
+**I want** to read the schema as documentation without running any
+agent
+**So that** I can see the contract the agent emits before deciding
+whether to use it.
+
+```gherkin
+Given diagnostic-legibility/templates/legibility-element.md
+When I read it without any prior context
+Then I understand what LegibilityElement is
+And I understand how architectural and domain instances differ in
+    practice (despite sharing a schema)
+And I see worked examples that show the validation rules in concrete
+    form
+```
+
+### 6.3 Story — the plugin version reflects the new template
+
+**As** the marketplace consumer
+**I want** the diagnostic-legibility plugin version to bump when
+content is added
+**So that** caches and version checks know the plugin has changed.
+
+```gherkin
+Given the merged main on this PR
+When I read diagnostic-legibility/.claude-plugin/plugin.json
+Then the version is "0.2.0"
+And the entry in .claude-plugin/marketplace.json for diagnostic-legibility
+    also shows version "0.2.0"
+And the top-level marketplace `version` is unchanged at "0.4.0"
+And the `plugin_version` field is unchanged at "0.39.0"
+And diagnostic-legibility/CHANGELOG.md has a new entry for 0.2.0
+```
+
+## 7. Files to add and modify
+
+### 7.1 New files
+
+| Path | Purpose |
+| --- | --- |
+| `diagnostic-legibility/templates/legibility-element.md` | The schema artefact (§5). Replaces the `.gitkeep` placeholder in `templates/`. |
+
+### 7.2 Removed files
+
+| Path | Reason |
+| --- | --- |
+| `diagnostic-legibility/templates/.gitkeep` | Replaced by the new template file. The directory no longer needs a placeholder. |
+
+### 7.3 Modified files
+
+| Path | Change |
+| --- | --- |
+| `diagnostic-legibility/.claude-plugin/plugin.json` | Bump `version` `0.1.0` → `0.2.0`. |
+| `diagnostic-legibility/CHANGELOG.md` | New `## 0.2.0 — 2026-05-26` entry naming the template addition and the sub-S1 disposition that produced it. |
+| `.claude-plugin/marketplace.json` | Bump the `diagnostic-legibility` entry in `plugins[]` from `version: "0.1.0"` to `"0.2.0"`. Top-level `version` and `plugin_version` unchanged. |
+| `README.md` (repo root) | Update the `diagnostic-legibility` badge from `v0.1.0` to `v0.2.0` and the marketplace table row's Version column from `v0.1.0` to `v0.2.0`. |
+
+## 8. Out of scope
+
+The slice narrowing keeps the following out of scope. They are listed
+so the spec is honest about what is *not* shipping in this PR:
+
+- **Any agent file under `diagnostic-legibility/agents/`.** Reserved
+  for sub-S2b (#335). The `agents/.gitkeep` placeholder stays in
+  place.
+- **The challenge-refine protocol design.** Reserved for sub-S2b.
+- **The cross-check protocol (parent S3, #332).**
+- **The surfacing interface (parent S4, #333).**
+- **A machine-readable JSON Schema file.** §3.2 explicitly defers
+  this. The markdown template is the canonical artefact at v0.2.0.
+- **A runtime validator that checks `LegibilityElement` instances at
+  agent-output time.** Validation is enforced by the agent during
+  construction (§3.3) until a later slice earns the validator.
+- **TDAD scenarios.** No agent, skill, or command file is added; the
+  TDAD-scenario-presence constraint and docs-reference-parity
+  constraint are both no-ops on this PR.
+
+## 9. Compatibility and rollout
+
+- **Backwards compatibility:** the diagnostic-legibility plugin was
+  shipped in v0.1.0 as a scaffold-only plugin. Adding a template file
+  does not break any consumer because no consumer exists yet.
+- **Cache behaviour:** `sync-marketplace-cache.sh` fires when
+  `.claude-plugin/marketplace.json` differs from `origin/main` —
+  this PR triggers it because the per-plugin version bumps.
+  `sync-to-global-cache.sh` rsyncs the new template into the
+  versioned plugin cache.
+- **CI gates:** all existing gates apply. Spec-first is satisfied
+  by this spec being the first commit on the branch. Version
+  consistency is satisfied: diagnostic-legibility's plugin.json
+  (0.2.0) matches its marketplace entry (0.2.0). TDAD and
+  docs-reference-parity are no-ops.
+
+## 10. Open questions resolved during brainstorming
+
+| Question | Decision |
+| --- | --- |
+| Same schema vs. distinct schemas | Same flat schema (`LegibilityElement`) |
+| Schema artefact location and format | Markdown spec at `diagnostic-legibility/templates/legibility-element.md` |
+| Field set | `name`, `description`, `evidence` (list of {path, excerpt}), `confidence` (low/medium/high), `challenge_notes` |
+| Collection wrapper | `LegibilityModel` with `scope`, `generated_at`, `generated_by`, `architectural[]`, `domain[]` |
+| Per-version bump | diagnostic-legibility 0.1.0 → 0.2.0 (minor: new content); marketplace listing unchanged at 0.4.0 |
+
+## 11. References
+
+- Issue #331 — parent S2 commission.
+- Issue #335 — deferred sub-S2b sibling (challenge protocol + agent).
+- Sub-slicing record: `docs/superpowers/slices/dl-s2-two-model-agent.md`.
+- Parent slicing record: `docs/superpowers/slices/diagnostic-legibility-plugin.md`.
+- S1 (parent) spec: `docs/superpowers/specs/2026-05-26-diagnostic-legibility-plugin-scaffold-design.md`.
+- Sibling pattern: `model-cards/templates/` for the templates/ convention.
+- `CLAUDE.md` — Semantic Versioning and Marketplace Versioning sections.


### PR DESCRIPTION
## Summary

Sub-S2a of the meta-iteration slicing at `docs/superpowers/slices/dl-s2-two-model-agent.md`, which itself slices parent S2 (issue #331) of the diagnostic-legibility roadmap. Ships the `LegibilityElement` schema artefact and bumps the plugin to v0.2.0.

The sub-S1 (this PR) and sub-S2b (issue #335) split came from carpaccio's meta-iteration on issue #331: the schema decision is a branching gate that propagates into every subsequent prompt, the cross-check (issue #332), and the surfacing (issue #333). Splitting it out keeps the schema-revision cost bounded — a schema rethink at this point costs nothing because no agent has been built against it yet.

Spec: `docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md`
Plan: `docs/superpowers/plans/2026-05-26-dl-s2a-legibility-element-schema.md`

## Schema decision recorded

**Same flat schema for both dimensions: `LegibilityElement`.**

Fields: \`name\`, \`description\`, \`evidence\` (list of \`{path, excerpt?}\`), \`confidence\` (low | medium | high), \`challenge_notes\` (list of strings). The two dimensions are typed by their *collection* (`architectural[]` vs `domain[]` inside the `LegibilityModel` wrapper) — the record itself is uniform. Dimension-specific framing lives in the free-text `description` field.

Trade-off accepted: the schema does not carry dimension-specific affordances (boundaries, collaborators, ubiquitous-language canonicals). A later iteration may revisit if descriptions become a junk drawer.

## What's in the PR

- New: `diagnostic-legibility/templates/legibility-element.md` (the schema artefact).
- Removed: `diagnostic-legibility/templates/.gitkeep` (replaced by the template).
- diagnostic-legibility plugin.json + CHANGELOG bumped 0.1.0 → 0.2.0.
- marketplace.json: diagnostic-legibility entry version 0.1.0 → 0.2.0 only. Listing version (0.4.0) and `plugin_version` (0.39.0) unchanged.
- Root README badge + table row bumped to v0.2.0.

## What's NOT in the PR

- No agent file (sub-S2b, #335).
- No challenge-refine protocol (sub-S2b, #335).
- No runtime validator (deferred).
- No machine-readable JSON Schema file alongside the markdown (deferred).

## Test plan

- [ ] Spec-first ordering passes (spec is first commit on branch).
- [ ] Per-plugin version sync passes: diagnostic-legibility plugin.json (0.2.0) matches marketplace entry (0.2.0).
- [ ] marketplace.json listing `version` (0.4.0) and `plugin_version` (0.39.0) unchanged.
- [ ] TDAD scenario presence check is a no-op (no agents/skills/commands files added).
- [ ] Docs reference parity check is a no-op.
- [ ] Markdown lint passes.
- [ ] Docs build check passes.

Tracks parent issue #331. Does **not** close it — sub-S2b (#335) closes #331 when the agent ships.