### PR TITLE
chore: advance HARNESS.md template marker to 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ unchanged; Part D is additive.
 
 Spec: `docs/superpowers/specs/2026-06-01-assess-operational-axes-design.md`.
 
+### Maintenance
+
+- `/harness-upgrade`: advanced the root `HARNESS.md` template-version
+  marker from 0.39.1 to 0.40.0 after confirming the dogfood harness
+  already contains all current template content (no new constraints,
+  GC rules, or sections to adopt).
+
 ## 0.39.1 — 2026-05-28
 
 ### Fix — /superpowers-status disposition counting

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.39.1 -->
+<!-- template-version: 0.40.0 -->
 
 ## Context
 


### PR DESCRIPTION
## What

Ran `/harness-upgrade`. The comparison found **no new template content to adopt** — this repo's `HARNESS.md` is the dogfood instance and already supersets the shipped template (26 constraints / 19 GC rules vs the scaffold's 5 / 14). Every template constraint, GC rule, and section is already present in customised form.

The only action was to advance the version markers:

- `HARNESS.md`: `template-version: 0.39.1` → `0.40.0`
- `.claude/.harness-upgrade-dismissed` (gitignored, per-machine): `0.39.1` → `0.40.0`

This stops the template-currency GC rule and the SessionStart hook from flagging an available upgrade.

## Why chore

Root-file marker bump only — no files inside `ai-literacy-superpowers/` changed, so no plugin version bump is required. Top CHANGELOG heading stays `0.40.0`, matching `plugin.json`. A `### Maintenance` note was appended under the existing `0.40.0` heading for traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)