### PR TITLE
/assess — ALCI Part D operational axes + Habitat Build Gap (v0.40.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.39.1",
+  "plugin_version": "0.40.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.39.1"
+      "version": "0.40.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.40.0 — 2026-06-01
+
+### `/assess` — ALCI Part D operational axes + Habitat Build Gap
+
+Brings `/assess` into line with the framework's latest ALCI, which was
+extended upstream with **Part D — four operational axes** and the
+**Habitat Build Gap** diagnostic (driving change:
+`ai-literacy-for-software-engineers` commits `f13d388`/#327 and
+`542f325`/#330). Parts A–C (the cognitive level placement) are
+unchanged; Part D is additive.
+
+- **Four operational axes** — Composition, Testing, Observability,
+  Governance — each placed L1–L5, measuring what the team's *habitat
+  actually delivers* alongside the cognitive level.
+- **Habitat Build Gap** — `cognitive level − operational axes mean`,
+  with three interpretation regimes (Coherent / Ambition outpaces
+  enablement / Inherited habitat). The signal is coherence, not the
+  size of the level.
+- **Hybrid administration** — evidence-first placement by default
+  (from the repo scan), with an opt-in 40-statement ALCI Part D survey
+  for teams wanting the rigorous per-axis score.
+- **Self-contained** — all axis definitions, the full L1–L5 marker
+  statements, the evidence map, the gap formula, and the regimes are
+  embedded in the plugin (new reference
+  `skills/ai-literacy-assessment/references/operational-axes.md`).
+  `/assess` reads no external repository at runtime; upstream refs are
+  provenance/re-sync pointers only.
+- **Governance** — the existing standalone Governance Dimension
+  deep-dive is retained; the new Governance operational axis is its
+  one-line operational summary. The two are cross-referenced and must
+  report a consistent level (enforced by the document validation
+  checkpoint).
+- Updated: the `ai-literacy-assessment` SKILL, the `assessor` agent,
+  the assessment template, the `/assess` command (document step +
+  validation checkpoint), the two evidence references, and the
+  `run-an-assessment` how-to. Structural tests added.
+
+Spec: `docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md`.
+
 ## 0.39.1 — 2026-05-28
 
 ### Fix — /superpowers-status disposition counting

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.39.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.40.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.39.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.40.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/assessor.agent.md
+++ b/ai-literacy-superpowers/agents/assessor.agent.md
@@ -151,6 +151,30 @@ alternative-path methodology will extend to the other artefacts
 listed above in a follow-up iteration; until then, prefer reporting
 "not found at the conventional path" rather than claiming absence.
 
+#### Phase 1c: Operational-axes evidence (ALCI Part D)
+
+Gather observable evidence for the **four operational axes** —
+Composition, Testing, Observability, Governance — using the evidence
+map in:
+
+```text
+ai-literacy-superpowers/skills/ai-literacy-assessment/references/operational-axes.md
+```
+
+That reference is the single, self-contained source for the axes, their
+L1–L5 markers, the evidence map, the Habitat Build Gap formula, and the
+interpretation regimes. **Do not read any external repository** — all
+the content needed is embedded there.
+
+Reuse the signals already collected in Phase 1b and map them to axes:
+custom agents / critics / orchestration → **Composition**; test suites /
+coverage / mutation / regression / agent-authored scenarios →
+**Testing**; logging / metrics / dashboards / snapshots / calibration /
+OTel → **Observability**; HARNESS.md constraints + enforcement ratio /
+policy-as-code CI / audit cadence → **Governance** (this reuses the
+Governance Dimension evidence). Record evidence per axis with file
+paths, exactly as for the cognitive level.
+
 ### Phase 2: Present findings and ask clarifying questions
 
 Present what you found to the user in a structured summary. Then ask
@@ -163,6 +187,20 @@ Present what you found to the user in a structured summary. Then ask
 - Whether specifications are written before or after code
 
 Ask ONE question at a time. Wait for the answer before asking the next.
+
+For the operational axes, the default is **evidence-first** placement
+(Phase 1c). Where an axis's evidence is ambiguous, fold one or two
+axis-specific questions into this phase (within the 3–5 budget). Then
+**offer the opt-in survey**:
+
+> "Place the operational axes from observable evidence (default), or
+> administer the full 40-statement ALCI Part D survey (≈10 min) for a
+> rigorous per-axis score?"
+
+On opt-in, administer the 40 marker statements from
+`references/operational-axes.md` on the Strongly-Disagree (1) →
+Strongly-Agree (5) scale, two statements per level, taking the
+higher-scoring level per axis. Record which mode was used.
 
 ### Phase 3: Assess the level
 
@@ -197,6 +235,25 @@ assessed projects should still produce roughly the same level on
 re-assessment unless the cited sophistication evidence genuinely
 changes the picture.
 
+#### Phase 3b: Place the operational axes and compute the Habitat Build Gap
+
+Independently of the cognitive level, place each of the four
+operational axes L1–L5 from the Phase 1c evidence (or the survey
+scores, if the survey was taken), citing evidence per axis. Then
+compute, per `references/operational-axes.md`:
+
+```text
+operational_axes_mean = mean(Composition, Testing, Observability, Governance)
+Habitat Build Gap     = level_placement − operational_axes_mean
+```
+
+Classify the gap into one of the three regimes (Coherent /
+Ambition outpaces enablement / Inherited habitat). The **Governance
+axis** placement must be **consistent** with the Governance Dimension
+deep-dive (Phase 4 / the Governance Dimension section) — they are two
+views of the same governance level, not independent scores. The axes
+are additive: they do **not** change the cognitive level placement.
+
 ### Phase 4: Generate the assessment document
 
 Create `assessments/` directory if it doesn't exist. Write the
@@ -207,6 +264,13 @@ File path: `assessments/YYYY-MM-DD-assessment.md`
 Fill in every section with specific evidence and rationale. Do not
 use placeholders or generic statements — every claim should
 reference a specific file, configuration, or response.
+
+The template now includes the **Operational Axes (ALCI Part D)** table
+and the **Habitat Build Gap** block — emit both, filling the axis
+placements and evidence from Phase 1c/3b, the axes mean, the signed
+gap, and the interpretation regime. State the placement mode
+(evidence-first or survey). Ensure the Governance axis row matches the
+Governance Dimension level (Phase 3b consistency rule).
 
 ### Phase 5: Update the README badge
 
@@ -232,6 +296,16 @@ git commit -m "AI Literacy Assessment: Level N — {{LEVEL_NAME}} (YYYY-MM-DD)"
 
 When producing the assessment report, include a dedicated Governance
 section that groups governance-related findings:
+
+> **Relationship to the Governance operational axis (ALCI Part D).** The
+> Governance Dimension is the governance **deep-dive**; the Governance
+> **axis** (in the Operational Axes section) is its one-line operational
+> placement that feeds the Habitat Build Gap. They are two views of the
+> same governance level and must report a **consistent** level — the
+> axis summarises, the Dimension expands. In the assessment document,
+> the Governance axis row cross-references this section ("see Governance
+> Dimension"), and this section notes its operational placement is
+> summarised as the Governance axis.
 
 ### In the Assessment Document
 

--- a/ai-literacy-superpowers/commands/assess.md
+++ b/ai-literacy-superpowers/commands/assess.md
@@ -63,6 +63,13 @@ are actually used.
 
 Ask ONE question at a time. Wait for each answer.
 
+The four **operational axes** (ALCI Part D) are placed **evidence-first**
+by default from the scan; fold one or two axis-specific questions in
+here only where an axis's evidence is ambiguous. Then offer the **opt-in
+40-statement ALCI Part D survey** for teams wanting the rigorous
+per-axis score (see the `ai-literacy-assessment` skill and
+`references/operational-axes.md`).
+
 ### 3. Assess
 
 Apply the scoring heuristic: the assessed level is the highest level
@@ -73,7 +80,12 @@ The weakest discipline is the ceiling.
 ### 4. Document
 
 Create `assessments/YYYY-MM-DD-assessment.md` using the template from
-the skill's references. Fill every section with specific evidence.
+the skill's references. Fill every section with specific evidence —
+including the **Operational Axes (ALCI Part D)** table (Composition,
+Testing, Observability, Governance, each placed L1–L5 with evidence)
+and the **Habitat Build Gap** block (level − axes mean = signed gap +
+interpretation regime). State which placement mode was used
+(evidence-first or survey).
 
 ### 5. Validate Assessment Document
 
@@ -84,17 +96,30 @@ against `ai-literacy-assessment/references/assessment-template.md`.
 **Structural checks:**
 
 1. Required sections present: Observable Evidence, Level Assessment,
-   Discipline Maturity, Strengths, Gaps, Recommendations
+   Discipline Maturity, Operational Axes (ALCI Part D), Habitat Build
+   Gap, Strengths, Gaps, Recommendations
 2. Level Assessment contains a level number (1-5) and a level name
    (e.g. "Level 3 — Adaptive Collaboration")
 3. Discipline Maturity contains a markdown table with rows for each
    scored discipline
 4. Gaps section contains at least one item (every project has gaps)
+5. Operational Axes table names all four axes (Composition, Testing,
+   Observability, Governance), each with a placement and evidence
+6. Habitat Build Gap block is internally consistent: the gap equals
+   level placement minus the operational axes mean (to one decimal),
+   and the interpretation matches the regime for that gap (`abs < 0.5`
+   → Coherent; `≥ +0.5` → Ambition outpaces enablement; `≤ −0.5` →
+   Inherited habitat)
+7. The Governance axis placement matches the Governance Dimension
+   level (the two governance views must not diverge)
 
 If any check fails, fix the document in place:
 
 - Add missing sections using the structure from the assessment
   template reference
+- Recompute the gap and correct the interpretation if they are
+  inconsistent; reconcile the Governance axis with the Governance
+  Dimension if they diverge
 - Ensure the level number is a single digit 1-5 that downstream
   portfolio aggregation can parse
 

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -120,13 +120,18 @@ Produce a timestamped Markdown document at
 4. **Level assessment**: primary level with rationale
 5. **Discipline maturity**: context engineering, architectural
    constraints, guardrail design — each rated
-6. **Strengths**: what the team does well at their current level
-7. **Gaps**: what's missing for the next level
-8. **Recommendations**: 3-5 specific actions to progress
-9. **Immediate adjustments applied**: what was fixed during this assessment
-10. **Workflow operation changes**: accepted changes to how artifacts are used
-11. **Reflection**: what the assessment itself revealed
-12. **Next assessment date**: suggested quarterly re-assessment
+6. **Operational axes (ALCI Part D)**: Composition, Testing,
+   Observability, Governance — each placed L1–L5 (see "Operational
+   Axes" below)
+7. **Habitat Build Gap**: the cognitive level minus the operational
+   axes mean, with its interpretation (see below)
+8. **Strengths**: what the team does well at their current level
+9. **Gaps**: what's missing for the next level
+10. **Recommendations**: 3-5 specific actions to progress
+11. **Immediate adjustments applied**: what was fixed during this assessment
+12. **Workflow operation changes**: accepted changes to how artifacts are used
+13. **Reflection**: what the assessment itself revealed
+14. **Next assessment date**: suggested quarterly re-assessment
 
 ### Phase 4: Immediate Habitat Adjustments
 
@@ -267,3 +272,63 @@ The adjustments are introduced conservatively at this release —
 prefer surfacing markers without changing previously-assigned levels
 unless the evidence is unambiguous. As the framework accumulates
 assessments using the markers, the adjustments will tune.
+
+## Operational Axes (ALCI Part D)
+
+The framework's ALCI was extended with **Part D — four operational
+axes** that measure what the team's *habitat actually delivers*,
+complementing the cognitive level placement from the scoring heuristic
+above. The four axes, their L1–L5 marker statements, the evidence map,
+the Habitat Build Gap formula, and the interpretation regimes are
+defined in full in `references/operational-axes.md` — the single,
+self-contained source (no external repo is read at runtime).
+
+The axes:
+
+- **Composition** — agent topology sophistication
+- **Testing** — verification rigour
+- **Observability** — agent-activity visibility and feedback loop
+- **Governance** — formality/enforceability of AI-use governance
+
+### Administration (hybrid)
+
+- **Evidence-first (default).** During Phase 1b, gather observable repo
+  evidence per axis (the evidence map in `references/operational-axes.md`)
+  and place each axis L1–L5, citing evidence per axis exactly as the
+  cognitive level is evidenced. Ask one or two clarifying questions for
+  an axis only where evidence is ambiguous, within the 3–5 question
+  budget.
+- **Survey (opt-in).** Offer the full 40-statement ALCI Part D survey
+  (4 axes × 5 levels × 2 statements) for teams wanting the rigorous
+  instrument. Administer on the Strongly-Disagree (1) →
+  Strongly-Agree (5) scale, taking the higher-scoring level per axis.
+  Record which mode was used in the assessment document.
+
+### Governance axis vs Governance Dimension
+
+The **Governance axis** is the one-line operational placement. The
+assessment document also carries the standalone **Governance Dimension**
+deep-dive (with the `/governance-constrain` improvement ladder). The two
+are cross-referenced and must report a **consistent** governance level —
+the axis is the summary, the Dimension is the deep-dive.
+
+### Habitat Build Gap
+
+Combine the cognitive view with the operational view:
+
+```text
+Habitat Build Gap = level_placement − operational_axes_mean
+```
+
+`operational_axes_mean` is the mean of the four axis scores. Interpret:
+
+| Gap | Name | Meaning |
+| --- | --- | --- |
+| `abs(gap) < 0.5` | **Coherent** | Team and habitat at the same level. |
+| `gap ≥ +0.5` | **Ambition outpaces enablement** | Build the habitat the team's thinking implies. |
+| `gap ≤ −0.5` | **Inherited habitat** | Literacy uplift before further harness extension. |
+
+The headline signal is **coherence**, not the size of the level: a
+coherent L2/L2 team is healthier than an incoherent L4/L1 team. See
+`references/operational-axes.md` for the full treatment and output
+format.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/assessment-template.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/assessment-template.md
@@ -66,6 +66,37 @@ Reference specific evidence.}}
 {{Identify which discipline is the ceiling — the one holding
 the team at this level rather than the next.}}
 
+## Operational Axes (ALCI Part D)
+
+{{Placement mode: evidence-first | survey — state which was used.}}
+
+| Axis | Placement | Evidence |
+| --- | --- | --- |
+| Composition | L{{1-5}} | {{Agent topology evidence — custom agents, critics, orchestration}} |
+| Testing | L{{1-5}} | {{Verification evidence — suites, coverage, mutation, regression}} |
+| Observability | L{{1-5}} | {{Visibility evidence — logging, metrics, dashboards, calibration}} |
+| Governance | L{{1-5}} | {{Enforcement evidence — see Governance Dimension below for the deep-dive}} |
+
+Operational axes mean: L{{mean to one decimal}}
+
+## Habitat Build Gap
+
+```text
+Level placement (from cognitive assessment): L{{N}}
+Operational axes mean (Part D):              L{{mean}}
+  Composition:    L{{1-5}}
+  Testing:        L{{1-5}}
+  Observability:  L{{1-5}}
+  Governance:     L{{1-5}}
+Habitat Build Gap:                           {{signed gap, e.g. +1.0}}
+Interpretation:                              {{Coherent | Ambition outpaces enablement | Inherited habitat}}
+```
+
+{{One-paragraph reading of the gap: what the coherence (or incoherence)
+between the cognitive level and the operational axes means for where to
+invest — habitat build (positive gap) or literacy uplift (negative gap).
+The signal is coherence, not the size of the level.}}
+
 ## Strengths
 
 {{3-5 bullet points — what the team does well at their current

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/operational-axes.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/operational-axes.md
@@ -1,0 +1,144 @@
+# Operational Axes (ALCI Part D)
+
+The single, self-contained source for the **four operational axes** and
+the **Habitat Build Gap** diagnostic. `/assess`, the `ai-literacy-assessment`
+SKILL, and the `assessor` agent all read this file — none of them read
+any external repository at runtime.
+
+> **Provenance.** The axis definitions, the L1–L5 marker statements, the
+> Habitat Build Gap formula, and the interpretation regimes are copied
+> verbatim from the AI Literacy framework's ALCI Part D (Appendix M) and
+> Appendix U ("The Cognitive–Operational Gap"). Upstream source:
+> `ai-literacy-for-software-engineers`, commits `f13d388` (#327, "Adopt
+> Habitat Maturity Model into framework — per-level rubric + ALCI Part D")
+> and `542f325` (#330, "unified cognitive+operational dimensions matrix").
+> This is an attribution and re-sync pointer only — the content below is
+> embedded in full so the plugin works standalone. If the framework's
+> markers or regimes change upstream, re-sync by copying the new text
+> into this file; never make `/assess` read the upstream repo.
+
+## What Part D measures
+
+Parts A–C of the ALCI measure where a team sits in the **cognitive**
+literacy progression — what its members can think and do. Part D
+measures what the team's **habitat actually delivers**, across four
+operational axes. Part D is **additive**: it does not change the
+cognitive level placement. The cognitive position (the assessed level)
+and the operational position (the mean of the four axes) together
+produce the **Habitat Build Gap**.
+
+Each axis is placed L1–L5. In **evidence-first** mode (the `/assess`
+default) the assessor places each axis from observable repository
+evidence (the evidence map below), citing evidence per axis exactly as
+it cites evidence for the cognitive level. In **survey** mode (opt-in)
+the assessor administers the marker statements as a questionnaire on the
+Strongly-Disagree (1) → Strongly-Agree (5) scale, two statements per
+level, taking the higher-scoring level per axis (if two adjacent levels
+tie, take the higher).
+
+## The four axes
+
+### Composition
+
+*How structurally sophisticated is the team's agent topology?*
+
+- **L1:** "I work with a single agent through ad-hoc prompts." / "I rarely save prompts or patterns between sessions."
+- **L2:** "I have a personal library of saved prompts and commands I reuse." / "I sometimes set up a critic agent alongside my primary."
+- **L3:** "My setup runs a primary agent with read-only critic agents that review its work." / "Agent composition is documented and consistent across the team."
+- **L4:** "I orchestrate bounded ensembles of agents composed by a harness." / "Multi-agent workflows are first-class in our process."
+- **L5:** "Agents self-orchestrate into constellations; I supervise outcomes, not orchestration." / "Composition is defined by specs and evolves through agent-led refinement."
+
+### Testing
+
+*How rigorously does the team verify what the collaboration produces?*
+
+- **L1:** "We rely on manual inspection of agent output." / "We have ad-hoc unit tests; coverage is uneven."
+- **L2:** "We write unit tests for everything agents produce, with disciplined review." / "We use mutation testing to verify our tests."
+- **L3:** "Our tests verify both code behaviour and basic business outcomes; agent-generated code includes tests before merge." / "We have automated functional tests covering critical workflows."
+- **L4:** "We have comprehensive test automation from both business and technical perspectives, including system-level regression tests." / "Manual exploratory plans complement automation; agents extend the test suite as work progresses."
+- **L5:** "Our testing covers risk from multiple perspectives, including post-deployment health and business outcomes in a prod-like test environment." / "Agents author and run test plans autonomously; certification is the human's role, not authoring."
+
+### Observability
+
+*How visible is agent activity, and how tight is the feedback loop back
+into agent behaviour?*
+
+- **L1:** "We inspect agent activity by eye when something feels off." / "We have no systematic capture of agent metrics."
+- **L2:** "We log agent activity in a place we can search." / "We track basic metrics: token spend, latency, request counts."
+- **L3:** "Agent activity is instrumented and visible in dashboards we check at known cadences." / "We track per-PR acceptance trends, mutation kill rates, and AI code acceptance rates."
+- **L4:** "We aggregate observability across teams and projects, with dashboards that surface cross-cutting AI collaboration health." / "Perception-reality calibration is tracked with measurement data, not just self-report."
+- **L5:** "Observability is closed-loop: outputs feed back into agent behaviour automatically (post-deployment metrics inform spec evolution)." / "Customer-observable metrics are part of the agent's input; the agent can detect and respond to production reality."
+
+### Governance
+
+*How formal and enforceable is the team's governance over AI use?*
+
+- **L1:** "Our governance for AI use is implicit and trust-based; we do not have written policies." / "Different team members use AI differently; there are no agreed norms."
+- **L2:** "We have conventional governance norms (informal team agreements about how to use AI)." / "We discuss AI usage in standups or retros but do not codify it."
+- **L3:** "We have a written constitution (CLAUDE.md / HARNESS.md) that constrains how agents operate, and we enforce it." / "Constraints are categorised and promoted through unverified → agent-backed → deterministic."
+- **L4:** "Governance is policy-as-code: machine-enforced constraints in CI, with explicit blocking rules." / "Governance constraints map to falsifiable behaviour, not aspirational language."
+- **L5:** "Governance is continuous certification: every change carries evidence of compliance with verifiable controls." / "The institutional reference frame is explicitly modelled alongside human and AI reference frames in our governance design."
+
+> The **Governance axis** is the one-line *operational* placement of the
+> team's governance. The `/assess` document also carries a standalone
+> **Governance Dimension** section (the governance deep-dive with the
+> `/governance-constrain` improvement ladder). The two are
+> cross-referenced and must report a **consistent** governance level —
+> the axis is the summary, the Dimension is the deep-dive.
+
+## Evidence map (evidence-first placement)
+
+Observable repository signals the assessor maps to an axis placement.
+These extend `sophistication-markers.md` and `tool-config-evidence.md`.
+
+| Axis | Signals that raise the placement |
+| --- | --- |
+| **Composition** | count and shape of custom agents; read-only critic/reviewer agents; orchestrator with safety gates; agent-team docs in AGENTS.md; multi-agent workflow scripts; specs that define composition |
+| **Testing** | test suites present; coverage enforcement; mutation testing config + cadence; tests-before-merge CI gates; system/regression suites; agent-authored test scenarios (e.g. a `tdad_tests/`-style layer); prod-like test environments |
+| **Observability** | agent-activity logging; metrics capture (token/latency/cost); dashboards; observability snapshots at a cadence; per-PR acceptance / mutation-kill / AI-acceptance tracking; perception-reality calibration; OTel config; closed-loop signals feeding agent behaviour |
+| **Governance** | HARNESS.md constraint count + enforcement ratio; policy-as-code CI checks; falsifiable (not aspirational) constraints; the unverified → agent → deterministic promotion ladder; governance audit cadence; institutional-frame modelling. (Reuses the Governance Dimension evidence.) |
+
+Where repo evidence is ambiguous for an axis, ask **one or two**
+clarifying questions for that axis (within the command's 3–5 question
+budget) rather than guessing.
+
+## The Habitat Build Gap
+
+The **Habitat Build Gap** combines the cognitive view (the assessed
+level) with the operational view (the axes mean):
+
+```text
+Habitat Build Gap = level_placement − operational_axes_mean
+```
+
+`operational_axes_mean` is the arithmetic mean of the four axis scores
+(each 1–5). Both values are on the same 0–5 scale, so the gap is signed.
+
+### Output format
+
+```text
+Level placement (from cognitive assessment): L3
+Operational axes mean (Part D):              L2.0
+  Composition:    L2
+  Testing:        L2
+  Observability:  L1
+  Governance:     L3
+Habitat Build Gap:                           +1.0
+Interpretation:                              Ambition outpaces enablement
+```
+
+### Interpretation regimes
+
+Framework working defaults (recalibrate after the first quarter of use):
+
+| Gap | Name | Interpretation |
+| --- | --- | --- |
+| `abs(gap) < 0.5` | **Coherent** | Team and habitat are at the same level. Collaboration is well-supported by the environment. |
+| `gap ≥ +0.5` | **Ambition outpaces enablement** | Team thinks at a higher level than the habitat supports. Build the habitat the team's thinking already implies. |
+| `gap ≤ −0.5` | **Inherited habitat** | Habitat is more mature than the team's current practice. Literacy uplift before further harness extension. |
+
+The headline signal is **coherence**, not the size of the level
+placement. A coherent low-level team (L2 cognitive / L2 operational) is
+healthier than an incoherent high-level team (L4 cognitive / L1
+operational). A positive gap points at habitat investment; a negative
+gap points at literacy uplift.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/sophistication-markers.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/sophistication-markers.md
@@ -202,3 +202,14 @@ markers, the adjustments may be tuned or refined.
 
 A reflection capturing observed level shifts after the first few
 assessments using this reference is the right next step for tuning.
+
+## Operational axes (ALCI Part D)
+
+The four operational axes — Composition, Testing, Observability,
+Governance — and their evidence map live in
+`references/operational-axes.md` (the single, self-contained source).
+The sophistication markers above feed the axis placements: agent /
+orchestration sophistication evidences **Composition**; hook and
+script sophistication evidences **Observability** and **Governance**;
+test-infrastructure sophistication evidences **Testing**. Cite the same
+markers under the axis they evidence in the Operational Axes table.

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/references/tool-config-evidence.md
@@ -112,3 +112,12 @@ is Level 3 for context engineering.
 
 Inline duplication of these paths or markers across the consumers is
 forbidden. Edits live in this file.
+
+## Operational axes (ALCI Part D)
+
+For the four operational-axes evidence signals (Composition, Testing,
+Observability, Governance), see `references/operational-axes.md` — the
+single, self-contained source for the axes, their L1–L5 markers, the
+evidence map, and the Habitat Build Gap. Governance-axis evidence
+overlaps with the governance constraint/enforcement signals here; cite
+each governance signal once, under the Governance axis.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
@@ -43,9 +43,10 @@ The agent creates `assessments/YYYY-MM-DD-assessment.md` with:
 3. Summary of your answers
 4. Level assessment with rationale
 5. Discipline maturity ratings (context engineering, constraints, guardrail design)
-6. Strengths at your current level
-7. Gaps preventing the next level
-8. 3-5 specific recommendations
+6. Operational axes (ALCI Part D) and the Habitat Build Gap (see below)
+7. Strengths at your current level
+8. Gaps preventing the next level
+9. 3-5 specific recommendations
 
 The assessed level is the highest level where you have substantial evidence across all
 three disciplines. The weakest discipline is the ceiling.
@@ -58,6 +59,35 @@ three disciplines. The weakest discipline is the ceiling.
 | L3 | CLAUDE.md + 3 or more enforced harness constraints + custom agents or skills |
 | L4 | Specifications before code + agent pipeline with safety gates |
 | L5 | Platform-level governance + cross-team standards + observability |
+
+### Operational axes and the Habitat Build Gap
+
+The cognitive level above measures *what your team can think and do*. The
+**operational axes** (ALCI Part D) measure *what your habitat actually
+delivers*, across four axes — **Composition** (agent topology), **Testing**
+(verification rigour), **Observability** (agent-activity visibility), and
+**Governance** (enforceability of AI-use rules) — each placed L1–L5.
+
+By default the agent places the axes **evidence-first** from the repo
+scan; you can opt into the full 40-statement ALCI Part D survey for a
+rigorous per-axis score.
+
+The **Habitat Build Gap** combines the two views:
+
+```text
+Habitat Build Gap = cognitive level − operational axes mean
+```
+
+- **Coherent** (`abs(gap) < 0.5`) — team and habitat at the same level.
+- **Ambition outpaces enablement** (`gap ≥ +0.5`) — build the habitat your
+  team's thinking already implies.
+- **Inherited habitat** (`gap ≤ −0.5`) — literacy uplift before further
+  harness extension.
+
+The signal is **coherence**, not the size of the level: a coherent L2/L2
+team is healthier than an incoherent L4/L1 team. The Governance axis is
+the one-line operational summary of the deeper **Governance Dimension**
+section in the same document.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md
+++ b/docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md
@@ -1,0 +1,250 @@
+# `/assess` — ALCI Part D operational axes + Habitat Build Gap — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-01 |
+| Status | Draft — awaiting plan approval |
+| Author | claude-opus-4-8[1m] (interactive session with russmiles) |
+| Driving change | Upstream framework: ALCI extended with **Part D — Operational Axes** and the **Habitat Build Gap** diagnostic |
+| Upstream refs | `ai-literacy-for-software-engineers` commits `f13d388` ("Adopt Habitat Maturity Model into framework — per-level rubric + ALCI Part D", #327) and `542f325` ("Add unified cognitive+operational dimensions matrix to Part II", #330). Framework source: `framework/framework.md` Appendix M (Part D, lines ~4051–4172) and Appendix U (The Cognitive–Operational Gap). |
+| Plugin version target | `ai-literacy-superpowers` v0.39.1 → v0.40.0 (behavioural change to a command, skill, and agent) |
+| PR ceremony | Cross-repo feature. Local spec (this file) satisfies the spec-first gate; PR links the upstream framework commits. Lighter path chosen by the human: spec → implement → integrate (adversarial + cartographer gates skipped for this change). |
+
+---
+
+## 1. Premise
+
+The AI Literacy framework's assessment instrument — the **AI Literacy
+Collaboration Index (ALCI)** — was extended in 2026-05 with a new
+**Part D: Operational Axes**. Parts A–C measure where a team sits in
+the *cognitive* literacy progression (what its members can think and
+do). Part D measures what the team's *habitat actually delivers* across
+four operational axes:
+
+- **Composition** — how structurally sophisticated the agent topology is.
+- **Testing** — how rigorously the collaboration's output is verified.
+- **Observability** — how visible agent activity is and how tight the
+  feedback loop back into agent behaviour is.
+- **Governance** — how formal and enforceable the team's governance over
+  AI use is.
+
+Each axis is placed L1–L5. The cognitive position (level placement from
+Part A) and the operational position (the mean of the four Part D axes)
+together produce the **Habitat Build Gap** — a coherence diagnostic:
+
+```text
+Habitat Build Gap = level_placement − operational_axes_mean
+```
+
+The plugin's `/assess` command currently produces a cognitive-level
+assessment (a single level + three-discipline maturity + a standalone
+Governance Dimension). It does not surface the operational axes or the
+Habitat Build Gap. This spec brings `/assess` into line with the
+framework's latest ALCI.
+
+## 2. Fixed decisions (human-set, not re-litigated here)
+
+1. **Hybrid administration.** `/assess` places the four operational axes
+   **evidence-first** by default (gather observable repo evidence per
+   axis and place each L1–L5, mirroring how the command already places
+   the cognitive level), and **offers the full 40-statement ALCI Part D
+   survey as an opt-in** for teams that want the rigorous instrument.
+2. **Keep both governance views, cross-referenced.** The existing
+   standalone **Governance Dimension** section (the governance deep-dive
+   with the `/governance-constrain` ladder) is retained. The new
+   **Governance operational axis** is added as the operational summary.
+   Each cross-references the other; the axis is the one-line operational
+   placement, the Dimension is the deep-dive. The Governance axis score
+   feeds the operational axes mean.
+3. **Local spec referencing upstream** (this document) for the
+   spec-first gate.
+
+## 3. The four operational axes
+
+Source: framework `framework.md` Appendix M, Part D. Each axis is placed
+L1–L5 using the framework's per-level markers (reproduced condensed
+below; the agent reference carries the full marker text).
+
+| Axis | What it measures | L1 → L5 shape (condensed) |
+| --- | --- | --- |
+| **Composition** | Agent topology sophistication | single ad-hoc agent → saved prompts/critic → primary+read-only critics, documented → harness-composed bounded ensembles → self-orchestrating constellations |
+| **Testing** | Verification rigour | manual inspection → unit tests + mutation → behaviour+business tests, agent tests before merge → comprehensive automation + system regression → multi-perspective + prod-like + agent-authored plans |
+| **Observability** | Agent-activity visibility + feedback loop | inspect by eye → searchable logs + basic metrics → instrumented dashboards at cadence → cross-team aggregation + perception-reality calibration → closed-loop (outputs feed agent behaviour) |
+| **Governance** | Formality/enforceability of AI-use governance | implicit/trust-based → informal norms → written constitution enforced → policy-as-code in CI → continuous certification with evidence |
+
+### 3.1 Evidence signals per axis (evidence-first path)
+
+The assessor maps observable repo signals to an axis placement. Working
+signal map (extends `references/sophistication-markers.md` and
+`tool-config-evidence.md`):
+
+- **Composition** — count and shape of custom agents; presence of
+  read-only critic/reviewer agents; orchestrator with safety gates;
+  agent-team docs in AGENTS.md; multi-agent workflow scripts.
+- **Testing** — test suites; coverage enforcement; mutation testing
+  config + cadence; tests-before-merge CI gates; system/regression
+  suites; agent-authored test scenarios (e.g. `tdad_tests/`).
+- **Observability** — logging of agent activity; metrics capture
+  (token/latency/cost); dashboards; observability snapshots at cadence;
+  perception-reality calibration; OTel config; closed-loop signals.
+- **Governance** — HARNESS.md constraint count + enforcement ratio;
+  policy-as-code CI checks; falsifiable constraints; governance audit
+  cadence; institutional-frame modelling. (Reuses the existing
+  Governance Dimension evidence.)
+
+Where repo evidence is ambiguous for an axis, the assessor may ask **one
+or two** clarifying questions for that axis (consistent with the
+command's existing 3–5 question budget) rather than guessing.
+
+## 4. The Habitat Build Gap
+
+Source: framework `framework.md` Appendix M ("Habitat Build Gap")
+and Appendix U ("The Cognitive–Operational Gap").
+
+```text
+Habitat Build Gap = level_placement − operational_axes_mean
+```
+
+Both values are on the 0–5 scale; the gap is signed. Interpretation
+regimes (framework working defaults):
+
+| Gap | Name | Interpretation |
+| --- | --- | --- |
+| `abs(gap) < 0.5` | **Coherent** | Team and habitat at the same level; collaboration well-supported. |
+| `gap ≥ +0.5` | **Ambition outpaces enablement** | Team thinks at a higher level than the habitat supports — build the habitat the team's thinking implies. |
+| `gap ≤ −0.5` | **Inherited habitat** | Habitat is more mature than current practice — literacy uplift before further harness extension. |
+
+The headline signal is **coherence**, not the size of the level. A
+coherent L2/L2 team is healthier than an incoherent L4/L1 team.
+
+Output format (matches the framework's worked example):
+
+```text
+Level placement (from cognitive assessment): L3
+Operational axes mean (Part D):              L2.0
+  Composition:    L2
+  Testing:        L2
+  Observability:  L1
+  Governance:     L3
+Habitat Build Gap:                           +1.0
+Interpretation:                              Ambition outpaces enablement
+```
+
+## 5. Hybrid administration
+
+### 5.1 Evidence-first (default)
+
+During the existing Phase 1b broader signal scan, the assessor also
+gathers the per-axis evidence (§3.1) and places each axis L1–L5,
+citing evidence per axis exactly as it cites evidence for the cognitive
+level. This adds no new interactive friction beyond the occasional
+per-axis clarifying question.
+
+### 5.2 Full survey (opt-in)
+
+After the evidence-first placement, the command offers:
+
+> "Place the operational axes from observable evidence (default), or
+> administer the full 40-statement ALCI Part D survey (≈10 min) for a
+> rigorous score?"
+
+On opt-in, the assessor administers the 40 statements (4 axes × 5 levels
+× 2 statements) on the framework's Strongly-Disagree→Strongly-Agree
+scale, taking the higher-scoring level per axis. The survey statements
+are carried in a new reference file (`references/operational-axes.md`)
+sourced verbatim from framework Part D so they stay faithful and
+auditable. Survey scores replace the evidence-first placement for that
+run; the assessment document records which mode was used.
+
+## 6. Changes per artifact
+
+| Artifact | Change |
+| --- | --- |
+| `ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md` | Add an "Operational Axes (ALCI Part D)" scoring section: the four axes, the evidence-first placement heuristic, the opt-in survey, and the Habitat Build Gap computation + interpretation regimes. |
+| `.../references/assessment-template.md` | Add two sections to the document template: `## Operational Axes (ALCI Part D)` (a 4-row table: axis · placement L1–L5 · evidence) and `## Habitat Build Gap` (the level/axes-mean/gap/interpretation block). Cross-reference the existing Governance Dimension from the Governance axis row. |
+| `.../references/operational-axes.md` (**new**) | The four axes' full L1–L5 marker statements (the 40 survey statements) sourced verbatim from framework Part D, plus the evidence-signal map (§3.1). Single source for both administration modes. |
+| `.../references/sophistication-markers.md`, `tool-config-evidence.md` | Add the operational-axis evidence signals (§3.1) so the existing evidence references cover them. |
+| `ai-literacy-superpowers/agents/assessor.agent.md` | Phase 1b: gather per-axis evidence. Document generation: emit the Operational Axes + Habitat Build Gap sections and compute the gap. Reconcile the existing **Governance Dimension** section with the new **Governance axis** (cross-reference; the axis is the operational summary, the Dimension the deep-dive; the axis score feeds the axes mean). Add the opt-in survey path. |
+| `ai-literacy-superpowers/commands/assess.md` | Step 4 (Document): add the Operational Axes + Habitat Build Gap sections. Step 5 (validation checkpoint): verify the new sections exist, the axes mean is computed, and the gap + interpretation are present and internally consistent (gap = level − mean, interpretation matches the regime). Add the §5.2 opt-in survey prompt to the flow. |
+| `docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md` | Document the operational axes, the hybrid administration, and how to read the Habitat Build Gap. |
+| `ai-literacy-superpowers/.claude-plugin/plugin.json`, `README.md` badge, `CHANGELOG.md`, marketplace entry `version` | Version bump 0.39.1 → 0.40.0. |
+| `tdad_tests/tests/` | Structural tests (see §10). |
+
+## 7. Governance reconciliation
+
+- The standalone **Governance Dimension** section (assessor agent +
+  template) is **retained** unchanged in substance — it remains the
+  governance deep-dive with the `/governance-constrain` improvement
+  ladder.
+- The new **Governance operational axis** is the one-line operational
+  placement (L1–L5) that sits alongside Composition/Testing/Observability
+  and feeds the operational axes mean.
+- **Cross-reference both ways**: the Governance axis row in the
+  Operational Axes table links to the Governance Dimension section ("see
+  Governance Dimension for the deep-dive"); the Governance Dimension
+  section notes that its operational placement is summarised as the
+  Governance axis. The two must report a **consistent** governance level
+  — the validation checkpoint (§6, step 5) checks they do not diverge.
+
+## 8. Out of scope
+
+- Parts A–C of the ALCI are unchanged (the cognitive level placement,
+  deep-dives, and lived-experience items).
+- The framework-document per-level Habitat Maturity Snapshot tables and
+  the unified Part II matrix are framework-doc presentation, not
+  `/assess` output; not reproduced here.
+- Portfolio aggregation (`/portfolio-assess`) consuming the Habitat
+  Build Gap is a **possible follow-up**, not this change. The assessment
+  document's existing single level number stays parseable by the
+  portfolio aggregator; the new sections are additive and do not break
+  it.
+
+## 9. Versioning
+
+A behavioural change to a command, skill, and agent → **minor bump**
+0.39.1 → **0.40.0** (CLAUDE.md Semantic Versioning: "0.MINOR.0 — new
+skills, agents, commands, or behavioural changes"). Update the four
+locations: `plugin.json`, README badge, CHANGELOG, marketplace entry
+`version`. The top-level marketplace listing `version` is unaffected by
+a plugin behavioural change (per the listing-vs-entry precedent).
+
+## 10. Acceptance scenarios (structural, offline)
+
+1. **Template has the new sections** — `assessment-template.md` contains
+   `## Operational Axes (ALCI Part D)` and `## Habitat Build Gap`.
+2. **Template Operational Axes table** names all four axes (Composition,
+   Testing, Observability, Governance) with a placement and an evidence
+   column.
+3. **Habitat Build Gap formula** is documented as
+   `level_placement − operational_axes_mean` with the three named
+   interpretation regimes (Coherent / Ambition outpaces enablement /
+   Inherited habitat).
+4. **SKILL.md documents Part D** — the four axes, evidence-first
+   placement, the opt-in survey, and the gap computation.
+5. **New reference file** `references/operational-axes.md` exists and
+   names the four axes with L1–L5 markers.
+6. **Assessor agent** documents gathering per-axis evidence, emitting the
+   two new sections, and computing the gap; and cross-references the
+   Governance Dimension ↔ Governance axis.
+7. **Command** documents the new document sections and a validation
+   checkpoint covering them (gap = level − mean; interpretation matches
+   regime; governance axis and Dimension consistent).
+8. **Hybrid opt-in** — the command/skill documents both the evidence-first
+   default and the opt-in 40-statement survey.
+9. **Version triplet at 0.40.0** — plugin.json, marketplace entry, and
+   CHANGELOG heading all show 0.40.0; the top-level marketplace listing
+   `version` is unchanged.
+10. **Docs** — `run-an-assessment.md` documents the operational axes and
+    the Habitat Build Gap.
+
+(Behavioural acceptance — that a live `/assess` run actually places the
+axes from evidence and computes a correct gap — is documentation-only at
+the structural layer, consistent with how the plugin's other commands
+are tested offline.)
+
+## 11. Upstream linkage
+
+This change tracks the framework. The PR body links the upstream
+commits (`f13d388`, `542f325`). If the framework's Part D markers or the
+Habitat Build Gap regimes change upstream, `references/operational-axes.md`
+and the SKILL's regime table are the sync points.

--- a/docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md
+++ b/docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md
@@ -58,6 +58,17 @@ framework's latest ALCI.
    feeds the operational axes mean.
 3. **Local spec referencing upstream** (this document) for the
    spec-first gate.
+4. **Self-contained — no runtime dependency on the upstream repo.** The
+   plugin ships standalone via the marketplace; an installing team will
+   not have `ai-literacy-for-software-engineers` checked out. Every
+   piece of supporting information `/assess` needs at runtime — the four
+   axes' definitions, the full L1–L5 marker statements, the evidence
+   map, the gap formula, and the interpretation regimes — is **embedded
+   in the plugin's own files** (the SKILL and its `references/`). No
+   artifact reads `framework/framework.md` or any upstream path at run
+   time. Upstream references in this spec and in the artifacts are
+   **provenance/attribution only** (where the content was sourced and
+   what to re-sync if the framework changes), never a runtime read.
 
 ## 3. The four operational axes
 
@@ -151,10 +162,12 @@ After the evidence-first placement, the command offers:
 On opt-in, the assessor administers the 40 statements (4 axes × 5 levels
 × 2 statements) on the framework's Strongly-Disagree→Strongly-Agree
 scale, taking the higher-scoring level per axis. The survey statements
-are carried in a new reference file (`references/operational-axes.md`)
-sourced verbatim from framework Part D so they stay faithful and
-auditable. Survey scores replace the evidence-first placement for that
-run; the assessment document records which mode was used.
+are **embedded in full** in a new reference file
+(`references/operational-axes.md`) — copied verbatim from framework
+Part D so they are faithful, auditable, and **available without the
+upstream repo** (decision §2.4). Survey scores replace the evidence-first
+placement for that run; the assessment document records which mode was
+used.
 
 ## 6. Changes per artifact
 
@@ -162,7 +175,7 @@ run; the assessment document records which mode was used.
 | --- | --- |
 | `ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md` | Add an "Operational Axes (ALCI Part D)" scoring section: the four axes, the evidence-first placement heuristic, the opt-in survey, and the Habitat Build Gap computation + interpretation regimes. |
 | `.../references/assessment-template.md` | Add two sections to the document template: `## Operational Axes (ALCI Part D)` (a 4-row table: axis · placement L1–L5 · evidence) and `## Habitat Build Gap` (the level/axes-mean/gap/interpretation block). Cross-reference the existing Governance Dimension from the Governance axis row. |
-| `.../references/operational-axes.md` (**new**) | The four axes' full L1–L5 marker statements (the 40 survey statements) sourced verbatim from framework Part D, plus the evidence-signal map (§3.1). Single source for both administration modes. |
+| `.../references/operational-axes.md` (**new**) | The four axes' full L1–L5 marker statements (the 40 survey statements) **embedded verbatim** (copied in full — the plugin does not read the upstream repo at runtime, per §2.4), plus the evidence-signal map (§3.1) and the Habitat Build Gap formula + interpretation regimes. Single self-contained source for both administration modes. |
 | `.../references/sophistication-markers.md`, `tool-config-evidence.md` | Add the operational-axis evidence signals (§3.1) so the existing evidence references cover them. |
 | `ai-literacy-superpowers/agents/assessor.agent.md` | Phase 1b: gather per-axis evidence. Document generation: emit the Operational Axes + Habitat Build Gap sections and compute the gap. Reconcile the existing **Governance Dimension** section with the new **Governance axis** (cross-reference; the axis is the operational summary, the Dimension the deep-dive; the axis score feeds the axes mean). Add the opt-in survey path. |
 | `ai-literacy-superpowers/commands/assess.md` | Step 4 (Document): add the Operational Axes + Habitat Build Gap sections. Step 5 (validation checkpoint): verify the new sections exist, the axes mean is computed, and the gap + interpretation are present and internally consistent (gap = level − mean, interpretation matches the regime). Add the §5.2 opt-in survey prompt to the flow. |
@@ -244,7 +257,18 @@ are tested offline.)
 
 ## 11. Upstream linkage
 
-This change tracks the framework. The PR body links the upstream
-commits (`f13d388`, `542f325`). If the framework's Part D markers or the
-Habitat Build Gap regimes change upstream, `references/operational-axes.md`
-and the SKILL's regime table are the sync points.
+This change tracks the framework, but is **self-contained at runtime**
+(§2.4): the upstream references are provenance and re-sync pointers, not
+runtime dependencies. The PR body links the upstream commits
+(`f13d388`, `542f325`). If the framework's Part D markers or the Habitat
+Build Gap regimes change upstream, `references/operational-axes.md` and
+the SKILL's regime table are the sync points — updated by copying the
+new content in, never by reading the upstream repo from `/assess`.
+
+### Acceptance scenario for self-containment
+
+11. **No upstream runtime dependency** — no assess artifact (command,
+    SKILL, agent, or any `references/` file) contains a path reference
+    to `ai-literacy-for-software-engineers`, `framework/framework.md`,
+    or any other upstream-repo read; the operational-axes reference
+    embeds the full marker text. (Structural test, offline.)

--- a/tdad_tests/tests/test_assess_operational_axes.py
+++ b/tdad_tests/tests/test_assess_operational_axes.py
@@ -1,0 +1,345 @@
+"""Structural tests for the /assess ALCI Part D alignment (v0.40.0).
+
+These are offline, deterministic, file-shape assertions translating the
+acceptance scenarios in the design spec:
+
+    docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md
+
+The framework's ALCI was extended upstream with Part D (four operational
+axes) and the Habitat Build Gap. /assess is brought into line. The
+behavioural contract (that a live /assess run places the axes and
+computes a correct gap) is documentation-only at this layer, consistent
+with how the plugin's other commands are tested offline.
+
+A load-bearing requirement is SELF-CONTAINMENT: the plugin ships
+standalone via the marketplace, so no assess artifact may read the
+upstream framework repo at runtime. The four axes' full marker text is
+embedded in references/operational-axes.md; the only upstream mention is
+the provenance/attribution block in that one file.
+"""
+
+from pathlib import Path
+
+import json
+
+import pytest
+
+
+SKILL_DIR_NAME = "ai-literacy-assessment"
+
+
+@pytest.fixture(scope="module")
+def assess_paths(plugin_path: Path) -> dict:
+    """Resolve the assess-related artifact paths once per module."""
+    skill = plugin_path / "skills" / SKILL_DIR_NAME
+    refs = skill / "references"
+    repo_root = plugin_path.parent
+    return {
+        "repo_root": repo_root,
+        "command": plugin_path / "commands" / "assess.md",
+        "skill": skill / "SKILL.md",
+        "agent": plugin_path / "agents" / "assessor.agent.md",
+        "template": refs / "assessment-template.md",
+        "operational_axes": refs / "operational-axes.md",
+        "sophistication": refs / "sophistication-markers.md",
+        "tool_config": refs / "tool-config-evidence.md",
+        "how_to": repo_root
+        / "docs"
+        / "plugins"
+        / "ai-literacy-superpowers"
+        / "how-to"
+        / "run-an-assessment.md",
+        "plugin_json": plugin_path / ".claude-plugin" / "plugin.json",
+        "marketplace": repo_root / ".claude-plugin" / "marketplace.json",
+        "changelog": repo_root / "CHANGELOG.md",
+    }
+
+
+FOUR_AXES = ("Composition", "Testing", "Observability", "Governance")
+REGIMES = (
+    "Coherent",
+    "Ambition outpaces enablement",
+    "Inherited habitat",
+)
+
+
+# -- Scenario 5: the new self-contained reference exists --------------
+
+
+def test_operational_axes_reference_exists(assess_paths: dict) -> None:
+    """Scenario 5: references/operational-axes.md exists."""
+    page = assess_paths["operational_axes"]
+    assert page.is_file(), (
+        f"Expected the self-contained operational-axes reference at "
+        f"{page} (spec §6)."
+    )
+
+
+def test_operational_axes_reference_names_four_axes_with_markers(
+    assess_paths: dict,
+) -> None:
+    """Scenario 5: the reference names all four axes and embeds L1–L5
+    marker text (proves the content is embedded, not referenced)."""
+    body = assess_paths["operational_axes"].read_text()
+    for axis in FOUR_AXES:
+        assert axis in body, (
+            f"operational-axes.md must name the {axis!r} axis."
+        )
+    # Embedded marker text — distinctive quotes from framework Part D.
+    embedded_markers = [
+        "Agents self-orchestrate into constellations",  # Composition L5
+        "We use mutation testing to verify our tests",  # Testing L2
+        "Observability is closed-loop",  # Observability L5
+        "written constitution (CLAUDE.md / HARNESS.md)",  # Governance L3
+    ]
+    for marker in embedded_markers:
+        assert marker in body, (
+            "operational-axes.md must EMBED the verbatim L1–L5 marker "
+            f"text (self-containment, §2.4). Missing: {marker!r}"
+        )
+
+
+# -- Scenario 3: Habitat Build Gap formula + regimes -----------------
+
+
+def test_habitat_build_gap_formula_and_regimes(assess_paths: dict) -> None:
+    """Scenario 3: the gap formula and the three interpretation regimes
+    are documented in the reference."""
+    body = assess_paths["operational_axes"].read_text()
+    assert "level_placement − operational_axes_mean" in body, (
+        "operational-axes.md must document the Habitat Build Gap "
+        "formula `level_placement − operational_axes_mean` (spec §4)."
+    )
+    for regime in REGIMES:
+        assert regime in body, (
+            f"operational-axes.md must name the {regime!r} interpretation "
+            "regime (spec §4)."
+        )
+
+
+# -- Scenario 1 + 2: assessment template sections --------------------
+
+
+def test_template_has_operational_axes_and_gap_sections(
+    assess_paths: dict,
+) -> None:
+    """Scenario 1: the template carries both new sections."""
+    body = assess_paths["template"].read_text()
+    assert "## Operational Axes (ALCI Part D)" in body, (
+        "assessment-template.md must add a `## Operational Axes "
+        "(ALCI Part D)` section (spec §6)."
+    )
+    assert "## Habitat Build Gap" in body, (
+        "assessment-template.md must add a `## Habitat Build Gap` "
+        "section (spec §6)."
+    )
+
+
+def test_template_operational_axes_table_names_axes(
+    assess_paths: dict,
+) -> None:
+    """Scenario 2: the template's Operational Axes table names all four
+    axes and has a placement + evidence column."""
+    body = assess_paths["template"].read_text()
+    for axis in FOUR_AXES:
+        assert axis in body, (
+            f"assessment-template.md Operational Axes table must row the "
+            f"{axis!r} axis (spec §6)."
+        )
+    assert "| Axis | Placement | Evidence |" in body, (
+        "assessment-template.md must give the Operational Axes table a "
+        "`Axis | Placement | Evidence` header (spec §6)."
+    )
+
+
+# -- Scenario 4 + 8: SKILL documents Part D + hybrid -----------------
+
+
+def test_skill_documents_part_d(assess_paths: dict) -> None:
+    """Scenario 4: the SKILL documents the four axes, the gap, and the
+    regimes."""
+    body = assess_paths["skill"].read_text()
+    assert "Operational Axes (ALCI Part D)" in body, (
+        "SKILL.md must document the Operational Axes (ALCI Part D) "
+        "section (spec §6)."
+    )
+    for axis in FOUR_AXES:
+        assert axis in body, f"SKILL.md must name the {axis!r} axis."
+    assert "Habitat Build Gap = level_placement − operational_axes_mean" in body, (
+        "SKILL.md must document the Habitat Build Gap formula."
+    )
+
+
+def test_skill_documents_hybrid_administration(assess_paths: dict) -> None:
+    """Scenario 8: the SKILL documents both the evidence-first default
+    and the opt-in survey."""
+    body = assess_paths["skill"].read_text()
+    assert "Evidence-first" in body or "evidence-first" in body, (
+        "SKILL.md must document the evidence-first default (spec §5.1)."
+    )
+    assert "40-statement" in body, (
+        "SKILL.md must document the opt-in 40-statement survey "
+        "(spec §5.2)."
+    )
+
+
+# -- Scenario 6: assessor agent --------------------------------------
+
+
+def test_agent_gathers_axes_and_computes_gap(assess_paths: dict) -> None:
+    """Scenario 6: the assessor agent gathers per-axis evidence, emits
+    the sections, computes the gap, and cross-references governance."""
+    body = assess_paths["agent"].read_text()
+    assert "operational-axes.md" in body, (
+        "assessor agent must point at references/operational-axes.md "
+        "for the axis methodology (self-contained source)."
+    )
+    assert "Habitat Build Gap" in body, (
+        "assessor agent must compute the Habitat Build Gap (spec §6)."
+    )
+    # Governance axis ↔ Governance Dimension cross-reference + consistency.
+    assert "Governance Dimension" in body and "Governance axis" in body, (
+        "assessor agent must cross-reference the Governance axis and the "
+        "Governance Dimension (spec §7)."
+    )
+    assert "consistent" in body, (
+        "assessor agent must state the Governance axis and Dimension "
+        "report a consistent level (spec §7)."
+    )
+
+
+# -- Scenario 7: command document step + validation checkpoint -------
+
+
+def test_command_documents_sections_and_checkpoint(
+    assess_paths: dict,
+) -> None:
+    """Scenario 7: the command documents the new document sections and a
+    validation checkpoint covering them."""
+    body = assess_paths["command"].read_text()
+    assert "Operational Axes (ALCI Part D)" in body, (
+        "assess.md must document the Operational Axes section in the "
+        "document step (spec §6)."
+    )
+    assert "Habitat Build Gap" in body, (
+        "assess.md must document the Habitat Build Gap (spec §6)."
+    )
+    # Validation checkpoint covers gap consistency + governance match.
+    assert "level placement minus the operational axes mean" in body, (
+        "assess.md validation checkpoint must verify gap = level − mean "
+        "(spec §6, checkpoint check 6)."
+    )
+    assert "Governance axis placement matches the Governance Dimension" in body, (
+        "assess.md validation checkpoint must verify the two governance "
+        "views do not diverge (spec §6, checkpoint check 7)."
+    )
+
+
+def test_command_offers_optin_survey(assess_paths: dict) -> None:
+    """Scenario 8: the command offers the opt-in survey."""
+    body = assess_paths["command"].read_text()
+    assert "opt-in" in body and "survey" in body, (
+        "assess.md must offer the opt-in ALCI Part D survey (spec §5.2)."
+    )
+
+
+# -- Scenario 9: version triplet at 0.40.0 ---------------------------
+
+
+def test_plugin_json_at_0_40_0(assess_paths: dict) -> None:
+    """Scenario 9: plugin.json is at 0.40.0."""
+    manifest = json.loads(assess_paths["plugin_json"].read_text())
+    assert manifest["version"] == "0.40.0", (
+        f"plugin.json must be 0.40.0 (was 0.39.1). Actual: "
+        f"{manifest['version']!r}"
+    )
+
+
+def test_marketplace_entry_and_plugin_version_at_0_40_0(
+    assess_paths: dict,
+) -> None:
+    """Scenario 9: the ai-literacy-superpowers marketplace entry version
+    and the top-level plugin_version are 0.40.0; the top-level listing
+    `version` is unchanged."""
+    marketplace = json.loads(assess_paths["marketplace"].read_text())
+    entry = next(
+        p
+        for p in marketplace["plugins"]
+        if p["name"] == "ai-literacy-superpowers"
+    )
+    assert entry["version"] == "0.40.0", (
+        f"ai-literacy-superpowers marketplace entry must be 0.40.0. "
+        f"Actual: {entry['version']!r}"
+    )
+    assert marketplace["plugin_version"] == "0.40.0", (
+        f"marketplace plugin_version must track 0.40.0. Actual: "
+        f"{marketplace['plugin_version']!r}"
+    )
+    assert marketplace["version"] == "0.4.0", (
+        "top-level marketplace listing `version` must be unchanged at "
+        f"0.4.0 (plugin behavioural bump does not move it). Actual: "
+        f"{marketplace['version']!r}"
+    )
+
+
+def test_changelog_has_0_40_0_heading(assess_paths: dict) -> None:
+    """Scenario 9: the CHANGELOG has a 0.40.0 heading."""
+    body = assess_paths["changelog"].read_text()
+    assert "## 0.40.0 — 2026-06-01" in body, (
+        "CHANGELOG.md must have a `## 0.40.0 — 2026-06-01` heading "
+        "(note the em dash, not a hyphen)."
+    )
+
+
+# -- Scenario 10: docs how-to ----------------------------------------
+
+
+def test_how_to_documents_axes_and_gap(assess_paths: dict) -> None:
+    """Scenario 10: run-an-assessment.md documents the operational axes
+    and the Habitat Build Gap."""
+    body = assess_paths["how_to"].read_text()
+    assert "Habitat Build Gap" in body, (
+        "run-an-assessment.md must document the Habitat Build Gap "
+        "(spec §6)."
+    )
+    for axis in FOUR_AXES:
+        assert axis in body, (
+            f"run-an-assessment.md must name the {axis!r} axis."
+        )
+
+
+# -- Scenario 11: no upstream runtime dependency ---------------------
+
+
+def test_no_upstream_runtime_dependency(assess_paths: dict) -> None:
+    """Scenario 11: the execution artifacts (command, SKILL, agent,
+    template, evidence references) contain no reference to the upstream
+    framework repo — all Part D content is embedded locally. The only
+    permitted upstream mention is the provenance block in
+    operational-axes.md (attribution + re-sync pointer, not a runtime
+    read)."""
+    upstream = "ai-literacy-for-software-engineers"
+    execution_artifacts = (
+        "command",
+        "skill",
+        "agent",
+        "template",
+        "sophistication",
+        "tool_config",
+        "how_to",
+    )
+    for key in execution_artifacts:
+        body = assess_paths[key].read_text()
+        assert upstream not in body, (
+            f"{key} ({assess_paths[key].name}) must not reference the "
+            f"upstream repo {upstream!r} — Part D content is embedded in "
+            "operational-axes.md; no artifact reads the upstream repo at "
+            "runtime (spec §2.4 / scenario 11)."
+        )
+    # operational-axes.md may name the upstream ONLY in provenance, and
+    # must embed the markers (proven by the embedded-markers test above).
+    ref_body = assess_paths["operational_axes"].read_text()
+    assert "Provenance" in ref_body, (
+        "operational-axes.md must confine its single upstream mention to "
+        "a clearly-marked Provenance block (spec §2.4)."
+    )


### PR DESCRIPTION
## What

Brings the `/assess` command into line with the framework's latest ALCI, which was extended **upstream** with **Part D — four operational axes** and the **Habitat Build Gap** diagnostic.

**Driving change (cross-repo):** `ai-literacy-for-software-engineers` commits [`f13d388`](https://github.com/russmiles/ai-literacy-for-software-engineers/commit/f13d388) (#327, "Adopt Habitat Maturity Model into framework — per-level rubric + ALCI Part D") and [`542f325`](https://github.com/russmiles/ai-literacy-for-software-engineers/commit/542f325) (#330, "unified cognitive+operational dimensions matrix"). Framework source: `framework/framework.md` Appendix M (Part D) and Appendix U (The Cognitive–Operational Gap).

Parts A–C (the cognitive level placement) are unchanged; Part D is additive.

## Design decisions (set with the human)

- **Hybrid administration** — evidence-first axis placement by default (from the repo scan), with an **opt-in 40-statement ALCI Part D survey** for teams wanting the rigorous score.
- **Keep both governance views** — the standalone Governance Dimension deep-dive is retained; the new Governance operational axis is its one-line operational summary; the two are cross-referenced and must report a **consistent** level.
- **Self-contained** — the plugin ships standalone, so **all** Part D content (axis definitions, full L1–L5 markers, evidence map, gap formula, regimes) is **embedded** in the new `references/operational-axes.md`. No assess artifact reads the upstream repo at runtime; upstream refs are provenance/re-sync pointers only. A structural test enforces this.
- **Lighter pipeline** (human-chosen): spec → implement → integrate; adversarial/cartographer gates skipped.

## The Habitat Build Gap

`cognitive level − operational axes mean`, with three regimes: **Coherent** (`abs < 0.5`), **Ambition outpaces enablement** (`≥ +0.5`), **Inherited habitat** (`≤ −0.5`). The signal is coherence, not the size of the level.

## Changes

New `references/operational-axes.md`; updated SKILL, assessor agent, assessment template, `/assess` command (document step + validation checkpoint), the two evidence references, and the `run-an-assessment` how-to. Version 0.39.1 → **0.40.0** (top-level marketplace listing unchanged). 15 structural tests added; full suite 218 passed / 31 skipped.

Spec: `docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md` (committed first; spec-first gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)