### PR TITLE
chore: correct harness enforcement badge to 25/26

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
 [![Agents](https://img.shields.io/badge/Agents-14-2E8B57?style=flat-square)](#agents-14)
 [![Commands](https://img.shields.io/badge/Commands-26-2E8B57?style=flat-square)](#commands-26)
-[![Harness](https://img.shields.io/badge/Harness-23%2F24_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-10-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)


### PR DESCRIPTION
## What

`/harness-audit` (2026-06-01) found the README harness badge read `23/24` while actual enforcement is `25/26` (96.2%). This corrects the badge to match `HARNESS.md` Status.

## Audit summary

- **25/26 constraints enforced** (16 deterministic, 9 agent); 1 explicitly unverified (*Tests must pass* — no test runner). 0 failing, 0 missing tools/workflows.
- **19/19 GC rules active.**
- Aggregate: **Healthy** (above the 70% threshold).
- Reflection-log archival coverage: 43 active entries, empty archive (no promoted entries yet — correct), 0 curation debt; both archival GC paths declared and operating.

## Open drift not in this PR

ONBOARDING.md is 3 days stale vs HARNESS.md/AGENTS.md/REFLECTION_LOG.md — remediated separately via `/harness-onboarding` (monthly cadence).

## Why chore

Root-file badge correction only — no files inside `ai-literacy-superpowers/` changed, so no plugin version bump. Top CHANGELOG heading stays `0.40.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)