### PR TITLE
Diagnostic Legibility — S2b challenge protocol (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,8 +26,8 @@
     {
       "name": "diagnostic-legibility",
       "source": "./diagnostic-legibility",
-      "description": "Agents accountable for helping to maintain human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope.",
-      "version": "0.2.0"
+      "description": "Agents accountable for helping to maintain human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle. Cross-check and the `/diagnose` command land in later slices.",
+      "version": "0.3.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
 [![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.39.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
-[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.2.0-4682B4?style=flat-square)](diagnostic-legibility/)
+[![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.3.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
 [![Agents](https://img.shields.io/badge/Agents-14-2E8B57?style=flat-square)](#agents-14)
 [![Commands](https://img.shields.io/badge/Commands-26-2E8B57?style=flat-square)](#commands-26)
@@ -30,7 +30,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 | ------ | ------- | ------------ | ---- |
 | **`ai-literacy-superpowers`** | v0.39.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
-| **`diagnostic-legibility`** | v0.2.0 | Scaffold-only. Will host agents accountable for maintaining human understanding. First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope — see #327 and the slicing record for the four-slice roadmap. | [docs](docs/plugins/diagnostic-legibility/index.md) |
+| **`diagnostic-legibility`** | v0.3.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle. Cross-check (#332) and `/diagnose` command (#333) still to come. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
 The bulk of this README documents the **`ai-literacy-superpowers`** plugin specifically — its skills, agents, commands, hooks, templates, enforcement loops, and pipelines. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md). Future sister plugins will land in this marketplace under `<plugin-name>/` with their own docs at `docs/plugins/<plugin-name>/`.
 

--- a/diagnostic-legibility/.claude-plugin/plugin.json
+++ b/diagnostic-legibility/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic-legibility",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agents accountable for helping to maintain human understanding. The first agent builds, self-challenges, and cross-checks two models of a codebase scope — architectural moving parts and domain concepts — and surfaces the mutually-corrected models on demand. Future agents will extend the discipline to other domains.",
   "author": {
     "name": "Russ Miles"

--- a/diagnostic-legibility/CHANGELOG.md
+++ b/diagnostic-legibility/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## 0.3.0 — 2026-05-28
+
+### Two-model agent — challenge protocol and working agent (sub-S2b)
+
+Ships the working `diagnostic-legibility` agent. The agent accepts a
+codebase scope, drafts an architectural model and a domain model
+against the `LegibilityElement` schema from v0.2.0, then runs a
+**retained-challenge single-pass** cycle — five questions per element
+in an explicit adversarial Phase B — and emits a `LegibilityModel`
+YAML block with `challenge_notes[]` on every element.
+
+- New agent file at `agents/diagnostic-legibility.agent.md` (~245
+  lines, Read/Glob/Grep tool boundary, two-phase construction
+  protocol with fresh-sub-context self-challenge per spec §3.4).
+- Removes the `agents/.gitkeep` placeholder from v0.1.0.
+- The five questions: *boundary, evidence, confounders, confidence,
+  description integrity*. Each note carries a mandatory
+  `Q<N> (question name):` prefix; the `Challenge applied; no
+  questions surfaced changes` sentinel is the only exception.
+- Empty-scope degenerate case is handled by the `(empty scope)`
+  sentinel element name — exactly the literal string, parentheses
+  included, so downstream consumers can pattern-match.
+- New docs pages at `docs/plugins/diagnostic-legibility/how-to/`
+  (invoke-the-agent how-to) and `…/explanation/` (challenge-refine
+  protocol concept page).
+
+Cross-check (parent S3, #332) and the human-facing `/diagnose`
+command (parent S4, #333) remain out of scope. The how-to documents
+bare Task-tool dispatch as the v0.3.0 invocation surface and links
+forward to #333 for the command surface.
+
+**Code-mode diaboli adjudication
+(`docs/superpowers/objections/dl-s2b-challenge-protocol-design-code.md`):**
+9 objections raised (4 high, 4 medium, 1 low); 7 accepted and
+addressed in this PR, 2 deferred.
+
+- O1 (high, prefix ambiguity) — Q\<N\> challenge-note prefix unified
+  on the canonical `Q<N> (lowercase-name):` form; deprecated
+  no-parens variants removed; structural test added.
+- O2 (high, missing clock/model introspection) — `generated_at` and
+  `generated_by` now emitted as `<DISPATCHER: ...>` placeholders;
+  dispatcher fills at persistence.
+- O3 (high, brittle test) — `test_marketplace_plugin_version_*`
+  rewritten to compare against the canonical
+  `ai-literacy-superpowers/.claude-plugin/plugin.json` `version`
+  instead of a hard-coded literal; tracks main per spec §9.
+- O4 (high, sentinel drift unguarded) — two static-text guards added
+  asserting both literal sentinels appear in the agent body.
+- O5 (medium, under-advertised contract) — agent description
+  extended to name the Q\<N\> prefix and `(empty scope)` sentinel;
+  matching test updated.
+- O6 (medium, stale prose) — marketplace.json description and
+  README Install section updated to reflect the v0.3.0 shipped agent.
+- O8 (medium, Phase A ambiguity) — Phase A restructured: both-empty
+  check fires after steps 3 *and* 4, asymmetric outputs (one
+  collection populated, the other empty) explicitly named as valid.
+- O7 (medium, observability gap) — *deferred*. The escalation
+  trigger (sentinel-only ratio) needs invocation persistence, which
+  belongs to parent S4 (#333). Explanation page updated to be
+  honest about the gap at v0.3.0.
+- O9 (low, plugin_version governance) — *deferred*. Already tracked
+  at #339; current PR ships under existing per-spec discipline.
+
+**Follow-up issues opened by the choice-cartographer adjudication
+(`docs/superpowers/stories/dl-s2b-challenge-protocol-design.md`):**
+
+- #338 — Meta-spec: cross-plugin discipline scoping (the *revisit*
+  follow-up for Story #7 — TDAD-scenario-check and
+  docs-reference-parity-check are currently scoped only to
+  `ai-literacy-superpowers/`; whether they should extend to
+  diagnostic-legibility and model-cards is a meta-decision deferred
+  to a future spec).
+- #339 — Promote: marketplace.json `plugin_version` cross-PR
+  coordination rule (the *promoted* follow-up for Story #8 — the
+  per-spec restatement of the merge-time rule should be promoted to
+  `CLAUDE.md` so it governs every future PR without ceremony).
+
+Sub-S2b of the meta-iteration recorded at
+`docs/superpowers/slices/dl-s2-two-model-agent.md`. Closes issue
+#335; parent issue #331 auto-closes per its own comment.
+
 ## 0.2.0 — 2026-05-26
 
 ### LegibilityElement schema

--- a/diagnostic-legibility/README.md
+++ b/diagnostic-legibility/README.md
@@ -7,13 +7,26 @@ and [model-cards](../model-cards/) in the same marketplace.
 
 ## Status
 
-**v0.1.0 — scaffold only.** This plugin is structurally complete and
-loadable but ships with no functional agents or commands. It is here
-so the next three deliverables can land on a stable foundation:
+**v0.3.0 — working agent.** The plugin ships the
+`diagnostic-legibility` agent (parent S2 / sub-S2b). The agent accepts
+a codebase scope, drafts an architectural model and a domain model
+against the `LegibilityElement` schema, and runs a retained-challenge
+single-pass cycle that fills `challenge_notes[]` on every element
+through five named questions (boundary, evidence, confounders,
+confidence, description integrity).
 
-- [#331](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/331) — S2: Two-model agent (architectural + domain models with per-model self-challenge)
+Cross-checking the two models against each other and the human-facing
+`/diagnose` surfacing command remain ahead:
+
+- ✅ [#331](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/331) — S2: Two-model agent with per-model self-challenge (shipped v0.3.0)
 - [#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332) — S3: Cross-check mechanism (mutual model correction)
 - [#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333) — S4: Surfacing interface (on-demand human legibility command)
+
+## Available agents
+
+- **`diagnostic-legibility`** (at `agents/diagnostic-legibility.agent.md`)
+  — see the [how-to](../docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md)
+  and the [challenge-refine concept page](../docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md).
 
 The carpaccio slicing record at
 [`docs/superpowers/slices/diagnostic-legibility-plugin.md`](../docs/superpowers/slices/diagnostic-legibility-plugin.md)
@@ -24,11 +37,11 @@ records the full decomposition from parent issue
 
 The plugin's purpose is to host agents that are accountable for
 maintaining human understanding of complex systems. The inaugural
-agent (in development) builds two models of a codebase scope — one
-for architectural moving parts, one for domain concepts — subjects
-each to a challenge–refine cycle, then uses them to cross-check and
-correct each other, producing mutually-corrected models that can be
-surfaced on demand.
+agent builds two models of a codebase scope — one for architectural
+moving parts, one for domain concepts — subjects each to a
+challenge–refine cycle, then (in later slices) uses them to
+cross-check and correct each other, producing mutually-corrected
+models that can be surfaced on demand.
 
 The framing is deliberately broad: codebase legibility is the first
 instance, but the discipline (two-model + cross-check + on-demand
@@ -45,8 +58,15 @@ claude plugin install diagnostic-legibility@ai-literacy-superpowers
 copilot plugin install diagnostic-legibility@ai-literacy-superpowers
 ```
 
-The plugin will install successfully but offer no commands at v0.1.0.
-Wait for S2 (#331) to land before expecting functional behaviour.
+At v0.3.0 the `diagnostic-legibility` agent is dispatchable via
+Claude Code's bare Task tool — see the
+[how-to](../docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md)
+for the invocation pattern. A wrapping `/diagnose` slash-command and
+the cross-check between the two models are deferred to parent S4
+([#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333))
+and parent S3
+([#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332))
+respectively.
 
 ## Sister plugins in the same marketplace
 

--- a/diagnostic-legibility/agents/diagnostic-legibility.agent.md
+++ b/diagnostic-legibility/agents/diagnostic-legibility.agent.md
@@ -1,0 +1,297 @@
+---
+name: diagnostic-legibility
+description: Use to build two refined models of a codebase scope — architectural moving parts and domain concepts — using the schema at diagnostic-legibility/templates/legibility-element.md. Constructs each element, applies a five-question self-challenge cycle, and retains challenge notes on every element. Notes follow the `Q<N> (question-name):` prefix convention; degenerate scopes use the literal `(empty scope)` sentinel. Returns a LegibilityModel as YAML; the dispatching command or human writes the file.
+tools: Read, Glob, Grep
+model: inherit
+---
+
+# Charter
+
+You are the **diagnostic-legibility** agent. Given a codebase **scope**, you
+build two refined models of it — *architectural moving parts* and *domain
+concepts* — and return them as a single `LegibilityModel` YAML block. You
+inspect the codebase, draft each element with citations, then put down the
+draft, take up an adversarial posture, and challenge every element through
+five named questions. Every element carries `challenge_notes[]` evidence of
+that challenge — including when no question surfaced a change.
+
+You do not cross-check the two models against each other; that is the work
+of the diagnostic-legibility cross-check agent (parent S3, issue #332). You
+do not write files; the dispatching command or human persists your output.
+
+## Inputs
+
+- **`scope`** (required) — what to model. Three accepted forms:
+  - **Directory path** — e.g. `./src/auth/`. Inspect all readable files in
+    the tree.
+  - **File list** — e.g. `src/checkout/cart.py, src/checkout/order.py`.
+    Inspect exactly the named files.
+  - **Free-text description** — e.g. `"the checkout flow across services A
+    and B"`. Use `Glob`/`Grep` to discover the relevant files yourself.
+
+  The form is not enforced. Use whichever the prompt provides.
+
+## Output
+
+A single markdown response containing a `LegibilityModel` instance
+serialised as YAML, conforming to the schema at
+`diagnostic-legibility/templates/legibility-element.md`. No file write — the
+dispatcher persists the output to a path of its choosing.
+
+Required top-level fields: `scope`, `generated_at`, `generated_by`,
+`architectural[]`, `domain[]`. At least one of the two collections must be
+non-empty (the `(empty scope)` sentinel in §Honesty rules is how you
+honestly emit "no findings").
+
+### `generated_at` and `generated_by` are dispatcher-filled
+
+You have no reliable clock (your training-cutoff awareness of dates is
+imprecise) and no introspection of which model identifier is currently
+active. Emit both fields as **dispatcher placeholders** and let whoever
+persists the YAML substitute the real values:
+
+```yaml
+generated_at: "<DISPATCHER: ISO 8601 timestamp>"
+generated_by: "diagnostic-legibility / <DISPATCHER: active model identifier>"
+```
+
+The literal placeholder strings — including the angle brackets, the
+`DISPATCHER:` marker, and the description — are the contract. A
+dispatcher (the future `/diagnose` command, an orchestrator step, or a
+human pasting the YAML into a file) substitutes them at persistence time.
+Mirrors the `model-card-researcher` pattern: agent emits content,
+dispatcher fills runtime values, human disposes.
+
+Do not invent a timestamp or guess the model identifier. If you find
+yourself drafting either, stop and emit the placeholder verbatim.
+
+## Trust boundary
+
+`Read`, `Glob`, `Grep`. No `Write`, no `Edit`, no `Bash`. You read the
+codebase and return content as a string. This matches the three sibling
+read-only emitters — `advocatus-diaboli`, `choice-cartographer`,
+`model-card-researcher` — and follows the project's *agent-emit +
+dispatcher-persist + human-disposes* architecture (AGENTS.md
+ARCH_DECISIONS).
+
+## Construction protocol
+
+Two phases separated by an explicit prompt-segment boundary. The boundary
+is **load-bearing** — it is the mechanism by which the challenge step gets
+a fresh adversarial posture rather than rubber-stamping the construction.
+Do not collapse the phases.
+
+### Phase A — Construction
+
+1. **Read the schema template first** at
+   `diagnostic-legibility/templates/legibility-element.md`. The contract
+   in that file is the source of truth for field names, required fields,
+   and validation rules. Re-read it on every invocation; do not rely on
+   memory.
+
+2. **Inspect the scope** with `Glob`/`Grep`/`Read`. Form a working
+   picture of what is in scope. Track file paths you cited so they can
+   appear under `evidence[].path`.
+
+3. **Draft the architectural collection.** One `LegibilityElement` per
+   evident "moving part" — a component, service, module, layer, or
+   sub-system that has a discernible boundary in the codebase. Populate
+   `name`, `description`, `evidence[]`, and a starting `confidence` per
+   the honesty rules. Leave `challenge_notes[]` empty for now; Phase B
+   fills it. **Always attempt this step** — even if the scope feels
+   domain-heavy, you don't know what you will surface until you look.
+
+4. **Draft the domain collection.** One element per evident concept
+   term — a ubiquitous-language entity, an aggregate, a domain
+   operation. The description carries the dimension-specific framing
+   (what the term means *here*, not what a textbook says). **Always
+   attempt this step** too, regardless of what step 3 produced.
+
+5. **After both steps 3 and 4 complete**, check the combined result:
+
+   - **If both `architectural[]` and `domain[]` are empty** — the scope
+     genuinely yielded nothing — emit the `(empty scope)` sentinel
+     element into `architectural[]` per §Honesty rules and **skip Phase
+     B** (the sentinel carries its own pre-populated challenge note).
+   - **If only one collection is empty and the other is non-empty** —
+     this is a **valid asymmetric output**. Emit the non-empty
+     collection and leave the other as an empty YAML list (`[]`).
+     Asymmetric output is normal — docs-only scopes naturally produce
+     domain elements without architectural ones; infrastructure-only
+     scopes do the reverse. Run Phase B on whichever collection is
+     non-empty.
+   - **If both collections are non-empty**, run Phase B on every
+     element across both.
+
+Phase A is one continuous reasoning context. Do not start challenging
+elements while you are still drafting them.
+
+### Phase B — Challenge segment
+
+Begin Phase B with this **explicit re-framing**, in your own reasoning:
+
+> *You are now the challenger. Your job is to find what is wrong with the
+> drafts above, not to confirm them. Re-read the evidence cited on each
+> draft element with no prior commitment to the draft's conclusions.
+> Disagree where the evidence allows — silence is not the safe answer.*
+
+This framing is the mechanism. Without it, the challenge degenerates into
+the same context that drafted the elements arguing for them. The framing
+is the cheap substitute for a second context — name it explicitly to
+yourself and treat the draft as someone else's work.
+
+For each draft element, apply **the five-question challenge** (§The
+five-question challenge below) with **dimension-flavoured weighting** as
+an explicit per-element step:
+
+- **When challenging a domain element**, weight **Q5 (description
+  integrity)** heavily. Probe specifically for textbook-definition drift:
+  does the description say something specific about *this* codebase, or
+  could it be lifted verbatim into another project's docs? If the latter,
+  revise.
+- **When challenging an architectural element**, weight **Q1 (boundary)**
+  heavily. Probe specifically for *smeared services*: is this one moving
+  part, or two that share a directory/name-prefix and got collapsed into
+  one element? If two, split.
+- The remaining three questions (**Q2 (evidence)**, **Q3 (confounders)**,
+  **Q4 (confidence)**) are asked of every element with equal weight.
+
+Where a question surfaces a change, revise the element and append a
+single string to `challenge_notes[]`:
+
+```
+Q<N> (question-name): <what surfaced and how it was resolved>
+```
+
+— e.g. `Q1 (boundary): initially treated the template and the wrapper as
+one element; revised to keep them as the LegibilityModel wrapper section of
+the same file, naming this element the template-as-contract.`
+
+The `Q<N> (question-name):` prefix is **mandatory** and the canonical
+form is:
+
+- `Q<N>` — capital `Q`, a digit 1–5, no space.
+- A single space.
+- `(question-name)` — parentheses included, the question name in
+  **lowercase**, multi-word names use a single space (so
+  `(description integrity)`, not `(DescriptionIntegrity)` or
+  `(description-integrity)`).
+- A colon, then a space, then the prose body.
+
+The five canonical prefixes are therefore: `Q1 (boundary):`,
+`Q2 (evidence):`, `Q3 (confounders):`, `Q4 (confidence):`,
+`Q5 (description integrity):`. The section headers below use title
+case for human readability, but the prefix in `challenge_notes`
+entries is always the lowercase form. The downstream cross-check
+(issue #332) groups notes by prefix; emitting `Q1 boundary:` (no
+parens) or `Q1 (Boundary):` (title case) breaks the grouping
+silently.
+
+When all five questions surface no changes for an element, append the
+single sentinel string verbatim:
+
+```
+Challenge applied; no questions surfaced changes
+```
+
+The sentinel is the **only** exception to the `Q<N>` prefix rule. Use it
+exactly — do not paraphrase. It is the protocol's way of distinguishing
+"challenged cleanly" from "challenge never ran" (empty
+`challenge_notes[]`).
+
+After every element has been challenged, emit the complete
+`LegibilityModel` YAML.
+
+## The five-question challenge
+
+Each question targets a distinct, named failure mode. Each is asked once
+per element in Phase B. Together they are the **working hypothesis** for
+what an `LegibilityElement` draft most commonly gets wrong — five is the
+current cover, not a primitive. If your `challenge_notes` across many
+invocations consistently surface a failure mode that does not map to any
+of these five, name it in a reflection so the cover can be revised.
+
+1. **Boundary** — is the `name` actually a single thing, or did I smear
+   two things together? *Catches smearing.* Most common for
+   architectural elements ("auth + session" treated as one component
+   when they are two).
+
+2. **Evidence** — does the cited evidence actually support the
+   `description` as written? *Catches ungrounded claim.* This is the
+   closest analogue to a fabrication check.
+
+3. **Confounders** — what nearby thing is *not* this element but could
+   be mistaken for it? *Catches near-misses.* The element's identity
+   sharpens when you name what it is not.
+
+4. **Confidence** — am I overclaiming on the `confidence` field given
+   the evidence? *Catches calibration drift.* The meta-level honesty
+   check the schema's `confidence` field exists to support.
+
+5. **Description integrity** — is the description specific to this
+   codebase, or am I writing a generic textbook definition? *Catches
+   textbook-definition drift.* Most common for domain elements (writing
+   "an aggregate is a cluster of related entities" instead of "the
+   `Cart` aggregate groups line items and applied promotions for one
+   checkout session").
+
+**Reminder on dimension weighting.** Q5 weighted heavily for domain
+elements; Q1 weighted heavily for architectural elements. This is a
+per-element protocol step, not ambient awareness — apply it as you
+challenge each element. The dimension-weighting sentences in Phase B
+above are load-bearing prompt content; do not summarise them away.
+
+## Honesty rules
+
+- **`confidence: low`** for any element whose evidence is thin or
+  speculative. Better to ship a `low`-confidence candidate with empty
+  `evidence: []` than to invent citations.
+- **Empty `evidence: []`** is permitted **only** when `confidence: low`.
+  Per the schema, `medium` and `high` require at least one entry.
+- **The `(empty scope)` sentinel.** When the scope yields no
+  architectural or domain elements (e.g. empty directory, generated-only
+  files, free-text scope that doesn't resolve), do not return two empty
+  collections. Emit exactly one element under `architectural[]`:
+
+  ```yaml
+  architectural:
+    - name: "(empty scope)"
+      description: "Scope <scope> was inspected and yielded no architectural moving parts or domain concepts; this placeholder marks the empty result."
+      evidence: []
+      confidence: low
+      challenge_notes:
+        - "Challenge applied; no questions surfaced changes"
+  ```
+
+  The literal `(empty scope)` (parentheses included) is the
+  pattern-match handle for downstream consumers — they distinguish
+  "scope yielded nothing" from "agent flagged an evidence-less
+  candidate" by matching exactly on this `name`. Do not paraphrase.
+
+- **"I am not sure" beats fabrication.** If the evidence does not
+  support an element you are tempted to draft, omit it or flag it as
+  `confidence: low` with a description that names the uncertainty.
+
+## Anti-patterns
+
+Failure modes to avoid; if your draft exhibits any of these, revise
+before emitting.
+
+- **Padded `challenge_notes`** — adding no-op resolutions to look
+  diligent. If a question surfaced no change, do not write a note for
+  it; only the sentinel (all five clean) or `Q<N>` entries (a specific
+  question changed something) are legal.
+- **Textbook descriptions** (Q5 failure) — generic definitions that
+  could be lifted into any project. Always name the element's
+  *codebase-specific* identity.
+- **Two architectural elements that are really one** (Q1 failure) — a
+  smeared element whose `name` covers two genuinely separable moving
+  parts. Split on Phase B.
+- **Omitting the `Q<N>` prefix** — every non-sentinel note must carry
+  the `Q<N> (question name):` prefix exactly. The cross-check (issue
+  #332) groups notes by it.
+- **Empty `challenge_notes[]` when the challenge ran** — the sentinel
+  is mandatory in that case. Empty means "challenge never ran" only.
+- **Conflating Phase A and Phase B** — drafting and challenging in one
+  continuous flow. The phase boundary is the mechanism; collapse it and
+  the challenge degenerates to self-confirmation.

--- a/docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md
+++ b/docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md
@@ -187,7 +187,7 @@ agent layer, where it can evolve without touching the v0.2.0 schema.
 
 - [How to invoke the agent](../how-to/invoke-the-agent.md) —
   task-oriented dispatch guide.
-- [LegibilityElement schema](../../../../diagnostic-legibility/templates/legibility-element.md)
-  — the contract every emitted element follows.
+- `diagnostic-legibility/templates/legibility-element.md` (in the
+  repository) — the contract every emitted element follows.
 - [Sub-S2b design spec](../../../superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md)
   — the full design record this protocol descends from.

--- a/docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md
+++ b/docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md
@@ -1,0 +1,193 @@
+# The challenge-refine protocol
+
+The diagnostic-legibility agent's anti-hallucination value lives in its
+challenge step. The agent does not just draft two model collections — it
+re-reads its own drafts adversarially, pressure-tests each element
+through five named questions, and retains evidence of what surfaced.
+This page explains the protocol design and why the agent ships in the
+shape it does at v0.3.0.
+
+## What the agent does
+
+The agent runs in two explicit phases per invocation:
+
+1. **Phase A — Construction.** Read the schema template, inspect the
+   scope, draft architectural elements (moving parts) and domain
+   elements (concepts). Each element gets `name`, `description`,
+   `evidence[]`, and a starting `confidence`. `challenge_notes[]`
+   stays empty for now.
+
+2. **Phase B — Challenge.** Re-frame as an adversarial reviewer.
+   Re-read the evidence on each draft. Apply the five questions —
+   *boundary, evidence, confounders, confidence, description
+   integrity* — with dimension-flavoured weighting (Q1 heavy for
+   architectural, Q5 heavy for domain). Where a question surfaces a
+   change, revise the element and append a `Q<N>` entry to
+   `challenge_notes[]`. Where all five run cleanly, append the
+   sentinel `Challenge applied; no questions surfaced changes`.
+
+The phase boundary is a load-bearing **prompt-segment boundary**, not
+just a documentation convenience. The boundary is the mechanism that
+gives the challenge step a fresh adversarial posture; collapse it and
+the challenge degenerates into the same context that drafted the
+elements arguing for them.
+
+## The five questions
+
+Each question targets a distinct named failure mode:
+
+| # | Question | Catches |
+| - | -------- | ------- |
+| Q1 | **Boundary** — is the `name` actually a single thing, or did I smear two? | Smearing (architectural-heavy) |
+| Q2 | **Evidence** — does the cited evidence actually support the description? | Ungrounded claim (fabrication-adjacent) |
+| Q3 | **Confounders** — what nearby thing is *not* this element but could be mistaken for it? | Near-misses |
+| Q4 | **Confidence** — am I overclaiming on the `confidence` field? | Calibration drift |
+| Q5 | **Description integrity** — is the description specific to this codebase or generic textbook? | Textbook-definition drift (domain-heavy) |
+
+The five together are *boundary, ground, identity-by-contrast,
+calibration, specificity*. They are not claimed to be complete — they
+are the **working hypothesis** for what an emitted `LegibilityElement`
+draft most commonly gets wrong, with the agent's own
+`challenge_notes[]` corpus as the falsification surface. If recurring
+failure modes do not map to any of the five, the cover is missing a
+question; if two questions consistently produce identical notes, the
+cover has redundancy. Either signal can be observed across a real
+invocation history without changing the schema.
+
+## Why retained-challenge single-pass
+
+Three candidate cycle architectures were considered:
+
+(a) **Single-pass critique-revise** — one challenge, one revision,
+    challenge artefact discarded.
+(b) **Retained-challenge single-pass** (selected) — same as (a) but
+    challenge notes are retained as `challenge_notes[]` on each
+    element.
+(c) **Iterative loop** — challenge–revise until stable or budget
+    exhausted.
+
+(b) is selected because:
+
+- The schema already commits to `challenge_notes[]` as a required
+  field on every `LegibilityElement`. (a) either leaves the field
+  empty (defeating the schema decision) or reconstructs notes after
+  the fact (weakening evidence quality). (b) makes the field
+  load-bearing without changing the schema.
+- The downstream cross-check (parent S3, [#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332))
+  will want diagnostic context — knowing *what was challenged* and
+  *what was revised* — to do its job. Retaining is cheap;
+  reconstructing later is expensive and lossy.
+- (c) adds variable token cost and a stopping-condition sub-decision
+  in the absence of any signal that (b) under-refines. (c) remains
+  available as an escalation — the schema accommodates iteration by
+  appending to `challenge_notes[]` on each pass — but ships first as
+  the simpler shape.
+
+## Why one agent, two postures
+
+The same architectural question — *how do we get the challenge step a
+fresh adversarial posture without doubling the agent-file surface?* —
+had three candidate resolutions:
+
+1. **One-context self-challenge.** The agent challenges its own drafts
+   in the same continuous reasoning context. Simplest. Named failure
+   mode: **self-confirmation** — an LLM in one context that has just
+   argued for a draft is statistically biased toward defending it.
+2. **Two-agent dispatch.** A separate `diagnostic-legibility-challenger`
+   agent file with its own charter and tool boundary. Maximal
+   independence. Doubles the agent-file surface for a v0.3.0
+   capability.
+3. **Fresh-sub-context self-challenge** (selected). One agent file,
+   two reasoning postures within it — *construct* and *challenge* —
+   separated by an explicit prompt-segment boundary. The independence
+   comes from the explicit re-framing, not from a separate context.
+
+The middle option ships first because it addresses the
+self-confirmation failure mode named in (1) without doubling the
+agent-file surface named in (2). The mechanism is the agent file's
+prompt itself: Phase B opens with an explicit re-framing instruction
+("*You are now the challenger. Disagree where the evidence allows.*")
+and treats the construction as someone else's work.
+
+If a real-invocation corpus shows the middle option still degenerates
+to self-confirmation — e.g. unusually high rates of sentinel-only
+`challenge_notes[]` across diverse scopes — the architecture can
+escalate to (2) without changing the schema or the spec's external
+contract. The progression (1) → (3) → (2) is the natural escalation
+path; v0.3.0 ships the cheapest move that takes the failure mode
+seriously rather than deferring it.
+
+**Honesty about the observability gap.** At v0.3.0 there is no
+corpus, no persistence path for invocations, and no command to
+aggregate sentinel-vs-`Q<N>` ratios. The escalation criterion above
+is currently a **manual-review pattern**: a human reading a handful
+of invocation outputs and noticing whether the sentinel dominates.
+When parent S4 ([#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333))
+lands the `/diagnose` command, the natural extension is for
+`/diagnose` to persist outputs to a known path and a follow-up rule
+to aggregate ratios; until then, treat the escalation as a hand-flag
+the dispatcher raises if the pattern is salient. The architectural
+fix is shipped; the falsification surface is deferred.
+
+## How `challenge_notes[]` connects schema to runtime
+
+`challenge_notes[]` is the bridge:
+
+- **At schema time** (v0.2.0): `challenge_notes` is a required list
+  of strings on every `LegibilityElement`. The schema says nothing
+  about what the strings *contain*.
+- **At runtime** (v0.3.0 — this page): the agent fills the field
+  with one of two things:
+  - One or more `Q<N> (question name): ...` entries — when at least
+    one of the five questions surfaced a change.
+  - The single sentinel `Challenge applied; no questions surfaced
+    changes` — when all five questions ran cleanly.
+
+The `Q<N>` prefix is **machine-parseable**: the downstream cross-check
+([#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332))
+groups notes by prefix to identify recurring failure modes across an
+element corpus. The sentinel is the **only** exception to the prefix
+rule; its presence disambiguates "challenge ran cleanly" from
+"challenge never ran" (the empty-list case).
+
+This pattern — a typed field on the schema whose values follow an
+in-string convention enforced by the agent rather than by the schema
+— is a tagged-string idiom (also called a "lightweight in-string
+schema"). It buys machine-readability without forcing the schema to
+encode structure it doesn't need elsewhere.
+
+## Two sentinels, one idiom
+
+The plugin uses two reserved literal strings as sentinels:
+
+- `Challenge applied; no questions surfaced changes` (in
+  `challenge_notes[]`) — signals "challenge ran, found nothing".
+- `(empty scope)` (in an element's `name`) — signals "scope yielded
+  nothing".
+
+Both solve the same shape of problem — an observable runtime state is
+ambiguous without an explicit marker — and both resolve it with a
+reserved literal string rather than with a new field or boolean. The
+cost is two new agreed-upon literals in the contract surface;
+downstream consumers (cross-check, future surfacing) must know them.
+The benefit is no schema change — the disambiguation lives at the
+agent layer, where it can evolve without touching the v0.2.0 schema.
+
+## What this slice does not do
+
+- **Cross-check the two models against each other.** Reserved for
+  parent S3, [#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332).
+- **Surface the models to a human.** A `/diagnose` command is the
+  deliverable of parent S4, [#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333).
+- **Validate `LegibilityElement` instances at runtime.** The schema
+  spec (v0.2.0) explicitly deferred this; the agent enforces the
+  contract through its prompt, not through a separate validator.
+
+## Further reading
+
+- [How to invoke the agent](../how-to/invoke-the-agent.md) —
+  task-oriented dispatch guide.
+- [LegibilityElement schema](../../../../diagnostic-legibility/templates/legibility-element.md)
+  — the contract every emitted element follows.
+- [Sub-S2b design spec](../../../superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md)
+  — the full design record this protocol descends from.

--- a/docs/plugins/diagnostic-legibility/explanation/index.md
+++ b/docs/plugins/diagnostic-legibility/explanation/index.md
@@ -1,0 +1,8 @@
+# Concepts
+
+Conceptual background for the `diagnostic-legibility` plugin.
+
+- [The challenge-refine protocol](challenge-refine-protocol.md) — the
+  five-question structure, why the agent uses a retained-challenge
+  single-pass cycle, and how `challenge_notes[]` connects the schema to
+  the agent's runtime behaviour.

--- a/docs/plugins/diagnostic-legibility/how-to/index.md
+++ b/docs/plugins/diagnostic-legibility/how-to/index.md
@@ -1,0 +1,7 @@
+# How-to Guides
+
+Task-oriented guides for using the `diagnostic-legibility` plugin.
+
+- [Invoke the diagnostic-legibility agent](invoke-the-agent.md) — how to
+  dispatch the agent against a codebase scope and read its `LegibilityModel`
+  output at v0.3.0.

--- a/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
+++ b/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
@@ -47,7 +47,7 @@ but not as in-scope elements"*).
 
 A single markdown response containing one YAML block. The block
 conforms to the `LegibilityModel` schema at
-[`diagnostic-legibility/templates/legibility-element.md`](../../../../diagnostic-legibility/templates/legibility-element.md).
+`diagnostic-legibility/templates/legibility-element.md`.
 
 A truncated example:
 
@@ -141,5 +141,5 @@ modes that would otherwise be indistinguishable.
 - [Challenge-refine protocol](../explanation/challenge-refine-protocol.md)
   — what the five questions catch and why the agent uses a
   retained-challenge single-pass cycle.
-- [LegibilityElement schema](../../../../diagnostic-legibility/templates/legibility-element.md)
-  — the contract every emitted element follows.
+- `diagnostic-legibility/templates/legibility-element.md` (in the
+  repository) — the contract every emitted element follows.

--- a/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
+++ b/docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md
@@ -1,0 +1,145 @@
+# How to invoke the diagnostic-legibility agent
+
+This guide covers the **v0.3.0** invocation surface for the
+`diagnostic-legibility` agent. The agent produces two refined models
+of a codebase scope — *architectural moving parts* and *domain
+concepts* — and emits them as a `LegibilityModel` YAML block.
+
+> **Note on the invocation surface.** At v0.3.0 there is no
+> `/diagnose` slash-command. The agent is dispatched directly via the
+> Task tool. A wrapping `/diagnose` command is the deliverable of
+> parent S4, tracked at
+> [issue #333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333).
+> When that ships, this how-to will be updated.
+
+## Inputs
+
+The agent takes one required input:
+
+- **`scope`** — what to model. Three accepted forms:
+  - Directory path — `./src/auth/`
+  - File list — `src/checkout/cart.py, src/checkout/order.py`
+  - Free-text description — `"the checkout flow across services A and B"`
+
+Use whichever form fits the question you are asking. The free-text form
+is acceptable when the scope is conceptual rather than directory-bounded.
+
+## Dispatch (bare Task-tool pattern)
+
+From an orchestrator, command, or interactive Claude Code session,
+invoke the Task tool with:
+
+- `subagent_type`: `diagnostic-legibility`
+- `description`: a short imperative — e.g. `"Model the auth module"`
+- `prompt`: a free-text body whose first line names the scope.
+
+The minimum prompt shape:
+
+```text
+scope: ./src/auth/
+```
+
+Add a second paragraph for any additional context (e.g. *"focus on
+the public API surface only; treat the integration tests as evidence
+but not as in-scope elements"*).
+
+## What you get back
+
+A single markdown response containing one YAML block. The block
+conforms to the `LegibilityModel` schema at
+[`diagnostic-legibility/templates/legibility-element.md`](../../../../diagnostic-legibility/templates/legibility-element.md).
+
+A truncated example:
+
+```yaml
+scope: "./src/auth/"
+generated_at: "<DISPATCHER: ISO 8601 timestamp>"
+generated_by: "diagnostic-legibility / <DISPATCHER: active model identifier>"
+architectural:
+  - name: AuthenticationService
+    description: |
+      The HTTP-level entry point for credential validation...
+    evidence:
+      - path: src/auth/service.py
+        excerpt: "class AuthenticationService:"
+    confidence: high
+    challenge_notes:
+      - "Q1 (boundary): initially smeared AuthenticationService and SessionStore into one element; revised to keep them separate because the session-store boundary is in a different module."
+domain:
+  - name: Credential
+    description: |
+      A username + password pair presented at login. Distinct from
+      `Session`, which is the authenticated artefact returned after
+      successful credential validation.
+    evidence:
+      - path: src/auth/models.py
+        excerpt: "@dataclass\nclass Credential:"
+    confidence: high
+    challenge_notes:
+      - "Challenge applied; no questions surfaced changes"
+```
+
+Every element carries `challenge_notes[]` — either one or more
+`Q<N> (question name):` entries (when a challenge question surfaced a
+change) or the single sentinel `Challenge applied; no questions
+surfaced changes` (when all five questions ran cleanly).
+
+## Persisting the output
+
+The agent does **not** write files. Your dispatcher is responsible
+for persisting the YAML to whatever path you choose. A common
+convention:
+
+```
+diagnostic-legibility/output/<YYYY-MM-DD>-<scope-slug>.legibility.yaml
+```
+
+The dispatcher (a command, an orchestrator step, or a human pasting
+into a file) writes the block; the agent stays read-only.
+
+### Substitute the dispatcher placeholders
+
+The agent emits two fields as literal placeholders because it has no
+reliable clock and no introspection of the active model identifier:
+
+```yaml
+generated_at: "<DISPATCHER: ISO 8601 timestamp>"
+generated_by: "diagnostic-legibility / <DISPATCHER: active model identifier>"
+```
+
+Before persisting, substitute both with real values — the current ISO
+8601 timestamp and the active Claude Code model identifier (e.g.
+`claude-sonnet-4-6`, `claude-opus-4-7[1m]`). If you skip the
+substitution, the persisted YAML carries the placeholder strings
+verbatim, which is fine for a draft but breaks any consumer that
+parses these fields as data.
+
+## Empty-scope handling
+
+If your scope yields no architectural or domain elements (an empty
+directory, generated-only files, a free-text description that doesn't
+resolve), the agent returns a single placeholder element under
+`architectural[]` with the literal name `(empty scope)`:
+
+```yaml
+architectural:
+  - name: "(empty scope)"
+    description: "Scope ./src/foo/ was inspected and yielded no architectural moving parts or domain concepts..."
+    evidence: []
+    confidence: low
+    challenge_notes:
+      - "Challenge applied; no questions surfaced changes"
+domain: []
+```
+
+Pattern-match exactly on `name == "(empty scope)"` to distinguish
+this from "I flagged an evidence-less candidate" — the two failure
+modes that would otherwise be indistinguishable.
+
+## Further reading
+
+- [Challenge-refine protocol](../explanation/challenge-refine-protocol.md)
+  — what the five questions catch and why the agent uses a
+  retained-challenge single-pass cycle.
+- [LegibilityElement schema](../../../../diagnostic-legibility/templates/legibility-element.md)
+  — the contract every emitted element follows.

--- a/docs/plugins/diagnostic-legibility/index.md
+++ b/docs/plugins/diagnostic-legibility/index.md
@@ -23,15 +23,20 @@ instance, but the discipline (two-model + cross-check + on-demand
 surfacing) generalises to other domains. Future agents may apply it
 to governance artefacts, decision records, or other complex systems.
 
-## Status: v0.1.0 — scaffold only
+## Status: v0.3.0 — working agent
 
-This plugin is structurally complete and loadable but ships with no
-functional agents or commands yet. The next three deliverables are
-filed as separate issues:
+The plugin ships the `diagnostic-legibility` agent. It accepts a
+codebase scope, drafts an architectural model and a domain model
+against the `LegibilityElement` schema, and runs a retained-challenge
+single-pass cycle that fills `challenge_notes[]` on every element via
+five named questions (boundary, evidence, confounders, confidence,
+description integrity).
 
-- [#331](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/331) — S2: Two-model agent
+Cross-check and the `/diagnose` command remain ahead:
+
+- ✅ [#331](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/331) — S2: Two-model agent (shipped v0.3.0)
 - [#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332) — S3: Cross-check mechanism
-- [#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333) — S4: Surfacing interface
+- [#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333) — S4: Surfacing interface (`/diagnose`)
 
 The carpaccio slicing that produced this decomposition is recorded at
 [`docs/superpowers/slices/diagnostic-legibility-plugin.md`](../../superpowers/slices/diagnostic-legibility-plugin.md)
@@ -40,7 +45,9 @@ and traces back to parent issue
 
 ## Quadrant pages
 
-No tutorials, how-to guides, reference, or concept pages exist yet.
-Per the project convention, each Diataxis quadrant folder will be
-scaffolded when its first page is written. Watch the three deferred
-issues above to see what lands when.
+- **How-to**: [Invoke the diagnostic-legibility agent](how-to/invoke-the-agent.md)
+- **Concepts**: [The challenge-refine protocol](explanation/challenge-refine-protocol.md)
+
+Tutorials and reference pages remain to be written; per the project
+convention, each Diataxis quadrant folder is scaffolded when its first
+page lands.

--- a/docs/superpowers/objections/dl-s2b-challenge-protocol-design-code.md
+++ b/docs/superpowers/objections/dl-s2b-challenge-protocol-design-code.md
@@ -1,0 +1,95 @@
+---
+spec: docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+date: 2026-05-29
+mode: code
+diaboli_model: claude-opus-4-7[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: high
+    claim: "The mandatory machine-parseable `Q<N> (question name):` prefix is ambiguous on capitalisation: the five-question section uses title-cased question names ('Boundary', 'Description integrity'), the prefix example uses lowercase ('Q1 (boundary):', 'Q5 (description integrity):'), and the dimension-weighting paragraph drops the parentheses entirely ('Q2 evidence', 'Q3 confounders', 'Q4 confidence'). Two reasonable runs will emit inconsistent prefixes; the downstream cross-check's grouping breaks silently."
+    evidence: "diagnostic-legibility/agents/diagnostic-legibility.agent.md lines 162–184 use 'Boundary', 'Evidence', 'Confounders', 'Confidence', 'Description integrity' as bolded section headers (title case). Line 130 — the canonical worked example — uses 'Q1 (boundary):' (lowercase). Lines 120–121 use 'Q2 evidence', 'Q3 confounders', 'Q4 confidence' without parentheses, contradicting the format spec on line 127 (`Q<N> (question name):`). The agent must pick one form per element; with three forms modelled in its system prompt, it will pick inconsistently across elements within a single invocation."
+    disposition: accepted
+    disposition_rationale: "Real bug in the prompt content. Pin one canonical form: `Q<N> (lowercase-question-name):`. Section headers (lines 162–184) stay title-cased as human-readable section titles, but the surrounding text and every example must use the canonical lowercase-in-parens form. Fix lines 120–121 (`Q2 evidence` → `Q2 (evidence)` etc.), add an explicit 'canonical form' callout near the format spec, propagate to the explanation page table. Add a structural test asserting the canonical form appears in the agent body."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The agent must populate `generated_at` (ISO 8601) and `generated_by` (agent + active model id) on every emission, but its Read/Glob/Grep trust boundary gives it no clock and no model-introspection capability. The agent file's Output section names the fields as required without explaining how the agent obtains them."
+    evidence: "diagnostic-legibility/agents/diagnostic-legibility.agent.md line 41: 'Required top-level fields: scope, generated_at (ISO 8601), generated_by (your name plus the active model identifier).' Frontmatter line 4: 'tools: Read, Glob, Grep' (no Bash). Nowhere in the agent body, the how-to, or the explanation does any guidance appear for how to derive a current ISO 8601 timestamp or the active model identifier. Compare model-cards/agents/model-card-researcher.agent.md, which faces the same problem and resolves it by deferring persistence (and these fields) to the dispatcher; this agent's spec §2.4 also defers persistence to the dispatcher but still requires the agent to emit the fields."
+    disposition: accepted
+    disposition_rationale: "Defer to the dispatcher. Agent emits placeholders `generated_at: \"<DISPATCHER: ISO 8601 timestamp>\"` and `generated_by: \"diagnostic-legibility / <DISPATCHER: active model identifier>\"`; the dispatcher fills both at persistence time. The agent file's Output section names the deferral explicitly; the how-to page documents the dispatcher's responsibility to substitute. Matches the model-card-researcher pattern."
+  - id: O3
+    category: risk
+    severity: high
+    claim: "The structural test `test_marketplace_plugin_version_unchanged` hard-codes `assert marketplace['plugin_version'] == '0.39.1'`, contradicting the spec §9 rule that the integration-agent should take main's value verbatim if it has moved between spec-time and merge-time. The test will fail at integration exactly in the scenario the spec explicitly anticipated, with no mechanism to relax the assertion without violating the test's own message ('this test guards the spec-time snapshot for the branch's own diff')."
+    evidence: "tdad_tests/tests/test_diagnostic_legibility_structural.py lines 122–135 hard-code '0.39.1'. Spec §9 says: 'If main has bumped ai-literacy-superpowers's plugin_version between spec-time and merge-time, take main's value verbatim during the integration-agent's rebase.' The test's own failure message acknowledges 'integration-agent may take a newer value from main at rebase time' but still hard-fails when it does. The version-check CI workflow at .github/workflows/version-check.yml lines 108–124 cross-validates plugin_version against ai-literacy-superpowers/plugin.json — so a moved main produces a CI-green but test-red state, the worst possible signal."
+    disposition: accepted
+    disposition_rationale: "Rewrite the test to assert `marketplace.plugin_version == ai-literacy-superpowers/.claude-plugin/plugin.json#version` (the canonical source) instead of the hard-coded literal. The test becomes a structural redundancy check on top of the CI version-check workflow, which is fine — its real value is catching local-edit drift before CI runs. Update the test's docstring and failure message to match the new assertion."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "The two load-bearing sentinel strings (`(empty scope)` in `name`, `Challenge applied; no questions surfaced changes` in `challenge_notes`) are documented as pattern-match handles for downstream consumers, but the structural test suite asserts nothing about them — the test docstring explicitly defers the sentinel contract to the spec 'as acceptance documentation rather than executable tests.' A drift in the sentinel string (a typo, a punctuation change, a model paraphrase) ships unguarded through every CI gate."
+    evidence: "tdad_tests/tests/test_diagnostic_legibility_structural.py lines 1–9 docstring: 'These are deterministic, file-shape assertions — the agent's behavioural contract (challenge_notes shape, Q<N> prefix, sentinels) is covered by the spec ... as acceptance documentation rather than executable tests.' The spec at §3.5 and §3.6 marks both sentinels as 'verbatim' / 'exactly this string' / 'do not paraphrase' — the strongest possible specification of an exact-match contract — yet no test, lint, or CI hook reads the agent file and asserts the literal strings appear unchanged. A reflexive edit (e.g. 'no question surfaced' → 'no questions surface') invalidates the downstream cross-check (#332) silently."
+    disposition: accepted
+    disposition_rationale: "Add two static-text guards to the structural test suite: assert the exact literal `(empty scope)` appears in the agent body; assert the exact literal `Challenge applied; no questions surfaced changes` appears in the agent body. These are static-text assertions on the agent file, not behavioural runtime tests — the test docstring's exclusion was right about behaviour but wrong about static guards. Cost: ~10 lines of test code. Benefit: drift in the contract surface fails CI."
+  - id: O5
+    category: implementation
+    severity: medium
+    claim: "The agent's frontmatter `description` — what the Claude Code skill matcher reads to route invocations — does not surface the two contract terms that matter most: the `Q<N>` prefix and the sentinel strings. A dispatcher (orchestrator, future /diagnose command, human grep) reading only the description has no signal that the agent emits a structured machine-parseable contract beyond 'LegibilityModel as YAML'."
+    evidence: "diagnostic-legibility/agents/diagnostic-legibility.agent.md line 3 description: 'Use to build two refined models ... applies a five-question self-challenge cycle, and retains challenge notes on every element. Returns a LegibilityModel as YAML.' No mention of `Q<N>` prefix, the sentinel strings, or the `(empty scope)` handle. The structural test test_agent_description_mentions_legibility_model (lines 251–268) asserts only that 'LegibilityModel' appears — exposing what the test author thought needed protection. Spec §3.5 calls the prefix 'mandatory and machine-parseable' and the parent S3 cross-check (#332) groups notes by it; a discovery surface that doesn't name it under-advertises the contract."
+    disposition: accepted
+    disposition_rationale: "Extend the description with a closing clause that names the machine-parseable contract: 'Notes follow the Q<N> (question-name): prefix convention; degenerate scopes use the literal `(empty scope)` sentinel.' Update the matching structural test to assert both `Q<N>` and the `(empty scope)` literal appear in the description. Cheap and pulls the contract surface into the discovery layer."
+  - id: O6
+    category: operational
+    severity: medium
+    claim: "Both downstream surfaces that human users see — the marketplace listing's `description` field and the `diagnostic-legibility/README.md` Install section — are stale and contradict v0.3.0 status. The marketplace says 'First agent (in development)'; the README still tells installers to 'Wait for S2 (#331) to land before expecting functional behaviour.' Anyone discovering the plugin through either surface gets the v0.1.0 message."
+    evidence: ".claude-plugin/marketplace.json line 29 (the diagnostic-legibility plugins[] entry): 'First agent (in development) builds, self-challenges, and cross-checks two models of a codebase scope.' diagnostic-legibility/README.md lines 60–62: 'The plugin will install successfully but offer no commands at v0.1.0. Wait for S2 (#331) to land before expecting functional behaviour.' Both files were modified for the version bump; both kept descriptive copy from earlier slices. The README Status section (lines 8–24) was updated; the Install section directly below it was not."
+    disposition: accepted
+    disposition_rationale: "Update both surfaces: the marketplace.json description loses 'in development' and names the shipped agent; the README Install section is rewritten to reflect v0.3.0 (the agent is dispatchable via bare Task tool; /diagnose command is parent S4)."
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "The fresh-sub-context self-challenge architecture (spec §3.4, adjudicated) depends on the model treating Phase B as 'someone else's work.' The agent file asserts twice that 'the phase boundary is load-bearing' but provides no observability — no log, no marker in the emitted YAML, no count — that would let a future reader detect whether the boundary actually fires or collapses into rubber-stamping. The escalation trigger named in the explanation ('unusually high rates of sentinel-only challenge_notes[]') has no instrument."
+    evidence: "diagnostic-legibility/agents/diagnostic-legibility.agent.md lines 56–61 ('the boundary is load-bearing — it is the mechanism') and 95–105 (Phase B re-framing). docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md lines 112–118: 'If a real-invocation corpus shows the middle option still degenerates to self-confirmation — e.g. unusually high rates of sentinel-only challenge_notes[] across diverse scopes — the architecture can escalate to (2).' But there is no corpus, no persistence path for invocations, no command to aggregate sentinel-vs-Q<N> ratios. The escalation criterion is asserted with no plan for gathering the evidence that would trigger it. The plugin ships the failure-mode acknowledgement and the architectural fix but not the falsification surface."
+    disposition: deferred
+    disposition_rationale: "Defer to parent S4 (#333). The sentinel-ratio escalation criterion requires invocation outputs to be persisted somewhere — that persistence is the surfacing-layer job, not the agent's job. Update the explanation page to be honest about the gap: at v0.3.0 escalation is a manual-review pattern (a human reading some invocation outputs and noticing a high sentinel rate). When #333's /diagnose command ships, the natural extension is for /diagnose to persist outputs to a known path and a follow-up rule aggregates ratios."
+  - id: O8
+    category: implementation
+    severity: medium
+    claim: "The agent has no instruction for ordering when both architectural and domain elements draft cleanly, but the empty-scope sentinel is documented as going only to `architectural[]` 'by convention.' A free-text scope that yields only domain concepts (e.g. 'the checkout pricing rules' against a docs-only directory) would have the agent emit a non-degenerate `domain[]` and an empty `architectural[]` — but the agent's reasoning protocol drafts architectural first, and 'if the scope yields nothing' triggers the architectural-only sentinel even when domain elements have not yet been attempted."
+    evidence: "diagnostic-legibility/agents/diagnostic-legibility.agent.md Phase A steps 3 (draft architectural), 4 (draft domain), 5: 'If the scope yields nothing, emit the (empty scope) sentinel ... and skip Phase B.' But 'yields nothing' is checked after architectural drafting (step 3) and before domain drafting (step 4) is not contractually clear — the wording can be read either way. A scope with no architectural shapes but rich domain concepts is a foreseeable input (docs-only scope, domain-glossary scope) and the protocol's behaviour on it is implementation-implicit. The spec §3.6 only addresses the both-empty case."
+    disposition: accepted
+    disposition_rationale: "Restructure Phase A so the both-empty check is unambiguous: rename step 5 to 'After steps 3 AND 4 complete, if both architectural[] and domain[] are empty, emit the (empty scope) sentinel into architectural[] and skip Phase B.' Single-collection-empty (e.g. domain elements found, no architectural) is normal — emit the non-empty collection and run Phase B on it; the empty collection stays as an empty YAML list. Document this 'asymmetric output is valid' rule in the agent body."
+  - id: O9
+    category: risk
+    severity: low
+    claim: "The CHANGELOG, the spec, and the agent's how-to all forward-link to issue #339 (the *promote* follow-up for the cross-PR `plugin_version` rule) — but the rule remains a per-spec restatement at merge-time, not a CLAUDE.md governance constraint. The current PR ships under the same fragility every prior diagnostic-legibility PR has shipped under, and the next plugin bump will need the same restatement until #339 ships."
+    evidence: "docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md §9 carries the per-spec rule. diagnostic-legibility/CHANGELOG.md lines 43–47 name #339 as the 'promote' follow-up to CLAUDE.md. The Tests/CI gates assume the rule will be applied at integration-time, but CLAUDE.md (the source of truth agents read on every session) currently carries no rule — the agent doing the integration has to discover the rule by reading the per-spec text. This makes #339's resolution time-sensitive in a way the spec deferred without flagging."
+    disposition: deferred
+    disposition_rationale: "Already tracked at #339; the current PR ships under the same per-spec discipline (§9). The O3 fix (canonical-version comparison) addresses the proximate brittleness in this PR; #339 closes the underlying governance gap for future PRs. No further action in this PR — the disposition is the audit trail."
+---
+
+# Adversarial Review — dl-s2b-challenge-protocol-design (code mode)
+
+Code under review: branch `dl-s2b-challenge-protocol`. Spec at
+`docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md`.
+Spec-mode adjudication is at
+`docs/superpowers/objections/dl-s2b-challenge-protocol-design.md` —
+this record does not re-litigate those dispositions.
+
+Nine objections raised: 4 high (O1, O2, O3, O4), 4 medium (O5, O6, O7, O8),
+1 low (O9). Distribution across categories: 1 specification quality, 3
+implementation, 4 risk, 1 operational, 0 premise/alternatives/scope.
+
+The implementation is structurally sound. The agent file lands at the
+spec-targeted length (245 lines), carries the read-only tool boundary,
+preserves the two-phase construction protocol with explicit re-framing,
+and ships the version-bump triplet correctly. The docs site quadrants
+scaffold the pages the spec promised. The CHANGELOG names the follow-up
+issues. What is weak is **the operationalisation of the load-bearing
+string contracts** — the `Q<N>` prefix appears in three inconsistent
+forms in the agent's own system prompt (O1), the sentinels have no
+automated guard (O4), and the agent must emit fields it has no mechanism
+to derive (O2). The marketplace.json and README staleness (O6) and the
+brittle plugin_version test (O3) are the operational debts the spec §9
+named but did not retire.

--- a/docs/superpowers/objections/dl-s2b-challenge-protocol-design.md
+++ b/docs/superpowers/objections/dl-s2b-challenge-protocol-design.md
@@ -1,0 +1,302 @@
+---
+spec: docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+date: 2026-05-28
+mode: spec
+diaboli_model: claude-opus-4-7[1m]
+objections:
+  - id: O1
+    category: premise
+    severity: high
+    claim: "The five-question challenge structure is asserted as a fixed list without explaining why these five questions (and not e.g. three or seven) are the right cut. The choice of five is unevidenced and could equally have been 'three' or 'eight' — the spec treats this as design when it is actually undefended invention."
+    evidence: "§3.5: 'Each LegibilityElement is challenged through five questions, asked once per element' followed by Boundary, Evidence, Confounders, Confidence, Description integrity. §10 row 'Number and form of challenge questions' says 'Five questions: boundary, evidence, confounders, confidence, description integrity (§3.5)' as if this were a settled design choice. No spec section explains why these five constitute a complete cover of the challenge surface, why fewer would be incomplete, or why more would be redundant. Compare the diaboli skill, which has six categories explicitly justified by their leverage at different pipeline stages."
+    disposition: accepted
+    disposition_rationale: "Add a §3.5 rationale paragraph naming what each of the five questions is meant to catch (boundary → smearing; evidence → ungrounded claim; confounders → near-misses; confidence → calibration; description integrity → textbook-definition drift) and mark the cover as a working hypothesis revisable when disposition data shows a category gap. The agent's own challenge_notes corpus becomes the falsification surface."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "Story 6.1 says 'every element has populated challenge_notes (or an explicit empty list when no question surfaced a change)' but the schema (PR #336) declares challenge_notes a required list-of-strings with no contract about when empty is meaningful. The spec's rule 'populate the field when a question surfaces a change, no note when nothing surfaces' means an empty list could mean either 'agent ran the challenge cleanly and nothing surfaced' or 'agent skipped the challenge entirely.' These are observationally indistinguishable to a downstream consumer."
+    evidence: "§3.5: 'Questions that surface nothing add no note (avoid noise — empty notes are not evidence of due diligence).' §6.1 acceptance: 'every element has populated challenge_notes (or an explicit empty list when no question surfaced a change)'. Schema (PR #336 template, lines 23–25): challenge_notes is required, list of strings, may be empty when challenge protocol has not yet run. The downstream consumer (parent S3 cross-check, issue #332) cannot distinguish 'challenged and clean' from 'never challenged' on inspection."
+    disposition: accepted
+    disposition_rationale: "Require a sentinel note when the challenge runs and surfaces no changes — e.g. `Challenge applied; no questions surfaced changes` as the single entry. Empty challenge_notes[] then unambiguously means 'challenge protocol not run'. Update §3.5 (replace 'add no note' with 'add the sentinel note') and §6.1 acceptance. No schema change required."
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "§3.4 commits to self-challenge in a single context but offers no mechanism for ensuring the challenge step actually happens. An LLM agent in a single context that drafts an element and then is asked to challenge it is statistically biased toward confirming its own draft — a documented failure mode of self-critique without independent perspective. The 'single-context self-challenge' decision is exactly the architecture that risks the agent rubber-stamping its own output."
+    evidence: "§3.4: 'A self-challenge in one context preserves the agent's evidence chain: the same context that drafted the element raises objections against it.' Followed by: 'A later slice may revisit this if disposition data shows that self-blindness is a recurring failure mode. The agent's own context can fail to see things a fresh context would catch; that is real. But again, no signal yet — ship the simpler shape first.' The spec acknowledges the failure mode it is choosing to defer. The challenge-refine cycle is the entire anti-hallucination value proposition of the agent (per the sub-slicing record line 98: 'The challenge-refine cycle is where the anti-hallucination value of the agent lives'). Shipping the architecture with the named failure mode unaddressed weakens the central claim."
+    disposition: accepted
+    disposition_rationale: "Adopt the O6 middle option (fresh sub-context within the same agent file) to mitigate the named self-confirmation failure mode without doubling file surface. The agent's reasoning protocol gains an explicit context-separation step: an 'act as challenger' prompt segment with adversarial framing, evidence re-read instruction, and instruction to disagree where the evidence allows. Document the rationale in §3.4 and operationalise in §4.3."
+  - id: O4
+    category: specification quality
+    severity: medium
+    claim: "The five-question challenge's questions are dimension-flavoured (§3.5 says 'domain elements pressure-test against question 5 most heavily, architectural elements against question 1') but the agent file's protocol does not say how this flavouring is operationalised. An implementer reading §4.3 'apply the five-question challenge to each' will produce the same prompt for both dimensions; the dimension-flavouring is implementation-implicit."
+    evidence: "§3.5 paragraph 2: 'The five questions are dimension-agnostic but apply with dimension-flavoured emphasis: domain elements pressure-test against question 5 most heavily (the textbook definition trap), and architectural elements pressure-test against question 1 most heavily (the smeared two services trap).' §4.3 protocol: 'apply the five-question challenge to each, populating challenge_notes[]' — no dimension-aware step. The agent file's 'The five-question challenge' section is described as 'the questions from §3.5, copy-pasted, with one paragraph per question explaining what it is looking for' (§4.3) but does not specify the dimension-flavoured emphasis as a separate step."
+    disposition: accepted
+    disposition_rationale: "Operationalise the dimension-flavoured emphasis in §4.3 as an explicit per-element step: 'When challenging a domain element, weight Q5 (description integrity) heavily and probe for textbook-definition drift; when challenging an architectural element, weight Q1 (boundary) heavily and probe for smeared services.' The agent file copies this guidance verbatim from the spec."
+  - id: O5
+    category: scope
+    severity: medium
+    claim: "The spec ships a how-to page and an explanation page in the same PR as the agent file, but never explains how a human actually invokes the agent. The how-to page is said in §6.5 to 'name the input form (scope)' but the agent is dispatched by Claude Code's Task tool — the actual invocation pattern (which command? what slash-command? direct Task tool? no command at all?) is unspecified. The spec describes the agent as if dispatchable but does not describe the dispatch surface."
+    evidence: "§2.1: 'The agent does not enforce one form.' §6.5: 'I navigate to docs/plugins/diagnostic-legibility/how-to/, Then there is a page on invoking the diagnostic-legibility agent, And the page names the input form (scope).' §7.1 ships the how-to page. But nowhere in §2 (the agent's contract) or §4 (the agent file) does the spec say how the agent is invoked. The sibling model-card-researcher is dispatched by the /model-card command (model-cards/commands/model-card.md exists); the diagnostic-legibility plugin has no command, and the spec adds none. The how-to page is asked to document an invocation pattern the plugin does not provide."
+    disposition: accepted
+    disposition_rationale: "Document the bare-Task-tool dispatch pattern as the v0.3.0 invocation surface (subagent_type: diagnostic-legibility, prompt naming the scope). The how-to page references this pattern explicitly and links forward to parent S4 (#333), which will deliver a /diagnose command. This honours carpaccio's slice boundary (S4 owns the human-facing command) without leaving v0.3.0 with a how-to page documenting a non-existent invocation."
+  - id: O6
+    category: alternatives
+    severity: medium
+    claim: "§3.4 considers and rejects 'second-pass challenger agent dispatch' purely on the basis of file-surface cost ('that doubles the surface area to maintain for a v0.3.0 capability'). It does not weigh the alternative of running the challenge step in a fresh sub-context within the same agent file (e.g., the agent could spawn a sub-task or restart its reasoning with a clean slate to act as challenger). That alternative gets the independence benefit without the second-file cost."
+    evidence: "§3.4: 'A second-pass dispatch would need a separate challenger agent with its own file, charter, and tool boundary. That doubles the surface area to maintain for a v0.3.0 capability.' The set of considered alternatives is binary: (a) one-context self-challenge, (b) two-agent dispatch. The middle option — same agent, two reasoning contexts (e.g., 'now drop everything you concluded and re-read the evidence as a challenger') — is not weighed. This middle option is what makes the anti-hallucination value of the cycle defensible without doubling the file surface."
+    disposition: accepted
+    disposition_rationale: "Adopt this middle option as the v0.3.0 architecture — pairs with O3's acceptance. §3.4 must name three alternatives (one-context, fresh-sub-context, two-agent dispatch), explain the choice of the middle option, and operationalise it in §4.3's reasoning protocol (explicit 'now act as challenger' segment, evidence re-read instruction, instruction to disagree where evidence allows)."
+  - id: O7
+    category: specification quality
+    severity: medium
+    claim: "Story 6.3 says the agent should 'refuse degenerate outputs' by emitting a low-confidence placeholder — but the schema requires LegibilityElement.evidence to have at least one entry when confidence is medium or high, and permits empty evidence only when confidence is low. The 'refuse degenerate output' rule is internally consistent with the schema only if the placeholder element carries low confidence AND empty evidence — meaning the agent's response to 'I couldn't find anything' is structurally indistinguishable from 'I found a candidate I have no evidence for'. The two failure modes need separate signal."
+    evidence: "§6.3: 'And that element has confidence: low / And its description names the degenerate scope condition.' Schema (PR #336 §3.3): 'evidence must have at least one entry when confidence is medium or high. low-confidence elements may have empty evidence (the agent flagged a candidate without ground).' The downstream consumer reading a list of low-confidence elements with empty evidence cannot distinguish 'this is a placeholder for empty-scope' from 'this is an evidence-less guess'."
+    disposition: accepted
+    disposition_rationale: "Adopt option (a): the degenerate-output placeholder element uses a sentinel name `(empty scope)` (exactly this string, surrounding parens included). Downstream consumers can pattern-match on `name == '(empty scope)'` to disambiguate. Avoids schema change; documented in §3 (new sentinel value section) and §6.3."
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "The spec name the version target 'plugin_version unchanged at v0.39.1' twice (header + §6.4 + §10), but the field's value depends on whatever was current at PR-creation time. If main moves before merge (e.g., another PR ships an ai-literacy-superpowers bump), this PR's marketplace.json edit could either incorrectly downgrade plugin_version or fail the version-consistency check. The spec hard-codes a value that is a function of external main state."
+    evidence: "Header: 'Marketplace listing | Unchanged at v0.4.0; plugin_version (pointer to ai-literacy-superpowers) unchanged at v0.39.1'. §6.4: 'And the plugin_version field is unchanged at \"0.39.1\"'. §10: 'plugin_version pointer unchanged at 0.39.1'. The spec's correctness depends on the assumption that ai-literacy-superpowers stays at 0.39.1 from spec-time through merge-time. The check is a cross-repo race condition that the spec acknowledges (header) but does not protect against."
+    disposition: accepted
+    disposition_rationale: "Add a §9 (Compatibility and rollout) clarification: 'plugin_version is owned by whichever PR most recently bumps ai-literacy-superpowers. If main has moved between spec-time and merge-time, the integration-agent's rebase will surface a conflict on marketplace.json — take main's plugin_version verbatim; this PR only owns the diagnostic-legibility plugins[] entry version bump.' The hard-coded 0.39.1 stays in the spec as the snapshot at authoring time, but the §9 rule is the operative instruction at merge-time."
+  - id: O9
+    category: alternatives
+    severity: low
+    claim: "§3.3 commits to a shared protocol across both dimensions. The decision rests on 'the schema is shared (PR #336 settled this); the prompt construction is symmetric.' But the schema being shared (one record type) does not imply the construction protocol must be shared. The agent could legitimately use two distinct construction loops — one targeting moving parts, one targeting concepts — with the dimension-flavoured challenge questions §3.5 already hints at. The 'symmetric construction' decision is a separate design choice that hides behind the schema decision."
+    evidence: "§3.3: 'The challenge protocol is the same shape for both architectural and domain elements, parameterised on the dimension. The schema is shared (PR #336 settled this); the prompt construction is symmetric.' Sub-slicing record line 140: 'per-model bespoke vs. parameterised prompts' was excluded as a separate slice on the grounds that 'the decision follows from the schema decision (same schema → parameterisable; distinct schemas → likely bespoke)'. The implication 'shared schema → shared construction' is asserted but not argued; the alternative is parameterised schema with bespoke construction loops."
+    disposition: accepted
+    disposition_rationale: "Add a §3.3 argument: shared construction is a design choice (not a logical consequence of shared schema). It is chosen because (a) the agent file's complexity scales linearly with protocol count and one shared loop is a smaller surface to maintain; (b) the dimension-flavoured emphasis (per O4) gives us dimension-aware behaviour without bifurcating the protocol; (c) bifurcation is recoverable — if signal emerges that the two dimensions need genuinely different construction sequences, the agent file can be split without schema changes."
+  - id: O10
+    category: specification quality
+    severity: low
+    claim: "§5.2 'Expected output shape' is presented as truncated YAML but the truncation hides whether the example demonstrates the schema's required `Q<N>` prefix discipline for challenge_notes. Both notes in the example use 'Q1' and 'Q5' prefixes — but §3.5 never establishes Q<N> as a required prefix; it is invented in §5.2 as illustrative."
+    evidence: "§5.2 output example: 'challenge_notes: - \"Q1 (boundary): initially treated the template and the wrapper as one element...\"' and 'challenge_notes: - \"Q5 (description integrity): first draft was generic...\"'. §3.5 lists the five questions by name but never names a prefix format. §5.2 narration: 'the Q<N> prefix in challenge_notes linking back to the five-question structure.' The format is introduced in §5.2 as if established, but it isn't established anywhere. Either §3.5 should mandate the prefix or §5.2 should describe it as an example convention rather than a requirement."
+    disposition: accepted
+    disposition_rationale: "Mandate the `Q<N> (question name):` prefix in §3.5 (e.g. 'Q1 (boundary):', 'Q5 (description integrity):'). Cheap and improves downstream machine-readability — parent S3 cross-check can group notes by question. The sentinel note from O2 ('Challenge applied; no questions surfaced changes') is exempt from the prefix convention since it spans all five questions."
+---
+
+# Adversarial Review — dl-s2b-challenge-protocol-design (spec mode)
+
+Spec under review: `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md`
+Mode: `spec`. Reviewer: `claude-opus-4-7[1m]`. Ten objections raised: 3 high (O1, O2, O3), 5 medium (O4, O5, O6, O7, O8), 2 low (O9, O10).
+
+Distribution across categories:
+
+- premise: 1 (O1)
+- implementation: 2 (O2, O3)
+- specification quality: 4 (O4, O7, O8, O10)
+- scope: 1 (O5)
+- alternatives: 2 (O6, O9)
+- risk: 0 (deprioritised at spec-time per the skill — no concrete code or runtime behaviour to ground)
+
+The spec is structurally sound — slicing intent, versioning ceremony, file inventory, and acceptance scenarios all map cleanly. What is weak is the **defence of the design decisions in §3**. The challenge-refine architecture is the central artefact this slice ships, and the spec defends three of those design decisions (single-pass over iterative, shared over bespoke, self-challenge over dispatch) more thinly than the decision warrants. The choice of *five* challenge questions is undefended (O1), the self-challenge in one context has a named failure mode that the spec acknowledges and ships anyway (O3), and the dimension-flavoured emphasis is described but not operationalised (O4).
+
+These are not blockers — they are honest debts. The "ship the simpler shape and observe" stance is principled, but the spec could be more honest about *what would constitute a signal to revisit* and *what we lose if the signal never comes*.
+
+## O1 — premise — high
+
+### Claim
+
+The five-question challenge structure is asserted as a fixed list without explaining why these five questions (and not e.g. three or seven) are the right cut. The choice of five is unevidenced and could equally have been three or eight — the spec treats this as design when it is actually undefended invention.
+
+### Evidence
+
+§3.5: "Each LegibilityElement is challenged through five questions, asked once per element" followed by:
+
+1. Boundary
+2. Evidence
+3. Confounders
+4. Confidence
+5. Description integrity
+
+§10 row "Number and form of challenge questions" says "Five questions: boundary, evidence, confounders, confidence, description integrity (§3.5)" as if this were a settled design choice. No spec section explains why these five constitute a complete cover of the challenge surface, why fewer would be incomplete, or why more would be redundant. Compare the diaboli skill, which has six categories explicitly justified by their leverage at different pipeline stages.
+
+### Why this matters
+
+The five questions are the main implementation deliverable of this slice — the challenge-refine cycle's *content*. If the questions are wrong or under-covering, the agent's output is wrong or under-covering. An undefended question list is the kind of decision that calcifies — once shipped, the next reader treats it as a primitive rather than a choice. Naming the rationale (or admitting "these are our best guess; observe and revise") is cheap; deferring it pushes the cost to whoever discovers the gap.
+
+## O2 — implementation — high
+
+### Claim
+
+Story 6.1 says "every element has populated challenge_notes (or an explicit empty list when no question surfaced a change)" but the schema (PR #336) declares challenge_notes a required list-of-strings with no contract about when empty is meaningful. The spec's rule "populate the field when a question surfaces a change, no note when nothing surfaces" means an empty list could mean either "agent ran the challenge cleanly and nothing surfaced" or "agent skipped the challenge entirely." These are observationally indistinguishable to a downstream consumer.
+
+### Evidence
+
+§3.5: "Questions that surface nothing add no note (avoid noise — empty notes are not evidence of due diligence)."
+
+§6.1 acceptance: "every element has populated challenge_notes (or an explicit empty list when no question surfaced a change)".
+
+Schema (PR #336 template, lines 23–25): challenge_notes is required, list of strings, may be empty when challenge protocol has not yet run.
+
+The downstream consumer (parent S3 cross-check, issue #332) cannot distinguish "challenged and clean" from "never challenged" on inspection.
+
+### Why this matters
+
+The schema field's semantic load is "evidence of due diligence." If empty means both "challenged and nothing surfaced" and "not challenged," the field loses its semantic load. A consumer needs either a separate boolean (`challenged: true/false`) or a sentinel note ("Challenge applied; no questions surfaced changes") to disambiguate. The spec doesn't choose either path.
+
+## O3 — implementation — high
+
+### Claim
+
+§3.4 commits to self-challenge in a single context but offers no mechanism for ensuring the challenge step actually happens. An LLM agent in a single context that drafts an element and then is asked to challenge it is statistically biased toward confirming its own draft — a documented failure mode of self-critique without independent perspective. The "single-context self-challenge" decision is exactly the architecture that risks the agent rubber-stamping its own output.
+
+### Evidence
+
+§3.4: "A self-challenge in one context preserves the agent's evidence chain: the same context that drafted the element raises objections against it."
+
+Followed by: "A later slice may revisit this if disposition data shows that self-blindness is a recurring failure mode. The agent's own context can fail to see things a fresh context would catch; that is real. But again, no signal yet — ship the simpler shape first."
+
+The spec acknowledges the failure mode it is choosing to defer. The challenge-refine cycle is the entire anti-hallucination value proposition of the agent (per the sub-slicing record line 98: "The challenge-refine cycle is where the anti-hallucination value of the agent lives"). Shipping the architecture with the named failure mode unaddressed weakens the central claim.
+
+### Why this matters
+
+If the self-challenge in one context degenerates to self-confirmation, the challenge_notes[] field becomes window-dressing — present but devoid of real signal. The downstream cross-check (parent S3) inherits the same blindness. The cost of catching this later is a redesign of the agent's reasoning architecture (e.g., second-pass dispatch, fresh sub-context, explicit "now act as challenger" prompt segment with clear instructions to disagree). Catching it now is cheaper — see O6 for one alternative.
+
+## O4 — specification quality — medium
+
+### Claim
+
+The five-question challenge's questions are dimension-flavoured (§3.5 says "domain elements pressure-test against question 5 most heavily, architectural elements against question 1") but the agent file's protocol does not say how this flavouring is operationalised. An implementer reading §4.3 "apply the five-question challenge to each" will produce the same prompt for both dimensions; the dimension-flavouring is implementation-implicit.
+
+### Evidence
+
+§3.5 paragraph 2: "The five questions are dimension-agnostic but apply with dimension-flavoured emphasis: domain elements pressure-test against question 5 most heavily (the textbook definition trap), and architectural elements pressure-test against question 1 most heavily (the smeared two services trap)."
+
+§4.3 protocol: "apply the five-question challenge to each, populating challenge_notes[]" — no dimension-aware step. The agent file's "The five-question challenge" section is described as "the questions from §3.5, copy-pasted, with one paragraph per question explaining what it is looking for" (§4.3) but does not specify the dimension-flavoured emphasis as a separate step.
+
+### Why this matters
+
+If the agent file does not operationalise the dimension-flavouring, the spec's claim that "the protocol is dimension-flavoured" is decorative. The implementer can build a correct agent file that ignores the flavouring and the spec's acceptance scenarios all pass. The cost is a weaker output: domain elements that fail to pressure-test against textbook-definition drift, architectural elements that smear services. Fix is cheap — name the flavouring as a per-element step in §4.3.
+
+## O5 — scope — medium
+
+### Claim
+
+The spec ships a how-to page and an explanation page in the same PR as the agent file, but never explains how a human actually invokes the agent. The how-to page is said in §6.5 to "name the input form (scope)" but the agent is dispatched by Claude Code's Task tool — the actual invocation pattern (which command? what slash-command? direct Task tool? no command at all?) is unspecified. The spec describes the agent as if dispatchable but does not describe the dispatch surface.
+
+### Evidence
+
+§2.1: "The agent does not enforce one form."
+
+§6.5: "I navigate to docs/plugins/diagnostic-legibility/how-to/, Then there is a page on invoking the diagnostic-legibility agent, And the page names the input form (scope)."
+
+§7.1 ships the how-to page.
+
+But nowhere in §2 (the agent's contract) or §4 (the agent file) does the spec say how the agent is invoked. The sibling model-card-researcher is dispatched by the `/model-card` command (`model-cards/commands/model-card.md` exists); the diagnostic-legibility plugin has no command, and the spec adds none. The how-to page is asked to document an invocation pattern the plugin does not provide.
+
+### Why this matters
+
+A how-to page that documents a non-existent invocation pattern either (a) ships with hand-wavy instructions like "use the Task tool with subagent_type: diagnostic-legibility" that don't actually work in the Claude Code product, or (b) ships with instructions for an invocation surface that should have been part of this slice but was overlooked. The spec must either add a `/diagnostic-legibility` command to the file inventory (§7.1) or explicitly document the bare-Task-tool dispatch pattern as the invocation surface.
+
+## O6 — alternatives — medium
+
+### Claim
+
+§3.4 considers and rejects "second-pass challenger agent dispatch" purely on the basis of file-surface cost ("that doubles the surface area to maintain for a v0.3.0 capability"). It does not weigh the alternative of running the challenge step in a fresh sub-context within the same agent file (e.g., the agent could spawn a sub-task or restart its reasoning with a clean slate to act as challenger). That alternative gets the independence benefit without the second-file cost.
+
+### Evidence
+
+§3.4: "A second-pass dispatch would need a separate challenger agent with its own file, charter, and tool boundary. That doubles the surface area to maintain for a v0.3.0 capability."
+
+The set of considered alternatives is binary: (a) one-context self-challenge, (b) two-agent dispatch. The middle option — same agent, two reasoning contexts (e.g., "now drop everything you concluded and re-read the evidence as a challenger") — is not weighed.
+
+### Why this matters
+
+This middle option is what makes the anti-hallucination value of the cycle defensible without doubling the file surface. It directly addresses the failure mode named in O3 (self-confirmation in shared context) without invoking a second agent file. The spec should at least name and dismiss this alternative or adopt it.
+
+## O7 — specification quality — medium
+
+### Claim
+
+Story 6.3 says the agent should "refuse degenerate outputs" by emitting a low-confidence placeholder — but the schema requires LegibilityElement.evidence to have at least one entry when confidence is medium or high, and permits empty evidence only when confidence is low. The "refuse degenerate output" rule is internally consistent with the schema only if the placeholder element carries low confidence AND empty evidence — meaning the agent's response to "I couldn't find anything" is structurally indistinguishable from "I found a candidate I have no evidence for". The two failure modes need separate signal.
+
+### Evidence
+
+§6.3: "And that element has confidence: low / And its description names the degenerate scope condition."
+
+Schema (PR #336 §3.3): "evidence must have at least one entry when confidence is medium or high. low-confidence elements may have empty evidence (the agent flagged a candidate without ground)."
+
+The downstream consumer reading a list of low-confidence elements with empty evidence cannot distinguish "this is a placeholder for empty-scope" from "this is an evidence-less guess".
+
+### Why this matters
+
+A consumer cannot tell whether to retry with a wider scope, abandon the scope, or follow up on a weak candidate. The fix is either (a) a sentinel `name` ("EMPTY_SCOPE" or similar) for the placeholder so consumers can pattern-match, or (b) a top-level field on LegibilityModel like `scope_yielded_results: bool`. Either would resolve the ambiguity without changing the schema's required fields.
+
+## O8 — specification quality — medium
+
+### Claim
+
+The spec names the version target "plugin_version unchanged at v0.39.1" twice (header + §6.4 + §10), but the field's value depends on whatever was current at PR-creation time. If main moves before merge (e.g., another PR ships an ai-literacy-superpowers bump), this PR's marketplace.json edit could either incorrectly downgrade plugin_version or fail the version-consistency check. The spec hard-codes a value that is a function of external main state.
+
+### Evidence
+
+Header: "Marketplace listing | Unchanged at v0.4.0; plugin_version (pointer to ai-literacy-superpowers) unchanged at v0.39.1".
+
+§6.4: "And the plugin_version field is unchanged at \"0.39.1\"".
+
+§10: "plugin_version pointer unchanged at 0.39.1".
+
+The spec's correctness depends on the assumption that ai-literacy-superpowers stays at 0.39.1 from spec-time through merge-time. The check is a cross-repo race condition that the spec acknowledges (header) but does not protect against.
+
+### Why this matters
+
+The integration-agent's pre-merge rebase will surface a conflict on `marketplace.json` if main has moved; the human resolving the conflict needs to know which side wins. The spec should say: "if main has bumped ai-literacy-superpowers in the interim, take main's plugin_version and leave the diagnostic-legibility entry's version bump." A one-line clarification in §9 (Compatibility and rollout) closes the gap.
+
+## O9 — alternatives — low
+
+### Claim
+
+§3.3 commits to a shared protocol across both dimensions. The decision rests on "the schema is shared (PR #336 settled this); the prompt construction is symmetric." But the schema being shared (one record type) does not imply the construction protocol must be shared. The agent could legitimately use two distinct construction loops — one targeting moving parts, one targeting concepts — with the dimension-flavoured challenge questions §3.5 already hints at. The "symmetric construction" decision is a separate design choice that hides behind the schema decision.
+
+### Evidence
+
+§3.3: "The challenge protocol is the same shape for both architectural and domain elements, parameterised on the dimension. The schema is shared (PR #336 settled this); the prompt construction is symmetric."
+
+Sub-slicing record line 140: "per-model bespoke vs. parameterised prompts" was excluded as a separate slice on the grounds that "the decision follows from the schema decision (same schema → parameterisable; distinct schemas → likely bespoke)".
+
+The implication "shared schema → shared construction" is asserted but not argued; the alternative is parameterised schema with bespoke construction loops.
+
+### Why this matters
+
+Low-severity because the choice is recoverable — even if shared construction proves limiting, the agent file can be rewritten to bifurcate without schema changes. Worth naming so future readers know it was a design choice rather than a necessity.
+
+## O10 — specification quality — low
+
+### Claim
+
+§5.2 "Expected output shape" is presented as truncated YAML but the truncation hides whether the example demonstrates the schema's required `Q<N>` prefix discipline for challenge_notes. Both notes in the example use 'Q1' and 'Q5' prefixes — but §3.5 never establishes Q<N> as a required prefix; it is invented in §5.2 as illustrative.
+
+### Evidence
+
+§5.2 output example:
+
+```yaml
+challenge_notes:
+  - "Q1 (boundary): initially treated the template and the wrapper as one element..."
+```
+
+and
+
+```yaml
+challenge_notes:
+  - "Q5 (description integrity): first draft was generic..."
+```
+
+§3.5 lists the five questions by name but never names a prefix format. §5.2 narration: "the Q<N> prefix in challenge_notes linking back to the five-question structure." The format is introduced in §5.2 as if established, but it isn't established anywhere. Either §3.5 should mandate the prefix or §5.2 should describe it as an example convention rather than a requirement.
+
+### Why this matters
+
+Low-severity formatting concern, but it affects machine-readability of challenge_notes downstream. If §3.5 mandates the `Q<N>` prefix, the cross-check (parent S3) can group notes by question; if not, consumers cannot rely on the convention. Cost of fixing: one sentence in §3.5 either way.
+
+## Explicitly not objecting to
+
+- **The choice of retained-challenge single-pass (option b) over option (a) or (c).** The rationale in §3.1 and §3.2 is well-evidenced — the schema already commits to `challenge_notes[]` as load-bearing, so option (a) self-contradicts; option (c) introduces a stopping-condition sub-decision with no signal to justify it. Option (b) is the right call.
+- **The tool boundary (Read, Glob, Grep).** Matches the three sibling read-only emitters and is consistent with the project's "agent-emit + dispatcher-persist + human-disposes" architecture named in AGENTS.md ARCH_DECISIONS. No challenge here.
+- **The agent name `diagnostic-legibility` matching the plugin name.** Reasonable convention when there is exactly one agent in a plugin; the carpaccio and choice-cartographer agents do the same within their plugins.
+- **The version bump 0.2.0 → 0.3.0 as a minor (adding behaviour) rather than a major.** Pre-1.0 semver per CLAUDE.md says minor for behavioural changes; this is textbook.
+- **The deliberate exclusion of cross-check (parent S3) and surfacing (parent S4) from this slice.** Carpaccio's parent slicing record is explicit on this; revisiting at sub-slice level would be re-slicing.
+- **The 150–250 line target for the agent file.** Comparable to siblings; not load-bearing on correctness.
+- **The free-text scope input form (§2.1).** Matches the model-card-researcher's permissive input style; downstream tightening is possible if it earns its keep.
+- **The docs site folder pattern (how-to + explanation quadrants only).** Per CLAUDE.md "A quadrant folder is created only when the plugin has at least one page in that quadrant" — the spec ships exactly the two quadrants it has content for, no scaffolding theatre.

--- a/docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
@@ -1,0 +1,487 @@
+# Diagnostic Legibility — sub-S2b — Challenge protocol and working agent — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-05-28 |
+| Status | Draft |
+| Author | claude-opus-4-7[1m] (interactive session with russmiles) |
+| Slice | sub-S2 of the meta-iteration record at `docs/superpowers/slices/dl-s2-two-model-agent.md` (which is itself S2 of the parent record `docs/superpowers/slices/diagnostic-legibility-plugin.md`) |
+| Parent issue | #335 (Diagnostic Legibility sub-S2b) |
+| Up-stack parent issue | #331 (S2 — auto-closes when #335 merges per its own comment) |
+| Plugin version target | `diagnostic-legibility` v0.2.0 → v0.3.0 |
+| Marketplace listing | Unchanged at v0.4.0; `plugin_version` (pointer to `ai-literacy-superpowers`) unchanged at v0.39.1 |
+| PR ceremony | feature — full `/diaboli` (spec + code) and `/choice-cartograph` |
+| Related work | S1 of parent shipped (PR #334, scaffold v0.1.0); sub-S1 of meta-iteration shipped (PR #336, schema v0.2.0); sibling pattern anchors are `model-cards/agents/model-card-researcher.agent.md` and `ai-literacy-superpowers/agents/advocatus-diaboli.agent.md` |
+
+---
+
+## 1. Premise
+
+The schema is settled (PR #336 shipped `LegibilityElement` and the
+`LegibilityModel` wrapper at v0.2.0). What is still missing is the
+agent that *constructs* and *refines* the two model collections.
+
+Issue #335 commissions the working agent. The cargo of this slice is:
+the agent file, the challenge-refine cycle that populates
+`challenge_notes[]` on each element, and enough surrounding
+documentation that a human can invoke it against a real codebase
+scope and read the two refined model collections back out.
+
+The decision focus this slice owns is the **shape of the
+challenge-refine cycle**. Three candidate architectures are named in
+the meta-iteration's S2 section (`docs/superpowers/slices/dl-s2-two-model-agent.md`,
+lines 102–110). One of those three is selected here; the rationale is
+in §3.
+
+What this slice deliberately does *not* own: cross-checking the two
+models against each other (parent S3, issue #332) and the
+human-facing surfacing format (parent S4, issue #333). The agent
+emits two refined collections; whatever the human reads next is
+out of scope.
+
+## 2. The agent's contract
+
+### 2.1 Input
+
+- **`scope` (required)** — a directory path, a file list, or a free-text
+  description of the area to be modelled. Examples:
+  - `./src/auth/`
+  - `src/checkout/cart.py, src/checkout/order.py`
+  - `"the checkout flow across services A and B"`
+
+  The agent does not enforce one form. The free-text form is
+  acceptable when the scope is conceptual rather than directory-bounded.
+
+### 2.2 Output
+
+A single markdown response containing a `LegibilityModel` instance
+serialised as YAML, per the schema at
+`diagnostic-legibility/templates/legibility-element.md`. The agent
+does **not** write the file; the dispatching command (or human user)
+writes the response to whatever path they choose. This mirrors the
+`model-card-researcher` agent's read-only emitter pattern (AGENTS.md
+ARCH_DECISIONS, "agent-emit + dispatcher-persist + human-disposes").
+
+### 2.3 Trust boundary
+
+`Read`, `Glob`, `Grep`. No `Write`, no `Edit`, no `Bash`. The agent
+inspects the codebase scope and returns content as a string. This
+matches the three sibling read-only emitters: `advocatus-diaboli`,
+`choice-cartographer`, `model-card-researcher`. The pattern is
+named and load-bearing in AGENTS.md.
+
+## 3. The challenge-refine cycle — decision
+
+The decision focus of this slice. Three candidates from the
+sub-slicing record:
+
+(a) **Single-pass critique-revise.** One challenge, one revision.
+    Challenge artefact discarded.
+(b) **Retained-challenge single-pass.** Same as (a), but the
+    challenge questions and their resolutions are retained as
+    `challenge_notes[]` on each element.
+(c) **Iterative loop with stopping condition.** Challenge–revise
+    until stable or budget exhausted.
+
+**Selected: (b) retained-challenge single-pass.**
+
+### 3.1 Why (b) over (a)
+
+The schema already commits to a `challenge_notes[]` field on every
+`LegibilityElement`. The schema spec (sub-S2a) names the field as
+"What the challenge-refine step surfaced and how it was resolved."
+Option (a) would either populate the field with reconstructed notes
+(authoring something after the fact, weakening evidence quality) or
+leave the field empty (defeating the schema decision). Option (b)
+makes the field load-bearing without changing the schema. The
+schema and the protocol agree.
+
+The downstream consumer (parent S3, the cross-check) will want
+diagnostic context. Knowing *what was challenged* and *what was
+revised* is the diagnostic context. Retaining it is cheap;
+reconstructing it later is expensive and lossy.
+
+### 3.2 Why (b) over (c)
+
+The iterative loop adds variable token cost and a stopping-condition
+sub-decision (token budget? change-rate threshold? fixed iteration
+count?). At v0.3.0 there is no measured signal that single-pass
+under-refines. Adding the loop now is premature optimisation in the
+absence of disposition data on what is being missed.
+
+The loop architecture is not foreclosed by (b): a later slice can
+add iteration on top of (b) by repeating the challenge-revise step
+and appending to `challenge_notes[]` per iteration. The schema
+accommodates this without breaking. The conservative move is to
+ship (b) first, observe a handful of real invocations, and decide
+whether the loop earns its keep on evidence.
+
+### 3.3 Shared protocol across both dimensions
+
+The challenge protocol is **the same shape** for both architectural
+and domain elements, parameterised on the dimension. The schema is
+shared (PR #336 settled this); the prompt construction is symmetric;
+the challenge questions are dimension-flavoured but follow the same
+five-question structure (§3.5). Sub-slicing notes (line 140 of the
+slicing record) explicitly excluded "per-model bespoke vs.
+parameterised prompts" as a separate slice — the schema decision
+already implied parameterisation.
+
+### 3.4 Self-challenge in one multi-turn context, not dispatch
+
+The agent runs the challenge-revise as a single self-directed
+sequence inside its own context, not as a second agent dispatch.
+Rationale:
+
+- A second-pass dispatch would need a separate challenger agent
+  with its own file, charter, and tool boundary. That doubles the
+  surface area to maintain for a v0.3.0 capability.
+- A self-challenge in one context preserves the agent's
+  evidence chain: the same context that drafted the element raises
+  objections against it. The challenge prompt can reference the
+  evidence the constructor saw directly.
+- Other sibling agents (advocatus-diaboli is the closest reference)
+  emit in a single pass; the diagnostic-legibility agent's
+  self-challenge is one more step in that pass, not a separate
+  dispatch.
+
+A later slice may revisit this if disposition data shows that
+self-blindness is a recurring failure mode. The agent's own context
+can fail to see things a fresh context would catch; that is real.
+But again, no signal yet — ship the simpler shape first.
+
+### 3.5 The five-question challenge structure
+
+Each `LegibilityElement` is challenged through five questions, asked
+once per element (the single pass in 3.1):
+
+1. **Boundary** — is the `name` actually a single thing, or did I
+   smear two things together?
+2. **Evidence** — does the cited evidence actually support the
+   `description` as written?
+3. **Confounders** — what nearby thing is *not* this element but
+   could be mistaken for it?
+4. **Confidence** — am I overclaiming on the `confidence` field
+   given the evidence?
+5. **Description integrity** — is the description specific to this
+   codebase, or am I writing a generic textbook definition?
+
+Each question is asked of the draft element. Where a question
+surfaces a change, the element is revised and the surfacing-question
++ resolution is appended to `challenge_notes[]`. Questions that
+surface nothing add no note (avoid noise — empty notes are not
+evidence of due diligence).
+
+The five questions are dimension-agnostic but apply with
+dimension-flavoured emphasis: domain elements pressure-test against
+question 5 most heavily (the "textbook definition" trap), and
+architectural elements pressure-test against question 1 most heavily
+(the "smeared two services" trap).
+
+## 4. The agent file
+
+### 4.1 Path
+
+`diagnostic-legibility/agents/diagnostic-legibility.agent.md`
+
+The agent name is `diagnostic-legibility`. Single agent in the
+plugin's `agents/` directory at v0.3.0. Replaces the `.gitkeep`
+placeholder from v0.1.0.
+
+### 4.2 Frontmatter
+
+```yaml
+---
+name: diagnostic-legibility
+description: Use to build two refined models of a codebase scope — architectural moving parts and domain concepts — using the schema at diagnostic-legibility/templates/legibility-element.md. Constructs each element, applies a five-question self-challenge cycle, and retains challenge notes on every element. Returns a LegibilityModel as YAML; the dispatching command or human writes the file.
+tools: Read, Glob, Grep
+model: inherit
+---
+```
+
+### 4.3 Sections
+
+The agent file follows the sibling-agent shape:
+
+- `# Charter` — what the agent does and what it does not do.
+- `## Inputs` — `scope` (required), serialisation choices for the
+  three forms in §2.1.
+- `## Output` — a `LegibilityModel` as YAML, single markdown
+  response, no file write.
+- `## Trust boundary` — Read/Glob/Grep, the rationale from §2.3.
+- `## Construction protocol` — how the agent reads the scope and
+  drafts the two collections. Calls out:
+  - read the schema template first
+  - inspect the scope (Glob/Grep/Read)
+  - draft architectural elements (one per evident "moving part")
+  - draft domain elements (one per evident concept term)
+  - apply the five-question challenge to each, populating
+    `challenge_notes[]`
+  - emit the full `LegibilityModel` YAML
+- `## The five-question challenge` — the questions from §3.5,
+  copy-pasted, with one paragraph per question explaining what it
+  is looking for.
+- `## Honesty rules` — `confidence: low` for unevidenced candidates,
+  empty `evidence: []` permitted only when confidence is `low`,
+  prefer "I am not sure" over fabrication.
+- `## Anti-patterns` — list of failure modes the agent should
+  avoid: padding `challenge_notes[]` with no-op resolutions,
+  generic textbook descriptions, two architectural elements that
+  are really one, etc.
+
+### 4.4 Length
+
+Target: 150–250 lines. Comparable to `model-card-researcher`
+(140 lines) and `advocatus-diaboli` (103 lines). Longer than
+absolutely necessary is fine; the agent file is loaded as system
+prompt context and a few extra lines on protocol clarity is good
+value for the token cost.
+
+## 5. Worked invocation example (for the agent file's body, and for docs)
+
+### 5.1 Input
+
+```text
+scope: ./diagnostic-legibility/
+```
+
+### 5.2 Expected output shape (truncated)
+
+```yaml
+scope: "./diagnostic-legibility/"
+generated_at: "2026-05-28T14:00:00Z"
+generated_by: "diagnostic-legibility / claude-sonnet-4-6"
+architectural:
+  - name: LegibilityElement template
+    description: |
+      The schema artefact at templates/legibility-element.md.
+      Documentation-only — referenced by the agent's prompt but
+      not loaded as code. Defines the contract every emitted
+      element follows.
+    evidence:
+      - path: diagnostic-legibility/templates/legibility-element.md
+    confidence: high
+    challenge_notes:
+      - "Q1 (boundary): initially treated the template and the wrapper as one element; revised to keep them as the LegibilityModel wrapper section of the same file, naming this element the template-as-contract."
+domain:
+  - name: LegibilityElement
+    description: |
+      The unit of legibility — one row of the model. Distinct from
+      LegibilityModel (the wrapper carrying both collections).
+      The ubiquitous-language term in this plugin's docs.
+    evidence:
+      - path: diagnostic-legibility/templates/legibility-element.md
+        excerpt: "# LegibilityElement"
+    confidence: high
+    challenge_notes:
+      - "Q5 (description integrity): first draft was generic ('a row of data'); revised to name the contrast with LegibilityModel."
+```
+
+The example demonstrates: dimensional symmetry, evidence with
+optional excerpts, the `Q<N>` prefix in `challenge_notes` linking
+back to the five-question structure.
+
+## 6. User stories and acceptance scenarios
+
+### 6.1 Story — the agent is invokable
+
+**As** a developer with a target codebase scope
+**I want** to dispatch the `diagnostic-legibility` agent with a
+scope
+**So that** I receive a `LegibilityModel` with both collections
+refined through the challenge cycle.
+
+```gherkin
+Given the merged main on this PR
+When I dispatch the diagnostic-legibility agent with scope ./src/auth/
+Then I receive a single markdown response
+And the response contains a LegibilityModel YAML block
+And the block has scope, generated_at, generated_by, architectural,
+    and domain fields per the LegibilityModel schema
+And at least one of architectural or domain is non-empty
+And every element has populated challenge_notes (or an explicit
+    empty list when no question surfaced a change)
+```
+
+### 6.2 Story — challenge notes carry diagnostic context
+
+**As** a human reading the agent's output
+**I want** to see what was challenged and what was revised
+**So that** I can decide whether to trust the refined element or
+investigate further.
+
+```gherkin
+Given an agent output for a non-trivial scope
+When I read any LegibilityElement with at least one challenge note
+Then the note names a question prefix (Q1–Q5)
+And the note describes what surfaced and how it was resolved
+And the note is grounded in the element's evidence, not a generic
+    statement
+```
+
+### 6.3 Story — the agent refuses degenerate outputs
+
+**As** the dispatching command
+**I want** the agent to surface a low-confidence placeholder rather
+than emit two empty lists
+**So that** I can distinguish "scope yielded nothing" from "agent
+failed silently".
+
+```gherkin
+Given a scope that the agent cannot find architectural or domain
+    elements in (e.g., an empty directory)
+When the agent runs
+Then the output contains at least one LegibilityElement
+And that element has confidence: low
+And its description names the degenerate scope condition
+```
+
+### 6.4 Story — the plugin version reflects the new agent
+
+**As** the marketplace consumer
+**I want** the diagnostic-legibility plugin version to bump when
+the agent is added
+**So that** caches and version checks know the plugin has changed.
+
+```gherkin
+Given the merged main on this PR
+When I read diagnostic-legibility/.claude-plugin/plugin.json
+Then the version is "0.3.0"
+And the entry in .claude-plugin/marketplace.json for diagnostic-legibility
+    also shows version "0.3.0"
+And the top-level marketplace `version` is unchanged at "0.4.0"
+And the `plugin_version` field is unchanged at "0.39.1"
+And diagnostic-legibility/CHANGELOG.md has a new entry for 0.3.0
+```
+
+### 6.5 Story — docs explain how to invoke the agent
+
+**As** a future reader of the docs site
+**I want** to find a how-to page explaining how to invoke the
+diagnostic-legibility agent and read its output
+**So that** I can use the plugin without reading the agent file
+itself.
+
+```gherkin
+Given the merged main on this PR
+When I navigate to docs/plugins/diagnostic-legibility/how-to/
+Then there is a page on invoking the diagnostic-legibility agent
+And the page names the input form (scope)
+And the page shows a worked example of the output
+And the page links to the schema reference at templates/legibility-element.md
+```
+
+## 7. Files to add and modify
+
+### 7.1 New files
+
+| Path | Purpose |
+| --- | --- |
+| `diagnostic-legibility/agents/diagnostic-legibility.agent.md` | The working agent (§4). Replaces the `agents/.gitkeep` placeholder from v0.1.0. |
+| `docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md` | How-to page (§6.5). |
+| `docs/plugins/diagnostic-legibility/how-to/index.md` | Quadrant landing page; minimal — one paragraph plus a link to the how-to. Per the docs convention, the quadrant folder is created only when there is at least one page. |
+| `docs/plugins/diagnostic-legibility/explanation/challenge-refine-protocol.md` | Concept page explaining the five-question challenge, why retained-challenge single-pass was chosen, and how `challenge_notes[]` connects schema to runtime. Linked from the how-to. |
+| `docs/plugins/diagnostic-legibility/explanation/index.md` | Quadrant landing page. |
+
+### 7.2 Removed files
+
+| Path | Reason |
+| --- | --- |
+| `diagnostic-legibility/agents/.gitkeep` | Replaced by the agent file. The directory no longer needs a placeholder. |
+
+### 7.3 Modified files
+
+| Path | Change |
+| --- | --- |
+| `diagnostic-legibility/.claude-plugin/plugin.json` | Bump `version` `0.2.0` → `0.3.0`. |
+| `diagnostic-legibility/CHANGELOG.md` | New `## 0.3.0 — 2026-05-28` entry naming the agent addition and the sub-S2b disposition that produced it. |
+| `.claude-plugin/marketplace.json` | Bump the `diagnostic-legibility` entry in `plugins[]` from `version: "0.2.0"` to `"0.3.0"`. Top-level `version` and `plugin_version` unchanged. |
+| `README.md` (repo root) | Update the `diagnostic-legibility` badge from `v0.2.0` to `v0.3.0` and the marketplace table row's Version column. |
+| `diagnostic-legibility/README.md` | Add a brief "Available agents" section referencing `diagnostic-legibility.agent.md`. |
+| `docs/plugins/diagnostic-legibility/index.md` | Update the "Status" section to reflect v0.3.0 and the new agent; surface the how-to and explanation pages as live links. |
+
+## 8. Out of scope
+
+The slice narrowing keeps the following out of scope:
+
+- **Cross-checking the two models against each other.** Reserved
+  for parent S3 / issue #332.
+- **The human-facing surfacing interface.** Reserved for parent
+  S4 / issue #333.
+- **An iterative challenge loop.** §3.2 explicitly defers this; the
+  ship is single-pass retained-challenge.
+- **A second-pass challenger agent dispatch.** §3.4 explicitly
+  defers this; the ship is self-challenge in one context.
+- **A runtime validator for `LegibilityElement` instances.** The
+  schema spec (sub-S2a) explicitly deferred this; nothing changes
+  here.
+- **Dimension-bespoke challenge prompts.** §3.3 commits to one
+  shared protocol across both dimensions. Per-dimension prompt
+  variation is implementation-level prompt-string crafting, not a
+  design gate.
+- **TDAD scenarios under `tdad_tests/scenarios/agents/diagnostic-legibility/`.**
+  The TDAD-scenario-check workflow (`tdad-scenario-check.yml`,
+  lines 5–10) is scoped to `ai-literacy-superpowers/skills/`,
+  `/agents/`, and `/commands/` paths. The diagnostic-legibility
+  plugin is out of scope for the workflow. Adding scenarios for
+  diagnostic-legibility components is a separate question of
+  whether the TDAD discipline should extend across plugins; that
+  is a meta-decision that belongs to a future spec, not this
+  slice.
+- **Docs-reference parity entries in
+  `docs/plugins/ai-literacy-superpowers/reference/agents.md`.**
+  The docs-reference-parity workflow is also scoped to the
+  `ai-literacy-superpowers` plugin. The diagnostic-legibility
+  plugin's reference pages do not yet exist (no reference quadrant
+  in the docs landing page). When and how to scaffold those is a
+  future decision.
+
+## 9. Compatibility and rollout
+
+- **Backwards compatibility:** the diagnostic-legibility plugin
+  was v0.2.0 (schema-only). Adding an agent does not break any
+  consumer because no consumer existed at v0.2.0 except the
+  marketplace cache hooks, which key on version strings.
+- **Cache behaviour:** `sync-marketplace-cache.sh` fires when
+  `.claude-plugin/marketplace.json` differs from `origin/main` —
+  this PR triggers it because the per-plugin version bumps.
+  `sync-to-global-cache.sh` rsyncs the new agent into the
+  versioned plugin cache.
+- **CI gates:**
+  - Spec-first is satisfied by this spec being the first commit
+    on the branch.
+  - Version consistency: diagnostic-legibility's plugin.json
+    (0.3.0) matches its marketplace entry (0.3.0).
+  - TDAD scenario check: no-op (the workflow is scoped to
+    `ai-literacy-superpowers/`).
+  - Docs-reference parity check: no-op (same scoping).
+  - Markdown lint, docs-build: must pass; the new how-to and
+    explanation pages need to render cleanly.
+
+## 10. Open questions resolved during brainstorming
+
+| Question | Decision |
+| --- | --- |
+| Challenge protocol shape | Retained-challenge single-pass (§3.1) |
+| Shared vs bespoke protocol across dimensions | Shared, parameterised (§3.3) |
+| Self-challenge in one context vs second-pass dispatch | Single-context self-challenge (§3.4) |
+| Number and form of challenge questions | Five questions: boundary, evidence, confounders, confidence, description integrity (§3.5) |
+| Agent name | `diagnostic-legibility` (the only agent in the plugin at v0.3.0) |
+| Tool boundary | Read, Glob, Grep — matches the three sibling read-only emitters |
+| Per-version bump | diagnostic-legibility 0.2.0 → 0.3.0 (minor: new behaviour and new component); marketplace listing unchanged at 0.4.0; plugin_version pointer unchanged at 0.39.1 |
+
+## 11. References
+
+- Issue #335 — this slice's parent.
+- Issue #331 — up-stack S2 commission (auto-closes when #335 ships).
+- Sub-slicing record: `docs/superpowers/slices/dl-s2-two-model-agent.md`.
+- Parent slicing record: `docs/superpowers/slices/diagnostic-legibility-plugin.md`.
+- Sub-S2a (schema) spec:
+  `docs/superpowers/specs/2026-05-26-dl-s2a-legibility-element-schema-design.md`.
+- Schema artefact:
+  `diagnostic-legibility/templates/legibility-element.md`.
+- Sibling agent pattern anchors:
+  - `model-cards/agents/model-card-researcher.agent.md`
+  - `ai-literacy-superpowers/agents/advocatus-diaboli.agent.md`
+- AGENTS.md ARCH_DECISIONS — "agent-emit + dispatcher-persist + human-disposes" pattern.
+- `CLAUDE.md` — Semantic Versioning and Marketplace Versioning sections.

--- a/docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
@@ -70,6 +70,38 @@ matches the three sibling read-only emitters: `advocatus-diaboli`,
 `choice-cartographer`, `model-card-researcher`. The pattern is
 named and load-bearing in AGENTS.md.
 
+### 2.4 Invocation surface (v0.3.0)
+
+At v0.3.0 the agent is dispatched via Claude Code's bare `Task`
+tool — there is no `/diagnose` slash-command in this slice. The
+invocation contract:
+
+- `subagent_type`: `diagnostic-legibility`
+- `description`: a short imperative (e.g. "Model the auth module")
+- `prompt`: free-text that names the `scope` and any additional
+  context. The minimum prompt shape is:
+
+  ```text
+  scope: <directory path | file list | free-text description>
+  ```
+
+  Additional context (e.g. "focus on the public API surface only")
+  is appended as a second paragraph.
+
+The dispatcher (orchestrator agent, command, or human) is
+responsible for persisting the agent's returned YAML to a path of
+its choosing — the agent itself does not write. This is the
+"agent-emit + dispatcher-persist + human-disposes" pattern from
+AGENTS.md ARCH_DECISIONS, shared with `model-card-researcher`,
+`advocatus-diaboli`, and `choice-cartographer`.
+
+A `/diagnose` slash-command that wraps this dispatch and handles
+file-write conventions is the deliverable of parent S4 (issue
+#333), out of scope here. The how-to page in this slice (§6.5,
+§7.1) documents the bare-Task-tool pattern as the v0.3.0
+invocation surface and links forward to S4 for the eventual
+command surface.
+
 ## 3. The challenge-refine cycle — decision
 
 The decision focus of this slice. Three candidates from the
@@ -122,33 +154,111 @@ The challenge protocol is **the same shape** for both architectural
 and domain elements, parameterised on the dimension. The schema is
 shared (PR #336 settled this); the prompt construction is symmetric;
 the challenge questions are dimension-flavoured but follow the same
-five-question structure (§3.5). Sub-slicing notes (line 140 of the
-slicing record) explicitly excluded "per-model bespoke vs.
-parameterised prompts" as a separate slice — the schema decision
-already implied parameterisation.
+five-question structure (§3.5).
 
-### 3.4 Self-challenge in one multi-turn context, not dispatch
+Shared construction is a **design choice**, not a logical
+consequence of the shared schema. The two are independent
+decisions: one could legitimately ship two construction loops — one
+targeting architectural moving parts, one targeting domain concepts
+— against the same record type, with each loop's prompts tuned for
+its dimension's failure modes. The schema does not foreclose that.
+Shared construction is chosen here for three reasons:
 
-The agent runs the challenge-revise as a single self-directed
-sequence inside its own context, not as a second agent dispatch.
-Rationale:
+1. **Complexity scaling.** The agent file's prompt complexity scales
+   roughly linearly with the number of distinct construction loops.
+   One shared loop is one prompt section to write, maintain, and
+   reason about; two bifurcated loops are two. At v0.3.0 there is
+   no signal that one shared loop under-serves either dimension.
 
-- A second-pass dispatch would need a separate challenger agent
-  with its own file, charter, and tool boundary. That doubles the
-  surface area to maintain for a v0.3.0 capability.
-- A self-challenge in one context preserves the agent's
-  evidence chain: the same context that drafted the element raises
-  objections against it. The challenge prompt can reference the
-  evidence the constructor saw directly.
-- Other sibling agents (advocatus-diaboli is the closest reference)
-  emit in a single pass; the diagnostic-legibility agent's
-  self-challenge is one more step in that pass, not a separate
-  dispatch.
+2. **Dimension-flavoured emphasis already gives dimension-aware
+   behaviour.** Per O4 / §3.5 / §4.3, the agent explicitly
+   weights Q5 heavily for domain elements and Q1 heavily for
+   architectural elements. The cross-dimension differentiation is
+   already operational without bifurcating the construction loop.
 
-A later slice may revisit this if disposition data shows that
-self-blindness is a recurring failure mode. The agent's own context
-can fail to see things a fresh context would catch; that is real.
-But again, no signal yet — ship the simpler shape first.
+3. **Recoverable.** If signal emerges from disposition data that
+   the two dimensions need genuinely different construction
+   sequences (not just weightings), the agent file can be split
+   into two construction loops without changing the schema, the
+   spec's external contract, or downstream consumers. The
+   architectural cost of starting shared and splitting later is
+   bounded; the cost of starting bifurcated and merging later is
+   roughly equivalent. The default of *one shape* wins on Occam.
+
+Sub-slicing notes (line 140 of the slicing record) excluded
+"per-model bespoke vs. parameterised prompts" as a separate slice
+on the grounds that the construction-loop question is
+implementation-level prompt crafting — that exclusion still holds,
+but the *choice* of shared-vs-bespoke is named here explicitly so
+future readers know it was deliberate rather than inherited from
+the schema decision.
+
+### 3.4 Fresh-sub-context self-challenge — three alternatives weighed
+
+Three candidate architectures for the challenge step were
+considered:
+
+1. **One-context self-challenge.** The agent drafts each element
+   and, in the same continuous reasoning context, asks the five
+   challenge questions of its own draft and revises in place.
+   Simplest. The named failure mode is **self-confirmation**: an
+   LLM in a single context that has just argued for a draft is
+   statistically biased toward defending it rather than disagreeing
+   with it. The challenge step risks degenerating into
+   rubber-stamping, which makes the `challenge_notes[]` field
+   window-dressing rather than evidence of due diligence.
+
+2. **Two-agent dispatch.** A separate `diagnostic-legibility-challenger`
+   agent file with its own charter and tool boundary. The constructor
+   emits draft elements; the challenger reads them and emits
+   challenge notes; the constructor (or dispatcher) merges.
+   Maximal independence. Cost: doubles the agent-file surface for a
+   v0.3.0 capability — twice the prompt to maintain, twice the
+   versioning ceremony, twice the place a future reader needs to
+   look to understand the cycle.
+
+3. **Fresh-sub-context self-challenge (selected).** The same agent
+   file runs the challenge step in an explicit context-separation
+   segment: the construction protocol ends, the agent re-reads the
+   evidence as an adversarial reviewer, and the five questions are
+   asked from that adversarial framing with the explicit instruction
+   to **disagree where the evidence allows**. One agent file, one
+   dispatch, but two reasoning postures within it — *construct* and
+   *challenge* — separated by an explicit prompt-segment boundary.
+
+The middle option is selected because it addresses the
+self-confirmation failure mode named in (1) without doubling the
+agent-file surface named in (2). The independence comes from the
+explicit re-framing rather than from a separate context; the cost
+is a few extra paragraphs in the agent file's reasoning protocol
+(operationalised in §4.3) rather than a whole second file.
+
+The mechanism is the agent file's prompt itself: §4.3's
+"Construction protocol" section will name an explicit
+**Challenge segment** that begins after all elements are drafted.
+That segment includes:
+
+- An instruction to re-read the evidence cited on each draft
+  element with no prior commitment to the draft's conclusions.
+- An adversarial framing line ("You are now the challenger. Your
+  job is to find what is wrong with the draft, not to confirm it.").
+- The five questions (§3.5), asked with explicit permission and
+  instruction to **disagree where the evidence allows** — silence is
+  not the safe answer.
+- The dimension-flavoured weighting from §3.5 applied per element.
+
+This is structurally a "fresh sub-context" without invoking a second
+agent: the framing instructions induce the agent to treat the
+challenge segment as separate work, even though the model context
+window is shared. If disposition data shows this still degenerates to
+self-confirmation (e.g. an unusually high rate of sentinel-only
+`challenge_notes[]` across diverse scopes), the architecture can
+escalate to (2) — a separate challenger agent — without changing the
+schema or the spec's external contract.
+
+The progression (1) → (3) → (2) is the natural escalation path; we
+ship the middle option first because it is the cheapest move that
+takes the failure mode seriously rather than deferring it.
 
 ### 3.5 The five-question challenge structure
 
@@ -166,17 +276,109 @@ once per element (the single pass in 3.1):
 5. **Description integrity** — is the description specific to this
    codebase, or am I writing a generic textbook definition?
 
+#### What each question is meant to catch (rationale)
+
+The five questions are not a primitive — they are a working hypothesis
+about what failure modes the agent's drafts most commonly exhibit.
+Each question targets a distinct failure mode:
+
+- **Q1 (Boundary)** catches **smearing** — drafting a single element
+  whose `name` covers two genuinely separable things. Most common for
+  architectural elements ("auth + session" treated as one component
+  when they are two).
+- **Q2 (Evidence)** catches **ungrounded claim** — the description
+  asserts something the cited evidence does not actually support.
+  This is the closest analogue to a fabrication check.
+- **Q3 (Confounders)** catches **near-misses** — neighbouring
+  artefacts in the codebase that share enough surface with the
+  element to be confused with it (e.g. two similarly-named domain
+  terms with different semantics). The element's identity is
+  sharpened by naming what it is *not*.
+- **Q4 (Confidence)** catches **calibration drift** — claiming
+  `confidence: high` when the evidence is thin, or `low` when the
+  evidence is in fact dense. This is the meta-level honesty check
+  that the schema's `confidence` field exists to support.
+- **Q5 (Description integrity)** catches **textbook-definition
+  drift** — writing a generic definition that could apply to any
+  codebase rather than describing what this specific concept means
+  here. Most common for domain elements (writing "an aggregate is a
+  cluster of related entities" instead of "the `Cart` aggregate
+  groups line items and applied promotions for one checkout session").
+
+These five together are the working cover — *boundary, ground,
+identity-by-contrast, calibration, specificity*. They are not
+claimed to be complete. The choice of five (and not three or seven)
+is a hypothesis revisable from disposition data: the agent's own
+`challenge_notes` corpus across real invocations is the falsification
+surface. If a recurring failure mode does not map to any of the five,
+the cover is missing a question. If two questions consistently produce
+identical notes, the cover has redundancy. Both signals are observable
+without changing the schema. A later slice may add, drop, or merge
+questions on that evidence.
+
 Each question is asked of the draft element. Where a question
 surfaces a change, the element is revised and the surfacing-question
-+ resolution is appended to `challenge_notes[]`. Questions that
-surface nothing add no note (avoid noise — empty notes are not
-evidence of due diligence).
++ resolution is appended to `challenge_notes[]` as a single string
+prefixed with `Q<N> (question name):` — e.g. `Q1 (boundary):`,
+`Q5 (description integrity):` — followed by a description of what
+surfaced and how it was resolved. The `Q<N>` prefix is mandatory and
+machine-parseable; the parent S3 cross-check (issue #332) groups
+notes by question prefix.
+
+When a challenge runs and all five questions surface no changes, the
+element receives the single sentinel note:
+
+```text
+Challenge applied; no questions surfaced changes
+```
+
+verbatim, with no `Q<N>` prefix. The sentinel is the only exception
+to the prefix convention. This rule makes the field unambiguous:
+**empty `challenge_notes[]` means the challenge protocol did not
+run; a non-empty list means it did.** Without the sentinel, an empty
+list would be observationally indistinguishable from a skipped
+challenge — a problem for the downstream S3 cross-check, which
+relies on `challenge_notes[]` as evidence of due diligence.
 
 The five questions are dimension-agnostic but apply with
 dimension-flavoured emphasis: domain elements pressure-test against
 question 5 most heavily (the "textbook definition" trap), and
 architectural elements pressure-test against question 1 most heavily
-(the "smeared two services" trap).
+(the "smeared two services" trap). The agent file operationalises
+this in its construction protocol (§4.3) as an explicit per-element
+weighting step, not as decorative guidance.
+
+### 3.6 Sentinel for the empty-scope degenerate case
+
+When the agent inspects the scope and finds no architectural or
+domain elements to draft (e.g. the scope is an empty directory, or
+a file list containing only generated artefacts with no human
+content), it does not return two empty collections. Instead it
+emits a single placeholder element under whichever collection it
+attempts first (architectural by convention) with the literal
+`name` value:
+
+```text
+(empty scope)
+```
+
+— exactly this string, parentheses included. The element carries
+`confidence: low`, an empty `evidence: []`, and a description that
+names the degenerate scope condition (e.g. "Scope `./src/foo/` was
+inspected and yielded no architectural moving parts or domain
+concepts; this placeholder marks the empty result"). The
+`challenge_notes[]` field carries the O2 sentinel
+(`Challenge applied; no questions surfaced changes`).
+
+Why the literal `(empty scope)` and not a low-confidence
+candidate? Per the schema, low confidence with empty evidence is
+already permitted for "agent flagged a candidate without ground"
+cases. The sentinel `name` lets a downstream consumer
+pattern-match exactly on `name == "(empty scope)"` to distinguish
+"scope yielded nothing" from "agent flagged an evidence-less
+candidate" — the two failure modes that would otherwise be
+indistinguishable. Avoids changing the schema. Documented in §6.3
+and again in the agent file's anti-patterns section.
 
 ## 4. The agent file
 
@@ -210,24 +412,72 @@ The agent file follows the sibling-agent shape:
   response, no file write.
 - `## Trust boundary` — Read/Glob/Grep, the rationale from §2.3.
 - `## Construction protocol` — how the agent reads the scope and
-  drafts the two collections. Calls out:
+  drafts the two collections. Two explicit phases separated by a
+  prompt-segment boundary, per §3.4:
+
+  **Phase A — Construction** (one continuous reasoning context):
   - read the schema template first
+    (`diagnostic-legibility/templates/legibility-element.md`)
   - inspect the scope (Glob/Grep/Read)
-  - draft architectural elements (one per evident "moving part")
+  - draft architectural elements (one per evident "moving part") —
+    populate `name`, `description`, `evidence[]`, and a starting
+    `confidence` per the honesty rules
   - draft domain elements (one per evident concept term)
-  - apply the five-question challenge to each, populating
-    `challenge_notes[]`
+  - if the scope yields nothing, emit the `(empty scope)` sentinel
+    placeholder per §3.6 and skip to emission with the O2 sentinel
+    note pre-populated
+
+  **Phase B — Challenge segment** (explicit re-framing per §3.4):
+  - begin with the framing instruction: *"You are now the
+    challenger. Your job is to find what is wrong with the drafts
+    above, not to confirm them. Re-read the evidence on each
+    element with no prior commitment to the draft's conclusions.
+    Disagree where the evidence allows — silence is not the safe
+    answer."*
+  - for each draft element, apply the five questions (§3.5) with
+    **dimension-flavoured weighting** as an explicit per-element
+    step:
+    - **When challenging a domain element**, weight Q5
+      (description integrity) heavily and probe specifically for
+      textbook-definition drift — does this description say
+      something specific about *this* codebase, or could it be
+      lifted verbatim into another project?
+    - **When challenging an architectural element**, weight Q1
+      (boundary) heavily and probe specifically for smeared
+      services — is this one moving part, or two that share a
+      directory or a name prefix and got collapsed into one?
+    - The remaining three questions (Q2 evidence, Q3 confounders,
+      Q4 confidence) are asked of every element with equal
+      weight.
+  - where a question surfaces a change, revise the element and
+    append a `challenge_notes[]` entry prefixed `Q<N> (question
+    name):` per §3.5
+  - where all five surface nothing for an element, append the
+    sentinel `Challenge applied; no questions surfaced changes`
   - emit the full `LegibilityModel` YAML
+
 - `## The five-question challenge` — the questions from §3.5,
-  copy-pasted, with one paragraph per question explaining what it
-  is looking for.
+  copy-pasted verbatim, with one paragraph per question explaining
+  what it is meant to catch (the rationale from the new §3.5
+  rationale block). The dimension-flavoured weighting is repeated
+  here as a one-paragraph reminder; the full operational guidance
+  lives in the Construction protocol Phase B above.
 - `## Honesty rules` — `confidence: low` for unevidenced candidates,
   empty `evidence: []` permitted only when confidence is `low`,
-  prefer "I am not sure" over fabrication.
+  prefer "I am not sure" over fabrication. The `(empty scope)`
+  sentinel from §3.6 is documented here too as the honest answer
+  to "scope yielded nothing".
 - `## Anti-patterns` — list of failure modes the agent should
-  avoid: padding `challenge_notes[]` with no-op resolutions,
-  generic textbook descriptions, two architectural elements that
-  are really one, etc.
+  avoid:
+  - padding `challenge_notes[]` with no-op resolutions to look
+    diligent
+  - writing generic textbook descriptions (Q5 failure)
+  - two architectural elements that are really one (Q1 failure)
+  - omitting the `Q<N>` prefix on challenge notes
+  - leaving `challenge_notes[]` empty when the challenge ran
+    (must use the sentinel)
+  - skipping the Phase B re-framing and conflating construction
+    with challenge in one continuous flow
 
 ### 4.4 Length
 
@@ -299,8 +549,11 @@ And the response contains a LegibilityModel YAML block
 And the block has scope, generated_at, generated_by, architectural,
     and domain fields per the LegibilityModel schema
 And at least one of architectural or domain is non-empty
-And every element has populated challenge_notes (or an explicit
-    empty list when no question surfaced a change)
+And every element has a non-empty challenge_notes list — either
+    one or more "Q<N> (question name): ..." entries when a question
+    surfaced a change, or the single sentinel
+    "Challenge applied; no questions surfaced changes" when no
+    question surfaced a change
 ```
 
 ### 6.2 Story — challenge notes carry diagnostic context
@@ -322,19 +575,28 @@ And the note is grounded in the element's evidence, not a generic
 ### 6.3 Story — the agent refuses degenerate outputs
 
 **As** the dispatching command
-**I want** the agent to surface a low-confidence placeholder rather
+**I want** the agent to surface a sentinel placeholder rather
 than emit two empty lists
-**So that** I can distinguish "scope yielded nothing" from "agent
-failed silently".
+**So that** I can distinguish "scope yielded nothing" from
+"agent flagged an evidence-less candidate" from "agent failed
+silently".
 
 ```gherkin
 Given a scope that the agent cannot find architectural or domain
     elements in (e.g., an empty directory)
 When the agent runs
-Then the output contains at least one LegibilityElement
+Then the output contains exactly one LegibilityElement
+And that element's name is the literal string "(empty scope)"
 And that element has confidence: low
-And its description names the degenerate scope condition
+And that element has an empty evidence list
+And that element's description names the degenerate scope condition
+And that element's challenge_notes carries the sentinel
+    "Challenge applied; no questions surfaced changes"
 ```
+
+The literal `(empty scope)` name (parentheses included) is the
+pattern-match handle for downstream consumers. See §3.6 for the
+rationale and §3.5 for the challenge-notes sentinel.
 
 ### 6.4 Story — the plugin version reflects the new agent
 
@@ -410,8 +672,12 @@ The slice narrowing keeps the following out of scope:
   S4 / issue #333.
 - **An iterative challenge loop.** §3.2 explicitly defers this; the
   ship is single-pass retained-challenge.
-- **A second-pass challenger agent dispatch.** §3.4 explicitly
-  defers this; the ship is self-challenge in one context.
+- **A separate challenger agent file (two-agent dispatch).** §3.4
+  weighs this as alternative (2) and defers it; the ship is the
+  middle option — fresh-sub-context self-challenge within one
+  agent file. Escalation to a separate challenger remains
+  available if disposition data shows the middle option still
+  degenerates to self-confirmation.
 - **A runtime validator for `LegibilityElement` instances.** The
   schema spec (sub-S2a) explicitly deferred this; nothing changes
   here.
@@ -447,6 +713,27 @@ The slice narrowing keeps the following out of scope:
   this PR triggers it because the per-plugin version bumps.
   `sync-to-global-cache.sh` rsyncs the new agent into the
   versioned plugin cache.
+- **`plugin_version` at integration time:** the `plugin_version`
+  field in `.claude-plugin/marketplace.json` is a pointer to the
+  current `ai-literacy-superpowers` plugin release. It is **not
+  owned by this PR**. The header and §6.4 acceptance hard-code
+  `0.39.1` as the spec-time snapshot, but the operative rule at
+  merge-time is:
+
+  > If `main` has bumped `ai-literacy-superpowers`'s
+  > `plugin_version` between spec-time and merge-time, take
+  > `main`'s value verbatim during the integration-agent's rebase.
+  > This PR only owns the `diagnostic-legibility` entry's
+  > `plugins[]` version bump (0.2.0 → 0.3.0). Conflicts on
+  > `plugin_version` are resolved in favour of `main`.
+
+  The version-consistency CI check passes as long as the
+  `diagnostic-legibility` entry's `version` matches
+  `diagnostic-legibility/.claude-plugin/plugin.json`; the
+  `plugin_version` pointer is checked independently against the
+  `ai-literacy-superpowers` plugin and is not coupled to this
+  slice.
+
 - **CI gates:**
   - Spec-first is satisfied by this spec being the first commit
     on the branch.
@@ -463,12 +750,17 @@ The slice narrowing keeps the following out of scope:
 | Question | Decision |
 | --- | --- |
 | Challenge protocol shape | Retained-challenge single-pass (§3.1) |
-| Shared vs bespoke protocol across dimensions | Shared, parameterised (§3.3) |
-| Self-challenge in one context vs second-pass dispatch | Single-context self-challenge (§3.4) |
-| Number and form of challenge questions | Five questions: boundary, evidence, confounders, confidence, description integrity (§3.5) |
+| Shared vs bespoke protocol across dimensions | Shared, parameterised — design choice not inherited from schema (§3.3) |
+| Challenge step independence: one-context vs fresh-sub-context vs dispatch | Fresh-sub-context self-challenge — explicit re-framing within one agent file (§3.4) |
+| Number and form of challenge questions | Five questions (boundary, evidence, confounders, confidence, description integrity) — working hypothesis revisable from disposition data (§3.5) |
+| `challenge_notes[]` semantics for "challenged but clean" | Sentinel note `Challenge applied; no questions surfaced changes`; empty list means "not challenged" (§3.5) |
+| `challenge_notes[]` entry prefix format | Mandatory `Q<N> (question name):` prefix, sentinel exempt (§3.5) |
+| Dimension-flavoured emphasis operationalisation | Explicit per-element weighting step in Construction protocol Phase B (§4.3) — Q5 heavy for domain, Q1 heavy for architectural |
+| Degenerate "empty scope" output | Literal sentinel name `(empty scope)`, parens included, with O2 sentinel note (§3.6, §6.3) |
+| Invocation surface at v0.3.0 | Bare Task-tool dispatch (`subagent_type: diagnostic-legibility`); `/diagnose` command deferred to parent S4 / #333 (§2.4) |
 | Agent name | `diagnostic-legibility` (the only agent in the plugin at v0.3.0) |
 | Tool boundary | Read, Glob, Grep — matches the three sibling read-only emitters |
-| Per-version bump | diagnostic-legibility 0.2.0 → 0.3.0 (minor: new behaviour and new component); marketplace listing unchanged at 0.4.0; plugin_version pointer unchanged at 0.39.1 |
+| Per-version bump | diagnostic-legibility 0.2.0 → 0.3.0 (minor: new behaviour and new component); marketplace listing unchanged at 0.4.0; `plugin_version` pointer taken from `main` at integration time (§9) |
 
 ## 11. References
 

--- a/docs/superpowers/stories/dl-s2b-challenge-protocol-design.md
+++ b/docs/superpowers/stories/dl-s2b-challenge-protocol-design.md
@@ -1,0 +1,567 @@
+---
+spec: docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+date: 2026-05-28
+mode: spec
+cartographer_model: claude-opus-4-7[1m]
+stories:
+  - id: 1
+    lens: [forces, coherence]
+    title: Five-question cover as falsifiable hypothesis
+    disposition: accepted
+    disposition_rationale: "Working-hypothesis frame is the right stance for a v0.3.0 cover. The named falsification surface (challenge_notes[] corpus across real invocations) is what the next /diagnose iterations are responsible for inspecting. The quiet failure mode the story flags — nobody actually looking — is real but bounded: parent S3 cross-check is the first natural reader."
+  - id: 2
+    lens: [patterns, consequences]
+    title: Q<N> prefix as lightweight in-string schema
+    disposition: accepted
+    disposition_rationale: "Mandated convention with one documented exemption (the Story #3 sentinel). S3's tolerance level will shape future pressure on this convention — that's the right consumer to discover whether the prefix is genuinely load-bearing or decorative."
+  - id: 3
+    lens: [patterns, defaults]
+    title: Sentinel values disambiguate runtime intent
+    disposition: accepted
+    disposition_rationale: "The coherence observation (two sentinels = one idiom) is valuable; both literals are documented in the spec and the agent file. Promotion to a cross-plugin pattern is plausible but premature — the diagnostic-legibility plugin is the only place the idiom currently appears. Revisit if a second plugin reaches for the same shape."
+  - id: 4
+    lens: [alternatives, consequences]
+    title: Reasoning posture as architectural surface
+    disposition: accepted
+    disposition_rationale: "Three alternatives weighed, middle option chosen and operationalised as a prompt-segment boundary in §4.3 Phase B. The escalation path to two-agent dispatch is named with a falsifiable trigger (high sentinel-only rate, low note diversity). This is the cleanest architectural defence in the spec."
+  - id: 5
+    lens: [defaults, alternatives]
+    title: Shared construction is choice, not consequence
+    disposition: accepted
+    disposition_rationale: "Recording the choice is the value — recoverability is conditional on someone noticing it was a choice. The story itself is the noticing surface. If §3.3 is ever pruned in a future edit, this story remains as the project's memory that the conflation is wrong."
+  - id: 6
+    lens: [patterns, consequences]
+    title: Dimension weighting as protocol step, not guidance
+    disposition: accepted
+    disposition_rationale: "Mechanism-over-decoration is the right framing. The dimension-weighting sentences in §4.3 Phase B are now load-bearing prompt content and any future trim of the agent file must treat them as protected — that protection should propagate into the agent file's literate-programming preamble."
+  - id: 7
+    lens: [defaults, coherence]
+    title: Discipline scoping inherited from workflow boundary
+    disposition: revisit
+    disposition_rationale: "Genuinely silent choice; the diagnostic-legibility plugin and any future sister plugins inherit discipline-light defaults without explicit consent. Open a follow-up issue for a meta-spec titled 'cross-plugin discipline scoping' that decides whether TDAD-scenario-check, docs-reference-parity-check, and similar PR-gates should extend across all marketplace plugins or stay scoped to ai-literacy-superpowers. This slice's PR description must link the follow-up issue."
+  - id: 8
+    lens: [consequences, patterns]
+    title: plugin_version as cross-PR shared mutable state
+    disposition: promoted
+    disposition_rationale: "Genuine project-wide invariant — every PR touching marketplace.json inherits the same coordination problem. Belongs in CLAUDE.md or HARNESS.md, not restated per-spec. Promotion target: a Marketplace Versioning subsection in CLAUDE.md saying 'plugin_version is owned by ai-literacy-superpowers PRs; per-plugin entries are owned by their respective plugin PRs; conflicts resolve in favour of the field's owner.' The actual promotion mechanism is a follow-up; this disposition is the signal."
+  - id: 9
+    lens: [alternatives, consequences]
+    title: Bare Task-tool dispatch as v0.3.0 surface
+    disposition: accepted
+    disposition_rationale: "Slice-boundary discipline is the right load-bearing reason. The forward-link in the how-to is the hand-off contract; S4's PR (issue #333) is on the hook to update the how-to when /diagnose ships. The hand-off must be explicit in the S4 spec's file inventory."
+---
+
+## Story #1 — Five-question cover as falsifiable hypothesis
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.5)
+**Lens:** forces, coherence
+**Refs:** O1
+
+**Context.** The challenge-refine cycle is the agent's anti-hallucination
+value proposition. The spec commits to exactly five questions — boundary,
+evidence, confounders, confidence, description integrity — and threads
+them through the schema's `challenge_notes[]` field, the agent file's
+protocol, and the downstream S3 cross-check. The number five and the
+particular five are not derived; they are asserted with rationale and
+explicitly marked as a working hypothesis.
+
+**Forces.** Completeness of the challenge cover versus prompt economy:
+more questions catch more failure modes but bloat the agent's reasoning
+and produce noisier `challenge_notes[]`. Defending a primitive count
+versus admitting the count is a guess: a "settled five" calcifies on
+first ship; an "admitted hypothesis" invites revision but signals
+under-confidence. The spec resolves toward admitted hypothesis with a
+named falsification surface (the agent's own `challenge_notes` corpus
+across real invocations).
+
+**Options not taken.**
+- Three questions (boundary + evidence + confidence) — tighter cover,
+  loses confounders and textbook-definition drift; lower coverage of
+  the specific failure modes the spec names.
+- Eight or more — borrows from analogues (the diaboli skill's six
+  categories) but at the cost of agent-context bloat and per-element
+  cost.
+- A dimension-bespoke cover (different questions for architectural vs.
+  domain) — would have foreclosed the shared-protocol choice in §3.3.
+
+**Choice as written.** Five named questions, each with a paragraph
+explaining what failure mode it catches, plus an explicit "this is a
+working hypothesis" frame and a named falsification surface. The five
+are *boundary, ground, identity-by-contrast, calibration, specificity*
+in semantic terms.
+
+**Consequences.** The agent's `challenge_notes[]` corpus across real
+invocations becomes data. If a recurring failure mode does not map to
+any of the five, the cover is missing a question; if two questions
+consistently produce identical notes, there is redundancy. Both are
+schema-stable observations — adding or merging questions is an agent-
+file change, not a schema break. The cover is structurally revisable
+in a way that the schema itself is not.
+
+**Pattern.** Working hypothesis with named falsification surface
+(Popper). The closest software-engineering analogue is the
+"tracer bullet" idiom (Hunt/Thomas, *The Pragmatic Programmer*) — ship
+the smallest end-to-end thing, observe what it gets wrong, refine on
+evidence rather than speculation. The five questions are the tracer
+bullet for the challenge cover.
+
+**Notes.** The disposition rationale on O1 named this stance explicitly;
+this story records it as a choice the team is now responsible for. The
+falsification only happens if someone is actually looking at the corpus
+— a quiet failure mode worth naming.
+
+---
+
+## Story #2 — Q<N> prefix as lightweight in-string schema
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.5, §4.3)
+**Lens:** patterns, consequences
+**Refs:** O10, #1
+
+**Context.** Each entry in `challenge_notes[]` is a free-text string,
+per the schema. The spec mandates that every entry begin with
+`Q<N> (question name):` — e.g. `Q1 (boundary):`. The prefix is not
+required by the schema (challenge_notes is `list[str]` with no
+internal structure); it is required by *this slice's* protocol.
+
+**Forces.** Machine-readability for downstream consumers (the S3
+cross-check wants to group notes by question) versus author overhead
+(prose-like notes become slightly more rigid). Schema purity versus
+in-string conventions: the schema deliberately stayed unopinionated
+about note format, so the spec must impose discipline outside the
+schema.
+
+**Options not taken.**
+- Structured `challenge_notes` records (`{question: int, name: str,
+  note: str}`) — would have changed the schema; foreclosed by sub-S2a
+  shipping schema as `list[str]`.
+- A separate `challenged_by_question: {Q1: bool, Q2: bool, ...}` map
+  on each element — denormalised, redundant with note content.
+- No prefix convention — notes are free-text, downstream consumers
+  parse heuristically or by content matching.
+
+**Choice as written.** Mandatory `Q<N> (question name):` prefix in
+every entry, with one explicit exemption (the sentinel from Story #3).
+The S3 cross-check can group notes by parsing the prefix; no schema
+change.
+
+**Consequences.** The prefix is now part of the agent's output
+contract — an implementer who omits it produces correct-by-schema but
+incorrect-by-protocol output. The protocol layer becomes a second
+contract surface that needs verification (an acceptance scenario in
+§6.1 covers it). If the convention is later loosened, every existing
+`challenge_notes` corpus becomes a mixed-format dataset.
+
+**Pattern.** Lightweight in-string schema, also known as "tagged
+strings" in DDD literature; cousin to log-format conventions like
+`level=info component=foo message="..."`. The pattern accepts that the
+underlying type is a string but adds machine-parseable discipline. The
+risk is the well-known one: any string-based schema drifts without
+enforcement; the spec depends on the agent following its prompt.
+
+**Notes.** The S3 cross-check (parent issue #332) is the first
+real consumer of the prefix. If S3 is built to be tolerant of
+prefix-less notes, the convention pressure relaxes; if S3 hard-fails
+on missing prefix, the convention pressure tightens.
+
+---
+
+## Story #3 — Sentinel values disambiguate runtime intent
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.5, §3.6, §6.3)
+**Lens:** patterns, defaults
+**Refs:** O2, O7
+
+**Context.** Two sentinels are introduced in the same spec: the
+`challenge_notes[]` entry `Challenge applied; no questions surfaced
+changes` (signals "challenge ran, found nothing") and the element
+`name: "(empty scope)"` (signals "scope yielded no elements"). Both
+solve the same shape of problem — an observable state is ambiguous
+without a marker — and both solve it by reserving a literal string as
+a signal.
+
+**Forces.** Disambiguation pressure (downstream consumers cannot tell
+"didn't run" from "ran and clean", "no candidates" from "no evidence")
+versus schema purity (adding fields, booleans, or status enums would
+have been the heavier-weight resolution). Cheap (string literal) versus
+robust (typed field).
+
+**Options not taken.**
+- A boolean `challenged: bool` on each element — schema change; would
+  have been the typed-and-robust path.
+- A top-level `scope_yielded_results: bool` on the LegibilityModel —
+  schema change; cleaner data but heavier.
+- Leave the ambiguity — the downstream S3 cross-check would need
+  out-of-band knowledge to interpret empty lists or empty collections.
+
+**Choice as written.** Two reserved literal strings. The first is a
+sentinel note entry; the second is a sentinel element-name. Both are
+documented in the spec and the agent file. Both are exact-match: the
+note must be byte-for-byte `Challenge applied; no questions surfaced
+changes`, the name must be byte-for-byte `(empty scope)` including
+parentheses.
+
+**Consequences.** Two new agreed-upon literals in the contract surface
+that downstream code must know about. If either string is rephrased
+casually (e.g. "Challenge applied; no changes surfaced") the
+disambiguation breaks silently. The contract lives in three places —
+the spec, the agent file, and the downstream consumer — and must agree
+across them.
+
+**Pattern.** Sentinel value, sibling to the Null Object pattern
+(GoF) — a literal that stands in for an absent or distinguished state
+without adding a new type. Also closely related to the "magic string"
+anti-pattern; what saves it from being magic is that the strings are
+documented and have exactly-one meaning. The risk transfers from "did
+we forget to mark this?" to "did we type the literal correctly?".
+
+**Notes.** Both sentinels were extracted from objections in the same
+adjudication pass (O2 and O7). Treating them as one design choice
+("how do we disambiguate observable runtime states with the existing
+schema?") rather than two unrelated decisions is the coherence
+observation. A future contributor reading either sentinel in isolation
+may not see they belong to the same idiom.
+
+---
+
+## Story #4 — Reasoning posture as architectural surface
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.4, §4.3 Phase B)
+**Lens:** alternatives, consequences
+**Refs:** O3, O6
+
+**Context.** The challenge step is where the agent's anti-hallucination
+value lives. The spec names three architectures: (1) one-context
+self-challenge, (2) two-agent dispatch, (3) fresh-sub-context within
+one agent. It picks the middle option and operationalises it as an
+explicit prompt-segment boundary inside the agent file: after
+construction, the agent re-frames itself adversarially and re-reads
+the evidence as a challenger.
+
+**Forces.** Independence-of-perspective (the named failure mode
+self-confirmation in §3.4 alternative 1) versus agent-file surface
+cost (the named failure mode duplication in alternative 2). The middle
+option says: independence can be induced by *framing*, not only by
+*context separation*. The cost is a few extra paragraphs in the agent
+file; the gamble is that adversarial framing produces enough
+self-challenge signal to be worth shipping.
+
+**Options not taken.**
+- One-context self-challenge — simplest; named failure mode is
+  rubber-stamping. Spec acknowledges and rejects.
+- Two-agent dispatch — most independent; doubles file surface for a
+  v0.3.0 capability. Spec acknowledges and defers (escalation path
+  preserved).
+
+**Choice as written.** A single agent file with two reasoning postures
+induced by an explicit prompt-segment boundary. Phase A constructs;
+Phase B re-frames the agent as a challenger and instructs it to
+disagree where evidence allows. The boundary is the prompt itself.
+
+**Consequences.** The agent's reasoning protocol becomes the primary
+mechanism for independence-of-perspective. If the prompt's framing is
+weak (e.g. an implementer writes "now review your work" instead of
+"you are now the challenger; disagree where evidence allows"), the
+mechanism degrades to alternative (1) without any structural signal
+that it has done so. The escalation path to alternative (2) is named
+in §3.4 — if disposition data shows the middle option still produces
+rubber-stamped output (high sentinel-only rate, low note diversity),
+the team has a documented next step.
+
+**Pattern.** No widely-named pattern; closest analogue is
+"role-prompting" in the LLM-application literature — inducing different
+reasoning postures within one model context by changing the framing of
+the prompt segment. Also resembles the "wear two hats" practice in
+review traditions (an author reviews their own draft after a deliberate
+context break, e.g. sleeping on it). Both rely on framing rather than
+structural separation.
+
+**Notes.** Story #6 (dimension weighting as protocol step) is the
+sister mechanism — both choices treat prompt structure as
+architecturally load-bearing rather than incidental. Together they
+make the agent file's prompt a primary mechanism rather than a
+description.
+
+---
+
+## Story #5 — Shared construction is choice, not consequence
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.3)
+**Lens:** defaults, alternatives
+**Refs:** O9
+
+**Context.** The schema is shared across both dimensions (architectural
+and domain elements use the same `LegibilityElement` record type — sub-
+S2a settled this). The temptation is to treat shared construction
+(one prompt loop emits both collections) as a logical consequence of
+the shared schema. The spec resists that conflation: §3.3 argues
+explicitly that shared construction is a *choice*, defensible on its
+own merits, not an inheritance.
+
+**Forces.** Inheritance economy (one loop is half the complexity of
+two) versus dimension-specific care (architectural and domain elements
+fail in different ways, and bespoke loops could tune for each). The
+schema's silence on construction means the architectural choice is
+genuinely independent — neither path is foreclosed.
+
+**Options not taken.**
+- Bifurcated loops with shared schema — two construction sequences,
+  each tuned to its dimension's failure modes, both emitting into the
+  same record type. Not foreclosed by the schema.
+- Per-dimension agent files — full bifurcation, would have meant two
+  agent files in `diagnostic-legibility/agents/`. Foreclosed by §3.4's
+  one-file constraint and by the §3.3 reasoning.
+- Schema-driven inference (no explicit choice) — the failure case
+  this story is recording.
+
+**Choice as written.** One shared construction loop, with dimension-
+flavoured weighting (Story #6) as the per-element adaptation point.
+The spec defends this on three grounds: linear complexity scaling,
+dimension-aware behaviour delivered by weighting rather than
+bifurcation, and recoverability if disposition data justifies a split.
+
+**Consequences.** Future contributors reading the agent file see one
+construction loop; their default assumption will be "shared because
+schema". The spec's explicit framing is the only artefact that
+prevents that assumption from becoming the explanation. If §3.3 is
+forgotten or pruned in a future edit, the choice silently
+re-conflates with the schema.
+
+**Pattern.** Default-as-decision (also "implicit defaults made
+explicit" — see Hunt/Thomas, Pragmatic Programmer, on the dangers of
+inherited defaults). The pattern is recordkeeping: name the choice so
+the future reader knows it was a choice. The story's job is the same
+recordkeeping at a layer above the spec.
+
+**Notes.** O9 was adjudicated as "low severity, recoverable" — the
+choice is genuinely cheap to reverse. The point of recording it is
+recoverability is conditional on someone noticing it was a choice;
+this story is the noticing surface.
+
+---
+
+## Story #6 — Dimension weighting as protocol step, not guidance
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§3.5, §4.3 Phase B)
+**Lens:** patterns, consequences
+**Refs:** O4, #4, #5
+
+**Context.** The spec asserts dimension-flavoured emphasis on the
+challenge questions: domain elements pressure-test Q5 (description
+integrity) heavily, architectural elements pressure-test Q1
+(boundary) heavily. The flavouring could have been left as decorative
+guidance ("apply the questions with awareness of dimension") or
+operationalised as an explicit per-element step in the agent's
+construction protocol. The spec chose the latter.
+
+**Forces.** Mechanism (the flavouring actually shapes the agent's
+behaviour) versus decoration (the flavouring is named but the agent
+implements without it, and the spec's claim is unverified). Agent-
+prompt economy (each per-element step costs prompt tokens and reader
+attention) versus correctness-by-construction (a documented step is
+testable).
+
+**Options not taken.**
+- Decorative-only — name the flavouring in §3.5 and trust the
+  implementer to apply it. The failure mode O4 raised explicitly: an
+  agent file that ignores the flavouring passes the spec's acceptance
+  scenarios.
+- Two construction loops with bespoke prompts — foreclosed by Story
+  #5's shared-construction choice.
+- Per-dimension question lists — also foreclosed by §3.5's shared
+  five-question structure.
+
+**Choice as written.** The construction protocol's Phase B (§4.3)
+includes an explicit "when challenging a domain element, weight Q5
+heavily" / "when challenging an architectural element, weight Q1
+heavily" step. The agent's prompt operationalises the flavouring as a
+discrete behaviour, not as ambient awareness.
+
+**Consequences.** The agent file becomes architecturally load-bearing
+in a specific way: deleting or weakening the dimension-weighting
+sentence in §4.3 silently weakens the agent's output. A future
+refactor of the agent file (e.g. trimming for prompt brevity) must
+treat that sentence as protected. The escalation path is also
+preserved — if dimension-weighting via prompt proves too weak, the
+next move is bifurcated construction (Story #5's deferred alternative).
+
+**Pattern.** Mechanism over decoration; closely related to
+"executable specification" (the spec section *is* the implementation
+contract for the prompt). The agent file is treated as code that
+encodes design decisions, not as documentation that describes them.
+
+**Notes.** Pairs with Story #4 (reasoning posture as architectural
+surface) — both choices treat the agent's prompt structure as a
+first-class mechanism rather than as incidental phrasing.
+
+---
+
+## Story #7 — Discipline scoping inherited from workflow boundary
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§8 Out of scope)
+**Lens:** defaults, coherence
+**Refs:** —
+
+**Context.** The plugin's two PR-time gates for new component files —
+TDAD-scenario-check and docs-reference-parity-check — are scoped by
+path regex to `ai-literacy-superpowers/skills/`, `/agents/`, and
+`/commands/`. The diagnostic-legibility plugin's `agents/` directory
+is outside that scope. This slice ships a new agent file with no TDAD
+scenario and no reference-page entry, and CI passes because the
+gates do not apply.
+
+**Forces.** Cross-plugin discipline consistency (the same rigor
+applied to one plugin should arguably apply to all) versus
+incrementalism (each plugin earns its discipline by experience, not
+by symmetry). The choice to scope the workflows narrowly was made in
+the workflows themselves, before diagnostic-legibility existed; this
+slice silently inherits the absence.
+
+**Options not taken.**
+- Broaden the workflows to all plugins now — out of slice scope; a
+  meta-decision belonging to a separate spec (§8 notes this).
+- Author TDAD scenarios voluntarily — possible, but creates
+  expectation drift (other plugins also have agents and would inherit
+  the implicit expectation).
+- Add a reference-page entry voluntarily — same drift risk; also the
+  diagnostic-legibility plugin has no reference quadrant yet, so the
+  entry would require scaffolding.
+
+**Choice as written.** Ship the new agent file with no TDAD scenario
+and no reference-page entry. §8 names this as inherited from workflow
+scoping, not as a per-slice choice. The §8 entries explicitly defer
+the meta-question ("should the discipline extend across plugins?") to
+a future spec.
+
+**Consequences.** The diagnostic-legibility plugin accumulates agent
+files that no PR-time gate verifies. The first new constraint of the
+plugin (e.g. its own TDAD discipline) will have to retroactively cover
+the existing agent file or admit a gap. The cost of catching this
+later grows with each agent file shipped without scenarios.
+
+**Pattern.** Inherited default — the discipline boundary was set by
+workflow design (one plugin in scope), not by spec design. The story
+records that the boundary is a choice the project has now propagated
+across two plugins; future plugin additions will inherit it again
+unless the boundary is reconsidered explicitly.
+
+**Notes.** This is the strongest "silent choice" candidate in the
+spec — the slice ships discipline-light components and the
+explanation lives in workflow files rather than in spec text. A
+reasonable disposition is "revisit" with a forward-looking
+disposition_rationale naming the meta-spec that would address it.
+
+---
+
+## Story #8 — plugin_version as cross-PR shared mutable state
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§9)
+**Lens:** consequences, patterns
+**Refs:** O8
+
+**Context.** `.claude-plugin/marketplace.json` carries a top-level
+`plugin_version` field that points to the current `ai-literacy-
+superpowers` plugin release. This slice does not change that field
+(it only bumps the `diagnostic-legibility` entry in `plugins[]`), but
+it must touch the same file, and main may have moved between spec-
+time and merge-time. §9 articulates the merge-time rule: take main's
+`plugin_version` verbatim on conflict.
+
+**Forces.** Spec correctness at authoring time (the spec asserts
+`plugin_version: 0.39.1` as the spec-time snapshot) versus operational
+correctness at merge time (whichever value main carries when the PR
+lands is the one that matters). The two correctness criteria can
+disagree silently if main moves.
+
+**Options not taken.**
+- Atomic per-PR ownership of `marketplace.json` (one PR at a time
+  edits it) — would have foreclosed parallel work on different
+  plugins.
+- Splitting `marketplace.json` into per-plugin files — would address
+  the shared-mutable-state problem at the cost of restructuring the
+  marketplace contract with Claude Code.
+- Leaving the conflict-resolution rule implicit — the previous
+  approach, surfaced by O8 as a latent footgun.
+
+**Choice as written.** A documented merge-time rule in §9: this PR
+owns the `diagnostic-legibility` entry's version bump only; conflicts
+on `plugin_version` are resolved in favour of main. The
+integration-agent's rebase is the point of enforcement; the human
+reviewing the rebase is the second line of defence.
+
+**Consequences.** Every future PR touching `marketplace.json` inherits
+the same shared-mutable-state coordination problem. The §9 rule is a
+per-spec restatement of a project-wide invariant; that invariant
+properly lives in HARNESS.md or in a project convention file, not in
+each spec. The pattern of restating it per-spec is a workaround until
+the invariant is promoted.
+
+**Pattern.** Shared mutable state with conflict-resolution policy;
+sibling to git-merge conventions for files with concurrent writers
+(e.g. `CHANGELOG.md`'s "append under most-recent version" convention
+in this codebase). The pattern recognises that some files are
+unavoidably shared across PRs and the question becomes "what is the
+merge rule?" rather than "how do we prevent the shared edit?".
+
+**Notes.** A reasonable promotion target: a HARNESS.md constraint
+("marketplace.json `plugin_version` is owned by ai-literacy-superpowers
+PRs; per-plugin entries are owned by their respective plugin PRs;
+conflicts resolve in favour of the field's owner"). If
+disposition is `promoted`, this is the rationale.
+
+---
+
+## Story #9 — Bare Task-tool dispatch as v0.3.0 surface
+
+**Source:** `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` (§2.4, §6.5)
+**Lens:** alternatives, consequences
+**Refs:** O5
+
+**Context.** The agent has no wrapping slash-command at v0.3.0. The
+spec documents bare Task-tool dispatch as the invocation surface
+(`subagent_type: diagnostic-legibility`, prompt names the scope). The
+how-to page in the same slice documents this pattern, with a forward
+link to parent S4 (issue #333) which will deliver `/diagnose`. The
+diagnostic-legibility plugin therefore ships an agent that humans
+must invoke through a lower-level surface than the model-card plugin's
+`/model-card` command exposes.
+
+**Forces.** Carpaccio's slice-boundary discipline (S2 ships the agent,
+S4 ships the command) versus user ergonomics at v0.3.0 (every
+invocation requires Task-tool literacy). The slice boundary is the
+load-bearing reason; without it, the temptation to bundle command and
+agent into one slice would erode the parent's carpaccio decomposition.
+
+**Options not taken.**
+- Ship a thin `/diagnose` command in this slice that wraps the agent
+  without doing more — would have been low-cost but conflated S2
+  with S4.
+- Ship the agent without a how-to page — would have removed the
+  surfacing problem at the cost of leaving the v0.3.0 release
+  undocumented for users.
+- Defer the agent file to S4 — would have collapsed S2 entirely.
+
+**Choice as written.** Agent in S2, command in S4. The how-to page
+documents bare Task-tool dispatch and forward-links to S4. The
+v0.3.0 plugin is dispatchable but not commanded.
+
+**Consequences.** Two readable surfaces (how-to page, agent file)
+documenting an invocation pattern that the project's typical user
+will not use directly once `/diagnose` exists. The how-to page will
+need to be updated when S4 lands, replacing the Task-tool example
+with the `/diagnose` example. The forward-link in the how-to is the
+hand-off contract — if S4 lands without updating the how-to, the
+plugin documentation goes stale.
+
+**Pattern.** Slice-boundary discipline (Henrik Kniberg's elephant
+carpaccio applied to design slices), trading short-term ergonomics
+for long-term decomposition integrity. The cost is paid up-front in
+documentation churn; the benefit is that each slice's deliverable is
+genuinely scoped.
+
+**Notes.** O5's adjudicated rationale named the forward-link
+explicitly. The disposition here is whether the project is comfortable
+shipping a v0.3.0 with a how-to that the user-facing surface will
+supersede; the alternative is the deferred ergonomics. A reasonable
+disposition is `accepted` with a note that S4's PR must update the
+how-to.

--- a/tdad_tests/tests/test_diagnostic_legibility_structural.py
+++ b/tdad_tests/tests/test_diagnostic_legibility_structural.py
@@ -1,0 +1,523 @@
+"""Layer 1 structural tests for the diagnostic-legibility plugin at v0.3.0.
+
+Sub-S2b ships the working `diagnostic-legibility` agent, the version
+bump from 0.2.0 to 0.3.0, the CHANGELOG entry, and two docs-site pages
+(how-to and explanation). These are deterministic, file-shape assertions
+— the agent's behavioural contract (challenge_notes shape, Q<N> prefix,
+sentinels) is covered by the spec at
+`docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md`
+as acceptance documentation rather than executable tests.
+
+The TDAD scenario discipline does not extend to the diagnostic-legibility
+plugin (the TDAD-scenario-check workflow is scoped to the
+`ai-literacy-superpowers/` plugin only). Story #7 / issue #338 documents
+the intentional gap. This file is the deterministic structural layer that
+guards the v0.3.0 deliverables; it mirrors the precedent set by
+`test_model_cards_structural.py` for the sibling plugin.
+
+Spec reference:
+    docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+# Resolve the diagnostic-legibility plugin directory once. Mirrors the
+# `model_cards_path` fixture pattern in conftest.py but kept local to
+# this test module because no other test file in the suite targets the
+# diagnostic-legibility plugin at v0.3.0.
+@pytest.fixture(scope="module")
+def diagnostic_legibility_path() -> Path:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    packaged = repo_root / "diagnostic-legibility"
+    if not packaged.is_dir():
+        pytest.fail(
+            f"diagnostic-legibility plugin directory not found at "
+            f"{packaged!r}. Has it been moved or renamed?"
+        )
+    return packaged
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestDiagnosticLegibilityVersioning:
+    """The plugin version bump from 0.2.0 to 0.3.0 must land in lockstep
+    across plugin.json, marketplace.json's per-plugin entry, and the
+    CHANGELOG heading.
+
+    The marketplace listing's top-level `version` (0.4.0) and its
+    `plugin_version` pointer (0.39.1 at spec time) are explicitly
+    unchanged by this slice — the spec §9 names this and the
+    integration-agent is responsible for taking `plugin_version` from
+    main verbatim at rebase time.
+    """
+
+    def test_plugin_json_at_0_3_0(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        manifest_path = (
+            diagnostic_legibility_path
+            / ".claude-plugin"
+            / "plugin.json"
+        )
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["version"] == "0.3.0", (
+            "diagnostic-legibility/.claude-plugin/plugin.json must "
+            "carry version '0.3.0' (was '0.2.0' at sub-S2a). "
+            f"Actual: {manifest['version']!r}"
+        )
+
+    def test_marketplace_entry_at_0_3_0(self, repo_root: Path) -> None:
+        marketplace_path = (
+            repo_root / ".claude-plugin" / "marketplace.json"
+        )
+        marketplace = json.loads(marketplace_path.read_text())
+        entry = next(
+            (
+                p
+                for p in marketplace["plugins"]
+                if p["name"] == "diagnostic-legibility"
+            ),
+            None,
+        )
+        assert entry is not None, (
+            "No diagnostic-legibility entry in marketplace.json plugins[]"
+        )
+        assert entry["version"] == "0.3.0", (
+            "marketplace.json diagnostic-legibility entry must be at "
+            f"'0.3.0'. Actual: {entry['version']!r}"
+        )
+
+    def test_marketplace_top_level_version_unchanged(
+        self, repo_root: Path
+    ) -> None:
+        marketplace_path = (
+            repo_root / ".claude-plugin" / "marketplace.json"
+        )
+        marketplace = json.loads(marketplace_path.read_text())
+        assert marketplace["version"] == "0.4.0", (
+            "marketplace.json top-level `version` must remain at '0.4.0' "
+            f"per spec §9. Actual: {marketplace['version']!r}"
+        )
+
+    def test_marketplace_plugin_version_matches_canonical(
+        self, repo_root: Path
+    ) -> None:
+        """Per spec §9 (code-mode O3), `plugin_version` is owned by
+        ai-literacy-superpowers PRs. This test asserts the field tracks
+        the canonical plugin.json rather than a hard-coded literal — so
+        if main bumps ai-literacy-superpowers between spec-time and
+        merge-time, the integration-agent's rebase resolves the conflict
+        in main's favour and this test still passes. A redundancy check
+        on top of the version-consistency CI workflow.
+        """
+        marketplace_path = (
+            repo_root / ".claude-plugin" / "marketplace.json"
+        )
+        canonical_path = (
+            repo_root
+            / "ai-literacy-superpowers"
+            / ".claude-plugin"
+            / "plugin.json"
+        )
+        marketplace = json.loads(marketplace_path.read_text())
+        canonical = json.loads(canonical_path.read_text())
+        assert marketplace["plugin_version"] == canonical["version"], (
+            "marketplace.json `plugin_version` must equal the canonical "
+            "ai-literacy-superpowers/.claude-plugin/plugin.json `version`. "
+            f"marketplace.json: {marketplace['plugin_version']!r}; "
+            f"canonical: {canonical['version']!r}. If these disagree, "
+            "this PR has either drifted from main or bumped a value it "
+            "does not own (per spec §9)."
+        )
+
+    def test_changelog_has_0_3_0_heading(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        changelog = (
+            diagnostic_legibility_path / "CHANGELOG.md"
+        ).read_text()
+        assert "## 0.3.0 — 2026-05-28" in changelog, (
+            "CHANGELOG.md must contain a `## 0.3.0 — 2026-05-28` heading. "
+            "Note: the dash is the em-dash (U+2014), matching the format "
+            "enforced by the version-consistency CI check."
+        )
+
+    def test_changelog_references_followup_issues(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """Stories #338 (revisit follow-up — TDAD scope) and #339
+        (promotion follow-up — observability) must be named in the
+        CHANGELOG so the audit trail surfaces them when someone reads
+        the release notes."""
+        changelog = (
+            diagnostic_legibility_path / "CHANGELOG.md"
+        ).read_text()
+        assert "#338" in changelog, (
+            "CHANGELOG entry must reference #338 (revisit follow-up "
+            "from the choice-cartographer record)."
+        )
+        assert "#339" in changelog, (
+            "CHANGELOG entry must reference #339 (promotion follow-up "
+            "from the choice-cartographer record)."
+        )
+
+
+# ---------------------------------------------------------------------
+# Agent file
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestDiagnosticLegibilityAgent:
+    """The agent file replaces the .gitkeep placeholder from v0.1.0 and
+    must carry the expected frontmatter. The body's full behavioural
+    contract is covered by the spec; this test only guards file-shape
+    and tool-boundary invariants that downstream consumers depend on.
+    """
+
+    def test_gitkeep_removed(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        gitkeep = diagnostic_legibility_path / "agents" / ".gitkeep"
+        assert not gitkeep.exists(), (
+            "diagnostic-legibility/agents/.gitkeep must be removed once "
+            "the agent file lands. The placeholder is no longer needed "
+            "and its presence signals an incomplete migration."
+        )
+
+    def test_agent_file_present(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        agent_file = (
+            diagnostic_legibility_path
+            / "agents"
+            / "diagnostic-legibility.agent.md"
+        )
+        assert agent_file.is_file(), (
+            "Expected agent file at "
+            f"{agent_file.relative_to(diagnostic_legibility_path.parent)}"
+        )
+
+    def test_agent_frontmatter_name(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        component = plugin_runner.find_component(
+            diagnostic_legibility_path,
+            name="diagnostic-legibility",
+            component_type="agent",
+        )
+        assert component.parse_error is None, (
+            "Agent frontmatter must parse as strict YAML. "
+            f"Parse error: {component.parse_error!r}"
+        )
+        assert component.frontmatter.get("name") == "diagnostic-legibility"
+
+    def test_agent_tool_boundary(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """The agent is a read-only emitter, matching the three sibling
+        emitters (advocatus-diaboli, choice-cartographer,
+        model-card-researcher). Tools must include Read, Glob, Grep —
+        and must NOT include Write, Edit, or Bash."""
+        component = plugin_runner.find_component(
+            diagnostic_legibility_path,
+            name="diagnostic-legibility",
+            component_type="agent",
+        )
+        tools_raw = component.frontmatter.get("tools", "")
+        # The tools field is conventionally a comma-separated string;
+        # split and normalise.
+        if isinstance(tools_raw, list):
+            tools = {t.strip() for t in tools_raw}
+        else:
+            tools = {t.strip() for t in str(tools_raw).split(",")}
+
+        for required in ("Read", "Glob", "Grep"):
+            assert required in tools, (
+                f"Agent tools must include {required!r}. "
+                f"Actual tools: {sorted(tools)!r}"
+            )
+        for forbidden in ("Write", "Edit", "Bash"):
+            assert forbidden not in tools, (
+                f"Agent tools must NOT include {forbidden!r} — the agent "
+                "is a read-only emitter per spec §2.3. "
+                f"Actual tools: {sorted(tools)!r}"
+            )
+
+    def test_agent_description_mentions_legibility_model(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """The description field is what the Claude Code skill matcher
+        reads to decide when to fire the agent. It must name the
+        artefact the agent emits (a LegibilityModel) so the matcher
+        can route invocations to it.
+
+        Per code-mode O5: also asserts the description surfaces the
+        two machine-parseable contract terms (Q<N> prefix and the
+        (empty scope) sentinel) so downstream consumers reading only
+        the description know what to grep for.
+        """
+        component = plugin_runner.find_component(
+            diagnostic_legibility_path,
+            name="diagnostic-legibility",
+            component_type="agent",
+        )
+        description = component.frontmatter.get("description") or ""
+        assert "LegibilityModel" in description, (
+            "Agent description must mention 'LegibilityModel' so the "
+            "skill matcher can route invocations to it. "
+            f"Actual description: {description!r}"
+        )
+        assert "Q<N>" in description, (
+            "Agent description must name the `Q<N>` prefix convention so "
+            "consumers reading only the description know the agent's "
+            "challenge_notes follow a machine-parseable format. "
+            f"Actual description: {description!r}"
+        )
+        assert "(empty scope)" in description, (
+            "Agent description must name the `(empty scope)` sentinel so "
+            "consumers know the literal pattern-match handle for the "
+            "degenerate case. "
+            f"Actual description: {description!r}"
+        )
+
+    def test_agent_body_references_schema_template(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """The agent's prompt must reference the schema template path so
+        readers (and the agent itself, via its system prompt) can locate
+        the contract its outputs must follow."""
+        agent_file = (
+            diagnostic_legibility_path
+            / "agents"
+            / "diagnostic-legibility.agent.md"
+        )
+        body = agent_file.read_text()
+        expected_path = "templates/legibility-element.md"
+        assert expected_path in body, (
+            f"Agent body must reference the schema template path "
+            f"{expected_path!r} so the contract is locatable from the "
+            "agent file itself."
+        )
+
+
+# ---------------------------------------------------------------------
+# Load-bearing string contracts (code-mode O1, O4)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestDiagnosticLegibilityStringContracts:
+    """The agent's downstream consumers (parent S3 cross-check, future
+    /diagnose command) pattern-match on exact literal strings emitted by
+    the agent. Drift in those literals — a typo, a punctuation change, a
+    well-meaning paraphrase — would ship through every other CI gate
+    silently. These tests guard the literals at the place they are
+    defined: the agent file itself.
+
+    The behavioural-runtime contract (the agent actually emitting these
+    strings on each invocation) is covered by the spec as acceptance
+    documentation — this layer guards the static text only.
+    """
+
+    def test_agent_body_contains_empty_scope_sentinel(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """Per spec §3.6 and code-mode O4: the literal `(empty scope)`
+        is the downstream pattern-match handle for the degenerate-output
+        case. The agent file must carry it verbatim, parentheses
+        included."""
+        agent_file = (
+            diagnostic_legibility_path
+            / "agents"
+            / "diagnostic-legibility.agent.md"
+        )
+        body = agent_file.read_text()
+        sentinel = "(empty scope)"
+        assert sentinel in body, (
+            f"Agent body must contain the literal sentinel {sentinel!r} "
+            "verbatim (parentheses included) — this is the pattern-match "
+            "handle downstream consumers (S3 cross-check #332, /diagnose "
+            "command #333) rely on for the degenerate-output case."
+        )
+
+    def test_agent_body_contains_challenge_applied_sentinel(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """Per spec §3.5 and code-mode O4: the literal `Challenge applied;
+        no questions surfaced changes` is the sentinel that disambiguates
+        'challenge ran cleanly' from 'challenge never ran' (empty
+        challenge_notes[]). The agent file must carry it verbatim."""
+        agent_file = (
+            diagnostic_legibility_path
+            / "agents"
+            / "diagnostic-legibility.agent.md"
+        )
+        body = agent_file.read_text()
+        sentinel = "Challenge applied; no questions surfaced changes"
+        assert sentinel in body, (
+            f"Agent body must contain the literal sentinel {sentinel!r} "
+            "verbatim. A reflexive edit (e.g. 'no question surfaced' "
+            "singular, or any punctuation change) invalidates the "
+            "downstream cross-check (#332) silently."
+        )
+
+    def test_agent_body_uses_canonical_q_prefix_form(
+        self, diagnostic_legibility_path: Path
+    ) -> None:
+        """Per code-mode O1: the `Q<N> (lowercase-question-name):`
+        prefix is the canonical form for challenge_notes entries.
+        Asserts the five canonical prefixes appear in the agent body
+        and the deprecated no-parens forms (`Q2 evidence`,
+        `Q3 confounders`, `Q4 confidence`) do not."""
+        agent_file = (
+            diagnostic_legibility_path
+            / "agents"
+            / "diagnostic-legibility.agent.md"
+        )
+        body = agent_file.read_text()
+        canonical_prefixes = (
+            "Q1 (boundary):",
+            "Q2 (evidence):",
+            "Q3 (confounders):",
+            "Q4 (confidence):",
+            "Q5 (description integrity):",
+        )
+        # The agent body should name the canonical form somewhere — at
+        # minimum the example, the protocol section, or the format-spec
+        # callout. We assert each canonical prefix appears at least once.
+        for prefix in canonical_prefixes:
+            assert prefix in body, (
+                f"Agent body must reference the canonical prefix form "
+                f"{prefix!r} (lowercase question-name, parentheses, colon) "
+                "so the agent's prompt teaches one consistent form."
+            )
+        # The deprecated no-parens forms (the original O1 evidence) must
+        # be absent — if they appear, the agent's prompt teaches an
+        # inconsistent form.
+        deprecated_forms = (
+            "Q2 evidence",
+            "Q3 confounders",
+            "Q4 confidence",
+        )
+        for deprecated in deprecated_forms:
+            assert deprecated not in body, (
+                f"Agent body must NOT contain the deprecated form "
+                f"{deprecated!r} (no parens). Use the canonical "
+                f"{deprecated.split()[0]} (lowercase-name): form instead."
+            )
+
+
+# ---------------------------------------------------------------------
+# Docs pages
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestDiagnosticLegibilityDocs:
+    """The docs site gains two content pages and their quadrant
+    landing pages (per the docs convention — quadrant folders are
+    scaffolded only when they have at least one page).
+
+    Per the docs convention in CLAUDE.md, pages live at
+    `docs/plugins/diagnostic-legibility/<quadrant>/<slug>.md`.
+    """
+
+    def test_how_to_page_present(self, repo_root: Path) -> None:
+        page = (
+            repo_root
+            / "docs"
+            / "plugins"
+            / "diagnostic-legibility"
+            / "how-to"
+            / "invoke-the-agent.md"
+        )
+        assert page.is_file(), (
+            f"Expected how-to page at {page.relative_to(repo_root)!s}"
+        )
+
+    def test_how_to_quadrant_index_present(self, repo_root: Path) -> None:
+        page = (
+            repo_root
+            / "docs"
+            / "plugins"
+            / "diagnostic-legibility"
+            / "how-to"
+            / "index.md"
+        )
+        assert page.is_file(), (
+            "Each Diataxis quadrant folder needs its own index.md so "
+            "mkdocs-awesome-pages renders the section as a navigable "
+            f"group. Missing: {page.relative_to(repo_root)!s}"
+        )
+
+    def test_explanation_page_present(self, repo_root: Path) -> None:
+        page = (
+            repo_root
+            / "docs"
+            / "plugins"
+            / "diagnostic-legibility"
+            / "explanation"
+            / "challenge-refine-protocol.md"
+        )
+        assert page.is_file(), (
+            f"Expected explanation page at {page.relative_to(repo_root)!s}"
+        )
+
+    def test_explanation_quadrant_index_present(
+        self, repo_root: Path
+    ) -> None:
+        page = (
+            repo_root
+            / "docs"
+            / "plugins"
+            / "diagnostic-legibility"
+            / "explanation"
+            / "index.md"
+        )
+        assert page.is_file(), (
+            "Each Diataxis quadrant folder needs its own index.md so "
+            "mkdocs-awesome-pages renders the section as a navigable "
+            f"group. Missing: {page.relative_to(repo_root)!s}"
+        )
+
+    def test_how_to_links_forward_to_issue_333(
+        self, repo_root: Path
+    ) -> None:
+        """The how-to page documents the bare-Task-tool invocation
+        pattern as the v0.3.0 surface and links forward to issue #333
+        (parent S4 — the `/diagnose` command) so a reader who hits the
+        ergonomics gap can find the work that closes it."""
+        page = (
+            repo_root
+            / "docs"
+            / "plugins"
+            / "diagnostic-legibility"
+            / "how-to"
+            / "invoke-the-agent.md"
+        )
+        body = page.read_text()
+        assert "#333" in body, (
+            "How-to page must reference issue #333 — the forward link "
+            "to parent S4 (the `/diagnose` command surface)."
+        )


### PR DESCRIPTION
## Summary

Ships the working `diagnostic-legibility` agent at v0.3.0. The agent accepts a codebase scope, drafts an architectural model and a domain model against the `LegibilityElement` schema (from v0.2.0), and runs a retained-challenge single-pass cycle — five questions per element in an explicit fresh-sub-context Phase B — emitting a `LegibilityModel` YAML block with `challenge_notes[]` on every element.

The agent does not cross-check the two models against each other (that's parent S3, [#332](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/332)) and there is no `/diagnose` slash-command yet (parent S4, [#333](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/333)). v0.3.0 invocation is bare-Task-tool — see the [how-to](docs/plugins/diagnostic-legibility/how-to/invoke-the-agent.md).

Closes #335. Parent issue #331 auto-closes per its own comment when this PR merges.

## Decision discipline

| Stage | Artefact | Outcome |
|---|---|---|
| Spec | `docs/superpowers/specs/2026-05-28-dl-s2b-challenge-protocol-design.md` | First commit on branch |
| Spec-mode diaboli | `docs/superpowers/objections/dl-s2b-challenge-protocol-design.md` | 10 objections, all accepted, absorbed into spec |
| Cartographer | `docs/superpowers/stories/dl-s2b-challenge-protocol-design.md` | 9 stories: 7 accepted, 1 revisit (#338), 1 promoted (#339) |
| Code-mode diaboli | `docs/superpowers/objections/dl-s2b-challenge-protocol-design-code.md` | 9 objections, 7 accepted/fixed in this PR, 2 deferred |

## Follow-up issues

- **#338** — Meta-spec: cross-plugin discipline scoping. The TDAD-scenario-check and docs-reference-parity-check workflows are scoped only to `ai-literacy-superpowers/` paths — sister plugins (including this one) ship without scenario or reference-parity coverage. Story #7 marks this as a `revisit`; a future meta-spec decides whether to broaden.
- **#339** — Promote: marketplace.json `plugin_version` cross-PR coordination rule. The per-spec restatement of the merge-time rule (this PR's §9) should be promoted to `CLAUDE.md` so it governs future PRs without ceremony. Story #8 marks this as `promoted`.

## Test plan

- [x] 37/37 structural tests pass locally (Layer-0, Layer-1, and the new 20-test `test_diagnostic_legibility_structural.py` suite)
- [x] Sentinel-string drift guards: literal `(empty scope)` and `Challenge applied; no questions surfaced changes` asserted in the agent body
- [x] Canonical `Q<N> (lowercase-name):` prefix asserted; deprecated no-parens forms blocked
- [x] `marketplace.plugin_version` test now tracks the canonical `ai-literacy-superpowers/.claude-plugin/plugin.json#version` per spec §9 (not a hard-coded literal)
- [ ] CI: spec-first-check (spec is the first commit on the branch)
- [ ] CI: version-consistency (plugin.json 0.3.0 ⟷ marketplace plugins[] entry 0.3.0)
- [ ] CI: markdownlint
- [ ] CI: docs-build
- [ ] CI: tdad-tests-fast
- [ ] CI: harness-constraints

## Versioning

`diagnostic-legibility` plugin: **0.2.0 → 0.3.0** (minor — new agent, new behaviour).

`ai-literacy-superpowers` plugin: **unchanged** at 0.39.1.

Top-level marketplace listing: **unchanged** at `version: 0.4.0`, `plugin_version: 0.39.1`. Per spec §9, if main has bumped `ai-literacy-superpowers` between spec-time and merge-time, the integration-agent's rebase resolves the `plugin_version` conflict in main's favour — the test now tracks main rather than hard-coding the spec-time snapshot.