### PR TITLE
fix /superpowers-status disposition counting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.39.0",
+  "plugin_version": "0.39.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.39.0"
+      "version": "0.39.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.39.1 — 2026-05-28
+
+### Fix — /superpowers-status disposition counting
+
+`/superpowers-status` could over-report pending dispositions when an
+objection or choice-story record contained the literal string
+`disposition: pending` inside an `evidence:` or `claim:` field — a
+common pattern when an objection itself critiques disposition handling.
+A naive `grep -c "disposition: pending"` matched those prose occurrences
+and reported them as unresolved entries. In 2026-05 this showed
+`choice-cartographer.md` as having 3 pending dispositions when every
+entry was in fact resolved.
+
+- `commands/superpowers-status.md` now defines a shared "Disposition
+  counting" algorithm before Section 7. The rule: count only lines
+  matching `^    disposition: pending(\s|$)` within the first
+  `---`…`---` frontmatter block. Provides an awk recipe agents and
+  humans can paste, and notes that a YAML-aware parser (`yq`,
+  `python -c "import yaml"`) is preferred when available.
+- Sections 7 (Diaboli) and 8 (Cartographer) reference the shared
+  algorithm so the same fix protects both panels.
+
 ## 0.39.0 — 2026-05-26
 
 ### Carpaccio agent — cadence governor for AI-generated decision streams

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.39.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.39.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.2.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.39.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.39.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.2.0 | Scaffold-only. Will host agents accountable for maintaining human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope — see #327 and the slicing record for the four-slice roadmap. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/superpowers-status.md
+++ b/ai-literacy-superpowers/commands/superpowers-status.md
@@ -85,6 +85,65 @@ Check for CI configuration:
 - If on a branch with an open PR, show the PR check status:
   `gh pr checks --json name,status,conclusion 2>/dev/null || echo "No open PR"`
 
+### Disposition counting (shared algorithm for Sections 7 and 8)
+
+`disposition:` and `disposition: pending` appear in objection and choice-story
+records in **two distinct places** and only one of them is a real disposition:
+
+1. **YAML frontmatter list items** — each entry under `objections:` or
+   `stories:` carries a `disposition:` field indented exactly four spaces.
+   These are the only values that count.
+2. **Prose / evidence text** — `evidence:`, `claim:`, body sections, and
+   quoted examples routinely contain the literal string `disposition: pending`
+   when an objection critiques disposition handling. **These must not be
+   counted.**
+
+A naive `grep -c "disposition: pending"` over the whole file produces false
+positives: in 2026-05 the `choice-cartographer.md` record reported as having
+3 pending dispositions when every entry was in fact resolved — the three
+matches were all inside O9's `evidence:` field quoting the spec.
+
+**Counting rule (use this exact awk recipe, or an equivalent YAML-aware
+parser):**
+
+```bash
+# Count entries with disposition: pending in YAML frontmatter only.
+# Matches lines with exactly 4 leading spaces, scoped to the file's first
+# `---`…`---` block, so prose occurrences are ignored.
+count_pending() {
+  awk '
+    /^---$/                                          { fm++; next }
+    fm == 1 && /^    disposition: pending([[:space:]]|$)/ { c++ }
+    END                                              { print c+0 }
+  ' "$1"
+}
+
+# Count total entries (objection IDs or story IDs) the same way.
+count_entries() {
+  awk '
+    /^---$/             { fm++; next }
+    fm == 1 && /^  - id:/ { c++ }
+    END                 { print c+0 }
+  ' "$1"
+}
+```
+
+Why this works: every list-item field in these records is indented exactly
+four spaces; list-item starts (`  - id:`) are indented two. Multi-line YAML
+block scalars (if introduced later) would indent content **deeper** than four
+spaces, so they cannot collide. Quoted-string lines start with the field's
+own key (`    evidence:`, `    claim:`) — the `disposition:` token inside
+those strings is therefore not at column 0–4.
+
+Apply this rule consistently when computing:
+
+- Section 7 spec-mode and code-mode `pending` counts and fully-resolved rates.
+- Section 8 `cartograph_pending_count` and fully-resolved rate.
+- Disposition distributions in both sections.
+
+If a YAML-aware parser (`yq`, `python -c "import yaml; ..."`) is available,
+prefer it — semantics match, parsing is structurally correct.
+
 ### Section 7: Diaboli activity
 
 Check `docs/superpowers/specs/` and `docs/superpowers/objections/`.
@@ -98,6 +157,10 @@ prefix and `.md` extension stripped.
 
 **Error handling**: if any file at `docs/superpowers/objections/` fails YAML parse,
 report it by name as "parse error" and exclude it from all metrics.
+
+**Counting**: use the shared algorithm in "Disposition counting" above for
+all `disposition: pending` and total-objection counts. Do not grep the whole
+file — only the YAML frontmatter list items count.
 
 #### Overall totals (all records, both modes)
 
@@ -147,6 +210,10 @@ A **choice-story record** matches `docs/superpowers/stories/<slug>.md`.
 
 **Error handling**: if any file at `docs/superpowers/stories/` fails YAML parse,
 report it by name as "parse error" and exclude it from all metrics.
+
+**Counting**: use the shared algorithm in "Disposition counting" above for
+all `disposition: pending` and total-story counts. The same prose-vs-frontmatter
+trap that bit Diaboli also applies here — count YAML list items only.
 
 #### Totals
 


### PR DESCRIPTION
## Summary

- `/superpowers-status` was counting `disposition: pending` occurrences inside `evidence:` and `claim:` prose, not just YAML frontmatter entries. In 2026-05 this falsely reported `docs/superpowers/objections/choice-cartographer.md` as having 3 pending dispositions when all 12 were resolved.
- Adds a shared **Disposition counting** algorithm before Section 7 of `commands/superpowers-status.md`. The rule: count only lines matching `^    disposition: pending(\s|$)` within the first `---`…`---` frontmatter block. Includes an awk recipe and a note to prefer a YAML-aware parser (`yq`, `python -c "import yaml"`) when available. Sections 7 (Diaboli) and 8 (Cartographer) both reference the rule.
- Patch bump 0.39.0 → 0.39.1; marketplace `plugin_version` and per-plugin `version` updated to match.

## Branch exemption

`fix/` branch prefix — bug fix in an existing plugin file, no design work needed.

## Test plan

- [x] Hand-verified all 12 dispositions in `choice-cartographer.md` are non-pending (rejected / accepted).
- [x] Validated the awk recipe across all 11 objection records and 3 story records — totals match the previous count (113 objections, 26 stories), pending counts all 0.
- [x] Confirmed the recipe is robust against YAML block scalars: continuation lines indent ≥6 spaces, so `^    disposition:` (exactly 4 spaces) cannot collide.
- [ ] CI green.