### PR TITLE
chore: sync surfaces to HARNESS.md

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -161,6 +161,13 @@ alwaysApply: true
 - **Tool**: `.github/workflows/docs-reference-parity-check.yml`
 - **Scope**: pr
 
+## Every marketplace plugin appears in the docs index pages
+
+- **Rule**: Every plugin listed in `.claude-plugin/marketplace.json` `plugins[]` must appear in both marketplace-level docs index pages: the homepage table (`docs/index.md`) and the canonical available-plugins table (`docs/plugins/index.md`). "Appears" means the plugin's landing-page link `<name>/index.md` is present in each file. Marketplace-scoped analogue of the per-plugin reference-page constraint; a whole-repo invariant checked on HEAD. Effective from 2026-06-01.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/marketplace-docs-coverage-check.yml`
+- **Scope**: pr
+
 ## Reflections via PR workflow
 
 - **Rule**: Every addition to `REFLECTION_LOG.md` must be committed on a branch and merged to `main` via a PR with CI passing. Direct commits to `main` that modify `REFLECTION_LOG.md` are prohibited. Applies to all `/reflect` invocations. Effective from 2026-04-20 — commits before that date are exempt.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,6 +131,10 @@ When a PR adds a new file matching one of `ai-literacy-superpowers/skills/<name>
 
 When a PR adds a new file matching one of `ai-literacy-superpowers/skills/<name>/SKILL.md`, `ai-literacy-superpowers/agents/<name>.agent.md`, or `ai-literacy-superpowers/commands/<name>.md`, the same PR must add an `### <name>` heading to the matching Diataxis reference page (`docs/plugins/ai-literacy-superpowers/reference/skills.md`, `.../agents.md`, or `.../commands.md`). For commands the heading is `### /<name>` (with the leading slash). Modifications to existing components are NOT gated. Effective from 2026-05-26. Enforcement: deterministic (`.github/workflows/docs-reference-parity-check.yml`). Scope: pr.
 
+### Every marketplace plugin appears in the docs index pages
+
+Every plugin listed in `.claude-plugin/marketplace.json` `plugins[]` must appear in both marketplace-level docs index pages: the homepage table (`docs/index.md`) and the canonical available-plugins table (`docs/plugins/index.md`). "Appears" means the plugin's landing-page link `<name>/index.md` is present in each file. Marketplace-scoped analogue of the per-plugin reference-page constraint; a whole-repo invariant checked on HEAD. Effective from 2026-06-01. Enforcement: deterministic (`.github/workflows/marketplace-docs-coverage-check.yml`). Scope: pr.
+
 ### Reflections via PR workflow
 
 Every addition to `REFLECTION_LOG.md` must be committed on a branch and merged to `main` via a PR with CI passing. Direct commits to `main` that modify `REFLECTION_LOG.md` are prohibited. Applies to all `/reflect` invocations. Effective from 2026-04-20. Enforcement: deterministic. Scope: weekly.

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -155,6 +155,13 @@
 - **Tool**: `.github/workflows/docs-reference-parity-check.yml`
 - **Scope**: pr
 
+## Every marketplace plugin appears in the docs index pages
+
+- **Rule**: Every plugin listed in `.claude-plugin/marketplace.json` `plugins[]` must appear in both marketplace-level docs index pages: the homepage table (`docs/index.md`) and the canonical available-plugins table (`docs/plugins/index.md`). "Appears" means the plugin's landing-page link `<name>/index.md` is present in each file. Marketplace-scoped analogue of the per-plugin reference-page constraint; a whole-repo invariant checked on HEAD. Effective from 2026-06-01.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/marketplace-docs-coverage-check.yml`
+- **Scope**: pr
+
 ## Reflections via PR workflow
 
 - **Rule**: Every addition to `REFLECTION_LOG.md` must be committed on a branch and merged to `main` via a PR with CI passing. Direct commits to `main` that modify `REFLECTION_LOG.md` are prohibited. Applies to all `/reflect` invocations. Effective from 2026-04-20 — commits before that date are exempt.

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -792,7 +792,7 @@ the per-reader policy table.
 
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
-Last audit: 2026-05-29
-Constraints enforced: 24/25
+Last audit: 2026-06-01
+Constraints enforced: 25/26
 Garbage collection active: 19/19
-Drift detected: no (convention files + snapshot + ONBOARDING synced via /harness-sync + /harness-onboarding 2026-05-29; docs-site strict-build GC rule added)
+Drift detected: yes (ONBOARDING.md stale vs the new marketplace-docs-coverage constraint — run /harness-onboarding; convention files + Status block synced via /harness-sync 2026-06-01)


### PR DESCRIPTION
## Why these changes

PR #354 added the deterministic constraint **"Every marketplace plugin appears in the docs index pages"** to HARNESS.md. The push-direction surfaces (convention files, HARNESS.md Status block) had drifted out of sync with it. `/harness-sync` detected and applied the fixes.

## Drift scan (before)

```
Surface / Finding                               Status      Action
.cursor/rules/                                  drifted     /convention-sync   [auto]
.github/copilot-instructions.md                 drifted     /convention-sync   [auto]
.windsurf/rules/                                drifted     /convention-sync   [auto]
HARNESS.md Status section accuracy              drifted     inline Status      [auto]
ONBOARDING.md                                   drifted     /harness-onboarding [manual]
Snapshot / Template / Constraint-reg / Reflection in sync   —
CI / CD                                         managed     handled at runtime
```

## Verification scan (after)

```
.cursor/rules/                     drifted → in sync ✓
.github/copilot-instructions.md    drifted → in sync ✓
.windsurf/rules/                   drifted → in sync ✓
HARNESS.md Status section accuracy drifted → in sync ✓
```

## Surfaces applied

- **Convention files** — `/convention-sync` regenerated the three constraint files to include the new constraint.
- **HARNESS.md Status block** — inline update: Last audit 2026-06-01, Constraints enforced 24/25 → 25/26 (GC 19/19 unchanged). Status-block-only mutation, within the trust boundary.

## Not applied (surfaced for follow-up)

- **ONBOARDING.md** `[manual]` — stale vs the new constraint. Run `/harness-onboarding` separately (sync never writes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)