### PR TITLE
Cost-estimation skill (S1): prospective token/time/cost estimate contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.40.0",
+  "plugin_version": "0.41.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.40.0"
+      "version": "0.41.0"
     },
     {
       "name": "model-cards",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,35 @@
   #7 and #8 (original promotion); `docs/superpowers/stories/dl-s4-diagnose-command-design.md`
   story #1 (ordering-invariant sharpening).
 
+- Decision: **an agent that DERIVES a judgment a human previously SUPPLIED
+  carries a disclosure obligation** — the disclosure-of-derived-judgment
+  contract. When an agent emits a value that was formerly ground-truth supplied
+  by a human (a derived *prediction*, not an inspected fact), the artefact must
+  disclose, in four parts, what it **included**, what it consciously
+  **excluded**, its **confidence**, and the **failure direction** when
+  confidence is below high — and never present a silent boundary or a single
+  number as fact. Reason: a supplied input cannot be wrong; a derived one can
+  under- or over-reach, so the derivation manufactures a correctness risk the
+  supplied case never had, and the four-part disclosure is what keeps the
+  derived value honest (it does not make it *useful* — that is a separate
+  validation question). This complements, and is disposed over through, the
+  agent-emit/dispatcher-persist/human-disposes architecture above: the
+  disclosure is the thing the human disposes over. Worked instance: the
+  `cost-estimation` skill's estimate-record operationalises it as a format
+  contract — token/time/cost ranges with per-axis confidence, an
+  included/excluded/confidence/failure-direction prose body, and `cost_usd`
+  omitted-with-disclosure rather than guessed when ungrounded. The same
+  principle independently surfaced for the diagnostic-legibility pipeline-map's
+  derived task→scope resolution; two independent surfacings argue it is
+  cross-cutting, not feature-local (Rule of Three pending a third). Scope note:
+  this is a design discipline these specs PROPOSE, not yet an enforced
+  invariant beyond each skill's own validation checklist — a trust-surface
+  audit should read the disclosure obligation, not just the tool list. Future
+  "let the agent infer X that the human used to supply" features inherit this
+  obligation rather than re-deriving it.
+  Source: `docs/superpowers/stories/cost-estimation-skill-design.md` story #8
+  (promoted disposition).
+
 - Decision: hook scripts never block, only warn. Reason: this is a
   plugin used across diverse projects — blocking hooks could break
   workflows the plugin authors cannot predict. Advisory messages let

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.41.0 — 2026-06-11
+
+### New skill — `cost-estimation` (prospective cost/token/time estimation)
+
+Ships S1 of the cost-estimator capability: the methodology and the format
+contract every later slice (the S2 agent, the S3 command, the S4
+orchestrator fold-in) consumes. No agent, command, or orchestrator wiring
+ships here.
+
+- **`skills/cost-estimation/SKILL.md`** — the prospective sibling of
+  `cost-tracking`. Describes how MODEL_ROUTING.md grounds token and
+  agent-compute-time ranges today, how an `observability/costs/` snapshot
+  adds a dollar figure only when it supplies a usable $/token rate (three
+  grounding states, no list-price fallback), the split-tier widening for
+  the implementer stage, the two-layer no-verdict guarantee, the
+  agent-compute / human-gate time split, and the calibration seam left
+  open for S6.
+- **`skills/cost-estimation/references/estimate-record-format.md`** — the
+  stable estimate-record field set (with `cost_usd`/`cost_basis`
+  conditional and `confidence` per-axis), the tier→model→$/token binding
+  table, the four-part disclosure body, the validation checklist
+  (including the positive-content no-verdict scan), and two worked
+  examples (cost-omitted and cost-present). This is the artefact a
+  downstream command's Output Validation Checkpoint parses.
+
 ## 0.40.0 — 2026-06-01
 
 ### `/assess` — ALCI Part D operational axes + Habitat Build Gap

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.40.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.41.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-33-2E8B57?style=flat-square)](#skills-33)
+[![Skills](https://img.shields.io/badge/Skills-34-2E8B57?style=flat-square)](#skills-34)
 [![Agents](https://img.shields.io/badge/Agents-14-2E8B57?style=flat-square)](#agents-14)
 [![Commands](https://img.shields.io/badge/Commands-26-2E8B57?style=flat-square)](#commands-26)
 [![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.40.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **33 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.41.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 14 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (33)
+### Skills (34)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -188,6 +188,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | portfolio-dashboard | Generate a self-contained HTML dashboard from portfolio assessment data with trend visualisation |
 | team-api | Create or update a Team Topologies Team API document with AI literacy portfolio data |
 | cost-tracking | Quarterly AI cost capture — record spend, compare trends, inform model routing |
+| cost-estimation | Prospective cost/token/time estimation — range-with-confidence estimate records, snapshot-grounded dollar figures, the prospective sibling of cost-tracking |
 | governance-constraint-design | Falsifiable governance constraint authoring — three-frame translation, anti-patterns gallery, governance constraint template |
 | governance-audit-practice | Governance audit methodology — five-stage semantic drift model, debt scoring matrix, frame alignment review |
 | governance-observability | Governance metrics catalogue, snapshot format extension, and HTML dashboard specification |
@@ -400,7 +401,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (33)                     Domain knowledge for agents
+│   └── Skills (34)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: cost-estimation
+description: Use when the user wants to estimate or predict the cost, token usage, or time of a task BEFORE it runs — "how much will this feature cost to build", "estimate the tokens for this spec", "what will this slice cost", "predict the agent-compute time before I commit" — produces a token + time estimate as a range with disclosed confidence, adding a dollar figure only when an observability/costs snapshot grounds it. The prospective sibling of cost-tracking, which records actual spend after the fact.
+---
+
+# Cost Estimation
+
+Estimate, *before* work runs, the token usage and time a task will
+consume flowing through the orchestrator pipeline — and a dollar cost
+**only when observed actuals exist to ground it**.
+
+This is the **prospective** counterpart to the **retrospective**
+`cost-tracking` skill. `cost-tracking` *records* what was spent into
+`observability/costs/YYYY-MM-DD-costs.md`; this skill *reads* those same
+snapshots as its $/token ground and *predicts* what a task will spend.
+The two are siblings — a reader who finds one should find the other (see
+[Sibling relationship](#sibling-relationship-to-cost-tracking)).
+
+The day-one deliverable is a **token + time estimate**. Both axes are
+fully groundable from `MODEL_ROUTING.md` today, so they are the honest
+first-version value of this capability. The dollar figure is an
+**actuals-gated enhancement** — present and grounded only when an
+`observability/costs/` snapshot supplies a usable $/token rate, otherwise
+omitted with an explicit disclosure (never a forced list-price guess).
+
+This skill is **methodology and a format contract**. It describes how an
+estimate is derived and what an estimate record must contain. It does not
+dispatch an agent, write a file, or decide go/no-go — see
+[What this skill does NOT do](#what-this-skill-does-not-do).
+
+## An Estimate Is a Range, Never a Point
+
+The material decision this skill locks: **an estimate is a range with
+disclosed confidence, never a point value.**
+
+A point value invites false precision. "12k tokens" reads as fact;
+"10k–18k tokens, confidence medium, more likely to overrun than underrun
+because the implementer stage spans two model tiers" reads as a
+prediction a human can interrogate. The whole point of the capability is
+to *inform* a human's choice, not to anchor it on a number dressed as a
+fact.
+
+Every quantitative field is therefore a `{ low, high }` range, and every
+record carries per-axis confidence and the disclosures the contract
+requires. The canonical field definitions live in the format reference:
+
+**Format reference: [`references/estimate-record-format.md`](references/estimate-record-format.md)** — the
+stable estimate-record field set, the tier→model→$/token binding table,
+the four-part disclosure body, the validation checklist, and two worked
+examples. A downstream command's Output Validation Checkpoint references
+that file by path.
+
+## Grounding Methodology
+
+The grounding sources are **fixed, not chosen** — the methodology names
+them, it does not offer a choice between them. Token ranges and
+agent-compute time are **always** groundable from `MODEL_ROUTING.md`. The
+dollar figure is groundable **only when a snapshot supplies a usable
+$/token rate**; otherwise it is omitted. Human-gate time is **not
+estimated numerically at S1**.
+
+### Token derivation from MODEL_ROUTING.md
+
+`MODEL_ROUTING.md` carries two tables the methodology consumes:
+
+- **Token Budget Guidance** — per-role ranges: spec-writer 50–100k,
+  tdd-agent 50–150k, implementer 100–250k, code-reviewer 50–100k,
+  integration-agent 30–80k. Each role's `low`–`high` becomes that stage's
+  `tokens` range.
+- **Agent Routing** — the agent→model-tier mapping (orchestrator,
+  spec-writer, advocatus-diaboli → `Most capable`; tdd-agent,
+  integration-agent → `Standard`; implementer → `Standard / Capable`;
+  code-reviewer → `Most capable`). Each stage's `model_tier` is read from
+  this table.
+
+The per-stage token ranges sum into the whole-record `tokens` range
+(stages may be correlated, so the whole-record range need not equal the
+arithmetic sum — when they differ the prose body must say why). Which
+stages a target exercises depends on `target_kind`: a docs-only spec may
+exercise spec-writer + review only, and the omitted stages **must** be
+disclosed in `Excluded`.
+
+**Split-tier stages.** The implementer stage maps to a **split tier**
+`Standard / Capable` ("Depends on task complexity"), and it carries the
+largest token budget (100–250k), so its rate dominates any cost figure.
+The methodology does **not** leave the tier choice to agent discretion.
+A split-tier stage is priced (when cost is computed at all) by **widening
+its cost contribution to span both ends of the split**: its low bound
+uses the cheaper end (`claude-sonnet-4`, the `Standard` representative)
+and its high bound uses the dearer end (`claude-opus-4`, the `Most
+capable` representative — the tier the split rises to for complex tasks,
+since `MODEL_ROUTING.md` carries no standalone `Capable` model). Because
+the two ends bind to **different** representative models, the widening
+produces a genuine spread for this dominant stage rather than collapsing
+to one rate. The `tokens_by_stage[].model_tier` field records the literal
+split label (`Standard/Capable`) so the breakdown stays traceable.
+
+### Cost derivation — only when a snapshot grounds it
+
+`cost_usd` is **present only when an `observability/costs/` snapshot
+supplies a usable per-tier $/token rate.** Deriving that rate requires a
+named binding, because `MODEL_ROUTING.md` tiers are abstract labels with
+no model or price, while the snapshot's Model Breakdown is keyed by model
+name. The binding is fixed in the format reference's
+**tier→model→$/token binding table**:
+
+| Model tier (MODEL_ROUTING) | Representative model (snapshot key) |
+| --- | --- |
+| Most capable | `claude-opus-4` |
+| Standard | `claude-sonnet-4` |
+| Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-opus-4` (high), widened |
+
+`MODEL_ROUTING.md` names exactly two tiers — `Standard` and `Most
+capable` — and one complexity-dependent split, the implementer's
+`Standard / Capable`. There is **no standalone `Capable` tier with its
+own model**; the dearer end of the split resolves to `Most capable`.
+
+**Deriving a per-model rate from a snapshot.** The snapshot's
+`## Model Breakdown` table gives, per model, quarter-aggregate
+input/output token volumes and an estimated cost. The methodology
+computes a per-model `$/token` as
+`estimated_cost ÷ (input_tokens + output_tokens)` — a single blended rate
+per model. The binding table maps each stage's tier to its representative
+model's blended rate, and
+`cost_usd = Σ over stages (stage tokens range × tier $/token)`, with
+split-tier stages widened as above.
+
+**The three grounding states.** The snapshot's Model Breakdown is marked
+"(if available)" in the cost-tracking format, so the methodology branches
+on **three** states, not two:
+
+1. **No snapshot exists** — today's state; `observability/costs/` is
+   empty (the 2026-05-29 health snapshot records "Last cost capture:
+   never"). → `cost_usd` **omitted**, omission disclosed in `Excluded`.
+2. **Snapshot exists but the Model Breakdown is absent or too coarse**
+   to yield a per-tier rate (only the always-present Provider Spend table
+   is populated, or the breakdown lacks the tiers the stage set needs). →
+   `cost_usd` **omitted**, omission disclosed in `Excluded` **naming this
+   specific cause** ("a cost snapshot exists but carries no usable
+   per-model breakdown"). The methodology does **not** silently fall
+   through to list price.
+3. **Snapshot exists with a usable Model Breakdown** → `cost_usd`
+   **present**, `cost_basis: snapshot-actuals`, `confidence.cost` set from
+   the snapshot's age and granularity, and the snapshot date/quality
+   disclosed in `Included`.
+
+**There is no list-price fallback.** A list-price guess is not an
+observed cost; emitting it as a first-class figure was the false
+precision this methodology opposes. When cost cannot be grounded in
+actuals, it is **omitted with disclosure**, and the day-one deliverable
+remains the token + time estimate.
+
+**The no-cost case is honest, not a failure.** When `cost_usd` is omitted
+(states 1 and 2), the record is **valid and complete** — it is the
+expected day-one shape. The `Excluded` section carries an explicit
+omission disclosure, e.g.:
+
+> "cost_usd: omitted — no repo cost snapshot exists yet, so no observed
+> $/token is available; cost is not estimated. Token and time figures
+> stand."
+
+A grounded token + time estimate plus an honest "dollars are not yet
+knowable" is more informative than a low-confidence list-price range that
+says "we don't really know" in numeric clothing. **No format change is
+required when the first snapshot lands** — the same
+`cost_usd`/`cost_basis`/`confidence.cost` fields simply begin to appear.
+This is the seam the [calibration section](#the-calibration-seam-s6) also
+contemplates.
+
+## The Disclosure / Confidence Contract
+
+This four-part disclosure body is a contract **this skill proposes** — it
+is not a pre-existing promoted AGENTS.md decision. It serves the real
+AGENTS.md **"agent-emit + dispatcher-persist + human-disposes"** trust
+architecture: a research-and-author agent emits content and the human
+disposes. The disclosure contract makes the derivation interrogable so
+the human's disposition is informed. An estimate record that does not
+satisfy this contract is invalid regardless of how good its numbers are.
+
+### Mandatory four-part disclosure body
+
+Every estimate record's prose body MUST contain four labelled sections:
+
+1. **Included** — what the estimate counts, and the provenance/quality of
+   each included input. Caveats about the *quality of an included input*
+   (an assumed compute band, a snapshot of a given age) live here or
+   under Confidence rationale, never under Excluded.
+2. **Excluded** — what the estimate does NOT count, stated plainly:
+   human-gate latency (excluded from `cost_usd` and `tokens` because
+   gates cost wall-clock not tokens); re-runs and diaboli/cartograph
+   cycles beyond one pass; any stages a target does not exercise. **When
+   `cost_usd` is omitted because no usable snapshot rate exists, that
+   omission is disclosed here.** Excluded items are the single most
+   important honesty signal — a number that silently omits a cost class
+   is worse than no number.
+3. **Confidence rationale** — why each confidence axis (`tokens`, `time`,
+   and, when present, `cost`) is what it is, tied to the `target_kind`
+   and the grounding richness.
+4. **Failure direction** — a one-line statement matching the
+   `failure_direction` field, naming WHY the estimate is more likely
+   wrong in that direction. **This section describes uncertainty only —
+   it must contain no imperative recommendation and no go/no-go
+   language.**
+
+A record missing any of the four sections fails validation.
+
+### Per-axis confidence
+
+Confidence is recorded **per axis** (`tokens`, `time`, and — only when
+`cost_usd` is present — `cost`), not as one whole-record tier. The
+`tokens`/`time` axes have a **ceiling tied to `target_kind`**; the `cost`
+axis has its own independent rule.
+
+- **Target-kind ceiling (tokens/time):** `task-text` caps at `low`;
+  `slicing-record`/`slice` at most `medium`; `spec` may reach `high`. The
+  ceiling is a cap, not a verdict — an axis may sit below it, but a
+  raw-text estimate's token confidence can never be `high`.
+- **Cost axis (independent):** exists only when `cost_usd` is present.
+  Set from the snapshot's quality (age, breakdown granularity), and
+  **independent of `target_kind`** — a spec-grounded target with a stale
+  snapshot can carry `tokens: high` beside `cost: low` without
+  contradiction.
+
+The `time` axis describes confidence in the `agent_compute_time` estimate
+**only** — `human_gate_time` carries no numeric estimate at S1, so there
+is no human-gate number for the `time` axis to qualify.
+
+### Confidence is disclosed, never decisive — the two-layer no-verdict guarantee
+
+The record carries confidence; it does **not** carry a verdict,
+recommendation, or go/no-go. The human reads the ranges and disclosures
+and decides. This guarantee has **two layers of differing strength**:
+
+1. **Field-absence layer (structural)** — there is no `recommendation`,
+   `verdict`, or `proceed` field. This layer IS a property of the format
+   itself, independent of any agent's behaviour: a field that does not
+   exist cannot carry a verdict. (Necessary but not sufficient: a verdict
+   could be smuggled into free-text prose.)
+2. **Positive-content layer (tripwire, not proof)** — the four disclosure
+   sections describe **inputs and uncertainty only**. They MUST NOT
+   contain imperative recommendation or go/no-go language. A validation
+   check scans the disclosure prose for prohibited patterns ("so proceed",
+   "do not proceed", "I recommend", "you should [ship|skip|approve|reject]",
+   "go/no-go") and **fails the record** if any appear. A "failure
+   direction: likely-overrun, so do not proceed" sentence fails this check
+   even though it passes field-absence. But this scan is a **closed
+   enumeration of common verdict phrasings — a tripwire, not a proof**: a
+   paraphrased verdict ("the high bound makes this not worth building")
+   can evade the listed patterns. Its strength is "catches the common
+   cases", not "independent of any agent's behaviour".
+
+The field-absence layer is a structural guarantee; the positive-content
+layer catches the common cases and leans on the agent not paraphrasing
+around the list. The enumerated checks live in the format reference's
+validation checklist.
+
+## The Time Split
+
+`agent_compute_time` and `human_gate_time` are **two separate required
+fields** with **different shapes**:
+
+- **`agent_compute_time`** is the wall-clock the model spends generating
+  — the predictable term. It is derived from token volume by applying a
+  disclosed tokens→wall-clock band (the reference fixes a default, e.g.
+  "~1–3 min per 10k tokens generated") to the `tokens` range, yielding a
+  numeric `{ low, high }` range. The band is stated as an assumption in
+  `Included`; it is not claimed to be an observed actual.
+- **`human_gate_time`** is the wall-clock spent waiting for a human at
+  the orchestrator's disposition gates. It **dominates** total wall-clock
+  and is the **least predictable** term — it depends on when a human next
+  sits down, not on the work itself. It is **not estimated numerically at
+  S1**: it is a disclosed **qualitative caveat string**, not a range. Its
+  grounding — the orchestrator gate set and how many gates a target
+  passes through — lives in the orchestrator (S4), which this slice does
+  not touch. Multiplying an ungrounded gate count by a per-gate band
+  would re-introduce the very false precision the range-not-point
+  decision exists to prevent.
+
+Collapsing the two into one number would hide the dominant source of
+variance. The failure-direction prose must reference this: an estimate
+whose wall-clock omits human-gate latency is `likely-underrun` on
+wall-clock unless the human-gate caveat is read alongside it.
+
+## The Calibration Seam (S6)
+
+Calibration (a per-PR actuals loop) is accepted in-scope for the
+capability but **ships later**. This skill's only obligation is to keep
+the seam open so a future actuals data source can be ingested **without a
+format change**:
+
+- `grounding_sources[]` permits a `kind: calibration` entry. Today only
+  `model-routing` and `cost-snapshot` entries appear; tomorrow a
+  `calibration` entry can be added without altering the field set.
+- The methodology is written so that calibration data, when it exists,
+  **refines** the $/token and the per-stage token ranges — narrowing
+  ranges and potentially raising confidence — rather than introducing a
+  new field.
+
+This skill does **not** implement calibration: no per-PR actuals format,
+no integration-agent change, no ingestion logic. It names calibration as
+a *future* grounding source and stops there.
+
+## Sibling Relationship to cost-tracking
+
+The `cost-estimation` skill is the **prospective** counterpart to the
+**retrospective** `cost-tracking` skill. The two reuse the same
+`observability/costs/` data:
+
+- `cost-tracking` **writes** the snapshots (via `/cost-capture`).
+- `cost-estimation` **reads** them as its $/token ground.
+
+`/cost-capture` records what *was* spent; the future `/cost-estimate`
+predicts what *will be* spent. A user who knows one half of the cost
+capability should discover the other from either skill's description.
+
+## What This Skill Does NOT Do
+
+- **Does not dispatch an agent.** The read-only `cost-estimator` agent
+  that *emits* a record is a downstream consumer, not this skill.
+- **Does not write files or run a command.** Writing and validating a
+  record is a downstream command's job; this skill defines what such a
+  record must contain.
+- **Does not wire into the orchestrator.** No gate is added, moved, or
+  re-weighted; the orchestrator fold-in is downstream.
+- **Does not implement calibration.** The calibration seam is named, not
+  built.
+- **Does not decide go/no-go.** It emits ranges and disclosures for a
+  human to dispose; it carries no verdict, recommendation, or
+  recommendation prose.

--- a/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
@@ -1,0 +1,395 @@
+# Estimate-Record Format Reference
+
+The canonical, stable definition of the **estimate record** — the
+structured markdown artefact a future cost-estimator agent emits, a
+future `/cost-estimate` command writes and validates, and the
+orchestrator fold-in surfaces fields from. It must be a stable contract.
+
+A downstream command's **Output Validation Checkpoint** references this
+file by path. Treat the field table, the binding table, the disclosure
+body spec, and the validation checklist as precise — they are parsed, not
+read loosely.
+
+## Canonical artefact
+
+The record is a single markdown file with **YAML frontmatter** for the
+machine-readable fields and a **prose body** for the disclosures. The
+frontmatter carries the structured fields a validation checkpoint parses;
+the body carries the human-readable disclosure prose.
+
+## Frontmatter field set
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `target` | string | yes | What was estimated — a path (slicing record, spec) or a short description of pasted task text. |
+| `target_kind` | enum | yes | One of `task-text`, `slicing-record`, `slice`, `spec`. Signals the grounding richness available; richer targets warrant higher confidence. |
+| `generated_at` | string (ISO 8601) | yes | Timestamp the estimate was produced. |
+| `generated_by` | string | yes | Agent name + model identifier (e.g. `"cost-estimator / claude-opus-4-8"`). |
+| `grounding_sources` | list of objects | yes | The inputs the estimate was built from. Each entry has `path` (string) and `kind` (one of `model-routing`, `cost-snapshot`, `calibration`). At minimum a `model-routing` entry and a `cost-snapshot` entry; a `calibration` entry is permitted but never required. |
+| `tokens` | range object | yes | Estimated total token usage as `{ low: int, high: int }`. The budget-derived bounds. |
+| `tokens_by_stage` | list of objects | yes | Per-stage breakdown. Each entry: `stage` (string — spec-writer, tdd-agent, implementer, code-reviewer, integration), `tokens` (range object), `model_tier` (string from the agent→model-tier mapping — may be a split tier such as `Standard/Capable`). May omit stages a target does not exercise; the omission must be reflected in the `Excluded` prose. |
+| `cost_usd` | range object | **conditional (present-when-grounded)** | Estimated dollar cost as `{ low: float, high: float }`. **Present ONLY when an `observability/costs/` snapshot supplies a usable per-tier $/token rate.** When no usable rate exists, the field is **omitted entirely** and the omission is disclosed in `Excluded`. The format must not carry a placeholder, a null, or a forced list-price value. |
+| `cost_basis` | enum | **conditional (present-when-grounded)** | Present **iff** `cost_usd` is present. One of `snapshot-actuals` (rate derived from a snapshot Model Breakdown) — currently the only grounded basis. Records the provenance of the $/token rate so a reader knows the cost is observed, not guessed. |
+| `agent_compute_time` | range object | yes | Estimated wall-clock spent in agent execution as `{ low: <duration>, high: <duration> }`. Durations are ISO 8601 durations or plain `"Nm"`/`"Nh"` strings. Derived from token volume. |
+| `human_gate_time` | string (qualitative caveat) | yes | A **disclosed qualitative caveat string**, NOT a numeric range. Total wall-clock is dominated by human availability at the orchestrator's disposition gates, and **is not estimated numerically at S1**. Carries a short prose statement to that effect, never a `{ low, high }` range. |
+| `confidence` | object | yes | **Per-axis** confidence object with keys `tokens`, `time`, and (iff `cost_usd` present) `cost`, each one of `low`, `medium`, `high`. A whole-record summary tier MAY be reported as `min()` of the present axes, but the per-axis values are authoritative. |
+| `failure_direction` | enum | yes | One of `likely-overrun`, `likely-underrun`, `symmetric`. The direction the estimate is most likely wrong in, with the rationale carried in the prose body. |
+
+There is **no** point-value, `recommendation`, `verdict`, or `proceed`
+field anywhere in the field set.
+
+## Range representation
+
+Every quantitative field that is **present** (`tokens`, each
+`tokens_by_stage[].tokens`, `cost_usd` *when present*,
+`agent_compute_time`) is a two-key object `{ low, high }`.
+`human_gate_time` is **not** a quantitative range — it is a qualitative
+caveat string and is exempt from these rules.
+
+- `low ≤ high` for every present range.
+- `cost_usd` is **conditional**: a record with `cost_usd` absent is valid
+  (and is the expected day-one state); when present it must be a
+  well-formed range and `cost_basis` must accompany it.
+- A degenerate range where `low == high` is **permitted but discouraged**
+  — it signals point-value thinking and should carry a `low` confidence
+  tier and a prose note explaining why the range collapsed.
+- The whole-record `tokens` range need not equal the arithmetic sum of
+  `tokens_by_stage` ranges (stages may be correlated); when they differ
+  the prose body must say why.
+
+## The time split
+
+`agent_compute_time` and `human_gate_time` are **two separate required
+fields with different shapes**:
+
+- **`agent_compute_time`** is a numeric `{ low, high }` range derived from
+  token volume. The methodology applies a disclosed tokens→wall-clock
+  band (default below) to the `tokens` range. The band is stated as an
+  assumption in `Included`; it does not claim to be an observed actual.
+- **`human_gate_time`** is a **qualitative caveat string, NOT a range**.
+  It is **not estimated numerically at S1** because the gate set lives in
+  the orchestrator (S4, #371), which this slice does not touch. Human-gate
+  latency **dominates** total wall-clock and is the **least-predictable**
+  term — it depends on when a human next disposes a gate, not on the work.
+  Example value:
+
+  > "human-gate latency dominates total wall-clock and is not estimated
+  > numerically at S1; it depends on when a human next disposes a gate,
+  > not on the work."
+
+### Default throughput band (assumption)
+
+`agent_compute_time` is derived by applying a **default throughput band
+of ~1–3 minutes per 10k tokens generated** to the `tokens` range. This is
+a stated assumption, not an observed actual, and must be named in
+`Included`. No per-gate human-gate band ships — `human_gate_time` carries
+no number at S1.
+
+## The four-part disclosure body
+
+Every estimate record's prose body MUST contain four labelled sections. A
+record missing any of the four **fails validation**.
+
+1. **Included** — what the estimate counts, and the provenance/quality of
+   each included input (the stage set at its MODEL_ROUTING tier; the
+   tokens→wall-clock band; *when a cost figure is present:* the $/token
+   rate derived from the dated snapshot Model Breakdown). Quality-of-input
+   caveats live here or under Confidence rationale.
+2. **Excluded** — what the estimate does NOT count: human-gate latency
+   (excluded from `cost_usd` and `tokens` because gates cost wall-clock
+   not tokens); re-runs and diaboli/cartograph cycles beyond one pass; any
+   stages a target does not exercise. **When `cost_usd` is omitted, the
+   omission is disclosed here** (naming the cause). A *used* input never
+   appears here.
+3. **Confidence rationale** — why each present confidence axis (`tokens`,
+   `time`, and, when present, `cost`) is what it is, in plain prose tied
+   to `target_kind` and grounding richness.
+4. **Failure direction** — a one-line statement matching the
+   `failure_direction` field, naming WHY the estimate is more likely wrong
+   in that direction. **Describes uncertainty only — no imperative
+   recommendation, no go/no-go language.**
+
+## Per-axis confidence mapping
+
+Confidence is recorded **per axis**, not as one whole-record tier.
+
+### Target-kind ceiling (applies to `tokens` and `time`)
+
+| Tier | When | Typical `target_kind` |
+| --- | --- | --- |
+| `low` | Built from raw task text only, before slicing or spec. Scope is a guess; stage set is assumed. | `task-text` |
+| `medium` | Built from a slicing record or a single slice — work decomposed but scenarios/files not yet enumerated. | `slicing-record`, `slice` |
+| `high` | Built from a spec that enumerates scenarios and files to touch. | `spec` |
+
+The ceiling is a **cap tied to grounding, not a verdict**. An axis may
+sit below the cap, but a raw-text estimate's token confidence can never
+be `high`.
+
+### Cost axis (independent rule)
+
+The `cost` axis exists **only when `cost_usd` is present**. It is set from
+the snapshot's quality (age, breakdown granularity) and is **independent
+of `target_kind`** — a spec-grounded target with a stale or coarse
+snapshot can carry `tokens: high` beside `cost: low` without
+contradiction.
+
+## Tier→model→$/token binding table
+
+The single source of the `tier → model` map for cost derivation. The cost
+derivation reads this table so the binding is **not left to agent
+discretion**.
+
+| Model tier (MODEL_ROUTING) | Representative model (snapshot key) | $/token source |
+| --- | --- | --- |
+| Most capable | `claude-opus-4` | blended rate from the snapshot Model Breakdown row for `claude-opus-4` |
+| Standard | `claude-sonnet-4` | blended rate from the snapshot Model Breakdown row for `claude-sonnet-4` |
+| Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-opus-4` (high) | **widened**: low bound uses the `claude-sonnet-4` rate, high bound uses the `claude-opus-4` rate |
+
+`MODEL_ROUTING.md` names exactly two tiers — `Standard` and `Most
+capable` — and one complexity-dependent split, the implementer's
+`Standard / Capable`. There is **no standalone `Capable` tier with its own
+model**; the dearer end of the split resolves to `Most capable`.
+
+**Stage/tier normalisation (the join key).** A `tokens_by_stage[].stage`
+maps to a MODEL_ROUTING Agent Routing row by **stripping the
+`{{LANGUAGE}}-` prefix** — so `implementer` ↔ `{{LANGUAGE}}-implementer`.
+Tier labels are compared **whitespace-insensitively** — so `Standard/Capable`
+↔ `Standard / Capable`. This gives a mechanical consumer a defined join key
+across the prefix and slash-spacing variants.
+
+**Split-tier widening rule.** The implementer stage (`Standard / Capable`,
+"Depends on task complexity") carries the largest token budget
+(100–250k), so its rate dominates any cost figure. Its cost contribution
+is **widened to span both ends of the split**: low bound priced at the
+`claude-sonnet-4` rate, high bound at the `claude-opus-4` rate. Because
+the two ends bind to **different** representative models, the widening
+produces a genuine spread rather than collapsing to one rate. The same
+widening applies to any stage MODEL_ROUTING.md lists with a slashed tier.
+`tokens_by_stage[].model_tier` records the literal split label
+(`Standard/Capable`) so the breakdown stays traceable.
+
+**Deriving a per-model rate from a snapshot.** The snapshot's
+`## Model Breakdown` table gives per-model quarter-aggregate
+input/output token volumes and an estimated cost. Compute a per-model
+`$/token` as `estimated_cost ÷ (input_tokens + output_tokens)`, then bind
+each stage's tier to its representative model's rate.
+`cost_usd = Σ over stages (stage tokens range × tier $/token)`, with
+split-tier stages widened.
+
+The input/output token distinction is **deliberately collapsed** into this
+single blended rate — this is the sanctioned spec-round blended-rate skew,
+an accepted simplification, not a bug to fix. The blend's accuracy assumes
+the estimated task's input/output ratio resembles the snapshot quarter's;
+when those mixes diverge the figure skews. This is by design, so a
+downstream S2 author should not "fix" it by reintroducing a per-direction
+rate.
+
+## The three grounding states for cost
+
+1. **No snapshot exists** → `cost_usd` and `cost_basis` **omitted**;
+   omission disclosed in `Excluded`. `tokens`/`agent_compute_time` still
+   produced; `human_gate_time` caveat still produced.
+2. **Snapshot present but Model Breakdown absent or too coarse** →
+   `cost_usd` **omitted**; `Excluded` names this specific cause ("a cost
+   snapshot exists but carries no usable per-model breakdown"). **No**
+   silent fall-through to list price.
+3. **Snapshot present with a usable Model Breakdown** → `cost_usd`
+   **present**, `cost_basis: snapshot-actuals`, `confidence.cost` from the
+   snapshot's age/granularity, snapshot date/quality disclosed in
+   `Included`.
+
+**There is no list-price fallback.** When cost cannot be grounded in
+actuals, it is omitted with disclosure — the no-cost record is **valid and
+complete**, not a failure. **No format change is required when the first
+usable snapshot lands**: the same `cost_usd`/`cost_basis`/`confidence.cost`
+fields simply begin to appear.
+
+## The calibration seam
+
+`grounding_sources[]` permits a `kind: calibration` entry alongside
+`model-routing` and `cost-snapshot`. Calibration data, when it exists,
+**refines** existing $/token and per-stage token ranges (narrowing ranges,
+potentially raising confidence) rather than introducing a new field. No
+per-PR actuals capture, format, or integration-agent change ships in this
+slice.
+
+## Validation checklist
+
+The checks a consuming command's Output Validation Checkpoint runs:
+
+- [ ] **Ranges well-formed** — every **present** range
+  (`tokens`, each `tokens_by_stage[].tokens`, `cost_usd` when present,
+  `agent_compute_time`) has `low ≤ high`.
+- [ ] **All four disclosure sections present** — Included, Excluded,
+  Confidence rationale, Failure direction. A record missing any fails.
+- [ ] **Per-axis confidence within cap** — each present `confidence` axis
+  is within the `target_kind` ceiling for `tokens`/`time`; the `cost` axis
+  is present **iff** `cost_usd` is present. Cap the `tokens`/`time` axes by
+  `target_kind` (`task-text`→`low`, `slicing-record`/`slice`→`medium`,
+  `spec`→`high`; see the Target-kind ceiling table above). Do **NOT** cap
+  the `cost` axis by `target_kind` — it is independent (see the Cost axis
+  rule above), so a `cost: low` beside `tokens: high` is valid.
+- [ ] **Cost pairing** — `cost_usd` and `cost_basis` are **both present or
+  both absent**; when absent, the `Excluded` section contains the
+  cost-omission disclosure.
+- [ ] **Time split** — both time fields present and **separate**:
+  `agent_compute_time` a `{ low, high }` range, `human_gate_time` a
+  qualitative caveat string (NOT a range).
+- [ ] **No-verdict, field-absence layer** — no `recommendation`,
+  `verdict`, or `proceed` field appears in the frontmatter.
+- [ ] **No-verdict, positive-content layer** — the disclosure prose
+  contains **no imperative recommendation or go/no-go language**. The scan
+  **fails the record** if any of the following representative prohibited
+  patterns appear: `"so proceed"`, `"do not proceed"`, `"I recommend"`,
+  `"you should ship"`, `"you should skip"`, `"you should approve"`,
+  `"you should reject"`, `"go/no-go"`. The **Failure direction** section
+  describes uncertainty only — a sentence like "failure direction:
+  likely-overrun, so do not proceed" **fails** the positive-content check
+  even though it passes the field-absence check. This scan is a **tripwire
+  for the common verdict phrasings, not a proof**: the pattern list is a
+  closed enumeration, so a paraphrased verdict ("the high bound makes this
+  not worth building", "budget does not justify the spend") can evade it.
+  Its strength is "catches the common cases", not "independent of any
+  agent's behaviour" — unlike the field-absence layer, which is structural.
+
+## Worked examples
+
+### Example 1 — cost-omitted (today's default: no usable snapshot)
+
+```markdown
+---
+target: docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+target_kind: spec
+generated_at: 2026-06-10T14:22:00Z
+generated_by: "cost-estimator / claude-opus-4-8"
+grounding_sources:
+  - path: MODEL_ROUTING.md
+    kind: model-routing
+  - path: observability/costs/
+    kind: cost-snapshot
+tokens: { low: 250000, high: 600000 }
+tokens_by_stage:
+  - stage: spec-writer
+    tokens: { low: 50000, high: 100000 }
+    model_tier: Most capable
+  - stage: tdd-agent
+    tokens: { low: 50000, high: 150000 }
+    model_tier: Standard
+  - stage: implementer
+    tokens: { low: 100000, high: 250000 }
+    model_tier: Standard/Capable
+  - stage: code-reviewer
+    tokens: { low: 50000, high: 100000 }
+    model_tier: Most capable
+agent_compute_time: { low: 25m, high: 3h }
+human_gate_time: "human-gate latency dominates total wall-clock and is not estimated numerically at S1; it depends on when a human next disposes a gate, not on the work."
+confidence:
+  tokens: high
+  time: medium
+failure_direction: likely-underrun
+---
+
+## Included
+
+The four orchestrator agent stages this spec exercises (spec-writer,
+tdd-agent, implementer, code-reviewer) at their MODEL_ROUTING tier, with
+token ranges from the Token Budget Guidance table. Agent-compute time is
+derived from token volume via the default band of ~1–3 minutes per 10k
+tokens generated, stated here as an assumption.
+
+## Excluded
+
+cost_usd: omitted — no repo cost snapshot exists yet (observability/costs/
+is empty), so no observed $/token is available; cost is not estimated.
+Token and time figures stand. Also excluded: human-gate latency (gates
+cost wall-clock, not tokens); re-runs and any diaboli/cartograph cycles
+beyond one pass; the integration stage, which this spec-only target does
+not exercise.
+
+## Confidence rationale
+
+tokens: high — the target is a spec that enumerates scenarios and files,
+so the stage set and rough volume are grounded in named artefacts. time:
+medium — the throughput band is an assumption, not an observed actual, so
+the derived wall-clock is one tier below the token grounding.
+
+## Failure direction
+
+likely-underrun on wall-clock: human-gate latency is unbounded and is not
+estimated as a number here, so total wall-clock will exceed the
+agent-compute range when the human-gate caveat is read alongside it.
+```
+
+### Example 2 — cost-present (a snapshot with a usable Model Breakdown exists)
+
+```markdown
+---
+target: docs/superpowers/slices/cost-estimator-pipeline.md
+target_kind: slice
+generated_at: 2026-09-01T09:00:00Z
+generated_by: "cost-estimator / claude-opus-4-8"
+grounding_sources:
+  - path: MODEL_ROUTING.md
+    kind: model-routing
+  - path: observability/costs/2026-08-15-costs.md
+    kind: cost-snapshot
+tokens: { low: 200000, high: 500000 }
+tokens_by_stage:
+  - stage: spec-writer
+    tokens: { low: 50000, high: 100000 }
+    model_tier: Most capable
+  - stage: tdd-agent
+    tokens: { low: 50000, high: 150000 }
+    model_tier: Standard
+  - stage: implementer
+    tokens: { low: 100000, high: 250000 }
+    model_tier: Standard/Capable
+cost_usd: { low: 0.95, high: 7.50 }
+cost_basis: snapshot-actuals
+agent_compute_time: { low: 20m, high: 2h30m }
+human_gate_time: "human-gate latency dominates total wall-clock and is not estimated numerically at S1; it depends on when a human next disposes a gate, not on the work."
+confidence:
+  tokens: medium
+  time: medium
+  cost: low
+failure_direction: likely-overrun
+---
+
+## Included
+
+The spec-writer, tdd-agent, and implementer stages at their MODEL_ROUTING
+tier, with token ranges from the Token Budget Guidance table.
+Agent-compute time derived from token volume via the ~1–3 min per 10k
+tokens band. The $/token rate is derived from the 2026-08-15 snapshot
+Model Breakdown (observed actuals): claude-sonnet-4 and claude-opus-4
+blended per-model rates. The implementer stage (Standard/Capable) is
+priced by widening across both ends of the split — its low bound uses the
+claude-sonnet-4 rate, its high bound uses the claude-opus-4 rate — so its
+$0.40–$5.00 cost band is visibly wider than its token-range spread alone
+would imply.
+
+## Excluded
+
+human-gate latency (gates cost wall-clock, not tokens, so they are
+excluded from cost_usd and tokens); re-runs and diaboli/cartograph cycles
+beyond one pass; the code-reviewer and integration stages, which this
+slice target does not yet enumerate.
+
+## Confidence rationale
+
+tokens: medium — the target is a single slice; work is decomposed but
+scenarios and files are not yet enumerated, so the stage set is partly
+assumed. time: medium — the throughput band is an assumption. cost: low —
+the snapshot is one quarter old and aggregates models coarsely, so the
+$/token rate is a stale blended figure; this is independent of the
+token grounding, which is why cost sits below tokens.
+
+## Failure direction
+
+likely-overrun: the per-stage budgets are upper-tier defaults and most
+slices land below them, so the high bound is more likely loose than the
+low bound is tight.
+```
+
+Neither worked example files an inclusion caveat under `Excluded`, and
+neither contains imperative recommendation or go/no-go language.

--- a/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
@@ -1,0 +1,90 @@
+---
+title: Prospective Cost Estimation
+---
+# Prospective cost estimation
+
+The `cost-estimation` skill answers a question you ask *before* work
+runs: **how much will this cost to build?** It estimates the token
+usage and agent-compute time a task will consume as it flows through
+the orchestrator pipeline — and a dollar figure, but only when observed
+actuals exist to ground it.
+
+It is the **prospective** half of a pair. Its **retrospective** sibling,
+`cost-tracking`, records what *was* spent after the fact (see
+[Track AI Costs](../how-to/track-ai-costs.md)). The two reuse the same
+`observability/costs/` data: `cost-tracking` **writes** the snapshots
+via `/cost-capture`; `cost-estimation` **reads** them as its $/token
+ground. A reader who finds one half of the cost capability should be
+able to discover the other.
+
+## An estimate is a range, never a point
+
+The material decision this skill locks: **an estimate is a range with
+disclosed confidence, never a point value.**
+
+A point value invites false precision. "12k tokens" reads as a fact;
+"10k–18k tokens, confidence medium, more likely to overrun than
+underrun because the implementer stage spans two model tiers" reads as
+a prediction a human can interrogate. The whole point is to *inform* a
+human's choice, not to anchor it on a number dressed as a fact. Every
+quantitative field is therefore a `{ low, high }` range carrying
+per-axis confidence and the disclosures the contract requires.
+
+## What is grounded, and what is not
+
+The grounding sources are **fixed, not chosen**:
+
+- **Token ranges and agent-compute time** are *always* groundable from
+  `MODEL_ROUTING.md` — its Token Budget Guidance table gives per-stage
+  ranges, and its Agent Routing table gives each stage's model tier. The
+  per-stage ranges sum into the whole-record `tokens` range. These two
+  axes are the honest day-one deliverable.
+- **The dollar figure is an actuals-gated enhancement.** `cost_usd`
+  appears *only* when an `observability/costs/` snapshot supplies a
+  usable per-tier $/token rate, derived through a fixed
+  tier→model→$/token binding. When no usable rate exists, the field is
+  **omitted with an explicit disclosure** — never a forced list-price
+  guess. The no-cost record is valid and complete, not a failure; the
+  same fields simply begin to appear once the first usable snapshot
+  lands, with no format change.
+- **Human-gate latency is not estimated numerically at S1.** It
+  dominates total wall-clock but depends on when a human next disposes a
+  gate, not on the work, so it is carried as a qualitative caveat rather
+  than a number that would re-introduce false precision.
+
+## Confidence is disclosed, never decisive
+
+The estimate record carries confidence; it does **not** carry a verdict,
+recommendation, or go/no-go. Confidence is recorded **per axis**
+(`tokens`, `time`, and — only when `cost_usd` is present — `cost`), with
+a ceiling tied to how richly grounded the target is: a raw task text
+caps low, a slice or slicing record at medium, a full spec may reach
+high. The cost axis follows its own rule, set from the snapshot's age
+and granularity, independent of the target.
+
+Every record's prose body must contain four labelled sections —
+**Included**, **Excluded**, **Confidence rationale**, and **Failure
+direction** — so the derivation is interrogable. The Excluded section is
+the single most important honesty signal: a number that silently omits a
+cost class is worse than no number. The no-verdict guarantee is
+structural in two layers: there is no recommendation field, *and* a
+validation check scans the disclosure prose for imperative or go/no-go
+language. The human reads the ranges and disclosures and decides.
+
+## Methodology and a format contract, not a command
+
+At its first slice this skill is **methodology and a format contract**.
+It describes how an estimate is derived and what an estimate record must
+contain — it does not dispatch an agent, write a file, or decide
+go/no-go. Emitting and validating a record is the job of downstream
+consumers (a read-only `cost-estimator` agent, a `/cost-estimate`
+command, and an orchestrator fold-in) that inherit this contract.
+
+## See also
+
+- [Track AI Costs](../how-to/track-ai-costs.md) — the retrospective
+  sibling capture workflow.
+- `ai-literacy-superpowers/skills/cost-estimation/SKILL.md` — the skill.
+- `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+  — the stable estimate-record format contract.
+- Spec: `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md`.

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -119,7 +119,11 @@ Team Topologies Team API document generation and update. Covers creating a new T
 
 ### cost-tracking
 
-Quarterly AI cost capture and tracking. Covers guiding users through provider billing dashboards, recording spend and token usage in a structured format, comparing to previous snapshots for trend analysis, and updating MODEL_ROUTING.md with observed cost patterns.
+Quarterly AI cost capture and tracking. Covers guiding users through provider billing dashboards, recording spend and token usage in a structured format, comparing to previous snapshots for trend analysis, and updating MODEL_ROUTING.md with observed cost patterns. The retrospective sibling of `cost-estimation`: `cost-tracking` records what *was* spent; `cost-estimation` predicts what *will be* spent.
+
+### cost-estimation
+
+Prospective cost, token, and time estimation before a task runs. The prospective sibling of `cost-tracking` — it reads the same `observability/costs/` snapshots that `cost-tracking` writes and uses them as its $/token ground. Covers deriving per-stage token and agent-compute-time ranges from MODEL_ROUTING.md, the estimate-record format contract (a `{ low, high }` range per quantitative field with per-axis confidence and a mandatory four-part disclosure body), the tier→model→$/token binding for cost derivation, and the present-when-grounded rule that emits a dollar figure only when a snapshot supplies an observed rate (never a list-price guess). Methodology and a format contract only — it does not dispatch an agent, write a file, or decide go/no-go.
 
 ### auto-enforcer-action
 

--- a/docs/superpowers/objections/cost-estimation-skill-design-code.md
+++ b/docs/superpowers/objections/cost-estimation-skill-design-code.md
@@ -1,0 +1,182 @@
+---
+spec: docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+date: 2026-06-11
+mode: code
+diaboli_model: claude-opus-4-8
+objections:
+  - id: O1
+    category: implementation
+    severity: medium
+    claim: "Both worked-example agent_compute_time low bounds contradict the stated throughput band, so the canonical examples the S2 agent will pattern-match against teach an unreproducible derivation."
+    evidence: "estimate-record-format.md:83 fixes the band at '~1–3 minutes per 10k tokens generated' applied to the tokens range; Example 1 (line 246, tokens.low 250000; line 260, agent_compute_time.low 23m) should yield 25m (250000/10000×1); Example 2 (line 312, tokens.low 200000; line 325, agent_compute_time.low 18m) should yield 20m (200000/10000×1)."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Correct the two low bounds (23m→25m, 18m→20m) so the
+      worked examples reproduce exactly from the stated throughput band.
+  - id: O2
+    category: implementation
+    severity: medium
+    claim: "The cost-derivation formula multiplies a whole-stage token range by the per-tier $/token rate but never specifies which of input vs output tokens it means, while the only blended rate it can compute is derived from a snapshot that distinguishes them — leaving the dominant cost figure ambiguous at the contract level."
+    evidence: "estimate-record-format.md:164-170 defines '$/token as estimated_cost ÷ (input_tokens + output_tokens)' (a blended rate over both) but then 'cost_usd = Σ over stages (stage tokens range × tier $/token)' where stage tokens (line 30, line 246) is a single undifferentiated total; cost-tracking SKILL.md:50 keys the breakdown by separate input/output columns. The MODEL_ROUTING Token Budget Guidance ranges the estimate consumes (MODEL_ROUTING.md:18-26) are also undifferentiated totals, so the input/output split is silently dropped without the contract saying so."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Add one sentence at the derivation disclosing the
+      input/output collapse as a deliberate, accepted simplification (the
+      sanctioned spec-round O4 skew), so a downstream S2 author knows it is
+      by-design, not a bug to fix.
+  - id: O3
+    category: risk
+    severity: medium
+    claim: "The positive-content no-verdict scan is specified as a fixed enumerated string-match list, which the format itself frames as 'representative' — a downstream command implementing exactly the listed patterns will pass verdict prose that paraphrases around them, so the structural guarantee is weaker than the contract claims."
+    evidence: "estimate-record-format.md:221-229 lists eight literal patterns ('so proceed', 'do not proceed', 'I recommend', 'you should ship/skip/approve/reject', 'go/no-go') and §5.3 (SKILL.md:228-248) calls the guarantee 'a property of the format itself, independent of any agent's good behaviour'; a sentence such as 'the high bound makes this not worth building' or 'budget does not justify the spend' matches none of the eight literals yet is a verdict the contract claims to forbid."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Downgrade the guarantee's wording from "independent of
+      any agent's good behaviour" to an honest "tripwire for common verdict
+      phrasings, not a proof"; keep the enumerated patterns as representative.
+      Honesty about the scan's own coverage is exactly this skill's thesis.
+  - id: O4
+    category: implementation
+    severity: low
+    claim: "The methodology consumes a 'tokens_by_stage[].stage' value of 'integration' and an Agent Routing row keyed '{{LANGUAGE}}-implementer', but the field table and worked examples use the bare stage name 'implementer' and a tier label 'Standard/Capable' without the slash-space MODEL_ROUTING actually prints, so a strict downstream parser binding stage→routing-row by literal match has no defined join key."
+    evidence: "MODEL_ROUTING.md:14 names the agent '{{LANGUAGE}}-implementer' with tier 'Standard / Capable' (slash-space); estimate-record-format.md:30 and :256 record model_tier as 'Standard/Capable' (no spaces) and stage as 'implementer'; the binding table (estimate-record-format.md:146) writes 'Standard / Capable (split)'. Three spellings of one tier and two of one stage are in play with no normalisation rule."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Add a one-line normalisation rule: stage names map to
+      MODEL_ROUTING agent rows by stripping the `{{LANGUAGE}}-` prefix; tier
+      labels are compared whitespace-insensitively.
+  - id: O5
+    category: specification quality
+    severity: low
+    claim: "The validation checklist's 'Per-axis confidence within cap' check is not mechanically runnable as written because the cap depends on target_kind but the checklist does not restate the mapping, and the cost-axis exemption ('independent of target_kind') is stated only in prose elsewhere — a command author implementing the checklist literally would either over-constrain cost or have no cap table to apply."
+    evidence: "estimate-record-format.md:210-212 says 'each present confidence axis is within the target_kind ceiling for tokens/time; the cost axis is present iff cost_usd is present' — it caps tokens/time but the ceiling table lives at lines 118-122 and the cost-axis independence at lines 130-134; the checklist item does not reference either, so the single 'Output Validation Checkpoint' the format is built to serve (lines 8-12) cannot execute this check from the checklist alone."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Make the checklist item self-contained: cross-reference
+      the target_kind ceiling table and the cost-axis exemption so a mechanical
+      consumer can run the check from the checklist alone.
+  - id: O6
+    category: implementation
+    severity: low
+    claim: "The cost-present worked example's whole-record cost_usd is asserted but the per-stage cost contributions are never shown in tokens_by_stage, so the example demonstrates the split-tier widening only in prose, not in the machine-readable structure the S2 agent must reproduce — the one place the contract could have made widening parseable, it did not."
+    evidence: "estimate-record-format.md:323 gives cost_usd { low: 0.95, high: 7.50 } and the Included prose (lines 339-345) narrates a '$0.40–$5.00' implementer band, but tokens_by_stage entries (lines 313-322) carry no cost_usd sub-field; the widening that §6.1/§6.2 make load-bearing is therefore unverifiable against the frontmatter and the cited $0.40–$5.00 + other-stage costs cannot be reconciled to the $0.95–$7.50 total by any reader."
+    disposition: deferred
+    disposition_rationale: >
+      Deferred to S2 (#369). Making per-stage cost machine-checkable (a cost_usd
+      sub-field on tokens_by_stage summing to the total) is a format addition
+      better decided when the S2 agent that must reproduce widening is built; the
+      prose demonstration suffices for S1, and adding the sub-field now would be
+      speculative structure ahead of its consumer.
+---
+
+## O1 — implementation — medium
+
+### Claim
+
+The two worked example records are the canonical shapes the S2 agent will pattern-match against and the S3 validation checkpoint will treat as reference-valid. Both of their `agent_compute_time` **low** bounds are inconsistent with the single throughput band the same reference fixes. The contract therefore ships a worked derivation a careful reader cannot reproduce from the stated rule.
+
+### Evidence
+
+`estimate-record-format.md:83` fixes the derivation: "a **default throughput band of ~1–3 minutes per 10k tokens generated**" applied "to the `tokens` range."
+
+- Example 1: `tokens.low` is `250000` (line 246). 250000 / 10000 × 1 min = **25m**. The record states `agent_compute_time: { low: 23m, ... }` (line 260).
+- Example 2: `tokens.low` is `200000` (line 312). 200000 / 10000 × 1 min = **20m**. The record states `agent_compute_time: { low: 18m, ... }` (line 325).
+
+Both high bounds (3h and 2h30m) check out exactly against the 3-min end, which makes the low-bound divergence look like an unreproducible adjustment rather than a deliberate documented one — nothing in the Included prose explains a downward nudge.
+
+### Why this matters
+
+The format reference explicitly instructs readers to "Treat the field table, the binding table, the disclosure body spec, and the validation checklist as precise — they are parsed, not read loosely" (lines 8-12). The worked examples are the executable specification of the band. An S2 agent that learns the band from the worked example will inherit a derivation it cannot defend; an S3 checkpoint author who spot-checks `agent_compute_time` against the band on a real record will see a "failing" record that matches the shipped example exactly. The fix is one of: correct 23m→25m and 18m→20m, or add a prose note explaining the adjustment. Either resolves it; leaving it silent bakes a contradiction into the contract every later slice consumes.
+
+## O2 — implementation — medium
+
+### Claim
+
+The cost figure is the most consequential and most contested axis in this design, and its arithmetic is under-specified at exactly the input/output-token seam. The rate is defined as a blend over input + output tokens; the multiplication is defined against an undifferentiated stage token total. The contract never states that the input/output distinction is intentionally collapsed, so two faithful implementers can produce materially different `cost_usd` figures from the same snapshot and the same token range.
+
+### Evidence
+
+`estimate-record-format.md:164-170`:
+
+> Compute a per-model `$/token` as `estimated_cost ÷ (input_tokens + output_tokens)` … `cost_usd = Σ over stages (stage tokens range × tier $/token)`
+
+The rate's denominator sums two distinct quantities the snapshot keeps separate (`cost-tracking` SKILL.md:50: `| Model | Tokens (input) | Tokens (output) | Estimated cost |`). The `stage tokens` multiplier is a single total (`estimate-record-format.md:30`, `:246`), itself sourced from MODEL_ROUTING Token Budget Guidance ranges that are also undifferentiated (`MODEL_ROUTING.md:18-26`). Output tokens are typically priced several times input tokens in real provider billing; a blended-rate-over-total approach is a defensible simplification, but the contract neither names it as a simplification nor warns that the blend's accuracy depends on the estimated task's input/output mix matching the snapshot quarter's mix.
+
+### Why this matters
+
+This is the residual the spec-mode round acknowledged as O4 (blended-rate mix skew) and explicitly sanctioned as a documented S2 residual. The objection here is **not** that the skew is unsolved — that adjudication stands. The objection is that the *implementation does not disclose the collapse at all* at the point of derivation, where the spec's own framing ("the methodology computes a per-model `$/token` … a single blended rate") at least flagged "blended." A downstream S2 author reading only the reference's formula will not know the input/output collapse is a known, accepted approximation versus a bug to fix. One sentence in the Included-disclosure guidance ("the blended rate assumes the estimated task's input/output ratio resembles the snapshot quarter's") would close the gap the spec opened but the reference left implicit.
+
+## O3 — risk — medium
+
+### Claim
+
+The two-layer no-verdict guarantee is the design's strongest honesty claim — "a property of the format itself, independent of any agent's good behaviour." The positive-content layer is implemented as a closed list of eight literal string patterns. A closed literal list does not deliver the open guarantee the prose claims; verdict prose that avoids the eight literals passes the scan, so the structural guarantee is narrower than advertised.
+
+### Evidence
+
+`estimate-record-format.md:221-229` enumerates the prohibited patterns as literals: `"so proceed"`, `"do not proceed"`, `"I recommend"`, `"you should ship"`, `"you should skip"`, `"you should approve"`, `"you should reject"`, `"go/no-go"`. `SKILL.md:240-247` frames the same check as making "the no-verdict guarantee a property of the format itself, independent of any agent's good behaviour."
+
+A failure-direction sentence such as "likely-overrun, and the high bound is not worth the spend" or "this is too expensive to justify" or "skip building this" matches none of the eight literals while delivering precisely the go/no-go the contract claims to structurally forbid. The format's own hedge — "representative prohibited patterns" (line 224) — concedes the list is non-exhaustive, which contradicts the "independent of any agent's good behaviour" claim: catching the open class still depends on the agent not paraphrasing around the list.
+
+### Why this matters
+
+The S3 command that implements this checklist literally inherits the gap, and the gap is invisible at the contract level because the prose oversells what the literal list achieves. This is groundable now (code time) in a way it was not at spec time: the implementation chose a closed enumeration where the guarantee needed either a semantic check or an explicit, honest scoping ("this scan catches common verdict phrasings; it is a tripwire, not a proof"). Re-framing the guarantee's strength in the reference (downgrade "independent of any agent's good behaviour" to "a tripwire for the common phrasings") would make the contract honest about its own coverage — which is, after all, this skill's entire thesis.
+
+## O4 — implementation — low
+
+### Claim
+
+The contract relies on a stage→routing-row join to read each stage's model tier, but the join key is spelled three ways for the tier and two ways for the implementer, with no normalisation rule. A strict downstream parser has no defined way to bind the worked example's `implementer` / `Standard/Capable` to the MODEL_ROUTING row `{{LANGUAGE}}-implementer` / `Standard / Capable`.
+
+### Evidence
+
+- `MODEL_ROUTING.md:14`: agent `{{LANGUAGE}}-implementer`, tier `Standard / Capable` (slash with spaces).
+- `estimate-record-format.md:30` and `:256`: `stage: implementer` (bare), `model_tier: Standard/Capable` (no spaces).
+- `estimate-record-format.md:146`: binding table row `Standard / Capable (split)`.
+
+Three spellings of the tier (`Standard / Capable`, `Standard/Capable`, `Standard / Capable (split)`) and two of the stage (`implementer`, `{{LANGUAGE}}-implementer`) coexist with no stated canonicalisation.
+
+### Why this matters
+
+The reference is built to be "parsed, not read loosely" (lines 8-12) by the S2 agent and the S3 checkpoint. Reading the model tier from Agent Routing (SKILL.md:70-74) requires matching the stage to a routing row; the templated `{{LANGUAGE}}-` prefix and the slash-spacing variance mean a literal string match fails. It is low severity because a human reader resolves it trivially and the routing table has only one split tier, but it is a real seam a mechanical consumer will trip on, and a one-line "stage names map to MODEL_ROUTING agent rows by stripping the `{{LANGUAGE}}-` prefix; tier labels are compared whitespace-insensitively" note in the reference would remove the ambiguity before S2 builds against it.
+
+## O5 — specification quality — low
+
+### Claim
+
+The validation checklist item for per-axis confidence cannot be executed from the checklist alone: it asserts a `target_kind` cap for tokens/time and a cost-axis exemption, but restates neither the cap mapping nor the exemption rule, so a command author implementing "the checklist a consuming command runs" must reach into prose elsewhere to know what to enforce — and a literal implementer risks applying the cap to the cost axis.
+
+### Evidence
+
+`estimate-record-format.md:210-212`:
+
+> **Per-axis confidence within cap** — each present `confidence` axis is within the `target_kind` ceiling for `tokens`/`time`; the `cost` axis is present **iff** `cost_usd` is present.
+
+The cap mapping (`task-text`→low, `slice`→medium, `spec`→high) lives at lines 118-122; the cost-axis "independent of `target_kind`" rule at lines 130-134. The checklist item references neither. The reference frames the checklist as the authoritative "checks a consuming command's Output Validation Checkpoint runs" (line 203).
+
+### Why this matters
+
+The whole point of a references-file Output Validation Checkpoint (per the CLAUDE.md convention the spec invokes in §8.2) is that the downstream command can implement the checks from the checklist. This item is the one check whose rule is non-trivial and table-driven, and it is the one the checklist leaves dangling. Low severity because the rules do exist in the same file a few sections up, but a checklist that is supposed to be self-contained for a mechanical consumer is, on its single hardest item, not. A cross-reference ("see Per-axis confidence mapping above") or an inline restatement closes it.
+
+## O6 — implementation — low
+
+### Claim
+
+The cost-present example is the only artefact that demonstrates the split-tier widening the design treats as load-bearing (O5-era spec concern), but it demonstrates it solely in Included prose. The frontmatter `tokens_by_stage` entries carry no per-stage cost sub-field, so the widening is unverifiable against machine-readable structure, and the narrated per-stage band cannot be reconciled to the whole-record total by any reader or parser.
+
+### Evidence
+
+`estimate-record-format.md:323`: `cost_usd: { low: 0.95, high: 7.50 }`. The Included prose (lines 339-345) narrates the implementer stage's "$0.40–$5.00 cost band." The `tokens_by_stage` entries (lines 313-322) have no `cost_usd` key. There is no spec-writer or tdd-agent per-stage cost shown, so a reader cannot check that $0.40–$5.00 (implementer) plus the unshown spec-writer and tdd-agent contributions sum to the stated $0.95–$7.50 whole-record range. (The low bounds are in fact irreconcilable on their face: a $0.40 implementer low alone already implies the other two stages contribute $0.55 at the low end, which is never shown.)
+
+### Why this matters
+
+The spec made the split-tier widening a first-class requirement (FR-7) and required the cost-present example to "demonstrate the split-tier widening … its implementer stage carries a non-zero cost band." The implementation demonstrates it in prose but not in the parseable structure, which is the half that matters for the S2 agent that must *reproduce* widening and the S3 checkpoint that must *validate* it. Low severity because the prose does convey the mechanism to a human, but the contract had the opportunity to make widening machine-checkable (a `cost_usd` sub-field on `tokens_by_stage[]`, summing to the total) and did not, leaving the most contested axis demonstrated only in unverifiable prose.
+
+## Explicitly not objecting to
+
+- **The cost-omitted-by-default day-one shape**: omitting `cost_usd` when `observability/costs/` is empty and disclosing the omission in `Excluded` is faithfully implemented across SKILL.md, the reference field table, and Example 1 — this is the spec's central restructure and the implementation realises it cleanly.
+- **The human_gate_time qualitative-caveat decision**: the implementation consistently carries `human_gate_time` as a caveat string (never a range) in the field table, the time-split section, both worked examples, and the validation checklist — the O2-era spec decision is realised without leakage into S4 gate-topology territory.
+- **The binding-table model names matching the snapshot keys**: the tier→model map (`claude-opus-4`, `claude-sonnet-4`) matches the actual `cost-tracking` Model Breakdown row keys (cost-tracking SKILL.md:52-53), so the binding is groundable — I confirmed this against the sibling format rather than assuming it, and it holds.
+- **O3/O4 spec-residual status**: the binding-table drift and blended-rate mix skew remain note-not-solved exactly as the spec-mode round-2 adjudication sanctioned; the implementation neither claims to solve them nor makes them worse, so per the dispatch scope I do not object to their being unresolved (O2 above objects only to an undisclosed *collapse*, not to the sanctioned skew itself).
+- **The version-bump triplet and the test-edit loosening**: plugin.json/marketplace.json/README/CHANGELOG consistency at 0.41.0 and the `== 0.40.0` → `>= 0.40.0` assertion change in test_assess_operational_axes.py are legitimate and were already PASSed by the prior reviewer; I re-examined the assertion (line 259) and it correctly prevents future-bump regressions without weakening coverage.
+- **The trigger carve against the retrospective sibling**: the `description` line distinguishes prospective ("before it runs", "how much will this cost to build") from retrospective capture and names the sibling, and the trigger scenario protects exactly that boundary — the carve is clean and I found no false-positive routing risk against `cost-tracking`.

--- a/docs/superpowers/objections/cost-estimation-skill-design.md
+++ b/docs/superpowers/objections/cost-estimation-skill-design.md
@@ -1,0 +1,136 @@
+---
+spec: docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+date: 2026-06-11
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: design
+    severity: major
+    claim: "The split-tier widening that resolves round-1 O5 collapses to a zero-width band, because the new tier-binding table (§6.2) maps BOTH `Standard` and `Capable` to the same representative model `claude-sonnet-4` — so the implementer's low and high cost bounds use an identical $/token and the 'widening' produces no spread at all."
+    evidence: "Spec §6.2 binding table (lines 394-396) lists `Standard → claude-sonnet-4` and `Capable → claude-sonnet-4`, and the split row as 'spans claude-sonnet-4 (low) … claude-sonnet-4 (high)'. §6.1 (lines 371-378) defines split-tier widening as 'its low bound uses the cheaper tier (Standard) and its high bound uses the dearer tier (Capable)'. When both tiers bind to one model, low rate == high rate; the widening the spec presents as the O5 fix is a no-op for the only stage it was written for (implementer, 100-250k, the dominant cost term)."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Either bind Capable to a dearer representative model
+      than Standard so the widening produces a real spread, or state the tiers
+      carry no cost distinction and drop the widening machinery as dead weight.
+      Whatever is chosen, the cost-present worked example must be able to
+      demonstrate it.
+  - id: O2
+    category: design
+    severity: major
+    claim: "`human_gate_time` is derived from `gate_count`, but S1 has no grounded source for the gate count of a target: the gate set lives in the orchestrator (S4, #371), which this slice explicitly does not touch, and the count depends on which stages a target exercises — a methodology judgement the spec leaves to the agent. The O9 fix replaced one ungrounded number (the gate-time range) with a formula whose own input (`gate_count`) is ungrounded at S1, and reaches into orchestrator topology the slice declares out of scope."
+    evidence: "Spec §4.3 (lines 197-205) and §6.3 (lines 459-464) define `human_gate_time = gate_count × per-gate latency band`, where gate_count is 'the number of human-disposition gates the target's stage set passes through (Slice Adjudication, Plan Approval, diaboli/cartograph dispositions, code review, integration)'. §2.2 (lines 83-101) places the orchestrator gate topology in S4 (#371) and instructs that S1 must not name 'which gate it appears in'. The gate list enumerated in §4.3 is exactly the orchestrator's gate set; no rule derives gate_count from target_kind."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix now. Add a gate_count-from-target_kind rule in the
+      methodology (accepting and flagging that it duplicates knowledge S4 will
+      own), OR demote human_gate_time from a required numeric range to a
+      disclosed qualitative caveat until S4 fixes the gate set. A required
+      multiplier with no derivation is the false-precision the spec opposes.
+  - id: O3
+    category: operational
+    severity: minor
+    claim: "The tier→model binding table is a new hardcoded maintenance artefact that will silently drift from MODEL_ROUTING.md and from reality: it pins representative model names (`claude-opus-4`, `claude-sonnet-4`) that are not derived from any source the methodology reads, and nothing in S1 keeps it synchronised when routing or model names change."
+    evidence: "Spec §6.2 binding table (lines 391-396) fixes `Most capable → claude-opus-4`, `Standard → claude-sonnet-4`, etc. These names appear in neither MODEL_ROUTING.md (which carries only abstract tiers, confirmed lines 8-16) nor in any other read source — they are authored into the reference. §6.2 line 398-400 says 'the reference fixes the representative model per tier and is the artefact S6 may revise as routing evolves', i.e. it is hand-maintained and only revisited at S6. The cost-tracking snapshot uses `claude-opus-4`/`claude-sonnet-4` keys (cost-tracking SKILL.md lines 52-54), so a future model rename breaks the join silently."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a documented residual; resolve at S2 implementation. Add a
+      methodology note that the tier→model binding must be re-verified against
+      MODEL_ROUTING.md and the latest snapshot's model keys whenever cost is
+      computed. Not blocking the spec.
+  - id: O4
+    category: failure
+    severity: minor
+    claim: "The per-model rate formula `estimated_cost ÷ (input_tokens + output_tokens)` (§6.2) blends input and output token prices into one rate, but real provider pricing charges output tokens several times the input rate; applied to the estimate's own token ranges (which are total-token budgets, not input/output-split), the derived cost can be materially wrong in a direction the spec does not disclose as a failure-direction case."
+    evidence: "Spec §6.2 (lines 402-409): 'computes a per-model $/token as estimated_cost ÷ (input_tokens + output_tokens) for that model row — a single blended rate per model'. MODEL_ROUTING.md Token Budget Guidance (lines 20-26) gives per-role total-token ranges with no input/output split, and the snapshot Model Breakdown (cost-tracking SKILL.md lines 50-54) reports input and output volumes separately. A stage whose generation mix differs from the quarter-aggregate mix is mispriced by the blended rate, and §5.1's failure_direction guidance (lines 269-275) never names blended-rate skew as a source of cost error."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a documented residual; resolve at S2 implementation. Name
+      blended-rate (input/output) mix skew in the §5.1 failure_direction
+      guidance / cost-confidence rationale so the snapshot-grounded dollar
+      figure discloses its mix-assumption. Not blocking the spec.
+---
+
+<!--
+  Round 2. This record OVERWRITES the round-1 review (12 objections, all
+  accepted) that drove the spec revision; the "Explicitly not objecting to"
+  section below documents which round-1 objections were confirmed genuinely
+  resolved (verified against source). Validation note: the dispatched diaboli
+  returned O2 under the code-mode category 'specification quality'; remapped to
+  the spec-mode category 'design' in place (its core is a structural
+  scope-coupling flaw), per advocatus-diaboli.agent.md lines 54-61. All other
+  categories/severities were returned valid.
+-->
+
+## O1 — design — major
+
+### Claim
+
+The split-tier widening introduced to resolve round-1 O5 collapses to a zero-width band. The new tier-binding table maps both `Standard` and `Capable` to the same representative model (`claude-sonnet-4`), so the implementer stage's low and high cost bounds are computed from an identical $/token rate. The "widening" the spec presents as the fix produces no spread for the very stage it was written for.
+
+### Evidence
+
+The §6.2 binding table (spec lines 391-396) reads:
+
+> | Standard | `claude-sonnet-4` |
+> | Capable | `claude-sonnet-4` |
+> | Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-sonnet-4` (high), widened per §6.1 |
+
+§6.1 (lines 371-378) defines the widening: "its low bound uses the cheaper tier (`Standard`) and its high bound uses the dearer tier (`Capable`)." But when `Standard` and `Capable` both bind to `claude-sonnet-4`, the cheaper and dearer tier resolve to one rate. The split row even spells this out: "spans `claude-sonnet-4` (low) … `claude-sonnet-4` (high)" — the same model on both ends. The implementer carries the largest budget (100-250k, MODEL_ROUTING.md line 24) and §6.1 says "its rate dominates any cost figure," so the no-op widening governs the dominant cost term.
+
+### Why this matters
+
+Round-1 O5 was accepted with the explicit instruction to "widen the cost range to span Standard..Capable rather than leaving the dominant term's rate to agent discretion." The revision added the widening mechanism but bound both tiers to the same model, which silently re-defeats the fix: the dominant stage's cost contribution has no tier-driven spread, and the only spread it carries is the token-range spread it would have had anyway. Either the binding table is wrong (Capable should bind to a dearer model than Standard), or the MODEL_ROUTING.md distinction between `Standard` and `Capable` carries no cost consequence — in which case the spec should say so and drop the widening machinery as dead weight rather than ship a mechanism the worked example cannot demonstrate. As written, a reviewer authoring the cost-present worked example (§8.2) cannot show a widened implementer band, because the table forbids one.
+
+## O2 — design — major
+
+### Claim
+
+`human_gate_time` is derived as `gate_count × per-gate latency band`, but S1 supplies no grounded source for `gate_count`. The gate set lives in the orchestrator, which this slice explicitly does not touch (S4, #371), and which gates a given target passes through depends on its stage set — a methodology judgement the spec leaves unspecified. The O9 fix replaced one ungrounded number (the human-gate range) with a formula whose own input is ungrounded at S1, and in doing so reaches into orchestrator topology the slice declares out of scope.
+
+### Evidence
+
+§4.3 (spec lines 197-205) and §6.3 (lines 459-464) define `human_gate_time = gate_count × per-gate latency band`, where `gate_count` is "the number of human-disposition gates the target's stage set passes through (Slice Adjudication, Plan Approval, diaboli/cartograph dispositions, code review, integration)." That parenthetical IS the orchestrator's gate set. Yet §2.2 (lines 98-101) instructs: "If a reviewer finds the skill describing ... *which gate it appears in* ... that is scope creep into S2-S5 and should be cut back to 'a consumer does X' without naming the consumer's mechanics." S4 (#371, "orchestrator fold-in at T1/T2") is where gates are defined. The spec gives no rule for deriving `gate_count` from `target_kind` — only the §6.1 token-stage rule ("a docs-only spec may exercise spec-writer + review only", lines 364-367), which is about token stages, not gate count, and the two sets are not the same.
+
+### Why this matters
+
+A required numeric range whose multiplier (`gate_count`) has no derivation rule will be invented per estimate — precisely the false-precision failure mode the §3 range-not-point decision exists to prevent, and the same failure O9 was raised to close. The fix moved the invented number down one level: the per-gate band is at least avowed as an assumption, but `gate_count` is presented as if it were a known quantity when its source (the orchestrator gate topology) does not ship until S4. Two reasonable agents will count gates differently for the same target (does a docs-only change pass diaboli? does it pass integration?), producing divergent `human_gate_time` ranges from an identical input — the divergent-implementation hazard the methodology was meant to eliminate. The spec should either define the gate-count derivation from `target_kind` as a stated table (accepting that it duplicates knowledge S4 will own, and flagging the coupling), or demote `human_gate_time` to a disclosed qualitative caveat until S4 fixes the gate set.
+
+## O3 — operational — minor
+
+### Claim
+
+The tier→model binding table is a new hand-maintained artefact that will drift silently. Its representative model names are authored into the reference, derived from no source the methodology reads, and synchronisation is deferred to S6 — so between S1 and S6 a routing change or a model rename breaks the snapshot join with no signal.
+
+### Evidence
+
+The §6.2 binding table (spec lines 391-396) pins `Most capable → claude-opus-4`, `Standard → claude-sonnet-4`, `Capable → claude-sonnet-4`. These names appear nowhere in MODEL_ROUTING.md, which carries only abstract tier labels (confirmed lines 8-16) — the binding is authored, not derived. §6.2 (lines 398-400) states "the reference fixes the representative model per tier and is the artefact S6 may revise as routing evolves," i.e. it is revisited only at S6. The snapshot Model Breakdown is keyed by these same model names (cost-tracking SKILL.md lines 52-54), so the cost derivation's join key is a hardcoded constant in two places that no S1-S5 mechanism keeps aligned.
+
+### Why this matters
+
+The spec's central honesty claim is that cost is grounded in observed actuals, not guesses. But the tier→model binding — the join that turns a snapshot rate into a per-stage rate — is itself an ungrounded editorial assertion ("`claude-opus-4` is the representative model for Most capable"). If routing shifts a stage to a different model, or the provider renames a model in the snapshot, the join silently maps to the wrong rate or to nothing, and the methodology has no check that flags the mismatch. This is the round-1 O2 problem relocated rather than removed: round-1 O2 said the tier→model→$/token binding was undefined; the revision defined it as a static table, which is correct in form but introduces a maintenance-drift surface the spec acknowledges only as "the artefact S6 may revise." A note in the methodology that the binding must be re-verified against MODEL_ROUTING.md and the latest snapshot's model keys whenever cost is computed would close it.
+
+## O4 — failure — minor
+
+### Claim
+
+The per-model $/token rate is computed as a single blended rate over input + output tokens, then multiplied against the estimate's total-token ranges. Because output tokens are priced well above input tokens in real provider billing, a stage whose generation mix differs from the snapshot's quarter-aggregate mix is mispriced, and the spec does not name blended-rate skew as a failure-direction case.
+
+### Evidence
+
+§6.2 (spec lines 402-409): "computes a per-model `$/token` as `estimated_cost ÷ (input_tokens + output_tokens)` for that model row — a single blended rate per model derived from the quarter aggregate. The binding table then maps each stage's tier to its representative model's blended rate, and `cost_usd = Σ over stages (stage tokens range × tier $/token)`." MODEL_ROUTING.md Token Budget Guidance (lines 20-26) gives total-token ranges with no input/output split; the snapshot Model Breakdown reports input and output volumes separately (cost-tracking SKILL.md lines 50-54). The §5.1 failure_direction guidance (lines 269-275) names "budgets are upper-tier defaults" and "human-gate latency is unbounded" as skew sources but never the blended-rate mix mismatch.
+
+### Why this matters
+
+The spec opposes numbers dressed as fact, and the blended rate quietly assumes the estimated task has the same input/output token ratio as a whole quarter of mixed activity. An estimate dominated by long-generation stages (implementer, spec-writer) will systematically under-price against a quarter blend weighted toward input-heavy usage, and vice versa. This is a smaller concern than O1/O2 because cost is conditional and disclosed-as-derived, but it is a real, undisclosed source of directional error in the one axis the spec works hardest to make honest. The failure_direction guidance (§5.1) or the cost-confidence rationale should name it so a reader knows the snapshot-grounded dollar figure still carries a mix-assumption, not just an age/granularity caveat.
+
+## Explicitly not objecting to
+
+- **O1 (round-1) — the AGENTS.md authority over-claim is genuinely resolved.** AGENTS.md line 104-105 carries the "agent-emit + dispatcher-persist + human-disposes" ARCH_DECISION exactly as the revised §5/§15 now cite it, and the spec correctly states (and a grep confirms) that no "disclosure-of-derived-judgment" decision exists — the four-part body is now honestly framed as a contract this spec proposes. I confirmed this against the source rather than trusting the revision note.
+- **O3 and O11 (round-1) — the cost-optional-until-actuals restructure is genuinely resolved.** `cost_usd` is now conditional (§4.2 line 164), the list-price fallback is removed (§6.2 lines 430-433), and the no-cost case is defined as valid-and-complete with disclosure (§6.4); the binding table carries no hardcoded prices — prices come only from a snapshot — so the day-one deliverable is honestly a token + time estimate. This is a clean fix and I am no longer objecting to the day-one cost grounding.
+- **O4 and O6 (round-1) — per-axis confidence is genuinely resolved.** `confidence` is now an object keyed `tokens`/`time`/conditional `cost` (§4.2 line 168, §5.2 lines 281-317), and the empty-snapshot collision is dissolved because the `cost` axis simply does not exist when `cost_usd` is absent — there is no longer a floor-vs-force contradiction, and the interaction with conditional cost (`confidence.cost` present iff `cost_usd` present) is specified cleanly in the §8.2 validation checklist.
+- **O8 (round-1) — the third grounding state is genuinely resolved.** §6.2 (lines 411-426) now defines all three states (no snapshot / snapshot-without-usable-breakdown / snapshot-with-breakdown) and routes the middle state to omit-with-disclosure rather than silently falling through, correctly modelling the "(if available)" optionality of the snapshot Model Breakdown.
+- **O10 and O12 (round-1) — disclosure placement and the positive-content no-verdict check are genuinely resolved.** The list-price inclusion caveat is gone, the omission caveat correctly belongs under Excluded as a genuine "does NOT count" case (§5.1 item 2), and the two-layer no-verdict guarantee with a positive-content prose scan (§5.3 lines 330-338, §8.2 checklist) closes the smuggled-verdict gap O12 raised.
+- **The range-not-point decision (§3):** Endorsed in round 1 and unchanged; it remains a sound schema choice that leaves no failure class undetected.
+- **The version-bump and maintenance mechanics (§8.4, §12):** A linter/convention concern, not an objection; the four-location 0.40.0→0.41.0 bump is correct per CLAUDE.md.

--- a/docs/superpowers/plans/2026-06-10-cost-estimation-skill.md
+++ b/docs/superpowers/plans/2026-06-10-cost-estimation-skill.md
@@ -1,0 +1,185 @@
+# Cost Estimation — S1 — cost-estimation skill + estimate-record format — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship S1 of the cost-estimator capability — the `cost-estimation` skill, the estimate-record format reference, and a TDAD scenario for the skill. This slice ships the methodology and the format contract that S2–S6 consume. No agent, no command, no orchestrator wiring. Plugin version bumps `0.40.0 → 0.41.0`.
+
+**Architecture:** A new skill (methodology + disclosure contract as loadable prose) plus a references file (the estimate-record format as a stable contract, one contract per file per the AGENTS.md references-file idiom). The format reference is the artefact the downstream S3 command's Output Validation Checkpoint references by path. The day-one deliverable is a **token + time estimate**, both grounded from `MODEL_ROUTING.md` (token budgets + tier mapping). The dollar figure is **actuals-gated**: `cost_usd` is present only when an `observability/costs/` snapshot supplies a usable per-model $/token rate (via a named tier→model→$/token binding table); otherwise it is **omitted with disclosure** — there is no list-price fallback. Every present quantitative figure is a range; confidence is recorded **per axis** (`tokens`/`time`/conditional `cost`); the time field is split into agent-compute (a numeric range) vs human-gate latency, with `human_gate_time` carried as a **qualitative caveat, not estimated numerically at S1** (its grounding — the orchestrator gate set — is S4 scope, #371). The no-verdict guarantee is structural in two layers (no verdict field + a positive-content check forbidding recommendation prose). The calibration seam (S6) is kept open via a `kind: calibration` grounding-source value without being implemented.
+
+**Revision note:** This plan reflects the post-diaboli revision in which all 12 objections (O1–O12) were adjudicated `accepted`. The central restructure — `cost_usd` optional-until-actuals (O11, resolving O2/O3/O4) — changes the schema from a required dollar field to a conditional one and removes the list-price fallback. The disclosure body is now framed as a contract this spec proposes, not a pre-existing AGENTS.md decision (O1).
+
+**Tech Stack:** Markdown + JSON. No new dependencies, no code.
+
+**This is one slice of a six-slice capability.** Downstream issues: S2 #369 (read-only agent), S3 #370 (`/cost-estimate` command), S4 #371 (orchestrator T1/T2 fold-in), S5 #372 (T0 ballpark), S6 #373 (calibration loop). None of them ship here.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md`
+
+---
+
+## Modules / files touched
+
+```
+ai-literacy-superpowers/
+├── .claude-plugin/plugin.json                          # MODIFIED: 0.40.0 → 0.41.0
+├── CHANGELOG.md                                         # MODIFIED: new 0.41.0 entry
+└── skills/cost-estimation/
+    ├── SKILL.md                                         # NEW — methodology + disclosure contract
+    └── references/
+        └── estimate-record-format.md                   # NEW — the format contract
+
+tdad_tests/scenarios/skills/cost-estimation/
+├── format-and-contract.md                              # NEW — structural scenario
+├── cost-conditional.md                                 # NEW — structural: cost present-when-grounded, three states, no fallback
+├── no-verdict-in-prose.md                              # NEW — structural: positive-content no-verdict check
+└── triggers-on-prospective-cost.md                     # NEW — trigger scenario
+
+docs/plugins/ai-literacy-superpowers/...                # NEW or MODIFIED — prospective-cost docs page (satisfies docs-reference-parity)
+
+.claude-plugin/marketplace.json                          # MODIFIED: ai-literacy-superpowers entry version + plugin_version 0.40.0 → 0.41.0
+README.md                                                # MODIFIED: plugin badge 0.40.0 → 0.41.0
+```
+
+Top-level marketplace `version` stays at `0.4.0`. No agent, command, or orchestrator file touched.
+
+---
+
+## Algorithm / key decisions (not pseudocode)
+
+- **Range, never point.** Every **present** quantitative field (`tokens`, `tokens_by_stage[].tokens`, `cost_usd` when present, `agent_compute_time`, `human_gate_time`) is a `{low, high}` object. There is no point-value, verdict, recommendation, or go/no-go field. This is the load-bearing schema decision (spec §3) and is checked by the structural scenario.
+- **`cost_usd` is conditional (present-when-grounded) — the central restructure (O11).** The day-one deliverable is token + time. `cost_usd` (plus `cost_basis`) appears only when a snapshot supplies a usable per-model rate; otherwise it is **omitted with disclosure** in `excluded`. **No list-price fallback.** Three grounding states: no snapshot / snapshot-without-usable-breakdown (both omit) / snapshot-with-breakdown (present, `cost_basis: snapshot-actuals`) (spec §6.2, §6.4, O2/O3/O8).
+- **Cost binding is named, not agent discretion (O5); split widens across two distinct models (O1).** A tier→model→$/token binding table ships in the reference; the per-model rate is `estimated_cost ÷ total_tokens` from the snapshot Model Breakdown. The implementer's `Standard / Capable` split is widened across **two distinct representative models** — low bound `claude-sonnet-4` (`Standard`), high bound `claude-opus-4` (`Most capable`, since MODEL_ROUTING.md has no standalone `Capable` model) — so the widening produces a real spread, not a zero-width band. The cost-present worked example demonstrates the non-zero implementer band.
+- **Time split is field-level, with different shapes (O2).** `agent_compute_time` and `human_gate_time` are two separate required fields. `agent_compute_time` derives from token volume as a numeric `{low, high}` range. `human_gate_time` is a **disclosed qualitative caveat, not estimated numerically at S1**: the withdrawn `gate_count × per-gate band` derivation had an ungrounded `gate_count` and reached into the orchestrator gate topology (S4, #371) the slice declares out of scope, so it is replaced by prose stating wall-clock is dominated by human availability and is not given a number until S4 fixes the gate set. Human-gate latency dominates wall-clock (spec §4.3, §6.3).
+- **Disclosure body is mandatory and four-part — proposed by this spec (O1).** included / excluded / confidence-rationale / failure-direction. This is a contract THIS SPEC PROPOSES; it is **not** a pre-existing "disclosure-of-derived-judgment" AGENTS.md decision (no such decision exists). It serves the real "agent-emit + dispatcher-persist + human-disposes" ARCH_DECISION (spec §5).
+- **Confidence is per-axis (O4, O6).** `confidence` is an object keyed `tokens`/`time`/conditional `cost`. `tokens`/`time` are capped by a `target_kind` ceiling (raw text → `low`); the `cost` axis exists only when `cost_usd` does and is set from snapshot quality, independent of `target_kind`. No collision on the empty-snapshot default because cost is simply omitted (spec §5.2).
+- **No-verdict guarantee is structural in two layers (O12).** Field-absence (no verdict/recommendation/proceed field) plus a positive-content check that fails a record whose disclosure prose carries imperative recommendation or go/no-go language (spec §5.3).
+- **Calibration seam open, not implemented.** `grounding_sources[]` accepts `kind: calibration`; methodology says calibration refines existing ranges rather than adding a field (spec §7). No per-PR capture, no integration-agent change. **Watch item (O7):** cost stays omitted across S2–S5 until S6; resequencing S6 earlier is a slicing decision to revisit, flagged not resolved.
+- **References-file idiom.** The format lives in `references/estimate-record-format.md`, one contract per file, so the S3 command's validation checkpoint references it by path (spec §8.2; AGENTS.md ARCH_DECISION on cross-cutting methodology).
+
+---
+
+## FR mapping table
+
+| FR | Requirement (abbrev) | Covering test case(s) |
+| --- | --- | --- |
+| FR-1 | SKILL.md present, well-formed, required sections | `format-and-contract.md` (structural) |
+| FR-2 | Format reference defines full field set; `cost_usd`/`cost_basis` conditional; `confidence` per-axis | `format-and-contract.md` |
+| FR-3 | Every present quantitative field a range; no verdict field | `format-and-contract.md` |
+| FR-4 | Four-part disclosure body mandated | `format-and-contract.md` |
+| FR-5 | Time split: two separate required fields — `agent_compute_time` a numeric range, `human_gate_time` a qualitative caveat not estimated numerically at S1 (gate set is S4 scope) | `format-and-contract.md` |
+| FR-6 | Per-axis confidence; target_kind ceiling for tokens/time; independent cost axis | `format-and-contract.md` |
+| FR-7 | Token ranges + tiers grounded in MODEL_ROUTING.md; split-tier widened across two distinct models (low `claude-sonnet-4`, high `claude-opus-4`) | `format-and-contract.md` (section presence) |
+| FR-8 | `cost_usd` conditional (present-when-grounded); no list-price fallback; three grounding states | `format-and-contract.md` + `cost-conditional.md` |
+| FR-8a | Named tier→model→$/token binding table in reference | `format-and-contract.md` |
+| FR-9 | calibration grounding source permitted; range-refinement | `format-and-contract.md` |
+| FR-10 | Names cost-tracking sibling; reuses observability/costs | `format-and-contract.md` + `triggers-on-prospective-cost.md` |
+| FR-11 | Two worked examples (cost-omitted + cost-present) + validation checklist; no inclusion caveat under excluded | `format-and-contract.md` |
+| FR-12 | Version bump 0.41.0 across all four locations | local version-consistency check (Task 5) |
+| FR-13 | TDAD structural + trigger scenarios present | all scenario files exist |
+| FR-14 | Validation checklist includes positive-content no-verdict check | `format-and-contract.md` + `no-verdict-in-prose.md` |
+
+---
+
+## Test case list
+
+(In the same form as the existing TDAD scenario corpus — `Given/When/Then` markdown scenarios under `tdad_tests/scenarios/skills/cost-estimation/`.)
+
+- `format-and-contract.md` (tier: structural) — SKILL.md frontmatter well-formed; required sections present (methodology, disclosure contract, time split, calibration seam, sibling, NOT-do); format reference exists; field table lists all of §4.2 including `cost_usd`/`cost_basis` marked conditional and a per-axis `confidence` object; every present quantitative field is a range; `agent_compute_time` is a numeric range and `human_gate_time` is a qualitative caveat string (not a range); no verdict/recommendation field; four-part disclosure body present; per-axis confidence with target_kind ceiling; named tier→model→$/token binding table present with the split row spanning two distinct models (`claude-sonnet-4` low … `claude-opus-4` high); the cost-present worked example shows a non-zero widened implementer band; calibration grounding-source value present; both cost-omitted and cost-present worked examples present; validation checklist present (including the positive-content no-verdict check).
+- `cost-conditional.md` (tier: structural) — the methodology defines `cost_usd` as present only when a snapshot supplies a usable per-model rate; defines the three grounding states (no snapshot → omit; snapshot without usable breakdown → omit; snapshot with breakdown → present); states there is **no list-price fallback**; the cost-omitted example carries a cost-omission disclosure in `excluded` and a confidence object with no `cost` axis.
+- `no-verdict-in-prose.md` (tier: structural) — the validation checklist enumerates both the field-absence check and the positive-content check; the worked examples contain no imperative recommendation or go/no-go language in their disclosure prose.
+- `triggers-on-prospective-cost.md` (tier: trigger) — skill description fires on "how much will this feature cost", "estimate the tokens for this spec", "what will this slice cost to build"; does NOT fire on "record our Anthropic spend", "capture the quarterly cost snapshot" (those belong to `cost-tracking`).
+
+---
+
+## Phase 1 — The skill and the format reference
+
+### Task 1: Write the format reference
+
+- Create `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`.
+- Content: the §4.2 frontmatter field table (with `cost_usd`/`cost_basis` marked **conditional** and `confidence` a **per-axis object**; `human_gate_time` typed as a qualitative caveat string, not a range); the §4.4 range rules (absent `cost_usd` is valid; `human_gate_time` exempt from range rules); the §4.3 time-split requirement — `agent_compute_time` a numeric range with the §6.3 token→wall-clock band, `human_gate_time` a qualitative caveat **not estimated numerically at S1** (no per-gate band, no gate count); the §5.1 four-part disclosure body; the §5.2 **per-axis** confidence mapping; the §6.2 **tier→model→$/token binding table** (split row spanning `claude-sonnet-4` low … `claude-opus-4` high, widened per §6.1); the §5.3 **two-layer** no-verdict guarantee; **two** worked example records — one **cost-omitted** (today's default) and one **cost-present** (`cost_basis: snapshot-actuals`, demonstrating the non-zero widened implementer band); a "Validation checklist" subsection for the downstream S3 command, including the positive-content recommendation-prose scan (O12) and the `cost_usd`/`cost_basis` both-present-or-both-absent rule.
+
+### Task 2: Write the skill
+
+- Create `ai-literacy-superpowers/skills/cost-estimation/SKILL.md`.
+- Frontmatter: `name: cost-estimation`; a `description` triggering on prospective-cost queries and naming the `cost-tracking` sibling.
+- Body: why estimate prospectively; the day-one token + time deliverable; the range-not-point decision; the grounding methodology (MODEL_ROUTING.md for token + time always; cost from a snapshot **only when grounded**, omitted-with-disclosure otherwise, **no list-price fallback**); the named tier→model→$/token binding and split-tier widening across two distinct models; the per-axis disclosure/confidence contract (framed as a contract this spec proposes, serving the agent-emit/dispatcher-persist/human-disposes ARCH_DECISION); the time split — `agent_compute_time` as a numeric range with its token→wall-clock band, `human_gate_time` as a qualitative caveat not estimated numerically at S1; the calibration seam (one paragraph, future) with the O7 cost-axis watch-item note; the sibling relationship; a "What this skill does NOT do" section (no dispatch, no file writes, no go/no-go — consumers' jobs).
+- Reference the format file by relative path.
+
+---
+
+## Phase 2 — TDAD scenarios
+
+### Task 3: Author the structural + trigger scenarios
+
+- Create `tdad_tests/scenarios/skills/cost-estimation/format-and-contract.md`, `cost-conditional.md`, `no-verdict-in-prose.md`, and `triggers-on-prospective-cost.md` per the test case list and the corpus format in `tdad_tests/README.md`.
+- These are the RED-phase deliverables of the tdd-agent's agent-artefact branch; the spec §8.3 / §10 fixes their `Then` shape.
+
+---
+
+## Phase 3 — Docs
+
+### Task 4: Prospective-cost docs page
+
+- Add or extend a page under `docs/plugins/ai-literacy-superpowers/` (how-to or explanation quadrant) describing prospective cost estimation and its relationship to the retrospective `cost-tracking` sibling. Satisfies the docs-reference-parity CI check that fires on the new skill.
+
+---
+
+## Phase 4 — Version bumps
+
+### Task 5: Bump plugin.json, CHANGELOG, marketplace.json, README
+
+- `ai-literacy-superpowers/.claude-plugin/plugin.json`: `version` `0.40.0` → `0.41.0`.
+- `ai-literacy-superpowers/CHANGELOG.md`: new `## 0.41.0 — 2026-06-10` heading with entries for the skill, the format reference, and the disclosure contract.
+- `.claude-plugin/marketplace.json`: bump the `ai-literacy-superpowers` `plugins[]` entry `version` and the top-level `plugin_version` to `0.41.0`; leave top-level `version` at `0.4.0`.
+- `README.md`: bump the `ai-literacy-superpowers` badge `v0.40.0` → `v0.41.0`.
+- Verify version consistency:
+
+```bash
+python3 -c "
+import json
+pj = json.load(open('ai-literacy-superpowers/.claude-plugin/plugin.json'))
+m = json.load(open('.claude-plugin/marketplace.json'))
+entry = next(p for p in m['plugins'] if p['name']=='ai-literacy-superpowers')
+assert pj['version']=='0.41.0', pj['version']
+assert entry['version']=='0.41.0', entry['version']
+assert m['plugin_version']=='0.41.0', m['plugin_version']
+assert m['version']=='0.4.0', m['version']
+print('version consistency OK')
+"
+```
+
+---
+
+## Phase 5 — Verify and ship
+
+### Task 6: Local CI gate checks
+
+- Spec-first ordering — first commit on branch is the spec:
+
+```bash
+git log main..HEAD --reverse --oneline | head -1
+```
+
+- TDAD scenario presence — the new skill ships with a scenario:
+
+```bash
+ls tdad_tests/scenarios/skills/cost-estimation/*.md
+```
+
+- Markdown lint, docs build, and the deterministic TDAD fast suite (Layers 0+1) pass.
+
+### Task 7: Push, PR, CI, merge
+
+- Push the `cost-estimator-pipeline` branch, open a PR (feature ceremony — full `/diaboli` spec + code and `/choice-cartograph` already run on the spec).
+- PR body states what ships (skill + format reference + scenarios + docs + version bump) and what does NOT (S2–S6, issues #369–#373).
+- Watch CI green; merge `--squash --delete-branch`; sync the marketplace cache.
+
+---
+
+## Out of scope (deferred to S2–S6)
+
+- The read-only `cost-estimator` agent (S2, #369).
+- The `/cost-estimate` command and its Output Validation Checkpoint against this format (S3, #370).
+- Orchestrator fold-in at T1 (Slice Adjudication) and T2 (Plan Approval) (S4, #371).
+- The T0 pre-carpaccio ballpark (S5, #372).
+- The calibration loop — per-PR actuals capture and the integration-agent change (S6, #373). S1 keeps the seam open only.
+- Any runtime validator of estimate-record instances (a consuming command's checkpoint does this in S3, not a standalone validator here).

--- a/docs/superpowers/slices/cost-estimator-pipeline.md
+++ b/docs/superpowers/slices/cost-estimator-pipeline.md
@@ -1,0 +1,508 @@
+---
+task: "Add a prospective cost-estimation capability (cost-estimation skill, read-only cost-estimator agent, /cost-estimate command) that estimates token usage, agent-compute vs human-gate time, and cost for work flowing through the orchestrator pipeline, surfaced at T0 (pre-carpaccio), T1 (Slice Adjudication), and T2 (Plan Approval); grounded in MODEL_ROUTING.md budgets and cost snapshot actuals; governed by the disclosure-of-derived-judgment decision."
+task_slug: cost-estimator-pipeline
+date: 2026-06-10
+carpaccio_model: claude-opus-4-8
+inseparable: false
+progressed_slice: S1
+slices:
+  - id: S1
+    title: Cost-estimation skill — methodology, estimate-record format, and the disclosure/confidence contract
+    scope: >
+      Author the `cost-estimation` skill under
+      ai-literacy-superpowers/skills/cost-estimation/SKILL.md. It defines the
+      estimation methodology (how MODEL_ROUTING.md per-stage token budgets and
+      the agent→model-tier mapping combine with observability/costs snapshot
+      $/token actuals to produce a cost figure), the estimate-record format
+      (the structured artefact the agent emits), and the disclosure/confidence
+      contract: every estimate is a RANGE with disclosed confidence, what it
+      included, what it excluded, and the failure direction — as required by the
+      promoted AGENTS.md "disclosure-of-derived-judgment" decision. The record
+      format must split time into agent-compute time vs human-gate latency. No
+      agent, no command, no orchestrator wiring yet — this slice ships the
+      methodology and the format contract that every other slice consumes.
+    decision_focus: >
+      What IS an estimate in this system, and what honesty contract governs it?
+      A point-value estimator and a ranges-with-disclosed-confidence estimator
+      are materially different artefacts with different record schemas and
+      different downstream-trust properties. This slice locks the estimate-record
+      shape (fields, range representation, confidence tiers, included/excluded
+      disclosure, failure direction, agent-compute vs human-gate time split) and
+      the grounding methodology BEFORE any code reads or writes it. Getting this
+      wrong is expensive to retrofit across the agent, command, and three
+      insertion points.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: >
+      Accepted and progressed this iteration. The foundation: zero dependencies,
+      and every other slice consumes the estimate-record format and disclosure
+      contract it defines. Spec-writer runs against this slice's scope. Because
+      S6 (calibration) is accepted in-scope, S1's methodology must keep the seam
+      open for a calibration data source even though S6 ships after the estimator.
+    file_as_issue: false
+    issue_url: null
+    merged_into: null
+
+  - id: S2
+    title: Read-only cost-estimator agent — emits an estimate record, never decides
+    scope: >
+      Build the `cost-estimator` agent at
+      ai-literacy-superpowers/agents/cost-estimator.agent.md with a Read/Glob/Grep
+      trust boundary, mirroring the carpaccio / advocatus-diaboli /
+      choice-cartographer pattern. The agent receives a target (raw task text, a
+      slicing record, or a spec), reads MODEL_ROUTING.md and the latest
+      observability/costs snapshot, and returns the estimate-record content (per
+      the S1 format) for the orchestrator or command to write to disk. The agent
+      never writes the file, never picks a confidence label as a verdict, and
+      never decides go/no-go — it emits, the human reads. Observable output: a
+      valid estimate record returned from a dispatch against a real target.
+    decision_focus: >
+      Does the estimator faithfully mirror the established read-only-agent-emits-
+      record-human-disposes pattern, or does it become a "smart" component that
+      returns a recommendation? The whole architecture hinges on the agent being
+      a derived-judgment emitter, not a decider. This slice decides the trust
+      boundary, the input contract (what targets it accepts), and the
+      emits-not-writes discipline that the disclosure contract depends on.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: >
+      Accepted; filed as a tracked issue for the next iteration. Build after S1.
+      The read-only-emits-record trust boundary is the load-bearing decision that
+      keeps the human in the disposition seat.
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/369
+    merged_into: null
+
+  - id: S3
+    title: /cost-estimate command — manual entry point on a slice or spec
+    scope: >
+      Add the `/cost-estimate` command at
+      ai-literacy-superpowers/commands/cost-estimate.md as a manual entry point.
+      It dispatches the S2 agent against a user-supplied target (a slicing record
+      path, a spec path, or pasted task text), writes the returned estimate
+      record to disk, and applies an output-validation checkpoint against the S1
+      format reference (per the CLAUDE.md Output Validation Checkpoints
+      convention). This is the human-facing, end-to-end surface that exercises
+      the skill + agent without depending on a full orchestrator run — the
+      prospective counterpart to the existing /cost-capture command.
+    decision_focus: >
+      Should there be a standalone manual surface at all, and what does it accept?
+      A command that only runs inside the orchestrator gates is a different
+      product from one a human can invoke ad hoc against any slice or spec. This
+      slice decides the command signature, the accepted target types, where the
+      record is written, and that the manual path carries its own validation
+      checkpoint rather than relying on orchestrator-only validation.
+    lens_used: end-to-end
+    disposition: accepted
+    disposition_rationale: >
+      Accepted; filed as a tracked issue. The cleanest standalone end-to-end
+      proof of S1+S2 — exercises the skill and agent through a real surface
+      without touching the orchestrator. Prospective sibling of /cost-capture.
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/370
+    merged_into: null
+
+  - id: S4
+    title: Orchestrator fold-in at T1 and T2 — estimates as informational fields in existing gates
+    scope: >
+      Wire the estimator into the orchestrator's EXISTING gates without adding
+      new hard gates. T1: after carpaccio, dispatch the estimator to produce a
+      per-slice token/cost breakdown and surface it as informational fields
+      inside the Slice Adjudication gate (step 0) so the human can see cost
+      while choosing which slice to progress/file/defer. T2: after spec-writer,
+      dispatch the estimator against the progressed slice's spec to produce a
+      tighter estimate and surface it as informational fields inside the Plan
+      Approval gate. Both fold in as fields alongside the existing record
+      summaries — they do NOT block, do NOT add a keypress, and do NOT let any
+      agent write dispositions.
+    decision_focus: >
+      Do estimates fold into existing gates as informational fields, or do they
+      become new decision points? This is the highest-value architectural
+      commitment in the task: T1 is named the most valuable moment because it
+      informs slice progression. Deciding "informational fold-in, never a hard
+      gate" — and exactly which fields appear in which gate summary — determines
+      whether the capability adds cognitive value or cognitive friction. The
+      fold-in must preserve the orchestrator's existing gate semantics
+      (carpaccio's hard gate, plan approval's hard+soft composite) unchanged.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: >
+      Accepted; filed as a tracked issue. The highest-value insertion — T1
+      informs which slice to progress/file/defer. Committed shape: informational
+      fold-in into the existing Slice Adjudication and Plan Approval gates, never
+      a new hard gate, no extra keypress.
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/371
+    merged_into: null
+
+  - id: S5
+    title: T0 pre-carpaccio ballpark — coarse whole-task go/no-go signal
+    scope: >
+      Add the T0 insertion: a cheap, coarse whole-task estimate from raw task
+      text ONLY, dispatched as a bonus before orchestrator step 0 (before
+      carpaccio). It produces an explicitly low-confidence ballpark surfaced to
+      the human as a go/no-go signal, with the confidence disclosure (per S1)
+      making its coarseness loud. It does not block carpaccio and carries no
+      gate.
+    decision_focus: >
+      Is the lowest-confidence, earliest insertion point worth shipping at all?
+      T0 estimates from raw text alone — before any slicing or spec — are the
+      least accurate and the most likely to mislead if their confidence framing
+      is weak. The decision is whether the go/no-go value of a pre-pipeline
+      ballpark outweighs the risk of an anchoring number presented before the
+      work is even sliced, and if so, where exactly it fires relative to branch
+      creation and issue creation. This is separable from S4: T0 lives outside
+      any existing gate, whereas T1/T2 fold into existing gates.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: >
+      Accepted; filed as a tracked issue. The T0 go/no-go ballpark, separable
+      from S4 because it lives outside any existing gate. Its in/out and exact
+      firing position (relative to branch/issue creation) are decided in its own
+      spec; the S1 confidence disclosure is what keeps a raw-text ballpark honest.
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/372
+    merged_into: null
+
+  - id: S6
+    title: Calibration loop — per-PR actuals capture for self-calibration over time
+    scope: >
+      Close the calibration loop: have the integration-agent capture actual
+      per-PR tokens/cost into observability/costs/ at merge time, so the
+      estimator calibrates against this repo's own history rather than only the
+      generic MODEL_ROUTING budgets. Today there is NO automatic per-PR actuals
+      capture — only quarterly provider-level snapshots — so this slice adds the
+      capture mechanism and the feedback path from captured actuals back into the
+      estimation methodology.
+    decision_focus: >
+      Is the calibration loop in scope for the first version, or a recorded
+      follow-on? The human explicitly flagged it as separable. First-version
+      estimates calibrate only against generic MODEL_ROUTING budgets; the loop
+      adds repo-specific accuracy but also adds a new integration-agent
+      responsibility and a new actuals-capture format. The decision is whether to
+      ship the estimator first and calibrate later, or treat self-calibration as
+      part of the initial delivery — and the answer shapes whether S1's
+      methodology must already accommodate a calibration data source.
+    lens_used: decision-boundary
+    disposition: accepted
+    disposition_rationale: >
+      Accepted in-scope (not deferred); filed as a tracked issue to ship after
+      the estimator itself. Because it is in-scope, S1's methodology must keep
+      the seam open for a calibration data source now. Adds a new integration-
+      agent responsibility and a per-PR actuals format distinct from the
+      quarterly snapshot.
+    file_as_issue: true
+    issue_url: https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/373
+    merged_into: null
+---
+
+## S1 — Cost-estimation skill — methodology, estimate-record format, and the disclosure/confidence contract — decision-boundary
+
+**Context**
+
+The plugin already has a retrospective cost sibling: the `cost-tracking`
+skill and `/cost-capture` command record actuals into
+`observability/costs/YYYY-MM-DD-costs.md`. This task adds the prospective
+counterpart. Before any agent or command can produce an estimate, the system
+needs a definition of what an estimate is: the methodology that combines
+MODEL_ROUTING.md per-stage token budgets (spec-writer 50-100k, tdd-agent
+50-150k, implementer 100-250k, code-reviewer 50-100k, integration 30-80k) and
+the agent→model-tier mapping with the snapshot $/token actuals, plus the
+record format and the honesty contract. The promoted AGENTS.md decision
+"disclosure-of-derived-judgment" governs that contract: an estimate is a
+derived prediction and must disclose what it included, what it excluded, and
+its confidence with failure direction.
+
+**Decision content**
+
+What IS an estimate in this system, and what honesty contract binds it? The
+material choice is between a point-value figure and a range-with-disclosed-
+confidence artefact — these are different record schemas with different
+downstream-trust consequences. This slice decides the estimate-record field
+set (range representation, confidence tiers, the included/excluded disclosure,
+the failure-direction statement), the agent-compute-time vs human-gate-latency
+split, and the grounding methodology that ties budgets and actuals to a cost
+range. Every other slice consumes this format; deciding it first prevents
+expensive retrofit across the agent, the command, and three insertion points.
+
+**Dependencies**
+
+None. The skill is the foundation. It can be authored against the existing
+MODEL_ROUTING.md and cost snapshot data without any new code.
+
+**Rationale**
+
+This is the decision that the entire capability rests on. The disclosure
+contract is not a presentation detail — it is the governance commitment that
+makes a prospective estimate honest rather than an anchoring number dressed as
+fact. Separating it as the first slice forces the format and the honesty
+contract to be reviewed before any consumer is built, which is where the
+disclosure-of-derived-judgment decision is cheapest to honour correctly.
+
+---
+
+## S2 — Read-only cost-estimator agent — emits an estimate record, never decides — decision-boundary
+
+**Context**
+
+The plugin's carpaccio, advocatus-diaboli, and choice-cartographer agents are
+all read-only by tool boundary (Read/Glob/Grep), return a structured record
+the orchestrator writes to disk, and surface that record at a human
+disposition gate. The agent never decides — the human reads the record and
+disposes. The cost estimator must mirror this exact pattern: it is a derived-
+judgment emitter, not a recommender.
+
+**Decision content**
+
+Does the estimator faithfully mirror the read-only-agent-emits-record-human-
+disposes pattern, or does it drift into returning a recommendation or a
+go/no-go verdict? The architecture hinges on the agent emitting an estimate
+record (per S1) and nothing more. This slice decides the Read/Glob/Grep trust
+boundary, the input contract (what targets the agent accepts — raw task text,
+a slicing record, a spec), and the emits-not-writes discipline. A "smart"
+agent that picks the answer would break both the established pattern and the
+disclosure contract, which depends on the human engaging with the range rather
+than receiving a verdict.
+
+**Dependencies**
+
+S1 (the estimate-record format and methodology must exist for the agent to
+emit a valid record).
+
+**Rationale**
+
+Mirroring the established read-only pattern is the load-bearing architectural
+decision for the agent. It is what keeps the human in the disposition seat and
+keeps the agent honest. Slicing it separately from the surfaces that invoke it
+(S3, S4, S5) lets the emits-not-decides contract be reviewed in isolation,
+before the agent is wired into any gate where a stray recommendation would do
+the most damage.
+
+---
+
+## S3 — /cost-estimate command — manual entry point on a slice or spec — end-to-end
+
+**Context**
+
+The retrospective sibling exposes `/cost-capture` as a manual command. The
+prospective capability needs an equivalent manual surface so a human can ask
+for an estimate ad hoc — against a slicing record, a spec, or pasted task text
+— without running a full orchestrator pipeline. The CLAUDE.md Output
+Validation Checkpoints convention requires any command that writes structured
+markdown to read it back and validate against the format reference.
+
+**Decision content**
+
+Should there be a standalone manual surface at all, and what targets does it
+accept? A command usable only inside orchestrator gates is a different product
+from one a human invokes directly against any slice or spec. This slice decides
+the `/cost-estimate` signature, the accepted target types, where the record is
+written, and that the manual path carries its own validation checkpoint rather
+than relying on orchestrator-only validation.
+
+**Dependencies**
+
+S1 and S2 (the command dispatches the S2 agent, which emits the S1 record;
+it cannot exist meaningfully without both).
+
+**Rationale**
+
+This slice is where the capability first becomes observable end-to-end for a
+human: dispatch → record written → validated → presented. It exercises the
+skill and agent through a real surface, independent of the orchestrator
+integration, so the core estimator can be proven before it is folded into the
+pipeline gates. It also matches the established symmetry with `/cost-capture`,
+keeping the prospective and retrospective surfaces discoverable as a pair.
+
+---
+
+## S4 — Orchestrator fold-in at T1 and T2 — estimates as informational fields in existing gates — decision-boundary
+
+**Context**
+
+The orchestrator already runs two human-disposition gates relevant here: the
+Slice Adjudication gate at step 0 (after carpaccio, where the human sets
+`progressed_slice` and dispositions) and the Plan Approval gate (after
+spec-writer and the diaboli/cartographer records). The task specifies that
+estimates FOLD INTO these existing gates as informational fields — they are
+explicitly NOT new hard gates. T1 (per-slice breakdown at Slice Adjudication)
+is named the highest-value moment because it informs which slice to
+progress/file/defer; T2 (tighter estimate at Plan Approval) is higher
+confidence because the spec enumerates scenarios and files.
+
+**Decision content**
+
+Do estimates fold into existing gates as informational fields, or do they
+become new decision points? This is the central architectural commitment of
+the task. The decision is to surface estimates as fields in the existing gate
+summaries — preserving carpaccio's hard gate and plan approval's hard+soft
+composite unchanged, adding no keypress and no block — and to decide exactly
+which estimate fields appear in which gate summary. An alternative that
+introduced a new "Cost Approval" gate would change the cadence of the pipeline
+and the human's cognitive load; this slice commits to fold-in, not a new gate.
+
+**Dependencies**
+
+S1 and S2 (needs the record format and the agent). Independent of S3 (the
+manual command) and S5 (the T0 insertion) — the orchestrator can dispatch the
+agent directly at T1/T2 without the command, and the T1/T2 fold-in does not
+require T0.
+
+**Rationale**
+
+The fold-into-existing-gates decision is what determines whether the capability
+adds value or friction. T1 is where cost most changes a human's choice (which
+slice to progress), so getting the informational-field placement right at Slice
+Adjudication is the payoff of the whole feature. Slicing T1 and T2 together is
+deliberate: they share one decision (informational fold-in into existing gates,
+never a new hard gate) and one mechanism (dispatch the S2 agent, surface fields
+in the existing gate summary), differing only in target and confidence. Splitting
+them per gate would be slicing on insertion points rather than on the decision.
+
+---
+
+## S5 — T0 pre-carpaccio ballpark — coarse whole-task go/no-go signal — decision-boundary
+
+**Context**
+
+The task proposes three insertion moments. T1 and T2 fold into existing gates
+(S4). T0 is different in kind: a coarse whole-task ballpark from raw task text
+ONLY, fired as a cheap bonus BEFORE orchestrator step 0 (before carpaccio),
+explicitly low-confidence, intended as a go/no-go signal. It lives outside any
+existing gate.
+
+**Decision content**
+
+Is the lowest-confidence, earliest insertion point worth shipping at all, and
+if so, where exactly does it fire? T0 estimates from raw text alone — before
+slicing or spec — are the least accurate and the most prone to anchoring a
+human on a number before the work is even understood. The decision weighs the
+go/no-go value of a pre-pipeline ballpark against that anchoring risk, and
+fixes the firing position relative to branch creation and issue creation. The
+S1 confidence disclosure is what makes a T0 ballpark defensible; whether that
+is enough to justify the insertion is the call here.
+
+**Dependencies**
+
+S1 and S2 (needs the format and the agent). Independent of S4 — T0 lives
+outside the existing gates, so it can land before or after the T1/T2 fold-in,
+and either can be dropped without affecting the other.
+
+**Rationale**
+
+T0 is separated from S4 because it is a different architectural commitment: S4
+folds into gates the orchestrator already owns and hard-enforces, whereas T0
+adds a brand-new pre-step-0 touchpoint with no gate and the weakest confidence.
+Conflating them would hide a genuine in/out decision (ship the riskiest, least
+accurate insertion at all?) inside the higher-value gate-fold-in work. As its
+own slice, the human can accept the high-value T1/T2 fold-in while deferring or
+dropping T0 on its own merits.
+
+---
+
+## S6 — Calibration loop — per-PR actuals capture for self-calibration over time — decision-boundary
+
+**Context**
+
+The human explicitly flagged this as separable fast-follow. Today there is no
+automatic per-PR actuals capture — only quarterly provider-level snapshots via
+`/cost-capture` — so first-version estimates calibrate only against the generic
+MODEL_ROUTING budgets. Closing the loop means having the integration-agent
+capture actual per-PR tokens/cost into `observability/costs/` at merge time, so
+the estimator calibrates against this repo's own history and grows more
+accurate over time.
+
+**Decision content**
+
+Is the calibration loop in scope for the first version, or a recorded follow-on?
+The loop adds repo-specific accuracy but also adds a new responsibility to the
+integration-agent and a new per-PR actuals-capture format distinct from the
+quarterly snapshot. The decision is whether to ship the estimator calibrated
+only against generic budgets first and add self-calibration later, or to treat
+the loop as part of the initial delivery — and that answer feeds back into S1,
+because the methodology must accommodate a calibration data source if the loop
+is in scope from the start.
+
+**Dependencies**
+
+Conceptually depends on S1 (the methodology must know how to ingest calibration
+data) and on the estimator existing (S2). It does not block S1–S5: the
+estimator ships and functions against generic budgets without it. This is the
+slice most likely to be dispositioned as a deferred follow-on.
+
+**Rationale**
+
+The human named this as separable, and the lens agrees: it is a distinct
+decision (ship now vs. defer) with a distinct downstream artefact (per-PR
+actuals capture wired into the integration-agent). Surfacing it as its own
+slice lets the human make the in/out call deliberately rather than having it
+silently bundled into the first version. If deferred, it becomes a clean
+follow-on issue; if accepted, S1's methodology must be specced to accept the
+calibration source from the outset.
+
+---
+
+## Sequencing recommendation
+
+S1 is the foundation and must land first — it defines the estimate-record
+format and the disclosure/confidence contract that S2 through S6 all consume.
+S2 (the read-only agent) follows directly, as it emits the S1 record.
+
+After S1 and S2, the consuming surfaces are largely independent of each other:
+
+- **S3** (`/cost-estimate` command) is the cleanest standalone proof — it
+  exercises S1+S2 end-to-end without touching the orchestrator. Good candidate
+  to progress first among the consumers.
+- **S4** (T1/T2 fold-in) and **S5** (T0 ballpark) both wire the agent into the
+  pipeline but at different points; neither depends on the other, and neither
+  depends on S3. S4 is the highest-value insertion (T1 informs slice
+  progression) and is the recommended progressed slice after the foundation if
+  the human wants impact first.
+- **S6** (calibration loop) is the natural last/deferred slice — it improves
+  accuracy over time but the estimator functions without it. Its disposition
+  also feeds back into S1's methodology scope, so if accepted it should be
+  decided before S1 is specced.
+
+Recommended chain if shipping incrementally: S1 → S2 → (S3 to prove
+end-to-end) → S4 (highest-value gate fold-in) → S5 → S6.
+
+## Explicitly not slicing on
+
+- **One slice per component (skill / agent / command).** Slicing strictly on
+  the three named components would be a code-organisation cut. The skill (S1)
+  is genuinely its own decision because it carries the disclosure contract; the
+  command (S3) is its own decision because it is a standalone surface. But the
+  agent (S2) is sliced on the read-only-emits-record DECISION, not because it
+  is a separate file — the file boundary and the decision boundary happen to
+  coincide here, and the slice is justified by the latter.
+
+- **One slice per insertion moment (T0 / T1 / T2).** Tempting, but T1 and T2
+  share a single decision — informational fold-in into existing gates, never a
+  new hard gate — and a single mechanism, so they are clustered into S4.
+  Splitting them would be slicing on insertion points (a layer/step cut) rather
+  than on the decision. T0 is split out from them because it is a genuinely
+  different decision (a new pre-step-0 touchpoint with no gate), not merely a
+  third insertion point.
+
+- **Grounding-data plumbing (reading MODEL_ROUTING.md and the cost snapshot).**
+  How the agent reads the budget table, the tier mapping, and the snapshot
+  $/token actuals is implementation detail inside S1 (methodology) and S2
+  (agent), not a separate design decision. The task specifies the data sources,
+  not a choice between them.
+
+- **The disclosure/confidence contract as a separate slice.** The
+  disclosure-of-derived-judgment contract is the core of S1's record format,
+  not a bolt-on. It cannot pass the end-to-end filter on its own (it ships
+  nothing observable independently of the record it governs), so it is folded
+  into S1 where it belongs.
+
+- **Time-split (agent-compute vs human-gate latency) as a separate slice.** The
+  two-way time split is a field-level property of the S1 estimate-record format,
+  not an independent decision with its own observable output. It is decided
+  within S1.
+
+- **Versioning, CHANGELOG, marketplace pointer, and docs pages.** Plugin
+  version bumps, CHANGELOG entries, marketplace `plugin_version` updates, and
+  the how-to/explanation docs pages follow from whichever component slices land,
+  per the standard CLAUDE.md conventions. They are maintenance steps attached to
+  each slice's PR, not decisions in their own right.

--- a/docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+++ b/docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
@@ -241,6 +241,13 @@ disclosure contract below is this spec's proposal for *what an estimate must
 disclose* so the human's disposition is informed; reviewers should evaluate it as
 a new contract, not check it against an authority that does not exist.
 
+> **Update (2026-06-11):** this contract was subsequently **promoted** to
+> AGENTS.md ARCH_DECISIONS as the *disclosure-of-derived-judgment* decision via
+> this design's choice-story #8 (promoted disposition). It is therefore no
+> longer merely proposed — it is now a named decision, with this spec as its
+> first operationalisation. The point-in-time text above records the state at
+> authoring (the decision did not yet exist); the grep claim is historical.
+
 The contract makes a prospective estimate honest rather than an anchoring number
 dressed as fact. An estimate record that does not satisfy this contract is
 invalid regardless of how good its numbers are.

--- a/docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+++ b/docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
@@ -1,0 +1,988 @@
+# Cost Estimation — S1 — methodology, estimate-record format, and the disclosure/confidence contract — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-10 |
+| Status | Draft |
+| Author | spec-writer (interactive session with russmiles) |
+| Slice | S1 of the slicing record at `docs/superpowers/slices/cost-estimator-pipeline.md` |
+| Progressed slice | S1 (this spec) |
+| Downstream slices | S2 (#369), S3 (#370), S4 (#371), S5 (#372), S6 (#373) — all out of scope here |
+| Plugin version target | `ai-literacy-superpowers` v0.40.0 → v0.41.0 (new skill — minor bump) |
+| Marketplace listing | Top-level `version` unchanged at v0.4.0; `plugin_version` 0.40.0 → 0.41.0 |
+| PR ceremony | feature — full `/diaboli` (spec + code) and `/choice-cartograph` |
+| Governing decision | AGENTS.md "agent-emit + dispatcher-persist + human-disposes" trust architecture (the pattern S2/S3 inherit). The four-part disclosure body in §5 is a contract THIS SPEC PROPOSES; it is not a pre-existing promoted decision. |
+
+---
+
+## 1. Premise
+
+The plugin already ships a **retrospective** cost capability: the `cost-tracking`
+skill and the `/cost-capture` command record actual spend into
+`observability/costs/YYYY-MM-DD-costs.md`. This capability is the
+**prospective** counterpart — a way to estimate, *before* work runs, the token
+usage and the time of a task flowing through the orchestrator pipeline, with a
+dollar cost added **only when observed actuals exist to ground it**.
+
+**The day-one deliverable is a token + time estimate.** Both axes are fully
+groundable from MODEL_ROUTING.md today (per-stage token budgets and the
+agent→model-tier mapping), so they are the honest first-version value of this
+capability. The dollar figure is an **actuals-gated enhancement**: it is present
+and grounded ONLY when an `observability/costs/` snapshot supplies a usable
+$/token rate; otherwise it is **omitted with an explicit disclosure**, not
+emitted as a forced-low list-price guess. See §6.2 and §6.4. This is the central
+restructure of this revision (resolving objections O2, O3, O4, O11): the dollar
+axis is not presented as a first-class day-one deliverable, because on day one
+there is no observed spend to ground it.
+
+Before any agent or command can produce an estimate, the system needs a
+definition of what an estimate *is*. This slice (S1) is that definition. It
+ships exactly three things and nothing else:
+
+1. **The estimation methodology** — how MODEL_ROUTING.md per-stage token
+   budgets and the agent→model-tier mapping produce token and time ranges
+   today, and how an `observability/costs/` snapshot adds a dollar figure when
+   one exists.
+2. **The estimate-record format** — the structured markdown artefact a future
+   agent (S2) emits and a future command (S3) writes and validates, in which
+   `cost_usd` is **conditional, not required** (present-when-grounded).
+3. **The disclosure/confidence contract** — the honesty rules the record
+   format follows. This four-part contract is **proposed by this spec**; it is
+   not a pre-existing promoted AGENTS.md decision (see §5 and O1). It serves the
+   real AGENTS.md **"agent-emit + dispatcher-persist + human-disposes" trust
+   architecture** that S2 and S3 inherit.
+
+This slice ships a **skill** (`SKILL.md`) and a **format reference file**. It
+ships **no agent, no command, and no orchestrator wiring**. Those are S2–S6.
+The deliverable is the contract every later slice consumes.
+
+## 2. Scope and non-goals
+
+### 2.1 In scope (S1)
+
+- A new skill at `ai-literacy-superpowers/skills/cost-estimation/SKILL.md`
+  describing the methodology and the disclosure contract in prose, for an
+  agent to load into context as reasoning guidance.
+- A format reference at
+  `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+  defining the estimate-record field set as a stable contract, suitable for a
+  downstream command's Output Validation Checkpoint (per the CLAUDE.md
+  convention).
+- A TDAD scenario covering the skill (structural + trigger layers), authored
+  under `tdad_tests/scenarios/skills/cost-estimation/`.
+- The plugin version bump, CHANGELOG entry, marketplace `plugin_version`
+  pointer update, and README badge — the maintenance steps that attach to any
+  new component.
+
+### 2.2 Out of scope (filed as separate issues)
+
+The slicing record (`docs/superpowers/slices/cost-estimator-pipeline.md`)
+carpaccio-sliced the whole capability into S1–S6. Only S1 ships here. The
+following are explicitly **not** in this PR and are tracked elsewhere:
+
+- **S2 — the read-only `cost-estimator` agent** (#369). No file under
+  `ai-literacy-superpowers/agents/` is added by this slice. The skill defines
+  what the agent *will* emit; it does not implement the emitter.
+- **S3 — the `/cost-estimate` command** (#370). No file under
+  `ai-literacy-superpowers/commands/`. The format reference is written to be
+  consumable by that command's validation checkpoint, but the command does not
+  exist yet.
+- **S4 — orchestrator fold-in at T1/T2** (#371). No change to
+  `agents/orchestrator.agent.md`. No gate is added, moved, or re-weighted.
+- **S5 — T0 pre-carpaccio ballpark** (#372). No pre-step-0 touchpoint.
+- **S6 — calibration loop** (#373). No per-PR actuals capture and no
+  integration-agent change. S6 is accepted **in-scope for the capability** but
+  ships later; S1's only obligation to S6 is to keep the methodology seam open
+  (see §7), not to implement calibration.
+
+This spec must not let any consumer leak into S1. If a reviewer finds the skill
+describing *who dispatches it*, *which gate it appears in*, or *how a command
+writes its output*, that is scope creep into S2–S5 and should be cut back to "a
+consumer does X" without naming the consumer's mechanics.
+
+## 3. What IS an estimate in this system (the decision)
+
+The material decision this slice locks: **an estimate is a range with disclosed
+confidence, never a point value.** The alternative — a single point figure — is
+a different record schema with different downstream-trust properties, and it is
+rejected here for the life of the capability.
+
+The reasoning:
+
+- An estimate is a **derived prediction**. The future agent derives a number a
+  human would otherwise have guessed or supplied, then emits it for the human to
+  dispose — mirroring the AGENTS.md **"agent-emit + dispatcher-persist +
+  human-disposes" trust architecture** (the agent emits, the command persists,
+  the human decides). Because the agent derives rather than observes, this spec
+  proposes a disclosure contract (§5) so the derivation is interrogable: what was
+  included, what was excluded, the confidence, and the failure direction. (NOTE:
+  the contract is proposed here, not an existing promoted decision — see O1 and
+  §5.)
+- A point value invites false precision. "12k tokens" reads as fact;
+  "10k–18k tokens, confidence medium, more likely to overrun than underrun
+  because the implementer stage spans two model tiers" reads as a prediction the
+  human can interrogate. The whole point of the capability is to *inform a
+  human's choice*, not to anchor it on a number dressed as a fact.
+- Locking range-with-confidence as the schema before any consumer is built is
+  the cheapest place to honour the disclosure contract. Retrofitting it across
+  an agent, a command, and three insertion points (S2–S5) would be expensive.
+  This is also why `cost_usd` is made **conditional rather than required** now
+  (§4.2, O11): the present-when-grounded shape needs no format change when the
+  first actuals snapshot lands, whereas a required low-confidence field would
+  bake the weakest axis into the contract.
+
+Every quantitative field in the record is therefore a **range** (`low`–`high`),
+and every record carries a confidence tier and the disclosures §5 requires.
+
+## 4. The estimate-record format
+
+The estimate record is the load-bearing deliverable. It is consumed by the S2
+agent (emits it), the S3 command (writes and validates it), and the S4
+orchestrator fold-in (surfaces fields from it). It must be a stable contract.
+
+### 4.1 Canonical artefact and format
+
+The record is a single markdown file with YAML frontmatter for the
+machine-readable fields and a prose body for the disclosures. The canonical
+field definitions live in the format reference file (§8.2); this section
+defines the field set.
+
+The frontmatter carries the structured fields a downstream validation
+checkpoint parses. The body carries the human-readable disclosure prose.
+
+### 4.2 Frontmatter field set
+
+| Field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `target` | string | yes | What was estimated — a path (slicing record, spec) or a short description of pasted task text. |
+| `target_kind` | enum | yes | One of `task-text`, `slicing-record`, `slice`, `spec`. Signals the grounding richness available; richer targets warrant higher confidence (§5.2). |
+| `generated_at` | string (ISO 8601) | yes | Timestamp the estimate was produced. |
+| `generated_by` | string | yes | Agent name + model identifier (e.g. `"cost-estimator / claude-opus-4-8"`). |
+| `grounding_sources` | list of objects | yes | The inputs the estimate was built from. Each entry has `path` (string) and `kind` (one of `model-routing`, `cost-snapshot`, `calibration`). At minimum a `model-routing` entry and a `cost-snapshot` entry; a `calibration` entry is permitted but never required (§7). |
+| `tokens` | range object | yes | Estimated total token usage as `{ low: int, high: int }`. Low and high are the budget-derived bounds (§6.1). |
+| `tokens_by_stage` | list of objects | yes | Per-stage breakdown. Each entry: `stage` (string — spec-writer, tdd-agent, implementer, code-reviewer, integration), `tokens` (range object), `model_tier` (string from the agent→model-tier mapping — may be a split tier such as `Standard/Capable`, see §6.1). May omit stages a target does not exercise; the omission must be reflected in the `excluded` prose (§5). |
+| `cost_usd` | range object | **conditional** | Estimated dollar cost as `{ low: float, high: float }`. **Present ONLY when an `observability/costs/` snapshot supplies a usable per-tier $/token rate** (§6.2). When no usable rate exists, the field is **omitted entirely** and the omission is disclosed in the `excluded` section (§6.4). The format must not carry a placeholder, a null, or a forced list-price value. |
+| `cost_basis` | enum | conditional | Present **iff** `cost_usd` is present. One of `snapshot-actuals` (rate derived from a snapshot Model Breakdown) — currently the only grounded basis. Records the provenance of the $/token rate so a reader knows the cost is observed, not guessed. |
+| `agent_compute_time` | range object | yes | Estimated wall-clock spent in agent execution as `{ low: <duration>, high: <duration> }`. Durations are ISO 8601 durations or plain `"Nm"`/`"Nh"` strings — the reference fixes the form. Derived from token volume per §6.3. |
+| `human_gate_time` | string (qualitative caveat) | yes | A **disclosed qualitative caveat**, not a numeric range: total wall-clock is dominated by human availability at the orchestrator's disposition gates, and **is not estimated numerically at S1** (§4.3). The field carries a short prose statement to that effect, never a `{ low, high }` range. It is not estimated as a number because the gate set and its per-target topology live in the orchestrator (S4, #371), which this slice does not touch (§2.2). |
+| `confidence` | object | yes | Per-axis confidence (§5.2). An object with keys `tokens`, `time`, and (iff `cost_usd` present) `cost`, each one of `low`, `medium`, `high`. A whole-record summary tier MAY be reported as `min()` of the present axes, but the per-axis values are authoritative — a high-confidence token estimate and a low-confidence cost figure are representable independently (O4). |
+| `failure_direction` | enum | yes | One of `likely-overrun`, `likely-underrun`, `symmetric`. The direction the estimate is most likely to be wrong in, with the rationale carried in the prose body (§5.1). |
+
+### 4.3 The time split is a field-level property
+
+`agent_compute_time` and `human_gate_time` are **two separate required fields**,
+not a single "time" field — but they carry **different shapes**:
+`agent_compute_time` is a numeric `{ low, high }` range, and `human_gate_time` is
+a **qualitative caveat string** (§4.2). This is a deliberate constraint:
+
+- **Agent-compute time** is the wall-clock the model spends generating. It is
+  the predictable term — it tracks token volume and tier — and is estimated as a
+  numeric range (§6.3).
+- **Human-gate latency** is the wall-clock spent waiting for a human at the
+  orchestrator's disposition gates. It dominates total wall-clock and is the
+  least predictable term — it depends on when a human next sits down, not on the
+  work itself.
+
+Collapsing the two into one number would hide the dominant source of variance
+and mislead a human reading the estimate. The record format keeps the split
+mandatory: agent-compute time is always shown, and human-gate latency is always
+named — but the latter is **named as a qualitative caveat rather than estimated
+numerically at S1**.
+
+**`human_gate_time` is a disclosed qualitative caveat, not a number (O2).** The
+previous draft derived `human_gate_time = gate_count × per-gate latency band`.
+That derivation was withdrawn because `gate_count` has no grounded S1 source: the
+gate set (Slice Adjudication, Plan Approval, diaboli/cartograph dispositions,
+code review, integration) **is the orchestrator's gate topology**, which §2.2
+places squarely in S4 (#371) and forbids this slice from naming. Multiplying a
+per-gate band by a gate count S1 cannot ground would re-introduce the very
+false-precision the §3 range-not-point decision exists to prevent — two agents
+would invent different gate counts for the same target. Rather than couple S1 to
+S4's gate topology, the methodology **demotes `human_gate_time` to a disclosed
+qualitative caveat**: the field states, in prose, that wall-clock is dominated by
+human availability at disposition gates and **is not estimated numerically until
+S4 fixes the gate set** (e.g. "human-gate latency dominates total wall-clock and
+is not estimated numerically at S1; it depends on when a human next disposes a
+gate, not on the work"). No gate count, no per-gate band, no numeric range. When
+S4 lands the orchestrator gate topology, a future slice may add a grounded
+numeric estimate; S1 deliberately does not. The failure-direction prose (§5.1)
+must still reference it: an estimate whose wall-clock omits human-gate latency
+(because gates cost wall-clock, not tokens) is `likely-underrun` on wall-clock
+unless the human-gate caveat is read alongside it.
+
+### 4.4 Range representation
+
+Every quantitative field that is present (`tokens`, each
+`tokens_by_stage[].tokens`, `cost_usd` *when present*, `agent_compute_time`) is a
+two-key object `{ low, high }`. `human_gate_time` is **not** a quantitative range
+— it is a qualitative caveat string (§4.2, §4.3) and is exempt from the range
+rules below. Validation rules:
+
+- `low` ≤ `high` for every present range.
+- `cost_usd` is **conditional**: a record with `cost_usd` absent is valid (and
+  is the expected day-one state); when present it must be a well-formed range and
+  `cost_basis` must accompany it (§4.2, §6.2).
+- A degenerate range where `low == high` is **permitted but discouraged** — it
+  signals point-value thinking and should carry a `low` confidence tier and a
+  prose note explaining why the range collapsed.
+- The whole-record `tokens` range need not equal the arithmetic sum of
+  `tokens_by_stage` ranges (stages may be correlated); when they differ the
+  prose body must say why.
+
+## 5. The disclosure/confidence contract
+
+**This four-part disclosure body is a contract THIS SPEC PROPOSES (O1).** It is
+*not* a pre-existing promoted AGENTS.md decision — a grep of AGENTS.md confirms
+no "disclosure-of-derived-judgment" decision exists by that name or content. The
+real governing decision it serves is the AGENTS.md **"agent-emit +
+dispatcher-persist + human-disposes" trust architecture** (ARCH_DECISIONS),
+under which a research-and-author agent emits content and the human disposes. The
+disclosure contract below is this spec's proposal for *what an estimate must
+disclose* so the human's disposition is informed; reviewers should evaluate it as
+a new contract, not check it against an authority that does not exist.
+
+The contract makes a prospective estimate honest rather than an anchoring number
+dressed as fact. An estimate record that does not satisfy this contract is
+invalid regardless of how good its numbers are.
+
+### 5.1 Mandatory disclosure body
+
+Every estimate record's prose body MUST contain four labelled sections:
+
+1. **Included** — what the estimate counts, **and the provenance/quality of each
+   included input**. E.g. "the five orchestrator agent stages at their
+   MODEL_ROUTING tier; agent-compute time derived from token volume via a stated
+   tokens→wall-clock band; *when* a cost figure is present: the $/token rate is
+   derived from the [date] snapshot Model Breakdown (observed actuals)." Caveats
+   about the *quality of an included input* (e.g. an assumed compute band, a
+   snapshot of a given age) live HERE or in Confidence rationale, never under
+   Excluded (O10).
+2. **Excluded** — what the estimate does NOT count, stated plainly. E.g.
+   "human-gate latency is excluded from `cost_usd` and `tokens` because gates
+   cost wall-clock not tokens; re-runs and diaboli/cartograph cycles beyond one
+   pass; any tdd/implementer stages a docs-only target does not exercise." **When
+   `cost_usd` is omitted because no usable snapshot rate exists, that omission is
+   disclosed here** — e.g. "cost_usd: omitted — no repo cost snapshot exists yet,
+   so no observed $/token is available; cost not estimated" (§6.4). An omission is
+   a genuine "does NOT count" case, so it belongs under Excluded; a *used*
+   list-price input never belonged here, which is what O10 corrected. Excluded
+   items are the single most important honesty signal — a number that silently
+   omits a cost class is worse than no number.
+3. **Confidence rationale** — why each confidence axis (`tokens`, `time`, and,
+   when present, `cost`) is what it is (§5.2), in plain prose tied to the
+   `target_kind` and the grounding richness. This is also where the
+   quality-of-input caveats for *present* figures are explained (e.g. "cost
+   confidence is `low` because the snapshot is one quarter old and aggregates
+   models coarsely").
+4. **Failure direction** — a one-line statement matching the
+   `failure_direction` field, naming WHY the estimate is more likely wrong in
+   that direction. E.g. "likely-overrun: budgets are upper-tier defaults and most
+   slices land below them" or "likely-underrun on wall-clock: human-gate latency
+   is unbounded and is not estimated as a number here, so total wall-clock will
+   exceed the agent-compute range." **This section
+   describes uncertainty only — it must contain no imperative recommendation and
+   no go/no-go language** (§5.3, O12).
+
+A record missing any of the four sections fails validation. This four-part body
+is this spec's proposed disclosure contract: included + excluded + confidence +
+failure-direction.
+
+### 5.2 Confidence tiers (per-axis)
+
+Confidence is recorded **per axis** (`tokens`, `time`, and — only when present —
+`cost`), not as one whole-record tier (O4). Each axis takes one of three tiers,
+mapped to grounding richness so the tier is not a free judgement. The mapping
+sets a **ceiling tied to `target_kind`** for the *grounding-richness* axes
+(`tokens`, `time`), and the *cost* axis has its own independent rule.
+
+**Target-kind ceiling (applies to `tokens` and `time`):**
+
+| Tier | When | Typical `target_kind` |
+| --- | --- | --- |
+| `low` | Estimate built from raw task text only, before slicing or spec. Scope is a guess; stage set is assumed. | `task-text` |
+| `medium` | Estimate built from a slicing record or a single slice — the work is decomposed but scenarios/files are not yet enumerated. | `slicing-record`, `slice` |
+| `high` | Estimate built from a spec that enumerates scenarios and files to touch — the stage set and rough volume are grounded in named artefacts. | `spec` |
+
+The `tokens`/`time` ceiling is a **cap tied to grounding, not a verdict**. The
+agent (S2) may set an axis below this cap if a target is unusually ambiguous, but
+it must not exceed it — a raw-text estimate's token confidence can never be
+`high`. This keeps the S5 T0 ballpark (raw text → `low`) honest by construction.
+
+The `time` axis describes confidence in the **`agent_compute_time` estimate only**
+— `human_gate_time` carries no numeric estimate at S1 (it is a qualitative
+caveat, §4.3), so there is no human-gate number for the `time` axis to be
+confident or unconfident about. The qualitative human-gate caveat is the honest
+substitute for what a confidence-capped number would otherwise have claimed.
+
+**Cost axis (independent rule, reconciles O6):**
+
+The `cost` confidence axis exists **only when `cost_usd` is present** — i.e. only
+when a snapshot supplies a usable $/token rate. There is therefore no collision
+between a target-kind floor and a "no-snapshot force": on today's empty-snapshot
+default, `cost_usd` is simply **omitted** (no axis, no forced-low value), and the
+`tokens`/`time` axes keep their target-kind grounding independently. When a
+snapshot does exist, the `cost` axis is set from the snapshot's quality (age,
+breakdown granularity) and is **independent of `target_kind`** — a spec-grounded
+target with a stale or coarse snapshot can carry `tokens: high` beside
+`cost: low` without contradiction (O4). This is exactly the representation the
+single whole-record enum could not express in the prior draft.
+
+### 5.3 Confidence is disclosed, never decisive
+
+The record format carries confidence; it does **not** carry a verdict, a
+recommendation, or a go/no-go. The human reads the ranges and the disclosures and
+decides. This supports the S2 "emits-not-decides" trust boundary, and this spec
+makes the guarantee **structural in two layers** rather than relying on field
+absence alone (O12):
+
+1. **Field-absence layer** — there is no `recommendation` field, no `verdict`
+   field, no `proceed` field. (Necessary but, as O12 showed, not sufficient: a
+   verdict could be smuggled into the free-text disclosure prose.)
+2. **Positive-content layer** — the four disclosure sections (§5.1) describe
+   **inputs and uncertainty only**. They MUST NOT contain imperative
+   recommendation or go/no-go language. A validation check (enumerated in §8.2)
+   scans the disclosure prose for prohibited imperative/recommendation patterns
+   (e.g. "so proceed", "do not proceed", "I recommend", "you should
+   [ship|skip|approve|reject]", "go/no-go") and **fails the record** if any
+   appear. A "failure direction: likely-overrun, so do not proceed" sentence —
+   which passed every check in the prior draft — now fails the positive-content
+   check.
+
+Together these make the no-verdict guarantee a property of the format itself,
+independent of any agent's good behaviour.
+
+## 6. The grounding methodology
+
+The skill describes how an estimate is derived. Token ranges and
+`agent_compute_time` are **always** groundable from MODEL_ROUTING.md (§6.1, §6.3);
+`human_gate_time` is **not estimated numerically at S1** — it is a qualitative
+caveat whose grounding (the orchestrator gate set) lives in S4 (§4.3, §6.3). The
+dollar figure is groundable **only when a snapshot supplies a usable $/token
+rate** (§6.2); otherwise it is omitted (§6.4). The grounding sources are **fixed,
+not chosen** — the methodology names them, it does not offer a choice between
+them.
+
+### 6.1 Token derivation from MODEL_ROUTING.md
+
+`MODEL_ROUTING.md` carries two tables the methodology consumes:
+
+- **Token Budget Guidance** — per-role ranges: spec-writer 50–100k, tdd-agent
+  50–150k, implementer 100–250k, code-reviewer 50–100k, integration-agent
+  30–80k. Each role's `low`–`high` becomes that stage's `tokens` range.
+- **Agent Routing** — the agent→model-tier mapping (orchestrator, spec-writer,
+  advocatus-diaboli → Most capable; tdd-agent, integration-agent → Standard;
+  implementer → Standard/Capable; code-reviewer → Most capable). Each stage's
+  `model_tier` is read from this table.
+
+The per-stage token ranges sum into the whole-record `tokens` range (with the
+correlation caveat of §4.4). Which stages a target exercises depends on
+`target_kind` and is a methodology judgement the skill describes — e.g. a
+docs-only spec may exercise spec-writer + review only, and the omitted stages
+must be disclosed in `excluded`.
+
+**Split-tier stages (O5).** The implementer stage maps to a **split tier**
+`Standard / Capable` ("Depends on task complexity"), and it carries the largest
+token budget (100–250k), so its rate dominates any cost figure. The methodology
+does **not** leave the tier choice to agent discretion. Instead, a split-tier
+stage is priced (when cost is computed at all, §6.2) by **widening its cost
+contribution to span both ends of the split**: its low bound uses the cheaper
+end (the `Standard` representative model) and its high bound uses the dearer end
+(the `Most capable` representative model — the tier the implementer's split rises
+to for complex tasks, since MODEL_ROUTING.md carries no standalone `Capable`
+model). Because the two ends bind to **different** representative models
+(`claude-sonnet-4` vs `claude-opus-4`, §6.2), the widening produces a genuine
+spread for this dominant stage rather than collapsing to one rate. The same
+widening applies to any stage MODEL_ROUTING.md lists with a slashed tier. The
+`tokens_by_stage[].model_tier` field records the literal split label
+(`Standard/Capable`) so the breakdown is traceable.
+
+### 6.2 Cost derivation — only when a snapshot grounds it (O2, O3, O8, O11)
+
+`cost_usd` is **present only when an `observability/costs/` snapshot supplies a
+usable per-tier $/token rate.** Deriving that rate from the snapshot requires a
+named binding, because MODEL_ROUTING.md tiers are abstract labels with no model
+or price, and the snapshot's Model Breakdown is keyed by model name. The
+methodology defines the binding explicitly:
+
+**The tier→model→$/token binding.** A named **tier-binding table** ships in the
+format reference (§8.2) and is the single source of the `tier → model` map:
+
+| Model tier (MODEL_ROUTING) | Representative model (snapshot key) |
+| --- | --- |
+| Most capable | `claude-opus-4` |
+| Standard | `claude-sonnet-4` |
+| Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-opus-4` (high), widened per §6.1 |
+
+MODEL_ROUTING.md names exactly two non-frontier-vs-frontier tiers — `Standard`
+and `Most capable` — and one complexity-dependent split, the implementer's
+`Standard / Capable` ("Depends on task complexity"). There is **no standalone
+`Capable` tier with its own model** in the routing table; the dearer end of the
+implementer's split resolves to the `Most capable` tier. The binding therefore
+maps the split's low bound to the `Standard` representative (`claude-sonnet-4`)
+and its high bound to the `Most capable` representative (`claude-opus-4`), so the
+widening (§6.1) produces a real cost spread rather than collapsing to a single
+rate. (The reference fixes the representative model per tier and is the artefact
+S6 may revise as routing evolves — the binding lives in a named place, not in
+agent judgement.)
+
+**Deriving a per-model rate from a snapshot.** The snapshot's `## Model
+Breakdown` table gives, per model, quarter-aggregate input/output token volumes
+and an estimated cost. The methodology computes a per-model `$/token` as
+`estimated_cost ÷ (input_tokens + output_tokens)` for that model row — a single
+blended rate per model derived from the quarter aggregate. The binding table then
+maps each stage's tier to its representative model's blended rate, and
+`cost_usd = Σ over stages (stage tokens range × tier $/token)`, with split-tier
+stages widened per §6.1.
+
+**The three grounding states (O8).** The snapshot's Model Breakdown is marked
+"(if available)" in the cost-tracking format, so the methodology branches on
+three states, not two:
+
+1. **No snapshot exists** (today's state — `observability/costs/` is empty; the
+   2026-05-29 health snapshot records "Last cost capture: never"). → `cost_usd`
+   **omitted**, omission disclosed in `excluded` (§6.4).
+2. **Snapshot exists but the Model Breakdown is absent or too coarse** to yield a
+   per-tier rate (only the always-present Provider Spend table is populated, or
+   the breakdown lacks the tiers the stage set needs). → `cost_usd` **omitted**,
+   omission disclosed in `excluded` naming this specific cause ("a cost snapshot
+   exists but carries no usable per-model breakdown"). The methodology does **not**
+   silently fall through to list price.
+3. **Snapshot exists with a usable Model Breakdown** → `cost_usd` **present**,
+   `cost_basis: snapshot-actuals`, `cost` confidence set from the snapshot's age
+   and granularity (§5.2), and the snapshot date/quality disclosed in `included`.
+
+There is **no list-price fallback.** The prior draft's "produce a list-price
+cost and force confidence low" path is removed (O3, O11): a list-price guess is
+not an observed cost, and emitting it as a first-class figure was the false
+precision this spec opposes. When cost cannot be grounded in actuals, it is
+omitted with disclosure (§6.4), and the day-one deliverable remains the
+token + time estimate.
+
+**The no-cost case is honest, not a failure (O3, O11).** When `cost_usd` is
+omitted (states 1 and 2 above), the record is **valid and complete** — it is the
+expected day-one shape. The `excluded` section MUST carry an explicit omission
+disclosure, e.g.:
+
+> "cost_usd: omitted — no repo cost snapshot exists yet, so no observed $/token
+> is available; cost is not estimated. Token and time figures stand."
+
+The human reads a grounded token + time estimate and an honest statement that
+dollars are not yet knowable — which is more informative than a low-confidence
+list-price range that says "we don't really know" in numeric clothing. **No
+format change is required when the first snapshot lands** (O11): the same
+`cost_usd`/`cost_basis`/`confidence.cost` fields simply begin to appear. This is
+the seam §7 already contemplates.
+
+### 6.3 Time derivation (O2)
+
+Both time fields are always present, but they have different shapes:
+
+- **`agent_compute_time`** is derived from token volume: the methodology applies
+  a disclosed tokens→wall-clock band (the reference fixes a default, e.g.
+  "~1–3 min per 10k tokens generated") to the `tokens` range, per tier, yielding
+  a numeric `{ low, high }` range. The band is stated as an assumption in
+  `included`.
+- **`human_gate_time`** is **not estimated numerically at S1**: it is a disclosed
+  qualitative caveat (§4.3, §4.2). Its grounding — the orchestrator gate set and
+  how many gates a given target passes through — lives in S4 (#371), which this
+  slice does not touch (§2.2). Rather than multiply an ungrounded gate count by a
+  per-gate band (the withdrawn O9-era derivation, which coupled S1 to S4 and
+  invited the per-estimate invention of `gate_count`), the methodology states in
+  prose that wall-clock is dominated by human availability and is not estimated
+  as a number until the gate set is fixed. A future slice may add a grounded
+  numeric human-gate estimate once S4 ships; S1 deliberately stops at the caveat.
+
+`agent_compute_time`'s band does not claim to be an observed actual — it is a
+stated assumption a human can interrogate. `human_gate_time` claims no number at
+all, which is the honest position while its grounding lives downstream.
+
+### 6.5 The retrospective sibling
+
+The `cost-estimation` skill is the **prospective** counterpart to the
+**retrospective** `cost-tracking` skill. The two reuse the same
+`observability/costs/` data: `cost-tracking` *writes* the snapshots,
+`cost-estimation` *reads* them as its $/token ground. The skill's frontmatter
+description and a short "Sibling" note make the pair discoverable — a reader who
+finds one should find the other. The two are symmetric:
+`/cost-capture` records what was spent; the future `/cost-estimate` (S3)
+predicts what will be spent.
+
+## 7. The calibration seam (S6, do not implement)
+
+S6 (the calibration loop, #373) is accepted in-scope for the capability but
+ships after the estimator. S1's only obligation is to keep the seam open so
+that a future per-PR actuals data source can be ingested **without a format
+change**. The seam is already present in §4.2:
+
+- `grounding_sources[]` permits a `kind: calibration` entry. Today only
+  `model-routing` and `cost-snapshot` entries appear; tomorrow S6 can add a
+  `calibration` entry pointing at per-PR actuals without altering the field
+  set.
+- The methodology (§6) is written so that calibration data, when it exists,
+  **refines the $/token and the per-stage token ranges** — it slots into the
+  same derivation, narrowing ranges and potentially raising confidence, rather
+  than introducing a new field.
+
+**Watch item — the cost axis cannot improve until S6 (O7).** Note for the
+slicing record's future revisit: no slice between S1 and S6 produces actuals, and
+S6 is currently sequenced last, so for the S2–S5 window `cost_usd` will be
+**omitted on most records** (the optional-cost restructure of this revision, not
+a forced low-confidence guess). The omission is honest and self-disclosing, which
+softens the harm O7 raised — but whether to resequence S6 earlier (so the dollar
+axis becomes groundable sooner) is a **slicing decision to revisit**, recorded
+here as a flag rather than resolved in this spec. This is a NOTE, not a structural
+change to S1.
+
+S1 does NOT implement calibration: no per-PR actuals format, no
+integration-agent change, no ingestion logic. The skill names calibration as a
+*future* grounding source in one short paragraph and stops there. Implementing
+it here would be scope creep into S6.
+
+## 8. Files to add and modify
+
+### 8.1 The skill (`SKILL.md`)
+
+`ai-literacy-superpowers/skills/cost-estimation/SKILL.md` — frontmatter
+(`name: cost-estimation`, a `description` that triggers on prospective cost /
+estimate / "how much will this cost" queries and names the sibling), then prose
+covering: why estimate prospectively, the range-not-point decision (§3), the
+grounding methodology (§6) — including that cost is present only when a snapshot
+grounds it (§6.2) and omitted-with-disclosure otherwise (§6.4) — the
+disclosure/confidence contract (§5), the time split — `agent_compute_time` as a
+numeric range with its token→wall-clock band, and `human_gate_time` as a
+qualitative caveat not estimated numerically at S1 (§4.3, §6.3) — the calibration
+seam (§7), the sibling relationship (§6.5), and a
+"What this skill does NOT do" section (it does not dispatch, does not write
+files, does not decide go/no-go — those are consumers' jobs).
+
+### 8.2 The format reference
+
+`ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+— the canonical, stable definition of the estimate-record field set (§4) and
+the disclosure body structure (§5.1), one contract per file per the AGENTS.md
+references-file idiom. This is the file a downstream command's Output
+Validation Checkpoint (S3) references by path. It contains:
+
+- The frontmatter field table (§4.2), including `cost_usd` and `cost_basis`
+  marked **conditional (present-when-grounded)** and the **per-axis `confidence`
+  object**.
+- The range representation rules (§4.4), including that an absent `cost_usd` is
+  valid.
+- The time-split requirement (§4.3): `agent_compute_time` as a numeric range and
+  `human_gate_time` as a qualitative caveat string, and the §6.3 time
+  derivation.
+- The four-part disclosure-body structure (§5.1).
+- The **per-axis confidence mapping** (§5.2): the `target_kind` ceiling for
+  `tokens`/`time`, and the snapshot-quality rule for the conditional `cost` axis.
+- The **tier→model→$/token binding table** (§6.2) — the named artefact the cost
+  derivation reads, so the binding is not left to agent discretion (O2). It also
+  fixes the split-tier widening rule for the implementer stage (O5).
+- The **default throughput band** the time derivation uses (§6.3): the
+  tokens→agent-compute band, stated as an assumption. (No per-gate human-gate
+  band ships — `human_gate_time` is a qualitative caveat at S1, §4.3, O2.)
+- The two-layer **no-verdict guarantee** (§5.3): field-absence plus the
+  positive-content prohibition.
+- **Two complete worked example records** so a reader sees both shapes. In both,
+  `human_gate_time` is a **qualitative caveat string**, not a range (§4.3, O2),
+  and `agent_compute_time` is a numeric range:
+  1. a **cost-omitted** record (today's default — no snapshot; `cost_usd` and
+     `cost_basis` absent; `confidence` has `tokens`/`time` only; `excluded`
+     discloses the cost omission per §6.4),
+  2. a **cost-present** record (a snapshot exists with a usable Model Breakdown;
+     `cost_usd` + `cost_basis: snapshot-actuals` present; `confidence.cost`
+     present and possibly below `tokens`). This example **demonstrates the
+     split-tier widening (O5)**: its implementer stage carries a non-zero cost
+     band whose low bound uses `claude-sonnet-4` and high bound uses
+     `claude-opus-4` (§6.1, §6.2), so the widened band is visibly wider than the
+     token-range spread alone. Neither example files an inclusion caveat under
+     `excluded` (O10 fixed).
+- A "Validation checklist" subsection enumerating the checks a consuming command
+  runs:
+  - every **present** range has `low ≤ high`;
+  - all four disclosure sections present;
+  - each present `confidence` axis is within the §5.2 cap for the `target_kind`
+    (for `tokens`/`time`) and `cost` axis present iff `cost_usd` present;
+  - `cost_usd` and `cost_basis` are either **both present or both absent**; when
+    absent, the `excluded` section contains the cost-omission disclosure (§6.4);
+  - both time fields present and separate — `agent_compute_time` a `{low, high}`
+    range, `human_gate_time` a qualitative caveat string (not a range), per §4.3;
+  - no verdict/recommendation **field** (field-absence layer); **and**
+  - the disclosure prose contains **no imperative recommendation or go/no-go
+    language** — a positive-content scan for patterns like "so proceed", "do not
+    proceed", "I recommend", "you should [ship|skip|approve|reject]", "go/no-go"
+    (O12 positive constraint, §5.3).
+
+### 8.3 TDAD scenario
+
+Per the `component-design-with-tdad` skill, a new skill warrants Layer 1
+(structural) + Layer 2 (trigger) coverage. Add under
+`tdad_tests/scenarios/skills/cost-estimation/`:
+
+- A structural scenario asserting the skill frontmatter is well-formed and the
+  required sections (methodology, disclosure contract, time split, sibling,
+  NOT-do) are present, and that the format reference file exists and contains
+  the field table (with `cost_usd` marked conditional and a per-axis
+  `confidence` object), the tier→model→$/token binding table, the four-part
+  disclosure body, and **both** the cost-omitted and cost-present worked
+  examples.
+- A trigger scenario asserting the skill description fires on prospective-cost
+  queries ("how much will this feature cost", "estimate the tokens for this
+  spec") and does NOT fire on retrospective-cost queries (those belong to
+  `cost-tracking`).
+
+The tdd-agent authors these in its agent-artefact branch; this spec fixes their
+`Then` shape.
+
+### 8.4 Maintenance files
+
+| Path | Change |
+| --- | --- |
+| `ai-literacy-superpowers/.claude-plugin/plugin.json` | Bump `version` `0.40.0` → `0.41.0` (new skill — minor). |
+| `ai-literacy-superpowers/CHANGELOG.md` | New `## 0.41.0 — 2026-06-10` heading with entries for the skill, the format reference, and the disclosure contract. |
+| `.claude-plugin/marketplace.json` | Bump the `ai-literacy-superpowers` entry `version` and the top-level `plugin_version` `0.40.0` → `0.41.0`. Top-level `version` unchanged at `0.4.0`. |
+| `README.md` (repo root) | Bump the `ai-literacy-superpowers` plugin version badge `v0.40.0` → `v0.41.0`. |
+
+## 9. Component design (per component-design-with-tdad)
+
+- **Type**: skill — the deliverable is methodology + a format contract loaded
+  as reasoning context; it is not a dispatchable behaviour (that is the S2
+  agent) nor a slash-command surface (that is the S3 command).
+- **Justification**: the methodology and disclosure contract must exist as
+  loadable guidance and a referenceable format before any agent or command can
+  consume them; a skill is the canonical home for cross-cutting methodology, and
+  the references-file idiom is the canonical home for a contract consumed by
+  multiple downstream components.
+- **TDAD layers targeted**: `[structural, trigger]` — Layer 1 always, Layer 2
+  because a skill has a description-vs-query match to verify. Layer 3 deferred
+  (no dispatchable side-effect ships in S1).
+- **Scenario shape**: the structural `Then` asserts the SKILL.md sections and
+  the format-reference field table exist; the trigger `Then` asserts the skill
+  fires on prospective-cost queries and not on retrospective-cost queries.
+- **Modification or new?** new — `skills/cost-estimation/`.
+- **Scenario vs finding**: scenario only — every assertion is falsifiable
+  (sections present, description triggers).
+
+## 10. User stories and acceptance scenarios
+
+### 10.1 Story — a future agent can emit a valid estimate record against the format
+
+**As** the developer building the S2 cost-estimator agent
+**I want** a committed, stable estimate-record format with a named field set
+**So that** my agent emits a record the orchestrator, the command, and the gates
+all parse identically.
+
+```gherkin
+Given the merged main on this PR
+When I read ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+Then it defines the frontmatter field set including target, target_kind,
+    grounding_sources, tokens, tokens_by_stage, cost_usd, cost_basis,
+    agent_compute_time, human_gate_time, confidence, and failure_direction
+And cost_usd and cost_basis are marked conditional (present only when grounded)
+And confidence is a per-axis object with keys tokens, time, and conditionally cost
+And every present quantitative field is specified as a {low, high} range
+And it specifies the four-part disclosure body (included, excluded,
+    confidence rationale, failure direction)
+And it contains a tier-to-model-to-$/token binding table
+And it contains both a cost-omitted and a cost-present worked example record
+And it contains a validation checklist a consuming command can run
+```
+
+### 10.2 Story — every estimate is a range with disclosed confidence, never a point value
+
+**As** a human reading an estimate to decide whether to proceed
+**I want** a range with disclosed confidence, included/excluded, and a failure
+direction
+**So that** I interrogate a prediction rather than anchor on a number dressed as
+fact.
+
+```gherkin
+Given the estimate-record format reference
+When I inspect how the quantities are represented
+Then tokens and agent_compute_time are {low, high} ranges
+And cost_usd, when present, is also a {low, high} range
+And human_gate_time is a qualitative caveat string, not a range, because it is
+    not estimated numerically at S1
+And there is no point-value, verdict, recommendation, or go/no-go field
+And the format mandates a failure_direction with a prose rationale
+And the format mandates an explicit "excluded" disclosure section
+And the disclosure prose is constrained to inputs and uncertainty only,
+    with a validation check that rejects imperative recommendation or
+    go/no-go language in the disclosure sections
+```
+
+### 10.2a Story — a verdict cannot be smuggled into disclosure prose
+
+**As** a human relying on the estimator to emit, not decide
+**I want** the no-verdict guarantee enforced on the prose, not just on field
+presence
+**So that** the failure-direction or confidence prose cannot deliver a go/no-go
+the format claims to forbid.
+
+```gherkin
+Given the estimate-record format reference validation checklist
+When I read how the no-verdict guarantee is enforced
+Then it lists a field-absence check (no recommendation/verdict/proceed field)
+And it lists a positive-content check that fails a record whose disclosure
+    prose contains imperative recommendation or go/no-go language
+And the worked examples contain no "so proceed" or "do not proceed" style text
+```
+
+### 10.3 Story — the time split is mandatory and separate
+
+**As** a human estimating wall-clock for a feature
+**I want** agent-compute time and human-gate latency surfaced as separate fields
+**So that** the dominant, least-predictable term (human-gate latency) is never
+hidden inside a single time number.
+
+```gherkin
+Given the estimate-record format reference
+When I read the time fields
+Then agent_compute_time and human_gate_time are two separate required fields
+And agent_compute_time is a {low, high} range derived from token volume
+And human_gate_time is a qualitative caveat string, not a numeric range
+And the reference states human_gate_time dominates wall-clock and is least predictable
+And the reference states human_gate_time is not estimated numerically at S1
+    because the gate set lives in the orchestrator (S4), which this slice does
+    not touch
+And the failure-direction guidance references the exclusion of human-gate latency
+    from the dollar/token figures
+```
+
+### 10.4 Story — token and time are the day-one deliverable; cost is present only when grounded
+
+**As** the developer authoring the estimator against today's repo
+**I want** the methodology to ground token and time from MODEL_ROUTING.md today,
+and to add a dollar figure only when a snapshot supplies an observed $/token
+**So that** the skill is honestly usable today even though `observability/costs/`
+is empty, with no forced low-confidence list-price guess.
+
+```gherkin
+Given ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+When I read the grounding methodology
+Then it derives per-stage token ranges from MODEL_ROUTING.md Token Budget Guidance
+And it reads model tiers from MODEL_ROUTING.md Agent Routing
+And it derives agent_compute_time from token volume
+And it states human_gate_time is a qualitative caveat not estimated numerically
+    at S1 (the gate set is S4 scope)
+And it defines a named tier-to-model-to-$/token binding for cost derivation
+And it widens a split-tier stage (implementer Standard/Capable) across both ends,
+    binding the low end to claude-sonnet-4 and the high end to claude-opus-4
+And it derives cost_usd only when a snapshot supplies a usable per-model rate
+And it specifies no list-price fallback
+```
+
+### 10.4a Story — no snapshot means cost is omitted with disclosure, not guessed
+
+**As** a human running the estimator on today's repo (empty `observability/costs/`)
+**I want** the cost figure omitted with an explicit disclosure while token and
+time still stand
+**So that** I get a grounded estimate plus an honest "cost not yet knowable"
+rather than a list-price number dressed as a prediction.
+
+```gherkin
+Given the estimate-record format reference and the SKILL.md methodology
+And no observability/costs snapshot exists
+When I read the methodology's no-snapshot behaviour
+Then tokens and agent_compute_time are still produced as ranges
+And human_gate_time is still produced as its qualitative caveat
+And cost_usd and cost_basis are omitted entirely
+And the "excluded" disclosure states cost is omitted because no observed
+    $/token exists yet
+And the confidence object carries tokens and time axes but no cost axis
+And the cost-omitted worked example in the reference matches this shape
+```
+
+### 10.4b Story — a snapshot without a usable model breakdown also omits cost
+
+**As** the developer reasoning about a sparse snapshot
+**I want** the third grounding state handled (snapshot present, Model Breakdown
+absent or coarse)
+**So that** the methodology does not assume a breakdown that the cost-tracking
+format marks "(if available)".
+
+```gherkin
+Given the SKILL.md grounding methodology
+When I read how a snapshot lacking a usable Model Breakdown is handled
+Then cost_usd is omitted (not derived from list price)
+And the "excluded" disclosure names this specific cause
+And only a snapshot with a usable Model Breakdown yields a present cost_usd
+    with cost_basis snapshot-actuals
+```
+
+### 10.5 Story — the calibration seam is open without being implemented
+
+**As** the developer who will later build S6 (calibration, #373)
+**I want** the format and methodology to already accommodate a per-PR actuals
+data source
+**So that** S6 adds calibration data without a format change.
+
+```gherkin
+Given the estimate-record format reference and the SKILL.md methodology
+When I look for how calibration data would enter
+Then grounding_sources permits a kind: calibration entry alongside model-routing and cost-snapshot
+And the methodology states calibration data refines existing ranges rather than adding a field
+And no per-PR actuals capture, format, or integration-agent change ships in this slice
+```
+
+### 10.6 Story — the prospective and retrospective siblings are discoverable as a pair
+
+**As** a user who knows `/cost-capture` and `cost-tracking`
+**I want** the prospective estimation skill to be discoverable as the sibling
+**So that** I find both halves of the cost capability from either one.
+
+```gherkin
+Given ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+When I read its frontmatter description and its body
+Then it names cost-tracking as its retrospective sibling
+And it states it reads the observability/costs snapshots that cost-tracking writes
+And its description triggers on prospective-cost queries distinct from cost-tracking's capture queries
+```
+
+### 10.7 Story — the plugin version reflects the new skill
+
+**As** the marketplace consumer
+**I want** the plugin version to bump when a new skill is added
+**So that** caches and version checks know the plugin changed.
+
+```gherkin
+Given the merged main on this PR
+When I read ai-literacy-superpowers/.claude-plugin/plugin.json
+Then the version is "0.41.0"
+And the ai-literacy-superpowers entry in .claude-plugin/marketplace.json shows "0.41.0"
+And plugin_version in .claude-plugin/marketplace.json is "0.41.0"
+And the top-level marketplace version is unchanged at "0.4.0"
+And CHANGELOG.md has a new "## 0.41.0 — 2026-06-10" entry
+And README.md shows the v0.41.0 badge
+```
+
+## 11. Functional requirements
+
+The requirements flow from the scenarios above and are numbered for the FR
+mapping table in the plan.
+
+- **FR-1** The skill ships at `ai-literacy-superpowers/skills/cost-estimation/SKILL.md`
+  with well-formed frontmatter and the required sections (methodology,
+  disclosure contract, time split, calibration seam, sibling, NOT-do).
+- **FR-2** A format reference ships at
+  `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+  defining the full frontmatter field set of §4.2, with `cost_usd` and
+  `cost_basis` marked **conditional (present-when-grounded)** and `confidence` a
+  **per-axis object**.
+- **FR-3** Every **present** quantitative field is a `{low, high}` range; the
+  format contains no point-value, verdict, recommendation, or go/no-go field.
+- **FR-4** The format mandates the four-part disclosure body (included,
+  excluded, confidence rationale, failure direction).
+- **FR-5** The format defines `agent_compute_time` and `human_gate_time` as two
+  separate required fields with different shapes: `agent_compute_time` is a
+  numeric `{low, high}` range derived from token volume, and `human_gate_time` is
+  a **qualitative caveat string, not estimated numerically at S1** — it states
+  that wall-clock is dominated by human availability at disposition gates and is
+  not given a number because the gate set lives in the orchestrator (S4, #371),
+  which this slice does not touch (O2). The format states the human-gate term
+  dominates and is least predictable.
+- **FR-6** The format defines **per-axis** confidence (§5.2): a `target_kind`
+  ceiling for `tokens`/`time` (raw text capped at `low`) and an independent
+  snapshot-quality rule for the conditional `cost` axis; the `tokens`/`time` and
+  `cost` axes are representable independently (O4, O6).
+- **FR-7** The methodology grounds token ranges in MODEL_ROUTING.md Token
+  Budget Guidance and tiers in MODEL_ROUTING.md Agent Routing, and prices the
+  split-tier implementer stage (`Standard / Capable`) by widening its cost
+  contribution across **two distinct representative models** — low bound
+  `claude-sonnet-4` (`Standard`), high bound `claude-opus-4` (`Most capable`) —
+  so the widening produces a genuine spread rather than a zero-width band
+  (O1, O5).
+- **FR-8** `cost_usd` is **conditional**: present (with `cost_basis:
+  snapshot-actuals`) only when an `observability/costs/` snapshot supplies a
+  usable per-model Model Breakdown, derived via the named tier→model→$/token
+  binding table; otherwise **omitted with disclosure** in `excluded`. There is
+  **no list-price fallback** (O2, O3, O8, O11). The three grounding states
+  (no snapshot / snapshot-without-usable-breakdown / snapshot-with-breakdown) are
+  each defined.
+- **FR-8a** The format reference contains the named **tier→model→$/token binding
+  table** the cost derivation reads (O2).
+- **FR-9** The format permits a `kind: calibration` grounding source and the
+  methodology describes calibration as range-refinement, without implementing
+  S6.
+- **FR-10** The skill names `cost-tracking` as its retrospective sibling and
+  states it reuses the `observability/costs/` data.
+- **FR-11** The format reference contains **two** worked example records (a
+  cost-omitted and a cost-present record) and a validation checklist suitable for
+  a downstream Output Validation Checkpoint. Neither example files an inclusion
+  caveat under `excluded` (O10).
+- **FR-14** The validation checklist includes a **positive-content check** that
+  fails a record whose disclosure prose contains imperative recommendation or
+  go/no-go language, making the no-verdict guarantee structural rather than
+  field-absence only (O12).
+- **FR-12** The plugin version bumps to 0.41.0 across plugin.json,
+  marketplace.json (`version` + `plugin_version`), CHANGELOG, and README.
+- **FR-13** A TDAD scenario (structural + trigger) covers the skill under
+  `tdad_tests/scenarios/skills/cost-estimation/`.
+
+## 12. Compatibility and rollout
+
+- **Backwards compatibility**: purely additive. No existing component changes.
+  No consumer of the format exists yet (S2–S5), so the format can be set without
+  migration concern — this is precisely why S1 ships first.
+- **Cache behaviour**: `sync-marketplace-cache.sh` fires because
+  `.claude-plugin/marketplace.json` changes (`plugin_version` bump).
+  `sync-to-global-cache.sh` rsyncs the new skill into the versioned plugin
+  cache.
+- **CI gates**: spec-first is satisfied by this spec as the first commit.
+  Version consistency is satisfied (plugin.json 0.41.0 = marketplace entry
+  0.41.0 = `plugin_version` 0.41.0). The TDAD-scenario-presence constraint
+  fires (a new skill file is added) and is satisfied by §8.3. The
+  docs-reference-parity constraint fires (a new skill) and is satisfied by the
+  docs check in §13.
+
+## 13. Docs site
+
+Per the CLAUDE.md Docs Site Review convention, a new skill warrants a docs
+touch. The skill adds a prospective-cost capability, so:
+
+- Add a how-to or explanation page under
+  `docs/plugins/ai-literacy-superpowers/` describing prospective cost
+  estimation and its relationship to the retrospective `cost-tracking` sibling,
+  OR extend the existing cost-tracking docs page to name the prospective sibling
+  and the estimate-record format. The plan fixes which.
+- The docs-reference-parity CI check requires the new skill to be referenced;
+  the docs touch satisfies it.
+
+## 14. Open questions resolved during design
+
+| Question | Decision |
+| --- | --- |
+| Point value vs range | Range with disclosed confidence, always. No point-value field. (§3) |
+| Is `cost_usd` required? | **No — conditional (present-when-grounded).** Day-one deliverable is token + time; cost appears only when a snapshot grounds it. (§4.2, §6.2, O11) |
+| Single time field vs split | Two separate required fields with different shapes: `agent_compute_time` a numeric range, `human_gate_time` a qualitative caveat. (§4.3) |
+| Confidence as verdict vs disclosure | Disclosure only; no verdict field **and** a positive-content check forbidding recommendation prose. (§5.3, O12) |
+| Confidence representation | **Per-axis** (`tokens`/`time`/conditional `cost`), not one whole-record enum. `target_kind` ceiling for tokens/time; independent snapshot-quality rule for cost. (§5.2, O4, O6) |
+| Grounding sources | Token + time from MODEL_ROUTING.md (always); cost from a snapshot (conditional). Fixed, not chosen. (§6) |
+| Cost binding | A named tier→model→$/token binding table in the reference; the implementer's `Standard / Capable` split is widened across two **distinct** representative models (low `claude-sonnet-4`, high `claude-opus-4`), so the spread is real not a no-op. (§6.1, §6.2, O1, O5) |
+| No snapshot / no usable breakdown | **`cost_usd` omitted with disclosure** in `excluded`. No list-price fallback. Three grounding states defined. (§6.2, §6.4, O3, O8, O11) |
+| `human_gate_time` derivation | **Demoted to a qualitative caveat — not estimated numerically at S1.** The withdrawn `gate_count × per-gate band` derivation had an ungrounded `gate_count` and reached into the orchestrator gate topology (S4 scope); a future slice may add a number once S4 fixes the gate set. (§4.3, §6.3, O2) |
+| AGENTS.md authority for the disclosure body | The four-part body is **proposed by this spec**, not a pre-existing decision; it serves the real "agent-emit + dispatcher-persist + human-disposes" ARCH_DECISION. (§5, O1) |
+| Cost axis vs S6 sequencing | Watch item: cost stays omitted across S2–S5 until S6; resequencing is a slicing decision to revisit. (§7, O7) |
+| Calibration in S1 | Seam only — `grounding_sources` accepts `kind: calibration`; methodology describes range-refinement; no implementation. (§7) |
+| Where the format lives | A references file, one contract per file, for downstream validation-checkpoint reference. (§8.2) |
+| Version bump | 0.40.0 → 0.41.0 (new skill, minor). (§8.4) |
+
+## 15. References
+
+- Slicing record: `docs/superpowers/slices/cost-estimator-pipeline.md`.
+- Downstream issues: S2 #369, S3 #370, S4 #371, S5 #372, S6 #373.
+- Governing decision: AGENTS.md ARCH_DECISION **"agent-emit + dispatcher-persist
+  + human-disposes"** trust architecture — the real promoted decision this
+  capability's S2/S3 consumers inherit. NOTE: no "disclosure-of-derived-judgment"
+  decision exists in AGENTS.md; the four-part disclosure body in §5 is a contract
+  **this spec proposes**, not an operationalisation of a pre-existing decision
+  (O1).
+- Grounding source: `MODEL_ROUTING.md` (Token Budget Guidance + Agent Routing).
+- Grounding source: `observability/costs/YYYY-MM-DD-costs.md` (none yet; format
+  defined by the `cost-tracking` skill).
+- Retrospective sibling: `ai-literacy-superpowers/skills/cost-tracking/SKILL.md`
+  and `ai-literacy-superpowers/commands/cost-capture.md`.
+- Component-design methodology: `ai-literacy-superpowers/skills/component-design-with-tdad/SKILL.md`.
+- References-file idiom: AGENTS.md ARCH_DECISION on cross-cutting methodology in
+  `skills/<name>/references/`.
+- `CLAUDE.md` — Semantic Versioning, Marketplace Versioning, Output Validation
+  Checkpoints, and Docs Site Review sections.

--- a/docs/superpowers/stories/cost-estimation-skill-design.md
+++ b/docs/superpowers/stories/cost-estimation-skill-design.md
@@ -1,0 +1,207 @@
+---
+spec: docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md
+date: 2026-06-11
+mode: spec
+cartographer_model: claude-opus-4-8[1m]
+stories:
+  - id: 1
+    lens: [forces, patterns]
+    title: The format is the contract; consumers are downstream
+    disposition: pending
+    disposition_rationale: null
+  - id: 2
+    lens: [forces, consequences]
+    title: cost_usd conditional rather than required-low
+    disposition: pending
+    disposition_rationale: null
+  - id: 3
+    lens: [forces, patterns]
+    title: human_gate_time named but not numbered
+    disposition: pending
+    disposition_rationale: null
+  - id: 4
+    lens: [patterns, alternatives]
+    title: Per-axis confidence object over a single enum
+    disposition: pending
+    disposition_rationale: null
+  - id: 5
+    lens: [defaults, consequences]
+    title: The tier-binding table as an authored artefact
+    disposition: pending
+    disposition_rationale: null
+  - id: 6
+    lens: [patterns, forces]
+    title: No-verdict enforced by positive-content scanning
+    disposition: pending
+    disposition_rationale: null
+  - id: 7
+    lens: [defaults, alternatives]
+    title: Reusing the cost-snapshot format as ground
+    disposition: pending
+    disposition_rationale: null
+  - id: 8
+    lens: [coherence]
+    title: A proposed contract, not an inherited decision
+    disposition: pending
+    disposition_rationale: null
+---
+
+## Story #1 — The format is the contract; consumers are downstream
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§1, §4)
+**Lens:** forces, patterns
+**Refs:** —
+
+**Context.** S1 ships a skill and a format reference and nothing else — "no agent, no command, and no orchestrator wiring" (§1). The estimate-record format is named "the load-bearing deliverable" (§4) that S2 emits, S3 writes, and S4 surfaces. The whole slice exists to lock a data contract before any code reads or writes it.
+
+**Forces.** The tension is between *something runnable now* and *something stable later*. A slice that shipped the agent first would demonstrate value immediately but would bake the record shape into emitter code, making the format expensive to change once three downstream consumers (S2–S5) depend on it. The spec resolves toward stability-first: lock the contract while it has zero consumers, when "the format can be set without migration concern" (§12).
+
+**Options not taken.** (1) Ship the agent and command together and let the record shape emerge from the implementation — faster to a demo, but the format becomes whatever the first emitter happened to produce. (2) Define the format inline inside the eventual agent prompt rather than as a standalone reference file — couples the contract to one consumer. (3) Skip a formal format entirely and let each consumer parse loosely — defers the schema cost to integration time across three insertion points.
+
+**Choice as written.** The spec makes the *artefact* — a markdown record with a YAML frontmatter field set and a four-part prose body — the unit of design, and treats every executing component as a downstream reader or writer of it. The skill is "methodology + a format contract loaded as reasoning context; it is not a dispatchable behaviour" (§9).
+
+**Consequences.** S1 ships nothing a human can run end-to-end; its value is entirely realised through later slices, so the slice's worth is unverifiable except by reading the contract. Accepted deliberately: §12 notes no consumer exists yet, which is "precisely why S1 ships first." The cost is that a format error here is silent until S2.
+
+**Pattern.** Data-contract-first / schema-first design (the published-interface discipline; cf. Fowler's *Published Interface*). Also a Tolerant Reader's mirror image — the producers and consumers are being designed against a fixed shared schema before either exists.
+
+**Notes.** —
+
+## Story #2 — cost_usd conditional rather than required-low
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§4.2, §6.2, §6.4)
+**Lens:** forces, consequences
+**Refs:** —
+
+**Context.** The central restructure of this revision: `cost_usd` is "conditional, not required" (§4.2) — present only when an `observability/costs/` snapshot supplies a usable $/token rate, omitted-with-disclosure otherwise. The day-one deliverable is explicitly a token + time estimate; dollars are an "actuals-gated enhancement" (§1).
+
+**Forces.** The tension is between *schema completeness* and *honest grounding*. A required `cost_usd` field gives every record a uniform shape and a dollar figure a human can sort on; but on day one there is no observed spend, so the only way to fill a required field is a list-price guess — "a number dressed as a fact" the spec exists to oppose (§3). Making the field conditional honours grounding at the cost of a record shape that varies by environment.
+
+**Options not taken.** (1) Required `cost_usd` with a forced-`low` confidence list-price value — the prior draft's path, rejected as false precision (§6.2). (2) Required `cost_usd` carrying an explicit `null` sentinel — keeps shape uniform but invites consumers to treat absence and zero alike. (3) A separate record *type* for cost-present vs cost-absent — two schemas instead of one conditional field, doubling the validation surface.
+
+**Choice as written.** A single field set where `cost_usd`/`cost_basis` are present-when-grounded and absent-but-valid otherwise, with the omission disclosed in the `excluded` prose (§6.4). "No format change is required when the first snapshot lands" (§6.4) — the same fields simply begin to appear.
+
+**Consequences.** Consumers (S2–S4) must handle a record whose field set legitimately varies — a `cost_usd` absence is a valid state, not an error, and downstream UI/gates must render "cost not yet knowable" as a first-class outcome. The spec's own §7 watch-item flags that across the entire S2–S5 window `cost_usd` will be omitted on most records because no slice produces actuals until S6 — the conditional shape is the *normal* shape for the foreseeable lifetime of the capability, not an edge case.
+
+**Pattern.** Option type / present-when-grounded (the same discipline as a nullable-but-meaningful absence; cf. Maybe/Optional rather than null). The "make-illegal-states-unrepresentable" instinct applied to *ungrounded* states: there is no representable forced-guess value.
+
+**Notes.** This is the round-1 O11 restructure; the diaboli round-2 record confirms it genuinely resolved. The story records the *decision*, not the resolved objection.
+
+## Story #3 — human_gate_time named but not numbered
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§4.3, §6.3)
+**Lens:** forces, patterns
+**Refs:** O2
+
+**Context.** `human_gate_time` is a required field, but it carries "a disclosed qualitative caveat, not a numeric range" (§4.2). The field must always be present and must always name that wall-clock is dominated by human availability at disposition gates — but it is "not estimated numerically at S1" (§4.3).
+
+**Forces.** Three forces collide: the dominant source of wall-clock variance must not be hidden; S1 has no grounded source for the gate count (the gate topology lives in S4); and the spec's own range-not-point principle forbids inventing a multiplier S1 cannot ground. A numeric estimate would satisfy the first force and violate the other two. Silence on the field would satisfy the last two and violate the first.
+
+**Options not taken.** (1) Derive `human_gate_time = gate_count × per-gate band` — the withdrawn prior derivation, whose `gate_count` reached into S4's gate topology this slice forbids naming (§4.3). (2) Drop the field entirely until S4 — hides the dominant variance term and lets a reader treat the agent-compute range as total wall-clock. (3) Make the field optional — weakens the honesty signal to a maybe-present caveat.
+
+**Choice as written.** A *required-but-qualitative* field: the dominant uncertainty is named on every record, in prose, without a fabricated number. "It claims no number at all, which is the honest position while its grounding lives downstream" (§6.3). The field shape itself encodes the decision — `agent_compute_time` is `{low, high}`, `human_gate_time` is a string.
+
+**Consequences.** The record format now carries two time fields of *different shapes*, which every consumer and validator must special-case (the §8.2 checklist explicitly checks one is a range and one is not). It also defers a real numeric estimate to a future slice once S4 fixes the gate set — the field is a placeholder that has to be revisited, not a closed decision. Accepted as the honest position; the cost is a heterogeneous field set.
+
+**Pattern.** Null Object's inverse — rather than a null or a fake default, a *named, speaking absence*: the field's job is to assert that the quantity exists and is deliberately not measured. Close to a documented "known unknown."
+
+**Notes.** Descends from round-2 O2 (accepted, fixed via this demotion). The story records why the qualitative-caveat shape was chosen over the two numeric alternatives, which the objection disposition only gestures at.
+
+## Story #4 — Per-axis confidence object over a single enum
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§4.2, §5.2)
+**Lens:** patterns, alternatives
+**Refs:** O2
+
+**Context.** `confidence` is an object keyed `tokens`, `time`, and (only when cost is present) `cost`, each `low`/`medium`/`high` (§4.2). A whole-record summary "MAY be reported as `min()` of the present axes, but the per-axis values are authoritative" (§4.2). This replaced a single whole-record enum from the prior draft.
+
+**Forces.** The tension is between *legibility of a single headline number* and *faithful representation of mixed grounding*. The token estimate can be spec-grounded and confident while the cost estimate rests on a stale, coarse snapshot — "a high-confidence token estimate and a low-confidence cost figure" (§4.2). A single enum forces these into one tier, and a `min()` collapse would drag a confident token range down to the weakest axis, hiding that the tokens are well-grounded.
+
+**Options not taken.** (1) A single whole-record confidence enum — simpler to read and sort, but cannot express divergent per-axis grounding, "exactly the representation the single whole-record enum could not express" (§5.2). (2) A confidence field per *stage* rather than per *axis* — finer-grained but mixes the grounding-richness story (target_kind) with the per-stage token story. (3) Free-text confidence prose only, no structured tier — defeats the validation checkpoint.
+
+**Choice as written.** Structured per-axis confidence with axis-specific rules: a `target_kind` ceiling for `tokens`/`time` (raw text capped at `low`), and an independent snapshot-quality rule for the conditional `cost` axis (§5.2). The axes are representable independently.
+
+**Consequences.** The conditional `cost` axis is coupled to `cost_usd`'s conditional presence — `confidence.cost` exists iff `cost_usd` does, adding a cross-field invariant the validator must enforce. A consumer wanting one headline tier must compute the `min()` itself; the format deliberately does not pick one for them.
+
+**Pattern.** Value Object decomposition — replacing a scalar with a structured value whose components carry independent meaning (cf. replacing a single status with a per-dimension health object). The axis-specific ceiling rule is a Specification-pattern constraint over the value's components.
+
+**Notes.** This is the round-1 O4/O6 fix, confirmed resolved by the round-2 diaboli. Cross-referenced to O2 because the per-axis `time` confidence only describes `agent_compute_time` (Story #3) — the human-gate caveat carries no number to be confident about (§5.2).
+
+## Story #5 — The tier-binding table as an authored artefact
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§6.2)
+**Lens:** defaults, consequences
+**Refs:** O3
+
+**Context.** Cost derivation needs a `tier → model → $/token` map, because MODEL_ROUTING.md tiers are abstract labels with no model name and the snapshot is keyed by model name. The spec ships a named tier-binding table in the format reference that authors `Most capable → claude-opus-4`, `Standard → claude-sonnet-4`, and a widened split for the implementer (§6.2).
+
+**Forces.** The tension is between *deriving the binding from a source* and *authoring it as a fixed artefact*. No source the methodology reads carries the tier→model mapping — MODEL_ROUTING.md has the tiers, the snapshot has the models, and nothing joins them. To compute cost at all, the join must be asserted *somewhere*. The spec chooses to assert it in a named, S6-maintained reference rather than leave it to per-estimate agent judgement.
+
+**Options not taken.** (1) Let the agent pick the representative model per tier at estimate time — rejected because it "leaves the tier choice to agent discretion" (§6.1), reintroducing per-estimate divergence. (2) Add the model binding to MODEL_ROUTING.md itself so it lives at the routing source of truth — would make it derived rather than authored, but expands the scope into a file this slice does not own. (3) Derive a rate without a tier→model join — impossible given the two sources don't share a key.
+
+**Choice as written.** A hand-authored binding table living "in a named place, not in agent judgement" (§6.2), explicitly flagged as "the artefact S6 may revise as routing evolves." The team accepts a known maintenance-drift surface in exchange for a single deterministic join point.
+
+**Consequences.** A model rename or routing change between S1 and S6 silently breaks the snapshot join, with no S1–S5 mechanism keeping it aligned — a drift cost the human accepted as a documented residual (O3 disposition: re-verify at S2 implementation). The central honesty claim ("cost is grounded in observed actuals") rests on one ungrounded editorial assertion: that these specific model names represent these tiers.
+
+**Pattern.** Adapter / anti-corruption layer (Evans, DDD) — the binding table is the translation seam between the routing domain's abstract tiers and the billing domain's concrete model keys. Also a lookup table as a Published Interface (the S6-revisable artefact).
+
+**Notes.** Refs O3 (the accepted drift residual) and O5 (the round-1 split-tier widening this table enables). The cartographer records the *decision to author rather than derive*; the diaboli owns the *drift-failure* framing. Routing Rule applied: the decision is recorded here, the failure class stays in the objection record.
+
+## Story #6 — No-verdict enforced by positive-content scanning
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§5.3)
+**Lens:** patterns, forces
+**Refs:** —
+
+**Context.** The record "carries confidence; it does not carry a verdict" (§5.3). The spec makes this structural in two layers: field-absence (no `recommendation`/`verdict`/`proceed` field) *and* a positive-content scan that fails any record whose disclosure prose contains imperative or go/no-go language (§5.3).
+
+**Forces.** The tension is between *trusting the emitter* and *enforcing the boundary in the format*. The S2 agent is meant to emit, not decide — but a verdict can be smuggled into free-text prose ("likely-overrun, so do not proceed") that passes every field-presence check. The spec resolves toward making the no-verdict guarantee "a property of the format itself, independent of any agent's good behaviour" (§5.3).
+
+**Options not taken.** (1) Field-absence only — necessary but, as the spec admits, "not sufficient" because prose can carry a verdict (§5.3). (2) Rely on the agent's instructions to not recommend — trusts behaviour the format is trying to make structural. (3) Forbid free-text disclosure entirely and allow only enumerated values — would kill the interrogable disclosure prose that is the whole point of the contract.
+
+**Choice as written.** A positive-content validation check that scans for prohibited imperative patterns ("so proceed", "I recommend", "you should [ship|skip|approve|reject]", "go/no-go") and fails the record (§5.3, §8.2). The guarantee is enforced on what the prose *says*, not just on which fields *exist*.
+
+**Consequences.** The validator now depends on a pattern list that can never be exhaustive — a paraphrased verdict ("the smart move here is…") may slip past the enumerated patterns, so the check raises the bar without closing the gap completely. It also constrains legitimate disclosure prose, which must describe uncertainty in a register that avoids any imperative the scan might match. This is a trust-boundary mechanism enforced at validation time, mirroring the AGENTS.md agent-emit/human-disposes architecture in the format layer.
+
+**Pattern.** Defence in depth (two independent layers for one guarantee). The positive-content scan is a denylist/Tolerant-Reader hybrid — structurally honest that it is a heuristic guard, not a proof.
+
+**Notes.** Round-1 O12 fix, confirmed resolved by the round-2 diaboli. The story records the *two-layer enforcement choice* and its inherent incompleteness, which the resolved objection does not dwell on.
+
+## Story #7 — Reusing the cost-snapshot format as ground
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§6.2, §6.5)
+**Lens:** defaults, alternatives
+**Refs:** —
+
+**Context.** The prospective `cost-estimation` skill reads its $/token ground from the same `observability/costs/` snapshots the retrospective `cost-tracking` skill writes — "the two reuse the same data" (§6.5). The estimator derives a blended per-model rate from the snapshot's `## Model Breakdown` table.
+
+**Forces.** The tension is between *reusing an existing retrospective format* and *defining a bespoke estimation-grounding format*. The snapshot was designed for human-readable quarterly spend capture, not for machine consumption by an estimator — its Model Breakdown is marked "(if available)" (§6.2) and aggregates models coarsely. Reusing it gives a single source of truth and a discoverable prospective/retrospective sibling pair; a bespoke format would fit estimation better but split cost data across two artefacts.
+
+**Options not taken.** (1) Define a dedicated estimation-rate file the estimator owns — cleaner machine contract, but duplicates cost data and breaks the one-snapshot story. (2) Read provider list prices directly as ground — rejected wholesale (no list-price fallback, §6.2). (3) Wait for S6's per-PR actuals format and ground only on that — would leave cost ungroundable until the last slice.
+
+**Choice as written.** The estimator consumes the retrospective sibling's existing output as its ground, accepting that output's optionality and coarseness as input-quality caveats it must disclose. The pair is made deliberately discoverable: "a reader who finds one should find the other" (§6.5), with the symmetry `/cost-capture` records spent : `/cost-estimate` predicts spend.
+
+**Consequences.** The estimator inherits the snapshot's "(if available)" optionality directly into its grounding states (no snapshot / no usable breakdown / usable breakdown, §6.2), and the blended-rate derivation inherits the snapshot's input/output mix assumptions (the O4 residual). The estimator's accuracy is now coupled to a format it does not control and that is refreshed only quarterly.
+
+**Pattern.** Shared Data integration (Hohpe/Woolf, *EIP*) — two components integrate through a common data store rather than a direct interface. Also a deliberate sibling-symmetry / discoverability pairing across the prospective/retrospective axis.
+
+**Notes.** A largely silent choice — the spec presents the reuse as obvious rather than as a decision between reuse and a bespoke format. Worth recording because the coupling to the snapshot's shape and refresh cadence is inherited, not chosen at estimation time.
+
+## Story #8 — A proposed contract, not an inherited decision
+
+**Source:** `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md` (§1, §5, §15)
+**Lens:** coherence
+**Refs:** #2
+
+**Context.** The spec is emphatic — in the header table, §1, §5, §15, and the §14 resolution table — that the four-part disclosure body is "a contract THIS SPEC PROPOSES" and "not a pre-existing promoted AGENTS.md decision" (§5). A grep confirms no "disclosure-of-derived-judgment" decision exists. Yet the slicing record this spec descends from repeatedly cites exactly such a decision as governing the contract ("as required by the promoted AGENTS.md 'disclosure-of-derived-judgment' decision", slicing record §S1 scope and Context).
+
+**Forces.** The tension is between *the slicing record's framing* and *the spec's corrected framing*. The slicing record was authored believing an AGENTS.md authority existed; the spec, after round-1 O1, discovered it does not and reframed the four-part body as a proposal serving the *real* "agent-emit + dispatcher-persist + human-disposes" ARCH_DECISION. The spec resolves the contradiction in its own favour but leaves the upstream slicing record carrying the now-falsified citation.
+
+**Options not taken.** (1) Promote the disclosure contract to AGENTS.md first, then have the spec operationalise it — would make the slicing record's framing true, but inverts the order (the contract is being proposed *by* this spec, not promoted before it). (2) Strip the disclosure-contract framing and rely solely on the existing trust-architecture decision — loses the specific four-part structure that is S1's actual value. (3) Correct the slicing record to match — out of scope for a spec, but leaves a coherence gap across the two artefacts.
+
+**Choice as written.** The spec chose to honestly re-label the contract as *proposed* and to serve the *existing* trust-architecture decision, even though this means the spec now contradicts the slicing record it descends from. The header table makes the re-labelling a first-class governing-decision note.
+
+**Consequences.** Two living artefacts now disagree about whether the disclosure contract is governed by an existing decision: the slicing record asserts it is, the spec asserts it is not. A future reader reconciling them must know the spec's framing is the corrected one. If the disclosure contract is later promoted (a candidate `promoted` disposition for this very capability), the slicing record's citation becomes retroactively true — the inheritance gap would close from the wrong direction. This is a coherence flag across the spec/slicing boundary, not a failure within the spec.
+
+**Pattern.** —
+
+**Notes.** Coherence lens used sparingly and deliberately: the incoherence is visible only across the spec and its parent slicing record, not within the spec (which is internally consistent on this point). Refs Story #2 because the conditional-cost shape is the other place the spec corrected an inherited framing in this revision. This story is a strong candidate for a `promoted` disposition — promoting the four-part disclosure contract to AGENTS.md would resolve the inheritance contradiction at the source.

--- a/docs/superpowers/stories/cost-estimation-skill-design.md
+++ b/docs/superpowers/stories/cost-estimation-skill-design.md
@@ -7,43 +7,75 @@ stories:
   - id: 1
     lens: [forces, patterns]
     title: The format is the contract; consumers are downstream
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Format-first S1 — locking the contract while it has zero
+      consumers — is a sound, deliberate sequencing choice; recorded so a future
+      refactor knows the data-contract-first stance was intentional.
   - id: 2
     lens: [forces, consequences]
     title: cost_usd conditional rather than required-low
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. cost_usd-conditional (present-when-grounded, omitted-with-
+      disclosure) is the right shape for an ungrounded axis; a strong reusable
+      principle, left feature-recorded rather than separately promoted because
+      its honesty rationale is carried by the now-promoted #8.
   - id: 3
     lens: [forces, patterns]
     title: human_gate_time named but not numbered
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. The required-but-qualitative human_gate_time — naming the
+      dominant uncertainty without faking a number — is the honest choice; the
+      heterogeneous-time-field cost is understood and accepted.
   - id: 4
     lens: [patterns, alternatives]
     title: Per-axis confidence object over a single enum
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Per-axis confidence over a single enum faithfully represents
+      mixed grounding; the cross-field invariant (confidence.cost iff cost_usd)
+      is a deliberate, recorded cost.
   - id: 5
     lens: [defaults, consequences]
     title: The tier-binding table as an authored artefact
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Authoring the tier→model binding table (rather than deriving it)
+      buys a deterministic join at a known drift cost — already tracked as the
+      O3 S2 residual; recorded so the trade is visible, not silent.
   - id: 6
     lens: [patterns, forces]
     title: No-verdict enforced by positive-content scanning
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. The two-layer no-verdict guarantee, honestly scoped after the
+      code-mode O3 fix (a tripwire for common phrasings, not a proof), is a sound
+      trust-boundary mechanism in the format layer.
   - id: 7
     lens: [defaults, alternatives]
     title: Reusing the cost-snapshot format as ground
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Reusing the cost-snapshot format as ground (over a bespoke
+      estimation format) keeps one source of truth and the prospective/
+      retrospective sibling symmetry; the inherited optionality and quarterly-
+      cadence coupling is understood and disclosed.
   - id: 8
     lens: [coherence]
     title: A proposed contract, not an inherited decision
-    disposition: pending
-    disposition_rationale: null
+    disposition: promoted
+    disposition_rationale: >
+      Promoted to AGENTS.md ARCH_DECISIONS as the disclosure-of-derived-judgment
+      contract (an agent that derives what a human previously supplied must
+      disclose included / excluded / confidence / failure-direction). Resolves
+      the spec↔slicing-record coherence gap at its source: the slicing record's
+      original citation is now accurate, and the spec carries a 2026-06-11
+      forward-note marking its point-in-time "proposed" framing as superseded.
+      The same principle independently surfaced on the (unmerged) dl-pipeline-map
+      branch's derived task→scope resolution, strengthening the cross-cutting
+      case; a third instance would complete the Rule of Three.
 ---
 
 ## Story #1 — The format is the contract; consumers are downstream

--- a/tdad_tests/scenarios/skills/cost-estimation/cost-conditional.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/cost-conditional.md
@@ -1,0 +1,96 @@
+---
+component: cost-estimation
+component_type: skill
+tier: structural
+---
+
+# Scenario: cost_usd is present only when a snapshot grounds it — three states, no list-price fallback
+
+## Given
+
+The `cost-estimation` skill's central restructure (spec §1, §6.2, §6.4;
+O2/O3/O8/O11) is that the dollar figure is an **actuals-gated
+enhancement**, not a day-one deliverable. The day-one deliverable is a
+**token + time estimate**, both groundable from MODEL_ROUTING.md today.
+`cost_usd` appears only when an `observability/costs/` snapshot supplies
+a usable per-model $/token rate; otherwise it is **omitted with an
+explicit disclosure** — never emitted as a forced-low list-price guess.
+
+The grounding source — `observability/costs/` — is **empty today** (the
+2026-05-29 health snapshot records "Last cost capture: never"), so the
+cost-omitted shape is the expected default.
+
+This scenario fixes the cost-conditional behaviour the methodology in
+`SKILL.md` and the field rules in
+`references/estimate-record-format.md` must describe (`FR-8`).
+
+## When
+
+The grounding methodology in `SKILL.md` and the conditional-cost rules
+in the format reference are read, with attention to how each of the
+three snapshot grounding states is handled.
+
+## Then
+
+**The three grounding states are each defined** (spec §6.2):
+
+- **State 1 — no snapshot exists** (today's state): `cost_usd` and
+  `cost_basis` are **omitted entirely**; `tokens` and
+  `agent_compute_time` are still produced as ranges; `human_gate_time`
+  is still produced as its qualitative caveat.
+- **State 2 — snapshot present but Model Breakdown absent or too coarse**
+  to yield a per-tier rate: `cost_usd` is **omitted**, and the
+  `Excluded` disclosure **names this specific cause** ("a cost snapshot
+  exists but carries no usable per-model breakdown"). The methodology
+  does NOT silently fall through to list price.
+- **State 3 — snapshot present with a usable Model Breakdown**:
+  `cost_usd` is **present**, accompanied by `cost_basis:
+  snapshot-actuals`, with `confidence.cost` set from the snapshot's age
+  and granularity and the snapshot date/quality disclosed in `Included`.
+
+**No list-price fallback** (spec §6.2; O3, O11):
+
+- The methodology states explicitly that there is **no list-price
+  fallback** anywhere — the prior "produce a list-price cost and force
+  confidence low" path is absent. When cost cannot be grounded in
+  actuals, it is omitted with disclosure, not guessed.
+
+**The omission is honest, not a failure** (spec §6.4):
+
+- The methodology states a record with `cost_usd` omitted is **valid and
+  complete** (the expected day-one shape), provided the `Excluded`
+  section carries the cost-omission disclosure (e.g. "cost_usd: omitted —
+  no repo cost snapshot exists yet, so no observed $/token is available;
+  cost is not estimated. Token and time figures stand.").
+
+**The cost-omitted worked example matches the no-snapshot shape** (spec
+§6.4, §8.2):
+
+- The cost-omitted worked example in the reference has `cost_usd` and
+  `cost_basis` absent, a `confidence` object carrying **`tokens` and
+  `time` axes but no `cost` axis**, and an `Excluded` section carrying
+  the cost-omission disclosure.
+
+**Format-stability seam** (spec §6.4; O11):
+
+- The methodology states **no format change is required** when the first
+  usable snapshot lands — the same `cost_usd`/`cost_basis`/
+  `confidence.cost` fields simply begin to appear.
+
+## Rubric
+
+Layer 1 structural: each assertion is verifiable by reading the
+methodology prose in `SKILL.md` and the conditional-cost field rules and
+the cost-omitted worked example in the format reference. The scenario
+fails if the methodology describes a list-price fallback, treats the
+no-cost case as an error, collapses the three states into two, or if the
+cost-omitted worked example carries a `cost` axis or a `cost_usd` value.
+
+## Notes
+
+This scenario is the honesty guarantee for the dollar axis. A snapshot
+fixture is NOT needed at Layer 1 — the assertions are about what the
+methodology and the worked example *describe*, not about running an
+estimate against a live snapshot. The watch-item (O7: cost stays omitted
+across S2–S5 until S6) is noted in the spec §7 but is a slicing decision
+to revisit, not a falsifiable assertion of this slice.

--- a/tdad_tests/scenarios/skills/cost-estimation/format-and-contract.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/format-and-contract.md
@@ -1,0 +1,147 @@
+---
+component: cost-estimation
+component_type: skill
+tier: structural
+---
+
+# Scenario: cost-estimation ships a well-formed skill and a complete estimate-record format contract
+
+## Given
+
+The `cost-estimation` skill is S1 of the cost-estimator capability
+(spec `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md`).
+It ships exactly two artefacts and nothing else:
+
+- `ai-literacy-superpowers/skills/cost-estimation/SKILL.md` — the
+  methodology and the disclosure/confidence contract as loadable prose.
+- `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+  — the canonical, stable definition of the estimate-record field set,
+  the artefact a downstream command's Output Validation Checkpoint
+  references by path.
+
+This scenario fixes the structural contract both files must satisfy
+(spec §4, §5, §6, §8.1, §8.2; FR-1 through FR-11, FR-8a, FR-14).
+
+## When
+
+The skill and its format reference are read directly from the
+filesystem during the design pass for the S2 agent, the S3 command, or
+the S4 orchestrator fold-in — the consumers that parse this contract.
+
+## Then
+
+**SKILL.md frontmatter and sections** (`FR-1`):
+
+- **YAML frontmatter present** with `name: cost-estimation` and a
+  non-empty `description` — required by the
+  `All frontmatter has name and description` HARNESS constraint.
+- **Body contains the required sections**, each surfaced as a heading:
+  - the grounding **methodology** (how MODEL_ROUTING.md grounds token
+    and time, and how a snapshot grounds cost);
+  - the **disclosure/confidence contract**;
+  - the **time split** (agent-compute vs human-gate);
+  - the **calibration seam** (S6, future-only);
+  - the **sibling** relationship to `cost-tracking`;
+  - a **"What this skill does NOT do"** section stating it does not
+    dispatch, does not write files, and does not decide go/no-go.
+- The body **references the format file** by relative path.
+
+**Format reference field set** (`FR-2`, `FR-3`):
+
+- The reference defines a frontmatter field table listing every field
+  of spec §4.2: `target`, `target_kind`, `generated_at`, `generated_by`,
+  `grounding_sources`, `tokens`, `tokens_by_stage`, `cost_usd`,
+  `cost_basis`, `agent_compute_time`, `human_gate_time`, `confidence`,
+  and `failure_direction`.
+- `cost_usd` and `cost_basis` are marked **conditional
+  (present-when-grounded)**, not required.
+- `confidence` is a **per-axis object** with keys `tokens`, `time`, and
+  (only when `cost_usd` is present) `cost`.
+- Every **present** quantitative field (`tokens`,
+  `tokens_by_stage[].tokens`, `cost_usd` when present,
+  `agent_compute_time`) is specified as a `{low, high}` range.
+- There is **no** point-value, `recommendation`, `verdict`, or `proceed`
+  field anywhere in the field set.
+
+**Time split** (`FR-5`):
+
+- `agent_compute_time` and `human_gate_time` are **two separate required
+  fields with different shapes**: `agent_compute_time` is a numeric
+  `{low, high}` range; `human_gate_time` is a **qualitative caveat
+  string, NOT a range**.
+- The reference states `human_gate_time` is **not estimated numerically
+  at S1** because the gate set lives in the orchestrator (S4, #371),
+  which this slice does not touch, and that human-gate latency dominates
+  wall-clock and is the least-predictable term.
+
+**Disclosure body** (`FR-4`):
+
+- The reference mandates the **four-part disclosure body**: Included,
+  Excluded, Confidence rationale, Failure direction. A record missing
+  any of the four fails validation.
+
+**Per-axis confidence mapping** (`FR-6`):
+
+- The reference defines the **`target_kind` ceiling** for `tokens`/`time`
+  (raw `task-text` capped at `low`; `slicing-record`/`slice` at most
+  `medium`; `spec` may reach `high`) and an **independent
+  snapshot-quality rule** for the conditional `cost` axis, so a
+  spec-grounded target can carry `tokens: high` beside `cost: low`.
+
+**Tier→model→$/token binding** (`FR-7`, `FR-8a`):
+
+- The reference contains a named **tier→model→$/token binding table**
+  mapping `Most capable → claude-opus-4`, `Standard → claude-sonnet-4`,
+  and the implementer's `Standard / Capable` **split row spanning two
+  distinct models** — low bound `claude-sonnet-4`, high bound
+  `claude-opus-4` — so the split-tier widening produces a real spread.
+
+**Calibration seam** (`FR-9`):
+
+- The `grounding_sources[]` field permits a `kind: calibration` entry
+  alongside `model-routing` and `cost-snapshot`, and the methodology
+  describes calibration as **range-refinement**, without implementing S6.
+
+**Sibling** (`FR-10`):
+
+- The reference/skill names `cost-tracking` as the retrospective sibling
+  and states the estimate reads the `observability/costs/` snapshots
+  that `cost-tracking` writes.
+
+**Worked examples and validation checklist** (`FR-11`, `FR-14`):
+
+- The reference contains **two complete worked example records** — one
+  **cost-omitted** (today's default: `cost_usd`/`cost_basis` absent,
+  `confidence` with `tokens`/`time` only) and one **cost-present**
+  (`cost_basis: snapshot-actuals`, `confidence.cost` present). In both
+  examples `human_gate_time` is a qualitative caveat string, not a range.
+- The **cost-present** example demonstrates the **split-tier widening**:
+  its implementer stage carries a **non-zero cost band** whose low bound
+  uses `claude-sonnet-4` and high bound uses `claude-opus-4`, visibly
+  wider than the token-range spread alone.
+- Neither worked example files an inclusion caveat under `Excluded`
+  (O10).
+- The reference contains a **"Validation checklist"** subsection
+  enumerating the checks a consuming command runs, including the
+  two-layer no-verdict guarantee (the field-absence check **and** the
+  positive-content scan of §5.3).
+
+## Rubric
+
+This is a Layer 1 structural scenario: every assertion is mechanically
+checkable by reading `SKILL.md` and `references/estimate-record-format.md`
+and matching against frontmatter, headings, the field table, the binding
+table, and the two worked example blocks. The scenario passes only when
+every assertion in `Then` can be verified by inspection of the two files.
+
+A future Layer 3 scenario could load the skill and ask a model to emit a
+record against the format, asserting the result validates — that
+behavioural verification is deferred (no dispatchable side-effect ships
+in S1; spec §9 targets `[structural, trigger]` only).
+
+## Notes
+
+Scope is S1 only. This scenario does NOT assert anything about the S2
+agent, the S3 command, the S4 orchestrator wiring, the S5 ballpark, or
+the S6 calibration implementation — only that the methodology and format
+contract those slices consume are present and well-formed.

--- a/tdad_tests/scenarios/skills/cost-estimation/no-verdict-in-prose.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/no-verdict-in-prose.md
@@ -1,0 +1,84 @@
+---
+component: cost-estimation
+component_type: skill
+tier: structural
+---
+
+# Scenario: the no-verdict guarantee is structural in two layers — field-absence plus a positive-content prose scan
+
+## Given
+
+The `cost-estimation` skill carries confidence but **never** a verdict,
+recommendation, or go/no-go (spec §5.3; O12). The estimate informs a
+human's choice; it does not anchor or make it, in service of the
+AGENTS.md "agent-emit + dispatcher-persist + human-disposes" trust
+architecture.
+
+The spec makes this guarantee **structural in two layers** rather than
+relying on field absence alone, because O12 showed a verdict could be
+smuggled into the free-text disclosure prose:
+
+1. **Field-absence layer** — no `recommendation`, `verdict`, or
+   `proceed` field exists.
+2. **Positive-content layer** — the four disclosure sections describe
+   inputs and uncertainty only and MUST NOT contain imperative
+   recommendation or go/no-go language; a validation check scans the
+   disclosure prose for prohibited patterns and **fails the record** if
+   any appear.
+
+This scenario fixes what the format reference's validation checklist and
+worked examples must contain (`FR-14`, supporting `FR-3`).
+
+## When
+
+The format reference at
+`ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+is read — specifically the "Validation checklist" subsection and the two
+worked example records.
+
+## Then
+
+**Field-absence layer** (spec §5.3 layer 1):
+
+- The validation checklist lists a **field-absence check**: no
+  `recommendation`, no `verdict`, and no `proceed` field may appear in
+  the record frontmatter.
+
+**Positive-content layer** (spec §5.3 layer 2):
+
+- The validation checklist lists a **positive-content check** that
+  **fails a record** whose disclosure prose contains imperative
+  recommendation or go/no-go language.
+- The checklist enumerates representative prohibited patterns, including
+  "so proceed", "do not proceed", "I recommend", "you should
+  [ship|skip|approve|reject]", and "go/no-go".
+- The reference states the **Failure direction** section describes
+  uncertainty only and must contain no imperative recommendation — i.e.
+  a sentence like "failure direction: likely-overrun, so do not proceed"
+  **fails** the positive-content check even though it passes the
+  field-absence check.
+
+**The worked examples are clean** (spec §10.2a; O12):
+
+- Neither worked example record contains "so proceed", "do not proceed",
+  "I recommend", "you should ship/skip/approve/reject", or any other
+  imperative recommendation or go/no-go language in its disclosure prose.
+
+## Rubric
+
+Layer 1 structural: the validation-checklist assertions are verifiable
+by reading the checklist subsection of the format reference; the
+worked-example assertions are verifiable by scanning the two example
+blocks' disclosure prose for the prohibited patterns. The scenario fails
+if either the field-absence check or the positive-content check is
+missing from the checklist, or if either worked example's prose carries
+go/no-go language.
+
+## Notes
+
+The positive-content check is what makes the no-verdict guarantee a
+property of the format itself rather than of any agent's good behaviour.
+This scenario asserts the **contract describes the check**; it does not
+itself execute the scan against arbitrary records — that runtime
+enforcement is the S3 command's Output Validation Checkpoint job, out of
+scope for S1.

--- a/tdad_tests/scenarios/skills/cost-estimation/triggers-on-prospective-cost.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/triggers-on-prospective-cost.md
@@ -1,0 +1,80 @@
+---
+component: cost-estimation
+component_type: skill
+tier: trigger
+---
+
+# Scenario: cost-estimation fires on prospective-cost queries and not on retrospective-capture queries
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded — so all
+skill descriptions, including `cost-estimation` and its retrospective
+sibling `cost-tracking`, are available for matching.
+
+The `cost-estimation` skill is the **prospective** counterpart to the
+**retrospective** `cost-tracking` skill / `/cost-capture` command (spec
+§6.5, §10.6; `FR-10`). The two reuse the same `observability/costs/`
+data: `cost-tracking` *writes* the snapshots, `cost-estimation` *reads*
+them as its $/token ground. The pair must be discoverable from either
+half — a reader who finds one should find the other — but a
+**prospective** query ("how much will this cost") must route to
+`cost-estimation`, and a **retrospective** query ("record what we spent")
+must route to `cost-tracking`.
+
+## When
+
+Each of the following user queries is sent to the model in isolation.
+
+Prospective queries that SHOULD fire `cost-estimation`:
+
+- "How much will this feature cost to build?"
+- "Estimate the tokens for this spec before we start."
+- "What will this slice cost to build?"
+- "Predict the agent-compute time for this task before I commit."
+
+Retrospective queries that should fire `cost-tracking` and NOT
+`cost-estimation`:
+
+- "Record our Anthropic spend for the quarter."
+- "Capture the quarterly cost snapshot from the provider dashboard."
+
+## Then
+
+For each **prospective** query, the model should identify
+`cost-estimation` as the skill to invoke — at minimum, `cost-estimation`
+appears in the list of skills the model says it would load.
+
+For each **retrospective** query, the model should identify
+`cost-tracking` (not `cost-estimation`) as the skill to invoke —
+`cost-estimation` must NOT appear, because recording observed spend is
+the sibling's job.
+
+The fourth prospective query ("predict the agent-compute time…")
+paraphrases the prospective intent without using the word "cost"; it
+tests whether the description carries the broader prospective-estimate
+concept (tokens, time, before-the-work) rather than only the literal
+token "cost".
+
+## Rubric
+
+A single inference suffices per query: hand the model the plugin's skill
+descriptions and the query, ask "which skills would you invoke for this
+query?", and parse the response. No fixture state needed.
+
+The discriminating signal this scenario protects is the
+**prospective-vs-retrospective** boundary in the `cost-estimation`
+`description:` line. If a future edit waters the description down until
+it no longer distinguishes "estimate before" from "record after", the
+retrospective queries will begin to match `cost-estimation` and this
+scenario will fail — surfacing the regression before it ships.
+
+## Implementation note
+
+The runner should:
+
+1. Load every skill's frontmatter `description` into a list.
+2. For each query, ask the model to identify the matching skills.
+3. Assert `cost-estimation` appears for the prospective queries and is
+   absent for the retrospective queries (where `cost-tracking` should
+   appear instead).

--- a/tdad_tests/tests/test_assess_operational_axes.py
+++ b/tdad_tests/tests/test_assess_operational_axes.py
@@ -247,10 +247,17 @@ def test_command_offers_optin_survey(assess_paths: dict) -> None:
 
 
 def test_plugin_json_at_0_40_0(assess_paths: dict) -> None:
-    """Scenario 9: plugin.json is at 0.40.0."""
+    """Scenario 9: plugin.json is at or beyond 0.40.0.
+
+    Originally pinned to 0.40.0 for the /assess Part D release; the
+    cost-estimation skill (0.41.0) advanced the floor. The assertion is
+    now ``>= 0.40.0`` so legitimate later minor bumps do not regress this
+    /assess scenario.
+    """
     manifest = json.loads(assess_paths["plugin_json"].read_text())
-    assert manifest["version"] == "0.40.0", (
-        f"plugin.json must be 0.40.0 (was 0.39.1). Actual: "
+    version = tuple(int(p) for p in manifest["version"].split("."))
+    assert version >= (0, 40, 0), (
+        f"plugin.json must be at least 0.40.0. Actual: "
         f"{manifest['version']!r}"
     )
 
@@ -267,13 +274,19 @@ def test_marketplace_entry_and_plugin_version_at_0_40_0(
         for p in marketplace["plugins"]
         if p["name"] == "ai-literacy-superpowers"
     )
-    assert entry["version"] == "0.40.0", (
-        f"ai-literacy-superpowers marketplace entry must be 0.40.0. "
-        f"Actual: {entry['version']!r}"
+    manifest = json.loads(assess_paths["plugin_json"].read_text())
+    # Pinned to 0.40.0 for the /assess Part D release; advanced to track
+    # the plugin manifest so later minor bumps (e.g. 0.41.0 for the
+    # cost-estimation skill) keep the marketplace triplet consistent
+    # without regressing this scenario.
+    assert entry["version"] == manifest["version"], (
+        "ai-literacy-superpowers marketplace entry must track plugin.json. "
+        f"entry={entry['version']!r} manifest={manifest['version']!r}"
     )
-    assert marketplace["plugin_version"] == "0.40.0", (
-        f"marketplace plugin_version must track 0.40.0. Actual: "
-        f"{marketplace['plugin_version']!r}"
+    assert marketplace["plugin_version"] == manifest["version"], (
+        "marketplace plugin_version must track plugin.json. "
+        f"plugin_version={marketplace['plugin_version']!r} "
+        f"manifest={manifest['version']!r}"
     )
     assert marketplace["version"] == "0.4.0", (
         "top-level marketplace listing `version` must be unchanged at "


### PR DESCRIPTION
## Slice S1 of the prospective cost-estimation capability

Adds a **`cost-estimation` skill** — the prospective counterpart to the existing retrospective `cost-tracking` skill / `/cost-capture`. It defines the methodology and the **estimate-record format contract** for predicting token usage, agent-compute vs human-gate time, and (when grounded) dollar cost for work flowing through the orchestrator pipeline.

This is **S1 of six** slices (slicing record: `docs/superpowers/slices/cost-estimator-pipeline.md`). S2–S6 are filed as #369–#373. S1 ships the contract every later slice consumes — **no agent, command, or orchestrator wiring** here by design.

### What's in the contract
- **Ranges, never point values**, with **per-axis disclosed confidence** (tokens / time / cost), governed by a disclosure contract this spec *proposes* (it serves the existing AGENTS.md agent-emit/dispatcher-persist/human-disposes decision).
- **`cost_usd` is conditional** — present only when an `observability/costs/` snapshot grounds a $/token rate; omitted-with-disclosure otherwise. The honest day-one deliverable is the token + time estimate.
- **`human_gate_time` is a qualitative caveat**, not a fabricated number (its grounding — the gate topology — lives in S4).
- A **two-layer no-verdict guarantee** (field-absence + a tripwire prose scan), keeping the estimator emits-not-decides.

### How it was built (full pipeline, dogfooded)
carpaccio → spec → **diaboli (spec, 2 rounds)** → choice-cartographer → plan approval → tdd-agent → implement → code-review (PASS) → **diaboli (code)**.
- Spec-mode round 1: 12 objections, all accepted, drove a large restructure (cost optional-until-actuals).
- Spec-mode round 2: 2 majors fixed & verified; 2 minors accepted as S2 residuals.
- Code-mode: 6 findings; **O1–O5 fixed**, O6 deferred to S2.

### Tests
`pytest tdad_tests/` → 218 passed, 31 skipped (skips are `needs_api` trigger/behavioural layers). Four TDAD scenarios under `tdad_tests/scenarios/skills/cost-estimation/`.

### Version
New skill → minor bump **0.40.0 → 0.41.0** (plugin.json, marketplace `plugin_version`, README badge/counts, CHANGELOG). Two stale `0.40.0`-pinned assertions advanced.

### Docs
`reference/skills.md` entry + a new `explanation/prospective-cost-estimation.md` page (Docs Site Review).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
