### PR TITLE
chore: bump HARNESS.md template-version marker to 0.39.1

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.38.0 -->
+<!-- template-version: 0.39.1 -->
 
 ## Context
 


### PR DESCRIPTION
## Summary

Bumps the HARNESS.md template-version marker from 0.38.0 → 0.39.1.

No new template content to absorb. `/harness-upgrade` scan against the synced marketplace cache:

| Bucket | Count |
|---|---|
| New constraints | 0 |
| New GC rules | 0 |
| New sections | 0 |
| Updated items | 0 |
| Removed items | 0 |

All 7 template constraints and all 21 template GC rules are already present in this project's HARNESS.md. The 18 additional active constraints and 4 additional GC rules are project-specific accretions (spec-discipline, TDAD, docs-reference parity, reflection-via-PR, plus per-plugin marketplace tooling).

The marker bump just acknowledges the plugin-version cadence (0.38.0 → 0.39.0 → 0.39.1 since the last marker update at PR #317) so the SessionStart template-currency check stops nudging.

## Test plan

- [ ] CI: markdownlint
- [ ] CI: spec-first-check (chore exemption)
- [ ] CI: version-consistency (no plugin code changes)
- [ ] CI: harness-constraints