### PR TITLE
Format-revision (#377): per-stage cost_usd sub-field + generated_by/grounding-path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.42.0",
+  "plugin_version": "0.43.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.42.0"
+      "version": "0.43.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.43.0 — 2026-06-11
+
+### Format revision — per-stage `cost_usd`, `generated_by` grammar, grounding-path sentinel
+
+Ships the format-revision slice (#377): a backward-compatible revision of the
+`cost-estimation` skill's estimate-record format reference, resolving three
+deferred residues from the S1/S2 reviews. Format/schema change to a plugin
+reference file — minor bump. No new skill, agent, or command.
+
+- **Per-stage `cost_usd` sub-field** — `references/estimate-record-format.md`
+  gains an optional `tokens_by_stage[].cost_usd` `{ low, high }` range,
+  **one-directionally coupled** to top-level `cost_usd` (sub-field present ⟹
+  top-level present is enforced; top-level present ⟹ bands SHOULD be populated
+  is an emitter obligation, not a rejection rule — **not** an `iff`, so S1-era
+  cost-present records without bands stay valid). Makes a split-tier band's
+  non-collapsed (strictly-spread) shape record-internally checkable.
+- **Two new validation-checklist lines** — *Per-stage cost coupling* (forbids
+  the incoherent inverse: a per-stage band with no whole-record cost) and
+  *Split-tier spread* (a present split-tier band, identified by the closed
+  `model_tier` contains-`/` rule, must have a strict `low < high`). A §4.4.1
+  CAN/CANNOT note states the honest floor: the validator can assert
+  presence/coupling, `low ≤ high`, and strict spread, but cannot assert the
+  band spans two tiers or equals the absolute snapshot rates — that
+  absolute-rate check defers to S3.
+- **Example 2 re-derived** from two fixed per-tier rates (sonnet `4.0e-6`, opus
+  `2.0e-5` $/token): spec-writer `{1.00, 2.00}`, tdd-agent `{0.20, 0.60}`,
+  implementer `{0.40, 5.00}`, summing to the whole-record `{1.60, 7.60}`.
+  Example 1 (cost-omitted) carries no per-stage band.
+- **`generated_by` grammar widened** — the field description admits a
+  `tier:<tier>` routing-tier label alongside a concrete model id, with `tier:`
+  defined as a reserved provenance prefix (a concrete model id never begins with
+  `tier:`) so consumers can distinguish the two forms with no rejecting check.
+  Makes the merged S2 agent's `tier:Standard` output documentation-conformant.
+- **Grounding-path sentinel documented** — the trailing-slash directory
+  `observability/costs/` is the defined cost-omitted sentinel; the reference
+  names that this entrenches an overloaded `path` meaning (file = grounded;
+  directory = looked-and-found-nothing) and carries the consumer special-case
+  (an aggregator must not count a trailing-slash path as a grounding), noted as
+  advisory/unenforced.
+
 ## 0.42.0 — 2026-06-11
 
 ### New agent — `cost-estimator` (read-only prospective-cost emitter)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.42.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.43.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-34-2E8B57?style=flat-square)](#skills-34)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.42.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.43.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
@@ -24,10 +24,11 @@ the body carries the human-readable disclosure prose.
 | `target` | string | yes | What was estimated — a path (slicing record, spec) or a short description of pasted task text. |
 | `target_kind` | enum | yes | One of `task-text`, `slicing-record`, `slice`, `spec`. Signals the grounding richness available; richer targets warrant higher confidence. |
 | `generated_at` | string (ISO 8601) | yes | Timestamp the estimate was produced. |
-| `generated_by` | string | yes | Agent name + model identifier (e.g. `"cost-estimator / claude-opus-4-8"`). |
-| `grounding_sources` | list of objects | yes | The inputs the estimate was built from. Each entry has `path` (string) and `kind` (one of `model-routing`, `cost-snapshot`, `calibration`). At minimum a `model-routing` entry and a `cost-snapshot` entry; a `calibration` entry is permitted but never required. |
+| `generated_by` | string | yes | Agent name plus **either** a concrete model identifier (e.g. `"cost-estimator / claude-opus-4-8"`) **or** a `tier:<tier>` routing-tier label when the concrete model is not available to the emitter at emit time (e.g. `"cost-estimator / tier:Standard"` — an agent running `model: inherit` that is not told its resolved model records the routing tier it reads from `MODEL_ROUTING.md`). The value is **never** a guessed or hard-coded model string. See the `generated_by` provenance grammar note below for the reserved `tier:` prefix. |
+| `grounding_sources` | list of objects | yes | The inputs the estimate was built from. Each entry has `path` (string) and `kind` (one of `model-routing`, `cost-snapshot`, `calibration`). At minimum a `model-routing` entry and a `cost-snapshot` entry; a `calibration` entry is permitted but never required. When no snapshot **file** exists (states 1 and 2 — cost-omitted), the mandatory `cost-snapshot` entry's `path` is the **directory** `observability/costs/` (trailing slash) — the **defined cost-omitted sentinel**; see the grounding-path sentinel note below. |
 | `tokens` | range object | yes | Estimated total token usage as `{ low: int, high: int }`. The budget-derived bounds. |
 | `tokens_by_stage` | list of objects | yes | Per-stage breakdown. Each entry: `stage` (string — spec-writer, tdd-agent, implementer, code-reviewer, integration), `tokens` (range object), `model_tier` (string from the agent→model-tier mapping — may be a split tier such as `Standard/Capable`). May omit stages a target does not exercise; the omission must be reflected in the `Excluded` prose. |
+| `tokens_by_stage[].cost_usd` | range object `{ low, high }` | **optional, one-directionally coupled** — **present ⟹ top-level `cost_usd` present** (enforced); top-level `cost_usd` present ⟹ bands **SHOULD** be populated by emitters, but their **absence does NOT invalidate** the record (**not** an `iff` — the asymmetry is deliberate) | The per-stage dollar contribution. Makes the split-tier widening a machine-readable disclosure surface and a **record-internal** spread check: a validator can assert a split-tier stage's band is **non-collapsed (strictly spread)** — `low < high` — consistent with the binding table's tier ordering. It **cannot** assert the bounds equal the absolute `claude-sonnet-4`/`claude-opus-4` rates — those live in the snapshot, not the record (see the per-stage cost validation notes below). |
 | `cost_usd` | range object | **conditional (present-when-grounded)** | Estimated dollar cost as `{ low: float, high: float }`. **Present ONLY when an `observability/costs/` snapshot supplies a usable per-tier $/token rate.** When no usable rate exists, the field is **omitted entirely** and the omission is disclosed in `Excluded`. The format must not carry a placeholder, a null, or a forced list-price value. |
 | `cost_basis` | enum | **conditional (present-when-grounded)** | Present **iff** `cost_usd` is present. One of `snapshot-actuals` (rate derived from a snapshot Model Breakdown) — currently the only grounded basis. Records the provenance of the $/token rate so a reader knows the cost is observed, not guessed. |
 | `agent_compute_time` | range object | yes | Estimated wall-clock spent in agent execution as `{ low: <duration>, high: <duration> }`. Durations are ISO 8601 durations or plain `"Nm"`/`"Nh"` strings. Derived from token volume. |
@@ -38,11 +39,55 @@ the body carries the human-readable disclosure prose.
 There is **no** point-value, `recommendation`, `verdict`, or `proceed`
 field anywhere in the field set.
 
+### `generated_by` provenance grammar — the reserved `tier:` prefix
+
+The `generated_by` value carries the agent name, a ` / ` separator, and a
+provenance token that is **either** a concrete model identifier **or** a
+`tier:<tier>` routing-tier label (used when an `model: inherit` agent is not
+told its resolved model and records the routing tier instead).
+
+So the two forms are mechanically distinguishable, **`tier:` is a reserved
+provenance prefix**: the provenance token after the ` / ` separator is a
+**tier label if and only if it begins with the literal `tier:`**; otherwise it
+is a **concrete model identifier**. A concrete model id **never** begins with
+`tier:` — no model in `MODEL_ROUTING.md` or any snapshot is named with a
+`tier:` prefix — so a consumer can mechanically decide which form it holds by
+testing the `tier:` prefix, **without any rejecting check being added**. This
+is a *grammar*, not a validator: the checklist adds **no** line that rejects a
+malformed `generated_by`; the prefix reservation simply removes the ambiguity
+for a consumer splitting on the separator. The value is **never** a guessed or
+hard-coded model string.
+
+### Per-stage `cost_usd` — the one-directional coupling
+
+The optional `tokens_by_stage[].cost_usd` sub-field is coupled to the
+top-level `cost_usd` as a **one-directional asymmetry, not a biconditional**
+(it is **not** an `iff`):
+
+- **Sub-field present ⟹ top-level `cost_usd` present** (enforced by the
+  validation checklist — a per-stage band never appears on a cost-omitted
+  record).
+- **Top-level `cost_usd` present ⟹ bands SHOULD be populated** by emitters (so
+  the per-stage decomposition that produced the whole-record figure is
+  surfaced), but a cost-present record that omits them is **still valid** —
+  this direction is an emitter obligation (a SHOULD), **not** a
+  validation-rejection rule. This asymmetry is what keeps S1-era cost-present
+  records (top-level cost, no per-stage bands) valid.
+- **Top-level `cost_usd` absent** → **no** stage carries a per-stage
+  `cost_usd`; the sub-field is absent everywhere (exactly as in Example 1).
+
+The whole-record `cost_usd` band need **not** equal the arithmetic sum of the
+per-stage bands (stages may be correlated, and the widening is applied per
+stage), consistent with the existing same-rule for `tokens` vs
+`tokens_by_stage[].tokens`. When they differ the prose body says why — no
+**new** disclosure-body rule is added.
+
 ## Range representation
 
 Every quantitative field that is **present** (`tokens`, each
-`tokens_by_stage[].tokens`, `cost_usd` *when present*,
-`agent_compute_time`) is a two-key object `{ low, high }`.
+`tokens_by_stage[].tokens`, each `tokens_by_stage[].cost_usd` *when present*,
+`cost_usd` *when present*, `agent_compute_time`) is a two-key object
+`{ low, high }`.
 `human_gate_time` is **not** a quantitative range — it is a qualitative
 caveat string and is exempt from these rules.
 
@@ -168,6 +213,19 @@ widening applies to any stage MODEL_ROUTING.md lists with a slashed tier.
 `tokens_by_stage[].model_tier` records the literal split label
 (`Standard/Capable`) so the breakdown stays traceable.
 
+**Per-stage band pricing convention (emitter methodology, NOT a checked
+invariant).** When an emitter surfaces a per-stage `tokens_by_stage[].cost_usd`
+band, a **split-tier** stage prices its **low** bound at the **cheaper**
+representative model (`claude-sonnet-4`) and its **high** bound at the
+**dearer** one (`claude-opus-4`), per the binding table. Because the two ends
+bind to different rates, a genuine widening produces a strictly-positive spread
+(`low < high`). The validator **cannot** confirm which bound binds to which
+model from the record alone (it sees two numbers and their order, never the
+per-model pricing); the cheaper-at-low / dearer-at-high ordering is therefore an
+**emitter convention**, not a checkable invariant. The only predicate the
+"Split-tier spread" checklist line tests on a present split-tier band is
+`low < high`.
+
 **Deriving a per-model rate from a snapshot.** The snapshot's
 `## Model Breakdown` table gives per-model quarter-aggregate
 input/output token volumes and an estimated cost. Compute a per-model
@@ -204,6 +262,44 @@ complete**, not a failure. **No format change is required when the first
 usable snapshot lands**: the same `cost_usd`/`cost_basis`/`confidence.cost`
 fields simply begin to appear.
 
+### The cost-snapshot grounding-path sentinel
+
+When no snapshot **file** exists (states 1 and 2 — cost-omitted), the
+mandatory `cost-snapshot` grounding entry's `path` is the **directory** the
+emitter inspected, written with a trailing slash (`observability/costs/`). This
+is the **defined cost-omitted sentinel**: the entry remains *present*
+(satisfying the "at minimum a cost-snapshot entry" rule), and the directory
+path records what the emitter actually read — the directory it inspected and
+found empty (or without a usable snapshot). The `Excluded` prose names that the
+directory held no usable snapshot. The entry is **never dropped** and **never
+given a fabricated snapshot file path**. When a usable snapshot file exists
+(state 3), the `path` is that **file** (e.g.
+`observability/costs/2026-08-15-costs.md`).
+
+**Consumer special-case (do not double-count).** Because the trailing-slash
+directory path means *looked-and-found-nothing* rather than
+*grounded-in-a-snapshot*, an aggregator that counts "how many records were
+grounded in a cost snapshot" **must not** count a `cost-snapshot` entry whose
+`path` ends in `/` as a grounding — it is a sentinel for the *absence* of a
+snapshot. Test the trailing slash (directory) versus a file path to distinguish
+the two meanings.
+
+**This does not "resolve" the semantic tension — it entrenches an overloaded
+meaning, deliberately.** A `cost-snapshot` entry's `path` now carries two
+meanings depending on whether it resolves to a **file** (grounded in that
+snapshot) or a **trailing-slash directory** (looked-and-found-nothing — the
+negative fact "no snapshot here"). Naming the directory a `grounding_sources`
+entry widens "the inputs the estimate was built from" to admit "a location an
+input was looked for and not found." This was chosen over inventing a new
+sentinel token on backward-compat grounds (zero consumer change, zero new parse
+case), and paid for with the consumer special-case above. The strain is
+**named and accepted**, not eliminated. **Noted residual:** the trailing-slash
+consumer special-case is **advisory/unenforced** — no validation-checklist line
+keys on `grounding_sources[].path` shape — so it externalises a silent-miscount
+risk onto every downstream counter; nothing catches a consumer that counts a
+trailing-slash directory entry as a real grounding. This is an accepted residual
+of the deliberate keep-the-directory-sentinel trade.
+
 ## The calibration seam
 
 `grounding_sources[]` permits a `kind: calibration` entry alongside
@@ -218,8 +314,41 @@ slice.
 The checks a consuming command's Output Validation Checkpoint runs:
 
 - [ ] **Ranges well-formed** — every **present** range
-  (`tokens`, each `tokens_by_stage[].tokens`, `cost_usd` when present,
+  (`tokens`, each `tokens_by_stage[].tokens`, each
+  `tokens_by_stage[].cost_usd` when present, `cost_usd` when present,
   `agent_compute_time`) has `low ≤ high`.
+- [ ] **Per-stage cost coupling** — if **any**
+  `tokens_by_stage[].cost_usd` is present, the record's top-level `cost_usd`
+  must also be present (per-stage cost bands never appear on a cost-omitted
+  record). A record with **no** per-stage `cost_usd` sub-fields satisfies this
+  check vacuously — **old records and cost-omitted records are not rejected.**
+  This check does **not** mandate that a cost-present record carry per-stage
+  bands; it only forbids the incoherent inverse (a per-stage band with no
+  whole-record cost). Emitters SHOULD populate per-stage bands on cost-present
+  records, but a cost-present record without them remains valid for
+  backward-compatibility with S1-era records.
+- [ ] **Split-tier spread** — for **every present**
+  `tokens_by_stage[].cost_usd` whose `model_tier` is a **split tier**, the band
+  must have a **strictly-positive ordered spread**: `low < high` (strict, not
+  merely `low ≤ high`). A `model_tier` **is a split tier if and only if its
+  label contains a `/`** (after the join-key whitespace normalisation);
+  otherwise it is a single tier. A collapsed band (`low == high`) on a
+  split-tier stage fails this check. **Single-tier** stages are exempt (they
+  may carry `low == high`, governed only by "Ranges well-formed"). A record
+  with no per-stage `cost_usd` satisfies this check vacuously. (`model_tier` is a
+  **required** sub-field of every `tokens_by_stage[]` entry, so a cost-bearing
+  stage with an absent `model_tier` is a structural failure caught by the
+  field-required checks — not a vacuous pass on this line.) (The
+  cheaper-at-low / dearer-at-high pricing rationale lives in the split-tier
+  widening methodology above, **not** here — the only predicate this line tests
+  is `low < high`.) The split-tier trigger is a **closed rule**: `MODEL_ROUTING.md`
+  names exactly the single tiers `Most capable` and `Standard` (neither contains
+  `/`) plus the one complexity-dependent split `Standard / Capable`, so
+  "contains `/`" is a sound *total* classifier over every tier label the
+  reference admits — and emitters **MUST** write only those enumerated labels
+  into `model_tier` (the field is documented as a `string` for forward-
+  compatibility, but is not free-form), so the classifier's totality holds for
+  every conformant record.
 - [ ] **All four disclosure sections present** — Included, Excluded,
   Confidence rationale, Failure direction. A record missing any fails.
 - [ ] **Per-axis confidence within cap** — each present `confidence` axis
@@ -251,6 +380,38 @@ The checks a consuming command's Output Validation Checkpoint runs:
   not worth building", "budget does not justify the spend") can evade it.
   Its strength is "catches the common cases", not "independent of any
   agent's behaviour" — unlike the field-absence layer, which is structural.
+
+### Per-stage cost — what the validator CAN and CANNOT assert
+
+The per-stage `cost_usd` sub-field makes a split-tier band's **non-collapsed
+(strictly-spread)** shape record-internally checkable. This is a **floor**, not
+the full widening — state it plainly:
+
+- The validator **CAN** assert: (1) **presence/coupling** — a per-stage band
+  implies top-level cost; (2) `low ≤ high` on every present band; (3) a
+  **strictly-positive ordered spread** (`low < high`) on every present
+  **split-tier** band — i.e. that the band is **non-collapsed (strictly
+  spread)**. A `{ 99.0, 100.0 }` band still *passes* `low < high`, so the check
+  earns only the move from "any ordered band (including a collapsed `{x, x}`)"
+  to "a non-collapsed split-tier band". It does **not** earn "the band spans two
+  tiers": a non-collapsed band is necessary, but not sufficient, for a genuine
+  two-tier widening.
+- The validator **CANNOT** assert: that the band **spans two tiers** (a
+  `{ 99.0, 100.0 }` band passes the strict-spread check while bearing no
+  relationship to the two rates), that the absolute `low`/`high` **equal** the
+  specific `claude-sonnet-4`/`claude-opus-4` rates, nor that the spread's
+  magnitude is *correct* for those rates — all three require the snapshot, which
+  the record does not carry. That absolute-rate falsification is a **runtime,
+  snapshot-grounded check** and is **deferred to S3's Output Validation
+  Checkpoint** (which can read both the record and the snapshot), not this
+  format-only contract edit.
+
+**Option (a) — having the record carry the per-model rates it used so the check
+is fully self-contained — was rejected**: it adds data the merged emitter does
+not emit, which (i) breaks backward-compat against every record that lacks the
+new field and (ii) re-introduces a new required field. The chosen mechanism is
+the **record-internal spread invariant** above (option (b)) — the strongest
+invariant available without snapshot data.
 
 ## Worked examples
 
@@ -338,13 +499,16 @@ tokens_by_stage:
   - stage: spec-writer
     tokens: { low: 50000, high: 100000 }
     model_tier: Most capable
+    cost_usd: { low: 1.00, high: 2.00 }
   - stage: tdd-agent
     tokens: { low: 50000, high: 150000 }
     model_tier: Standard
+    cost_usd: { low: 0.20, high: 0.60 }
   - stage: implementer
     tokens: { low: 100000, high: 250000 }
     model_tier: Standard/Capable
-cost_usd: { low: 0.95, high: 7.50 }
+    cost_usd: { low: 0.40, high: 5.00 }
+cost_usd: { low: 1.60, high: 7.60 }
 cost_basis: snapshot-actuals
 agent_compute_time: { low: 20m, high: 2h30m }
 human_gate_time: "human-gate latency dominates total wall-clock and is not estimated numerically at S1; it depends on when a human next disposes a gate, not on the work."
@@ -362,11 +526,20 @@ tier, with token ranges from the Token Budget Guidance table.
 Agent-compute time derived from token volume via the ~1–3 min per 10k
 tokens band. The $/token rate is derived from the 2026-08-15 snapshot
 Model Breakdown (observed actuals): claude-sonnet-4 and claude-opus-4
-blended per-model rates. The implementer stage (Standard/Capable) is
-priced by widening across both ends of the split — its low bound uses the
-claude-sonnet-4 rate, its high bound uses the claude-opus-4 rate — so its
-$0.40–$5.00 cost band is visibly wider than its token-range spread alone
-would imply.
+blended per-model rates. Each stage's per-stage dollar contribution is
+surfaced as a `tokens_by_stage[].cost_usd` band (not only described): spec-writer
+$1.00–$2.00 (Most capable → claude-opus-4), tdd-agent $0.20–$0.60 (Standard →
+claude-sonnet-4), implementer $0.40–$5.00 (Standard/Capable, split). The
+implementer stage (Standard/Capable) is priced by widening across both ends of
+the split — its low bound uses the claude-sonnet-4 rate, its high bound uses the
+claude-opus-4 rate — so its $0.40–$5.00 cost band is visibly wider than its
+token-range spread alone would imply. The three per-stage bands sum to the
+whole-record $1.60–$7.60 cost band **here by construction** — this exact
+equality is a property of this worked example, **not** a contract rule: the
+"Ranges well-formed" correlation note above permits the whole-record band to
+differ from the per-stage sum (a record whose bands deliberately diverge is
+valid, provided its prose says why). Do not read this example as a must-sum
+mandate.
 
 ## Excluded
 

--- a/docs/superpowers/objections/format-revision-per-stage-cost-design-code.md
+++ b/docs/superpowers/objections/format-revision-per-stage-cost-design-code.md
@@ -1,0 +1,265 @@
+---
+spec: docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md
+date: 2026-06-11
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: medium
+    claim: "Example 2's whole-record `tokens` range and its `tokens_by_stage` sum are exactly equal, and (newly) its whole-record cost_usd is set exactly equal to the per-stage cost sum 'by construction' — so the sole canonical cost-present example demonstrates exact equality on every axis, which the reference's own correlation note explicitly disclaims as required, risking over-generalisation into a false must-sum mandate."
+    evidence: "estimate-record-format.md L491 `tokens: { low: 200000, high: 500000 }` equals the stage sum (L493-504); L79-83 says the whole-record band need NOT equal the sum and the prose explains only when they DIFFER — but Example 2 now shows equality on both tokens and cost simultaneously, with no differing-band example."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Add a one-line note to Example 2's prose: the whole-record
+      band equals the per-stage sum here by construction, and the correlation
+      note (§4.4) permits them to differ — so the example is not a must-sum
+      mandate.
+  - id: O2
+    category: implementation
+    severity: medium
+    claim: "The merged S2 agent names two different literal forms for the emitted split-tier `model_tier` value — `Standard / Capable` (spaced) and `Standard/Capable` (unspaced) — while the reference's binding table instructs emitting the literal `Standard/Capable`. The new Split-tier spread rule is robust (it whitespace-normalises before testing `/`), but the agent's emitted-value contract leaves the actual byte-string undefined, so an exact-string consumer of `model_tier` would diverge."
+    evidence: "cost-estimator.agent.md L146 `the split tier Standard / Capable` vs L162 `Standard/Capable split`; estimate-record-format.md L213-214 `records the literal split label (Standard/Capable)`."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted residual (out of #377's format-only scope — it touches
+      the merged S2 agent). The Split-tier spread rule normalises whitespace, so
+      conformance holds; the agent's two literal forms are a pre-existing S2 doc
+      inconsistency. Filed as a tiny follow-on issue to normalise the agent's
+      emitted `model_tier` literal; not fixed in this format slice.
+  - id: O3
+    category: risk
+    severity: medium
+    claim: "The Split-tier spread closed rule is proved total by 'no single tier label contains /', but the rule fires on the EMITTED `model_tier` value, and the reference types `model_tier` as an open `string` with no validation-checklist line constraining the emitted value to the enumerated binding-table labels — so the totality is closed by convention, not construction; a future emitter writing a free-form `model_tier` containing `/` would be silently misclassified as split-tier."
+    evidence: "estimate-record-format.md L341-345 grounds soundness in the labels MODEL_ROUTING.md admits; but L30 types `model_tier` as `string ... may be a split tier such as Standard/Capable`, and the validation checklist (L312-376) has no line restricting the emitted `model_tier` to the enumerated set."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Add a one-line note that the contains-`/` classifier is
+      total only over the binding-table labels, and emitters MUST write only those
+      enumerated labels into `model_tier` — making the convention explicit rather
+      than implied.
+  - id: O4
+    category: specification quality
+    severity: low
+    claim: "The Split-tier spread checklist line keys on a stage's `model_tier` being a split tier but does not state the verdict when a `tokens_by_stage[]` entry carries a per-stage cost_usd while its `model_tier` is absent — `model_tier` is required per the field table so a well-formed record cannot hit this, but the checklist line does not cross-reference that dependency, leaving an S3 author to decide in isolation."
+    evidence: "estimate-record-format.md L330-345 keys on `model_tier` being a split tier with no clause for an absent `model_tier`; the only guard is the separate required-ness of `model_tier` at L30, which the checklist line does not name."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Add a parenthetical to the Split-tier spread checklist line
+      cross-referencing that `model_tier` is a required sub-field, so an S3 author
+      implementing the line in isolation knows an absent `model_tier` is a
+      structural failure handled elsewhere, not a vacuous pass.
+  - id: O5
+    category: implementation
+    severity: low
+    claim: "Example 1 carries four stages (incl. code-reviewer) and Example 2 carries three (code-reviewer and integration dropped, named in Excluded), so the canonical demonstration of the new per-stage cost_usd sub-field lands on a different, smaller stage roster than the cost-omitted example — a reader cannot read the two as a clean before/after of the same record gaining bands."
+    evidence: "estimate-record-format.md Example 1 L426-438 (4 stages); Example 2 L492-504 (3 stages), L536-538 Excluded names code-reviewer and integration as not enumerated."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted residual (clarity, not correctness — both examples
+      validate). The differing rosters are acceptable for now; a future docs pass
+      could align them for a clean before/after, but it is not worth a format
+      churn in this slice.
+  - id: O6
+    category: risk
+    severity: low
+    claim: "The grounding-path consumer special-case (don't count a trailing-slash directory path as a grounding) is advisory/unenforced, and at code time the risk is the COMMON case not a tail: the directory-sentinel path is the day-one default the merged S2 agent emits on every record (empty observability/costs/), so a downstream counter that doesn't special-case the trailing slash miscounts 100% of today's records as snapshot-grounded."
+    evidence: "estimate-record-format.md L279-285 (special-case) + L296-301 ('advisory/unenforced ... silent-miscount risk'); cost-estimator.agent.md L282-284: the agent emits the directory path on the cost-omitted (today's only producible) record."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted residual. The miscount risk is consciously accepted
+      (the keep-the-directory-sentinel trade); the code-time sharpening — that it
+      is the 100%-of-records common case today, not a tail — is recorded here so
+      the S3 checkpoint author treats the trailing-slash special-case as
+      mandatory, not optional.
+---
+
+## O1 — specification quality — medium
+
+### Claim
+
+Example 2's whole-record `tokens` range and the arithmetic sum of its
+`tokens_by_stage[].tokens` are exactly equal, and (newly) its whole-record
+`cost_usd` is set exactly equal to the per-stage cost sum "by construction". The
+reference's explicit rule (L79-83) is that the whole-record band need **not** equal
+the sum, and the prose must explain only **when they differ**. Example 2 satisfies
+the rule vacuously, but it now demonstrates exact equality on **both** axes
+simultaneously, as the single canonical cost-present example. An author reading only
+the example — the reference instructs readers to parse, not read loosely — may
+over-generalise this into a false "per-stage bands must sum to the whole-record band"
+mandate, the rigidity the correlation note exists to prevent.
+
+### Evidence
+
+`estimate-record-format.md` L491 `tokens: { low: 200000, high: 500000 }`; stages
+(L493-504) sum to `{200000, 500000}`. Spec §4.5 step 4 sets the whole-record cost
+equal to the per-stage sum. The reference's own rule (L79-83): "The whole-record
+band need **not** equal the arithmetic sum ... When they differ the prose body says
+why."
+
+### Why this matters
+
+The single worked example is the most-copied surface of a contract. Demonstrating
+exact equality on every band, with no example of a deliberately-differing band and
+its prose justification, undercuts the correlation note's intent and invites a future
+emitter or S3 checkpoint to enforce a sum constraint the format explicitly disclaims.
+A one-line note in the Example 2 prose ("the whole-record band equals the sum here by
+construction; the correlation note permits them to differ") would close it.
+
+## O2 — implementation — medium
+
+### Claim
+
+The merged S2 agent must stay conformant to the edited reference, but the agent's own
+description of the value it emits into `tokens_by_stage[].model_tier` is internally
+ambiguous: `Standard / Capable` (spaced) at L146 and `Standard/Capable` (unspaced) at
+L162. The reference's binding table (L214) instructs emitting the literal
+`Standard/Capable`. The new Split-tier spread closed rule is robust to this (it
+whitespace-normalises before testing for `/`), but the agent's emitted-value contract
+does not pin which literal it writes.
+
+### Evidence
+
+`cost-estimator.agent.md` L146 "the split tier `Standard / Capable`" vs L162
+"`Standard/Capable` split". `estimate-record-format.md` L213-214: "records the literal
+split label (`Standard/Capable`)".
+
+### Why this matters
+
+A reference that calls `model_tier` "the literal split label" while its sole merged
+consumer names two different literals leaves the emitted byte-string undefined. The
+Split-tier rule absorbs it today, but any consumer doing an exact-string match on
+`model_tier` (not the normalised join key) would diverge by emitted form. This is a
+pre-existing S2 ambiguity the format edit did not introduce but now interacts with —
+worth a one-word S2 agent fix (pick the unspaced literal) or a noted residual, since a
+format-only slice should not silently depend on an ambiguous consumer.
+
+## O3 — risk — medium
+
+### Claim
+
+The Split-tier spread closed rule is proved total by "no single (non-split) tier label
+contains a `/`" (L341-345). That proof is over the labels `MODEL_ROUTING.md` admits,
+but the rule fires on the **emitted** `model_tier` value, and the reference does not
+constrain an emitter to write only binding-table labels into that field. The field-table
+type (L30) is `string ... may be a split tier`, descriptive rather than a closed enum,
+and no validation-checklist line restricts the emitted `model_tier`. A future emitter
+writing a free-form `model_tier` containing `/` for a non-split reason would be silently
+classified as split-tier and subjected to the strict `low < high` check it should not face.
+
+### Evidence
+
+`estimate-record-format.md` L341-345 grounds soundness in "`MODEL_ROUTING.md` names
+exactly the single tiers `Most capable` and `Standard` ... plus the one ... split". But
+L30 types `model_tier` as an open `string`, and the validation checklist (L312-376) has no
+line constraining the emitted `model_tier` to that enumerated set.
+
+### Why this matters
+
+A "closed rule" whose totality depends on a property of an unvalidated free-text field is
+closed only by convention. The slice markets the contains-`/` trigger as a sound total
+classifier; true for admitted labels, but the format does not enforce that emitters only
+produce admitted labels, so the guarantee is weaker than stated for any future
+non-conformant emitter. A one-line note ("the contains-`/` classifier is total only over
+the binding-table labels; emitters MUST write only those into `model_tier`") would make the
+convention explicit.
+
+## O4 — specification quality — low
+
+### Claim
+
+The Split-tier spread checklist line is keyed on a stage's `model_tier` being a split tier,
+but does not state the verdict when a `tokens_by_stage[]` entry carries a per-stage
+`cost_usd` while its `model_tier` is absent. Because `model_tier` is required per the field
+table, a well-formed record cannot hit this, but the checklist line does not cross-reference
+that dependency, so an S3 Output Validation Checkpoint author implementing the line in
+isolation must independently decide whether an absent `model_tier` is a vacuous pass or a
+structural fail.
+
+### Evidence
+
+`estimate-record-format.md` L330-345: the line tests "every present
+`tokens_by_stage[].cost_usd` whose `model_tier` is a split tier" with no clause for an
+absent `model_tier`; the only guard is the separate required-ness of `model_tier` at L30,
+which the checklist line does not name.
+
+### Why this matters
+
+The slice's deterministic-parse goal is that an S3 checkpoint author implements exactly one
+behaviour from the line as written. A dependency on a separate field's required-ness the line
+does not surface is a small residual ambiguity a careful author resolves and a careless one
+may not. A parenthetical "(`model_tier` is a required sub-field per §4.x)" closes it.
+
+## O5 — implementation — low
+
+### Claim
+
+The two worked examples model different stage rosters: Example 1 carries four stages
+(including code-reviewer at `Most capable`), Example 2 carries three (code-reviewer and
+integration dropped, named in Excluded). Each is internally consistent, but the canonical
+demonstration of the new per-stage `cost_usd` sub-field lands on a smaller, different stage
+set than the cost-omitted example, so a reader cannot read the two as a clean before/after
+of the same record gaining bands.
+
+### Evidence
+
+`estimate-record-format.md` Example 1 L426-438 (spec-writer, tdd-agent, implementer,
+code-reviewer); Example 2 L492-504 (spec-writer, tdd-agent, implementer only), L536-538
+Excluded names code-reviewer and integration as not enumerated.
+
+### Why this matters
+
+The clearest way to teach an optional additive sub-field is the same record with and without
+it. The differing rosters make the examples teach two things at once (stage selection AND
+per-stage cost), a minor clarity cost on the contract's most-read surface. Not a correctness
+defect — both examples validate.
+
+## O6 — risk — low
+
+### Claim
+
+The grounding-path consumer special-case (an aggregator must not count a trailing-slash
+directory path as a grounding) is advisory and unenforced, with no checklist line keying on
+`grounding_sources[].path` shape. At code time the risk is concrete and not a tail case: the
+directory-sentinel path is the day-one default the merged S2 agent emits on every record
+(empty `observability/costs/`), so every currently-producible record carries the overloaded
+`path`, and any downstream counter that does not special-case the trailing slash miscounts
+100% of today's records as snapshot-grounded.
+
+### Evidence
+
+`estimate-record-format.md` L279-285 (consumer special-case) and L296-301 ("advisory/
+unenforced ... externalises a silent-miscount risk"). `cost-estimator.agent.md` L282-284:
+the agent emits the directory path on the cost-omitted path, today's only producible record.
+
+### Why this matters
+
+The slice consciously accepts this residual, so it is recorded, not re-litigated. The
+code-time sharpening is that the overloaded path is the universal case today, not an edge
+case — so the first consumer to count groundings without reading the advisory note silently
+over-counts every record. The unenforced convention puts the full weight of correctness on
+each downstream author reading prose, with no structural backstop. Worth the human noting the
+risk is 100%-of-records, not a corner.
+
+## Explicitly not objecting to
+
+- **Version bump correctness**: `plugin.json` (0.43.0), `marketplace.json` (`plugin_version`
+  + entry 0.43.0, top-level `version` left at 0.4.0), `README.md` badge (v0.43.0), and the
+  `CHANGELOG.md` `## 0.43.0 — 2026-06-11` heading are mutually consistent and match the spec
+  §9 / CLAUDE.md minor-bump rule.
+- **Example 2 cost arithmetic**: every band re-derives exactly from the two fixed rates
+  (sonnet `4.0e-6`, opus `2.0e-5`) — `1.00/2.00`, `0.20/0.60`, `0.40/5.00`, summing to
+  `1.60/7.60` — and the split-tier implementer band has the required strict `0.40 < 5.00`
+  spread; the numbers are correct.
+- **The one-directional coupling vs `iff`**: the field table, §4.1 prose, the checklist
+  coupling line, and the backward-compat scenario all consistently state the asymmetric
+  (non-biconditional) coupling — the class-B hazard is genuinely closed in the implementation
+  text.
+- **S2 conformance on `generated_by` and grounding-path**: the merged agent emits
+  `cost-estimator / tier:Standard` and the directory path, both admitted by the widened
+  description and documented sentinel with zero agent change.
+- **The §4.4.1 CAN/CANNOT honesty note**: the reference states plainly that a `{99.0, 100.0}`
+  band passes and that absolute-rate falsification defers to S3 — the floor-not-full-widening
+  framing is accurate, not over-claimed.
+- **Out-of-scope deferrals**: the absence of the S3 command, S4 wiring, and the deferred
+  emitter enhancement (#380) is correct for a format-only slice.

--- a/docs/superpowers/objections/format-revision-per-stage-cost-design.md
+++ b/docs/superpowers/objections/format-revision-per-stage-cost-design.md
@@ -1,0 +1,319 @@
+---
+spec: docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md
+date: 2026-06-11
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: high
+    claim: "Example 2's per-stage bands are presented as a reproducible derivation from two representative-model rates, but they cannot be back-solved to two consistent per-model $/token rates: the spec-writer (opus) and tdd-agent (sonnet) bands imply per-token rates that disagree with the very sonnet/opus rates the implementer band defines, so the worked example demonstrates a number-fitting to the sum envelope, not a rate-grounded widening."
+    evidence: "§4.5 step 1 fixes sonnet=4.0e-6, opus=2.0e-5 from the implementer band. But spec-writer (Most capable/opus) implies 0.35/50000=7.0e-6 (low) and 1.50/100000=1.5e-5 (high) — neither equals opus 2.0e-5; tdd-agent (Standard/sonnet) implies 0.20/50000=4.0e-6 (low) and 1.00/150000=6.67e-6 (high) — the high exceeds sonnet 4.0e-6. The bands were allocated to hit {0.95,7.50} (§4.5 step 2), not computed from the two fixed rates."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Re-derive Example 2's three bands from two FIXED per-tier
+      rates: each single-tier stage = its tier's rate × its token range; the
+      split implementer = sonnet rate × low-tokens, opus rate × high-tokens. Let
+      the per-stage sums land where they land and set the whole-record cost_usd
+      to match (the correlation note permits ≠ envelope). The canonical example
+      must PASS the absolute-rate validator S3 is told to build.
+  - id: O2
+    category: implementation
+    severity: medium
+    claim: "The 'Split-tier spread' check relies on a validator knowing a stage's model_tier is a 'split tier' by matching a slashed label, but the field reference permits the split label to be written either 'Standard/Capable' or 'Standard / Capable' and the binding table names a tier ('Capable') that does not exist as a standalone model — a record-internal validator has no closed list of which slashed labels are split tiers, so the check's trigger condition is under-specified."
+    evidence: "§4.4 check keys on 'a slashed label such as Standard / Capable, normalised whitespace-insensitively per the join key'; reference line 30 writes the example label as 'Standard/Capable'; reference lines 148-151 state there is 'no standalone Capable tier'. The check names only one example split label, not an enumerated closed set the validator tests against."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. State the split-tier trigger as a CLOSED rule (a model_tier
+      is a split tier iff its label contains "/" after the join-key
+      normalisation; confirm no single-tier label contains a slash), not an
+      example.
+  - id: O3
+    category: specification quality
+    severity: medium
+    claim: "The §4.4.1 CAN/CANNOT note honestly disclaims absolute-rate checking, but §1, §2, FR-3b, and the story title still describe the deliverable as making 'the WIDENING machine-checkable', when the check delivered (a strictly-positive ordered spread) only proves the band is non-collapsed — a {0.01, 99.0} implementer band passes while bearing no relation to a genuine two-tier widening, so the headline framing still over-claims relative to what the check earns."
+    evidence: "§4.4 check-3 header: 'Split-tier spread (the O3 headline — makes the WIDENING, not just the band's presence, machine-checkable)'; FR-3b: 'the validator CAN assert a split-tier band spans two tiers'; §4.4.1 concedes the validator 'CANNOT assert ... the spread's magnitude is correct' and that a '{99.0,100.0} band still passes'. 'Spans two tiers' and 'passes any non-collapsed ordered band' are not the same claim."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Align FR-3b, the check-3 header, and the §11.1 story to
+      §4.4.1's honest floor: the validator asserts a "non-collapsed
+      (strictly-spread) split-tier band", NOT that it "spans two tiers" or makes
+      the widening fully "machine-checkable". Every surface agrees with §4.4.1.
+  - id: O4
+    category: specification quality
+    severity: low
+    claim: "The 'Split-tier spread' check states the band 'prices its low bound at the cheaper representative model and its high bound at the dearer one (per the binding table)', asserting a low=cheaper/high=dearer ordering the validator cannot actually verify from the record — the validator sees only two numbers and their order, never which end binds to which model, so the binding-table sentence describes an emitter convention but reads as if it were a checkable invariant."
+    evidence: "§4.4 check-3: 'A split-tier stage prices its low bound at the cheaper representative model and its high bound at the dearer one (per the binding table ...), so a genuine widening must produce a non-zero spread.' §4.4.1 confirms the validator CANNOT assert the bounds equal the rates — so 'cheaper at low, dearer at high' is unverifiable from the record alone."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. In the checklist line state ONLY what the check tests
+      (low < high on split-tier bands); move the cheaper-at-low/dearer-at-high
+      rationale into the methodology prose, where it is an emitter convention,
+      not a checked invariant.
+  - id: O5
+    category: risk
+    severity: low
+    claim: "The grounding-path consumer special-case ('an aggregator must not count a cost-snapshot entry whose path ends in / as a grounding') is documented prose with no validation-checklist enforcement, so the same closed-world-silence argument used to prove backward-compat also guarantees nothing ever catches an aggregator that ignores the special-case — the de-duplication rule is advisory only."
+    evidence: "§6.1 consumer special-case is stated in the grounding_sources description prose; §2.3 confirms 'no path-must-be-a-file check'; the validation checklist (§4.4) adds only the per-stage coupling and spread lines, none keying on grounding path shape. The trailing-slash convention is a parsing instruction, not an enforced check."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted residual. The trailing-slash consumer special-case
+      stays advisory (no checklist enforcement is added); record in the spec that
+      it externalises a silent-miscount risk onto downstream counters (S3 and any
+      cost aggregator), consistent with the deliberate keep-the-directory-sentinel
+      trade. No further change required in this slice.
+---
+
+## O1 — specification quality — high
+
+### Claim
+
+Example 2 is the single artefact that demonstrates the whole per-stage widening
+mechanism, and §4.5 presents its three bands as a "reproducible, not invented"
+derivation grounded in two representative-model `$/token` rates. But the three
+bands cannot be reproduced from two consistent per-model rates. They were
+back-solved to make the per-stage sums hit the whole-record envelope
+`{ 0.95, 7.50 }` exactly (§4.5 step 2), and the resulting per-token rates for the
+two single-tier stages contradict the sonnet/opus rates the implementer band
+defines. The worked example therefore demonstrates *arithmetic that sums*, not
+*a widening grounded in two snapshot rates* — which is the property the slice
+claims to make checkable.
+
+### Evidence
+
+§4.5 step 1 fixes the two rates from the implementer band:
+
+> cheaper-tier (sonnet) low bound `0.40 ÷ 100000 = 4.0e-6` $/token; dearer-tier
+> (opus) high bound `5.00 ÷ 250000 = 2.0e-5` $/token.
+
+Now apply those fixed rates to the other two stages' tiers:
+
+- **spec-writer** is `Most capable` → `claude-opus-4`, so every per-token figure
+  should be the opus rate `2.0e-5`. Its band `{0.35, 1.50}` over tokens
+  `{50000, 100000}` implies `0.35 ÷ 50000 = 7.0e-6` (low) and
+  `1.50 ÷ 100000 = 1.5e-5` (high). **Neither equals opus `2.0e-5`.**
+- **tdd-agent** is `Standard` → `claude-sonnet-4`, so every per-token figure
+  should be the sonnet rate `4.0e-6`. Its band `{0.20, 1.00}` over tokens
+  `{50000, 150000}` implies `0.20 ÷ 50000 = 4.0e-6` (low — matches) and
+  `1.00 ÷ 150000 = 6.67e-6` (high — **exceeds sonnet `4.0e-6`**).
+
+§4.5 step 3 ("Tier-ordering sanity") only checks that opus figures are *greater
+than* sonnet figures — which they are — but that is a far weaker property than
+"each stage's band is its tier's single rate applied to its token range." The
+spec's own §4.5 step 2 admits the construction: "allocated so the per-stage sums
+hit the whole-record envelope `{ 0.95, 7.50 }` exactly."
+
+### Why this matters
+
+The round-1 O3 disposition demanded the slice "deliver the S1-O6 checkability the
+slice exists for; do not settle for 'a place to put the band.'" The revision
+answered with a record-internal spread check (defensible) *and* a worked example
+billed as a reproducible derivation. But if Example 2 — the reference's own
+demonstration of a correctly-priced widening — does not itself hold to "one rate
+per tier applied to the token range," then a future S3 author who builds the
+absolute-rate validator (the half deferred to S3 per §4.4.1) will find the
+reference's canonical cost-present example *fails* that validator: spec-writer's
+opus stage prices below the opus rate the same example declares. The example
+that teaches the widening cannot be the example that breaks the deferred check.
+Either the bands must be re-derived from two fixed per-tier rates (accepting the
+sum will not land on `{0.95, 7.50}` exactly, which the correlation note already
+permits), or §4.5 must stop calling the bands a rate-grounded derivation and
+admit they are an envelope-fit chosen for arithmetic tidiness.
+
+## O2 — implementation — medium
+
+### Claim
+
+The "Split-tier spread" check fires only on stages whose `model_tier` "is a split
+tier (a slashed label)". For a record-internal validator to apply the check, it
+must decide *which* labels are split tiers. The reference gives it only one
+example label and a normalisation rule, not a closed set — and the one split tier
+that exists names a phantom tier (`Capable`) with no standalone model. A validator
+cannot reliably distinguish "a split tier that must have a strict spread" from "a
+single tier that may collapse" without an enumerated list the reference does not
+provide.
+
+### Evidence
+
+The check (§4.4, check-3):
+
+> for **every present** `tokens_by_stage[].cost_usd` whose `model_tier` is a
+> **split tier** (a slashed label such as `Standard / Capable`, normalised
+> whitespace-insensitively per the join key) ...
+
+The reference writes the label two ways — `Standard/Capable` (line 30, field
+table) and `Standard / Capable` (line 146, binding table) — and states (lines
+148-151) that `MODEL_ROUTING.md` "names exactly two tiers ... and one
+complexity-dependent split" with "**no** standalone `Capable` tier." So "is it a
+split tier?" reduces to "does the label contain a slash?" — but that heuristic is
+asserted nowhere as the closed rule; the check says "such as," which is an example,
+not a definition.
+
+### Why this matters
+
+The whole point of FR-3b is that a *collapsed* split-tier band fails while a
+single-tier band may collapse. That distinction is only as strong as the
+validator's ability to classify a label as split-or-not. If the trigger is "label
+contains `/`," the spec should say so as a closed rule (and confirm no single
+tier ever contains a slash); if it is "label appears in an enumerated split-tier
+set," the set must be named. As written, the check's firing condition is an
+example, which is exactly the kind of ambiguity that yields divergent validators
+— one treating any slashed label as split, another requiring an exact match
+against `Standard / Capable`.
+
+## O3 — specification quality — medium
+
+### Claim
+
+§4.4.1 is an honest CAN/CANNOT note, and it materially narrows the over-claim
+that round-1 O3 flagged. But the *headline framing* the note is meant to discipline
+still survives intact elsewhere: §4.4's check-3 header, FR-3b, and the §11.1 story
+all describe the deliverable as making "the WIDENING machine-checkable" and the
+validator able to assert a band "spans two tiers." The check actually delivered
+proves only that the band is *not collapsed*. The note rescues the honesty locally
+while the load-bearing section headers still say more than the check earns.
+
+### Evidence
+
+§4.4 check-3 header:
+
+> **Add one new check line — "Split-tier spread" (the O3 headline — makes the
+> WIDENING, not just the band's presence, machine-checkable)**
+
+FR-3b: "the validator CAN assert a split-tier band spans two tiers (positive
+ordered spread, cheaper at low per the binding table)".
+
+§4.4.1 then concedes the limit:
+
+> A `{ 99.0, 100.0 }` band still *passes* `low < high` ... The validator
+> **CANNOT** assert ... the spread's magnitude is *correct*.
+
+"Spans two tiers" (FR-3b) and "passes for any non-collapsed ordered band, including
+`{99.0, 100.0}`" (§4.4.1) are not the same claim. The first implies a relationship
+to the two rates; the second is satisfied by any two distinct ascending numbers.
+
+### Why this matters
+
+This is the precise crux the round-1 disposition asked to be judged: did the slice
+"quietly redefine machine-checkable widening down to non-collapsed band"? §4.4.1
+answers honestly in one place — but a reader who reads §1, §2, the FR list, or the
+user story (the surfaces most likely to be quoted downstream) still comes away
+with "the widening is machine-checkable." The fix is small: make the FR-3b and
+check-3 language say "a non-collapsed (strictly-spread) split-tier band" rather
+than "spans two tiers," so every surface agrees with §4.4.1's honest floor. Left
+as-is, the slice's own summary sections re-introduce the over-claim §4.4.1 was
+written to retire.
+
+## O4 — specification quality — low
+
+### Claim
+
+The "Split-tier spread" check sentence asserts the band "prices its low bound at
+the cheaper representative model and its high bound at the dearer one (per the
+binding table)." Read as part of a *validation* check, this implies the validator
+verifies low-binds-to-cheaper / high-binds-to-dearer. It cannot: the validator
+sees two numbers and their order, never which end was priced by which model.
+§4.4.1 correctly says so, but the check line itself reads as if the ordering were
+a checked invariant rather than an emitter convention the check cannot confirm.
+
+### Evidence
+
+§4.4 check-3:
+
+> A split-tier stage prices its low bound at the **cheaper** representative model
+> and its high bound at the **dearer** one (per the binding table — for
+> `Standard / Capable`, `claude-sonnet-4` is the cheaper tier and `claude-opus-4`
+> the dearer), so a genuine widening **must** produce a non-zero spread.
+
+§4.4.1, by contrast:
+
+> The validator **CANNOT** assert: that the absolute `low`/`high` **equal** the
+> specific `claude-sonnet-4`/`claude-opus-4` rates.
+
+If the validator cannot tie either bound to a model rate, it equally cannot
+confirm "cheaper at low, dearer at high" — that ordering is unverifiable from the
+record. The only thing the check verifies is `low < high`.
+
+### Why this matters
+
+This is low severity because §4.4.1 states the true boundary plainly, so a careful
+reader is not misled. But the check-line prose mixes an emitter-side convention
+("price low at the cheaper model") into the *checklist*, which is the section the
+reference explicitly says is "parsed, not read loosely" (reference line 10). A
+checklist line that describes behaviour the check does not perform invites a future
+maintainer to "complete" it into the absolute-rate check §4.4.1 deliberately
+defers to S3. Cleanest to state in the check line only what the check tests
+(`low < high` on split-tier bands) and relocate the cheaper/dearer rationale to
+the methodology prose, where it is a convention, not a check.
+
+## O5 — risk — low
+
+### Claim
+
+The grounding-path resolution leans on a consumer special-case — an aggregator
+"must not count a `cost-snapshot` entry whose `path` ends in `/` as a grounding" —
+that lives entirely in description prose with no checklist enforcement. The same
+closed-world-silence property the spec uses to prove backward-compatibility also
+guarantees that nothing ever detects a consumer that ignores the special-case.
+The de-duplication rule is therefore advisory, and a non-conforming aggregator
+silently miscounts non-groundings as groundings with no validation signal.
+
+### Evidence
+
+§6.1 consumer special-case:
+
+> an aggregator that counts "how many records were grounded in a cost snapshot"
+> **must not** count a `cost-snapshot` entry whose `path` ends in `/` as a
+> grounding.
+
+§2.3 confirms the slice adds "no ... `path`-must-be-a-file check," and the
+validation-checklist edits (§4.4) add only the per-stage coupling and spread
+lines. No check keys on `grounding_sources[].path` shape. The special-case is a
+parsing instruction to future consumers, not an enforced invariant.
+
+### Why this matters
+
+This is low severity and largely unavoidable given the deliberate (and correct)
+choice to keep the directory-path sentinel rather than invent a new token —
+O5/round-1 already accepted that trade and the spec now names the entrenchment
+honestly. The residual note is that the *cost* of the entrenchment (every
+snapshot-counting consumer must implement the trailing-slash special-case, with
+nothing to catch one that does not) is borne by consumers the slice does not
+control, including the S3 checkpoint and any future cost aggregator. Worth the
+human noting that "named and accepted" entrenchment still externalises a silent
+miscount risk onto every downstream counter, since this is the kind of overloaded
+field a later reader will mis-handle precisely because no check guards it.
+
+## Explicitly not objecting to
+
+- **O1/round-1 (the `iff`) — confirmed resolved.** §4.1 removes `iff` from the
+  field table and states the one-directional asymmetry there (sub-field present ⟹
+  top-level cost present; reverse is an emitter SHOULD), and FR-1 matches; a literal
+  reader can no longer tighten it into the class-B-breaking mandate.
+- **O2/round-1 (under-specified Example 2) — confirmed resolved.** §4.5 now fixes
+  all three bands concretely; the values are no longer discretionary (my O1 above
+  challenges their *derivation*, not their *presence*).
+- **The sum arithmetic — confirmed correct.** Low `0.35+0.20+0.40 = 0.95` and high
+  `1.50+1.00+5.00 = 7.50` both equal the whole-record `{0.95, 7.50}` exactly, every
+  band has `low ≤ high`, and the implementer split-tier band satisfies the strict
+  spread (`0.40 < 5.00`); I do not challenge the envelope math, only what it claims
+  to ground (O1).
+- **O4/round-1 (SHOULD falsifiable home) — confirmed resolved.** §4.3.1 gives the
+  SHOULD a falsifiable home (the deferred §12 emitter issue's acceptance criterion)
+  and an honest scope note; it is now distinguishable from a MAY.
+- **O5/round-1 (entrenchment named) — confirmed resolved.** §6.1 explicitly states
+  the directory sentinel "entrenches an overloaded meaning, deliberately" rather
+  than claiming the tension is resolved (my O5 above only flags that the
+  special-case is unenforced).
+- **O6/round-1 (`tier:` reserved prefix) — confirmed resolved.** §5.1 defines
+  `tier:` as a reserved provenance prefix giving consumers a total mechanical
+  discriminator without a rejecting check; the parse ambiguity is closed.
+- **O7/round-1 (delivered-vs-deferred honesty) — confirmed resolved.** §8 cleanly
+  separates what structural inspection delivers from what an actual parser run
+  would falsify (deferred to S3); "demonstrated" is no longer over-claimed.
+- **O8/round-1 (inverse-rejection scope note) — confirmed resolved.** §4.3.2
+  records that the inverse-rejection rule guards a not-yet-producible shape and is
+  kept as a cheap guard rail for S3-era emitters.
+- **The decision to defer absolute-rate checking to S3 (§4.4.1)** and **no S2 agent
+  change in this slice (§7)** — both the correct decomposition, unchanged from
+  round 1.

--- a/docs/superpowers/plans/2026-06-11-format-revision-per-stage-cost.md
+++ b/docs/superpowers/plans/2026-06-11-format-revision-per-stage-cost.md
@@ -1,0 +1,491 @@
+# Cost Estimation — format-revision slice — per-stage `cost_usd`, `generated_by` wording, grounding-path convention — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the three deferred format concerns against the estimate-record
+format reference this slice **owns** — add an optional, **one-directionally
+coupled** per-stage `tokens_by_stage[].cost_usd` sub-field with a **split-tier
+spread check** (making a split-tier band's NON-COLLAPSED, strictly-spread shape
+record-internally checkable — `low < high`; NOT the full widening, whose
+absolute-rate check is deferred to S3), widen the `generated_by` field description
+to admit a `tier:<tier>`
+label with **`tier:` as a reserved prefix**, and document the directory
+grounding-path (`observability/costs/`) as the named cost-omitted sentinel (an
+**entrenched** overloaded meaning with a consumer special-case, honestly stated)
+— with each change **demonstrated** backward-compatible against the closed-world
+validation checklist. Plugin version bumps `0.42.0 → 0.43.0`.
+
+**This is a format-revision slice, not a carpaccio slice.** It is a scoped residue
+of S2's diaboli, deliberately split out so the contract mutation gets its own
+adversarial pass with the backward-compat claim *demonstrated, not asserted*. It
+ships **format-only** changes: the reference, its TDAD scenarios, and the version
+tail. **No S3 command, no S4 orchestrator wiring, no S6 calibration.**
+
+**No S2 agent change ships.** All three resolutions widen / document the format to
+**admit the merged S2 agent's existing output** (cost-omitted shape, `tier:Standard`
+provenance, directory grounding-path), so the merged agent stays conformant with
+zero edits. The follow-on emitter enhancement (populate per-stage bands on
+cost-present records) is named and deferred to a standalone issue, not shipped.
+
+**Architecture:** A single canonical reference edit (the
+`skills/<name>/references/<contract>.md` idiom per AGENTS.md). The reference is
+referenced by path by its consumers (the merged S2 agent, the future S3
+checkpoint); editing it in one place propagates. The validation checklist and the
+worked examples both live in the reference and **must stay mutually consistent** —
+the new checklist line and Example 2's per-stage bands are edited in the same
+change.
+
+**Tech Stack:** Markdown + JSON. No new dependencies, no code, no runtime validator.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md`
+
+---
+
+## Modules / files touched
+
+```
+ai-literacy-superpowers/
+├── .claude-plugin/plugin.json                              # MODIFIED: 0.42.0 → 0.43.0
+└── skills/cost-estimation/references/
+    └── estimate-record-format.md                           # MODIFIED — this slice OWNS it:
+                                                             #   + tokens_by_stage[].cost_usd sub-field (field table, one-directional coupling, NOT iff)
+                                                             #   + "Per-stage cost coupling" + "Split-tier spread" checklist lines + Ranges-well-formed enum
+                                                             #   + §4.4.1 "what the validator CAN/CANNOT assert" note (record-internal spread, not absolute rates)
+                                                             #   + Example 2 per-stage cost_usd bands {1.00,2.00}/{0.20,0.60}/{0.40,5.00} (re-derived from sonnet 4.0e-6, opus 2.0e-5 $/token); whole-record cost_usd → {1.60,7.60}; Example 1 UNCHANGED
+                                                             #   ~ generated_by description widened (admits tier:<tier>; tier: = reserved prefix)
+                                                             #   ~ grounding_sources / three-grounding-states: directory-path sentinel documented
+                                                             #     (entrenchment named + consumer special-case: don't count trailing-slash dir as a grounding)
+#   NOTE: agents/cost-estimator.agent.md is NOT touched — the format is widened to
+#   admit its existing output; no S2 agent change ships (spec §7, FR-11).
+
+CHANGELOG.md                                                 # MODIFIED: new 0.43.0 entry (repo root, not under the plugin dir)
+
+tdad_tests/scenarios/skills/cost-estimation/
+├── format-and-contract.md                                  # MODIFIED — extend Then: sub-field in field table; new checklist line;
+│                                                            #   Example 2 per-stage bands; generated_by tier form; grounding-path sentinel
+├── cost-conditional.md                                     # MODIFIED — extend Then: cost-omitted shape carries NO per-stage band;
+│                                                            #   directory-path sentinel is the documented cost-omitted convention
+└── per-stage-cost-backward-compat.md                       # NEW — structural; the backward-compat invariant (four record classes
+                                                             #   accepted, incoherent inverse rejected; no generated_by-shape check;
+                                                             #   no path-must-be-a-file check)
+
+.claude-plugin/marketplace.json                              # MODIFIED: entry version + plugin_version 0.42.0 → 0.43.0
+README.md                                                    # MODIFIED: plugin badge 0.42.0 → 0.43.0
+```
+
+Top-level marketplace `version` stays at `0.4.0`. No agent, command, or
+orchestrator file touched. No docs-site page change is required (the reference
+content is the contract; the explanation page authored in S2 still describes the
+emitter accurately — confirm at Task 5, add a note only if it references the old
+`generated_by` wording).
+
+---
+
+## Algorithm / key decisions (not pseudocode)
+
+- **Owner edits the contract (legitimate).** Unlike S2 (a pure consumer forbidden
+  from mutating the reference), this slice OWNS
+  `estimate-record-format.md` and edits it deliberately. The edits are minimal and
+  backward-safe by construction (spec §2.3): one optional, one-directionally
+  coupled sub-field (present ⟹ top-level cost present; NOT an `iff`), one
+  description widening, one documentation note — no new required field, no new
+  grounding state, no new shape-check.
+- **Per-stage `cost_usd` — optional, ONE-DIRECTIONALLY coupled to top-level cost
+  (NOT an `iff`).** Sub-field present ⟹ top-level `cost_usd` present (enforced);
+  top-level present ⟹ bands SHOULD be populated by emitters but their absence does
+  NOT invalidate the record. **State this asymmetry in the field table itself** —
+  the prior draft's `iff` (a biconditional) was the O1 trap a literal reader would
+  tighten into a class-B-breaking mandate. The field table and the §4.4 check must
+  say the same thing. The whole-record band need not equal the per-stage sum
+  (existing correlation note) (spec §4.1, O1).
+- **The forward-optional checklist semantics (load-bearing — the class-B trap).**
+  The "Per-stage cost coupling" check keys on the **presence of the sub-field**,
+  NOT on the presence of top-level cost: sub-field present + no top-level cost →
+  FAIL; sub-field present + top-level cost → check `low ≤ high`; sub-field absent →
+  check does not fire (PASS). This keeps an S1-era cost-present record WITHOUT
+  per-stage bands (class B) valid. The check must **NOT** be a biconditional
+  ("top-level cost present ⟺ every stage has a band") — that would reject class B
+  (spec §4.3).
+- **The "Split-tier spread" check — asserts a NON-COLLAPSED (strictly-spread)
+  split-tier band, NOT that it spans two tiers (O3 honest floor).** Add a SECOND new
+  checklist line: for every present per-stage `cost_usd` whose `model_tier` is a
+  **split tier**, require a **strictly-positive ordered spread** (`low < high`,
+  strict). A collapsed band (`low == high`) on a split-tier stage FAILS. Single-tier
+  stages are exempt (governed only by Ranges-well-formed). **The split-tier trigger
+  is a CLOSED rule (O2): a `model_tier` is a split tier IFF its label contains a `/`
+  (after the join-key whitespace normalisation), and no single (non-split) tier
+  label contains a slash (`Most capable`, `Standard` — neither does), so "contains
+  `/`" is a sound TOTAL classifier — not an example.** The checklist line states
+  ONLY the testable predicate (`low < high` on present split-tier bands); the
+  cheaper-at-low / dearer-at-high ordering is an **emitter convention** that lives
+  in the methodology prose, NOT the checklist (O4 — the validator cannot confirm
+  which bound binds to which model from the record alone). **The snapshot-dependency
+  was resolved by choosing a record-internal invariant, NOT by exposing per-model
+  rates in the record (option (a) rejected — it would add data the merged S2 agent
+  does not emit, breaking backward-compat).** State plainly in a §4.4.1 note what the
+  validator CAN assert (presence/coupling; `low ≤ high`; a non-collapsed / strictly-
+  spread split-tier band) and CANNOT (that the band SPANS TWO TIERS — a `{99.0,100.0}`
+  band passes — nor that the bounds equal the absolute claude-sonnet-4/claude-opus-4
+  rates; that snapshot-grounded check is S3's) (spec §4.4, §4.4.1, O2, O3, O4).
+- **The SHOULD-populate obligation has a falsifiable home (O4).** Keep the SHOULD
+  distinct from the rejection rule, AND give it a falsifiable home: it is an
+  acceptance criterion on the deferred follow-on emitter issue (§12). Honestly
+  scope it within this slice as "the format admits the band; no producer yet
+  populates it" — not indistinguishable from MAY (spec §4.3.1).
+- **The inverse-rejection check guards a not-yet-producible shape (O8).** Keep the
+  inverse-rejection rule but record in the reference/spec that no current emitter
+  can produce the inverse (the merged S2 agent emits only cost-omitted records); it
+  is a cheap guard rail for S3-era emitters (spec §4.3.2).
+- **Ranges-well-formed enum extension is guarded by "present".** Add
+  `each tokens_by_stage[].cost_usd when present` to the existing enumeration; the
+  "every **present** range" guard means an absent sub-field is never checked
+  (classes A/B/C unaffected) (spec §4.4).
+- **Example 2 — three CONCRETE per-stage bands, RE-DERIVED from two fixed per-tier
+  rates (O1).** Fix two rates: **sonnet (cheaper) = `4.0e-6` $/token**, **opus
+  (dearer) = `2.0e-5` $/token** (5× sonnet, consistent with the binding table).
+  Every band is a rate × a token bound — nothing is allocated to a sum envelope.
+  Single-tier stages use one rate at both bounds; the split-tier implementer widens
+  from the cheaper rate at low to the dearer rate at high:
+  - spec-writer (opus, 50k–100k): `2.0e-5 × 50000 = 1.00` … `2.0e-5 × 100000 = 2.00`
+    → `{ 1.00, 2.00 }`.
+  - tdd-agent (sonnet, 50k–150k): `4.0e-6 × 50000 = 0.20` … `4.0e-6 × 150000 = 0.60`
+    → `{ 0.20, 0.60 }`.
+  - implementer (split, 100k–250k): `4.0e-6 × 100000 = 0.40` (cheaper rate, low) …
+    `2.0e-5 × 250000 = 5.00` (dearer rate, high) → `{ 0.40, 5.00 }` (matches the
+    Included prose `$0.40–$5.00`).
+
+  **Whole-record `cost_usd` = the per-stage sum, set equal by construction:** low
+  `1.00+0.20+0.40 = 1.60`; high `2.00+0.60+5.00 = 7.60` → `{ 1.60, 7.60 }` (replaces
+  the old `{ 0.95, 7.50 }`). Each single-tier band's low and high equal its tier-rate
+  × the respective token bound (so the band would PASS an absolute-rate check); the
+  split-tier implementer band has a strictly-positive spread (`0.40 < 5.00`). Update
+  the Included prose's whole-record dollar figure to `$1.60–$7.60`. Example 1 is
+  UNCHANGED (spec §4.5).
+- **`generated_by` — description widening + `tier:` reserved prefix, no rejecting
+  check (O6).** Admit a concrete model id OR a `tier:<tier>` label; define `tier:`
+  as a **reserved provenance prefix** so a consumer can mechanically distinguish a
+  tier label from a model id (a concrete model id never begins with `tier:`)
+  WITHOUT a rejecting check. State the value is never a guessed/hard-coded model.
+  Add **no** `generated_by`-shape checklist line (a shape-check could retroactively
+  fail a record; the prefix grammar closes the ambiguity without a check) (spec §5,
+  O6).
+- **Grounding-path — document the directory sentinel, name the entrenchment, no
+  path-shape check (O5).** Keep `observability/costs/` (trailing slash) as the named
+  cost-omitted sentinel; state-3 uses the snapshot file path. **Acknowledge this
+  ENTRENCHES an overloaded meaning (file = grounded; trailing-slash directory =
+  looked-and-found-nothing) rather than resolving the tension, and add a consumer
+  special-case note** (an aggregator must not count a trailing-slash directory path
+  as a grounding). Add **no** `path`-must-be-a-file check (it would retroactively
+  fail Example 1 and the merged S2 default record). **Record the O5 noted residual:**
+  the special-case is advisory/unenforced (no checklist line keys on path shape), so
+  it externalises a silent-miscount risk onto downstream counters (S3, any
+  aggregator) — an accepted residual, not a deferred fix (spec §6.1, O5).
+- **Closed-world property is the backward-compat lever.** Every demonstration
+  turns on the checklist being a closed enumeration: it rejects only on a named
+  check failing, never for an un-named field. A new optional field is invisible to
+  every check that does not name it; the one new check that names it passes on its
+  absence (spec §3).
+- **No S2 agent change (spec §7, FR-11).** The format is widened to admit the
+  merged agent's output. The follow-on emitter enhancement (per-stage bands on
+  cost-present records) is named and deferred to a standalone issue filed at
+  adjudication — not shipped, not orphaned.
+- **Structural TDAD only.** No dispatchable side-effect ships (the agent is
+  unchanged; the S3 checkpoint is out of scope), so Layer 1 structural is the
+  whole test surface — same posture as the S1 `format-and-contract` scenario
+  (spec §8).
+
+---
+
+## FR mapping table
+
+| FR | Requirement (abbrev) | Covering test case(s) |
+| --- | --- | --- |
+| FR-1 | `tokens_by_stage[].cost_usd` optional `{low,high}`, ONE-DIRECTIONAL coupling stated in field table (NOT iff) | `format-and-contract.md` (extended) |
+| FR-2 | Sub-field named in "every present range has low≤high" enum (present-guarded) | `format-and-contract.md` (extended) |
+| FR-3 | "Per-stage cost coupling" line: fails inverse, passes vacuously, does NOT mandate bands on cost-present | `format-and-contract.md` (extended) + `per-stage-cost-backward-compat.md` (new) |
+| FR-3b | "Split-tier spread" line: split-tier band needs strictly-positive spread (low<high); rejects collapsed band; closed trigger rule (split tier IFF label contains `/`); asserts NON-COLLAPSED band NOT "spans two tiers"; cheaper-at-low/dearer-at-high is emitter convention in prose not checklist; §4.4.1 CAN/CANNOT note | `format-and-contract.md` (extended) + `per-stage-cost-backward-compat.md` (new) |
+| FR-4 | Example 2 three concrete bands {1.00,2.00}/{0.20,0.60}/{0.40,5.00}, re-derived from two fixed per-tier rates, sum to whole-record {1.60,7.60}; each single-tier band = tier-rate × token bound; implementer split-tier spread matches prose | `format-and-contract.md` (extended) |
+| FR-5 | Example 1 carries NO per-stage band, stays valid (class A/C) | `cost-conditional.md` (extended) + `per-stage-cost-backward-compat.md` (new) |
+| FR-6 | Backward-compat invariant demonstrated: 4 classes valid, inverse rejected | `per-stage-cost-backward-compat.md` (new) |
+| FR-7 | `generated_by` description admits model id OR `tier:<tier>`; defines `tier:` reserved prefix (mechanical distinction, no rejecting check); never guessed model | `format-and-contract.md` (extended) |
+| FR-8 | No `generated_by`-shape checklist line (no retroactive rejection) | `per-stage-cost-backward-compat.md` (new) |
+| FR-9 | Directory path documented as cost-omitted sentinel; never dropped/fabricated; state-3 uses file | `format-and-contract.md` (extended) + `cost-conditional.md` (extended) |
+| FR-10 | No `path`-must-be-a-file checklist line (directory path stays valid) | `per-stage-cost-backward-compat.md` (new) |
+| FR-11 | No S2 agent change; merged agent records conformant; follow-on named + deferred | (no scenario — verified by absence of any S2 edit in module-touch list at PR time) |
+| FR-12 | Version bump 0.42.0 → 0.43.0 across four locations; checklist ↔ examples consistent | local version-consistency check (Task 4) |
+
+---
+
+## Test case list
+
+(In the same form as the existing TDAD skill scenario corpus — `Given/When/Then`
+markdown scenarios under `tdad_tests/scenarios/skills/cost-estimation/`, all
+Layer 1 structural ($0, every PR). Two existing scenarios extended, one new
+scenario. No scenario deleted.)
+
+- `format-and-contract.md` (tier: structural, EXTENDED) — in addition to its
+  current S1 assertions, the `Then` now asserts: the field table defines
+  `tokens_by_stage[].cost_usd` as optional with a ONE-DIRECTIONAL coupling stated
+  in the table (sub-field present ⟹ top-level cost present; reverse is an emitter
+  SHOULD, NOT an `iff`); the "every present range has `low ≤ high`" enumeration
+  names the per-stage sub-field; the validation checklist carries the "Per-stage
+  cost coupling" AND "Split-tier spread" lines with their backward-safe wording
+  (coupling fails the inverse, passes vacuously, does not mandate bands on
+  cost-present; spread requires `low < high` on split-tier stages, with the split
+  trigger a CLOSED rule — split tier IFF label contains `/`); a §4.4.1-style note
+  states the validator CAN assert the split-tier band is NON-COLLAPSED (strictly
+  spread) but CANNOT assert it spans two tiers nor the absolute snapshot rates, and
+  the cheaper-at-low/dearer-at-high ordering is an emitter convention in the prose,
+  not the checklist; Example 2 carries the three concrete bands (spec-writer
+  `{1.00,2.00}`, tdd-agent `{0.20,0.60}`, implementer `{0.40,5.00}`), each a fixed
+  tier-rate × token bound, summing to the whole-record `{1.60,7.60}`, with the
+  split-tier implementer band showing a strictly-positive spread and matching the
+  Included prose; Example 1 carries no per-stage band; the
+  `generated_by` description admits the `tier:<tier>` form, defines `tier:` as a
+  reserved prefix, and forbids a guessed model; the grounding-path directory
+  sentinel (with its entrenchment note and consumer special-case) is documented.
+- `cost-conditional.md` (tier: structural, EXTENDED) — in addition to its current
+  three-grounding-states assertions, the `Then` now asserts: the cost-omitted
+  worked example (and the cost-omitted shape generally) carries NO
+  `tokens_by_stage[].cost_usd` sub-field; the cost-snapshot grounding entry's
+  directory path `observability/costs/` is the documented cost-omitted sentinel
+  (present, never dropped, never a fabricated file path), with the consumer
+  special-case note (an aggregator must not count the trailing-slash directory as a
+  grounding).
+- `per-stage-cost-backward-compat.md` (tier: structural, NEW) — a STRUCTURAL
+  scenario (asserts the checklist TEXT and the four-class argument a human traces,
+  NOT the output of a parser actually run — that runtime falsification is S3's).
+  Reads the edited reference's validation checklist as a closed-world parser and
+  asserts: an old cost-omitted record (no top-level cost, no per-stage band) is
+  VALID; an old cost-present record with top-level cost but NO per-stage bands is
+  VALID (the coupling check does not mandate the sub-field); a new cost-omitted
+  record is VALID; a new cost-present record with per-stage bands on every stage is
+  VALID; a record with a per-stage `cost_usd` and NO top-level `cost_usd` is
+  REJECTED (the incoherent inverse — a not-yet-producible shape, a guard rail for
+  S3-era emitters); a record whose split-tier stage carries a collapsed band
+  (`low == high`) is REJECTED by "Split-tier spread"; no checklist line keys on
+  `generated_by` shape; no checklist line requires `grounding_sources[].path` to be
+  a file. This is the load-bearing backward-compat invariant in its own falsifiable
+  scenario.
+
+---
+
+## Phase 1 — The format reference edit
+
+### Task 1: Edit `estimate-record-format.md` (this slice owns it)
+
+- [ ] **Field table** — add a row (or a sub-row note under `tokens_by_stage`) for
+  `tokens_by_stage[].cost_usd`: type `range object { low, high }`, required
+  **optional, one-directionally coupled — sub-field present ⟹ top-level `cost_usd`
+  present (enforced); top-level present ⟹ bands SHOULD be populated but absence
+  does NOT invalidate**. **Do NOT use the word `iff`** — state the asymmetry in the
+  field table (the iff-removal fix). Purpose: "per-stage dollar contribution; a
+  record-internal spread check on split-tier bands (asserts a non-collapsed,
+  strictly-spread band — `low < high`; cannot assert the absolute snapshot rates)"
+  (spec §4.1, FR-1).
+- [ ] **Range representation section** — add `each tokens_by_stage[].cost_usd
+  (when present)` to the list of present quantitative ranges that must have
+  `low ≤ high` (spec §4.4, FR-2).
+- [ ] **Validation checklist** — extend the "Ranges well-formed" line to name the
+  per-stage sub-field "when present"; add a **"Per-stage cost coupling"** line
+  immediately after the existing "Cost pairing" line (fails an inverse record,
+  passes vacuously on absence, does NOT mandate per-stage bands on a cost-present
+  record; emitters SHOULD populate them); add a **"Split-tier spread"** line
+  requiring a strictly-positive ordered spread (`low < high`) on every present
+  split-tier band, rejecting a collapsed band, single-tier stages exempt, vacuous on
+  absence. **State the split-tier trigger as a CLOSED rule (O2): a `model_tier` is a
+  split tier IFF its label contains a `/` (after the join-key whitespace
+  normalisation); confirm in prose that no single tier label contains a slash, so
+  "contains `/`" is a total classifier — not an example.** **The checklist line
+  states ONLY the testable predicate (`low < high`); the cheaper-at-low /
+  dearer-at-high ordering moves to the methodology prose as an emitter convention,
+  NOT the checklist (O4).** Exact wording per spec §4.4 (spec §4.4, FR-3, FR-3b, O2,
+  O4).
+- [ ] **Add the §4.4.1 CAN/CANNOT note** — a short note stating the validator CAN
+  assert presence/coupling, `low ≤ high`, and that a split-tier band is NON-COLLAPSED
+  (strictly spread, `low < high`), but CANNOT assert the band SPANS TWO TIERS (a
+  `{99.0,100.0}` band passes) nor that the bounds equal the absolute
+  claude-sonnet-4/claude-opus-4 rates (that snapshot-grounded check is S3's). Make
+  explicit that option (a) — carrying per-model rates in the record — was rejected
+  (it would add data the merged S2 agent does not emit) (spec §4.4.1, FR-3b, O3).
+- [ ] **Methodology/prose** — add a short note that a new emitter SHOULD populate
+  per-stage `cost_usd` on cost-present records while a cost-present record without
+  them stays valid for S1-era backward-compat — keeping the SHOULD distinct from
+  the validation-rejection rule; AND note its falsifiable home is the deferred
+  follow-on emitter issue (§12), honestly scoped within this slice as "the format
+  admits the band; no producer yet populates it"; AND note the inverse-rejection
+  check guards a not-yet-producible shape (O8); **AND state the cheaper-at-low /
+  dearer-at-high pricing as an emitter convention here in the prose (O4) — the
+  validator cannot confirm which bound binds to which model, so this is a
+  convention, not a checked invariant** (spec §4.3, §4.3.1, §4.3.2, §4.4, O4).
+- [ ] **Example 2 (cost-present) — UPDATE** — add `cost_usd: { low, high }` to each
+  of the three `tokens_by_stage[]` entries with the CONCRETE bands RE-DERIVED from
+  two fixed per-tier rates (sonnet `4.0e-6`, opus `2.0e-5` $/token):
+  spec-writer `{ low: 1.00, high: 2.00 }` (opus rate × 50k/100k), tdd-agent
+  `{ low: 0.20, high: 0.60 }` (sonnet rate × 50k/150k), implementer
+  `{ low: 0.40, high: 5.00 }` (sonnet rate × 100k low … opus rate × 250k high). They
+  sum to the whole-record `{ 1.60, 7.60 }` — **also update the whole-record
+  `cost_usd` to `{ 1.60, 7.60 }`** (set equal by construction; replaces the old
+  `{ 0.95, 7.50 }`). The implementer (split-tier) band has a strictly-positive
+  spread; it matches the Included prose's `$0.40–$5.00`. Update the Included prose to
+  say the per-stage bands are surfaced as fields and to cite the whole-record band as
+  `$1.60–$7.60` if it states a dollar figure (spec §4.5, FR-4).
+- [ ] **Example 1 (cost-omitted) — DO NOT TOUCH the per-stage entries** — confirm
+  no `tokens_by_stage[].cost_usd` is added (spec §4.5, FR-5).
+- [ ] **`generated_by` description — WIDEN + define the reserved prefix** — admit a
+  concrete model id OR a `tier:<tier>` routing-tier label when the concrete model
+  is unavailable; define **`tier:` as a reserved provenance prefix** (a concrete
+  model id never begins with `tier:`, so a consumer can mechanically distinguish
+  the two forms without any rejecting check); state the value is never a
+  guessed/hard-coded model; add no `generated_by`-shape check (spec §5, FR-7, FR-8,
+  O6).
+- [ ] **`grounding_sources` description + three-grounding-states — DOCUMENT the
+  sentinel, NAME the entrenchment, add the consumer special-case** — the directory
+  path `observability/costs/` (trailing slash) is the named cost-omitted sentinel
+  for the mandatory cost-snapshot entry; the entry is never dropped, never given a
+  fabricated file path; state-3 uses the snapshot file path; **acknowledge this
+  entrenches an overloaded meaning (file = grounded; trailing-slash directory =
+  looked-and-found-nothing) rather than resolving the tension, and add the consumer
+  special-case note** (an aggregator must not count a trailing-slash directory path
+  as a grounding); **record the O5 noted residual** — the special-case is
+  advisory/unenforced, externalising a silent-miscount risk onto downstream counters
+  (S3, any aggregator); add no `path`-must-be-a-file check (spec §6, §6.1, FR-9,
+  FR-10, O5).
+- [ ] **Consistency self-check** — re-read the checklist and both worked examples
+  together; confirm the new checklist lines (coupling + spread), the field table,
+  Example 2's three re-derived per-stage bands, and the whole-record `cost_usd` are
+  mutually consistent (the bands sum exactly to the whole-record `{1.60,7.60}`, each
+  single-tier band = its tier-rate × token bound, and the implementer band satisfies
+  the spread rule) (spec §9).
+
+---
+
+## Phase 2 — TDAD scenarios
+
+### Task 2: Extend two scenarios, add one
+
+- [ ] **Extend `format-and-contract.md`** with the per-stage sub-field
+  (one-directional coupling stated in the field table, NOT `iff`), BOTH new
+  checklist lines (coupling + split-tier spread), the §4.4.1 CAN/CANNOT note,
+  Example 2's three concrete bands, the `generated_by` widening with the reserved
+  `tier:` prefix, and the grounding-path sentinel (with entrenchment + consumer
+  special-case) assertions (test case list above). Keep all existing S1 assertions
+  intact.
+- [ ] **Extend `cost-conditional.md`** with the no-per-stage-band-on-cost-omitted
+  and directory-sentinel assertions, including the consumer special-case note. Keep
+  all existing assertions intact.
+- [ ] **Create `per-stage-cost-backward-compat.md`** (tier: structural) — a
+  STRUCTURAL scenario (asserts the checklist TEXT + the four-class argument, NOT a
+  parser actually run — runtime falsification is S3's): the four-record-class
+  backward-compat invariant, the rejected inverse (a not-yet-producible guard rail
+  for S3-era emitters), the rejected collapsed split-tier band, and the
+  no-`generated_by`-shape-check / no-`path`-file-check assertions. Follow the
+  corpus format in `tdad_tests/README.md` and the existing
+  `cost-estimation` scenario frontmatter (`component: cost-estimation`,
+  `component_type: skill`, `tier: structural`).
+- [ ] Confirm **no S2 agent scenario** under `tdad_tests/scenarios/agents/cost-estimator/`
+  is modified — this slice changes the format the agent consumes, not the agent.
+
+---
+
+## Phase 3 — Version bumps
+
+### Task 3: Bump plugin.json, CHANGELOG, marketplace.json, README
+
+- [ ] `ai-literacy-superpowers/.claude-plugin/plugin.json`: `version` `0.42.0` → `0.43.0`.
+- [ ] `CHANGELOG.md` (repo root): new `## 0.43.0 — <today>` heading with entries
+  for: the optional, one-directionally coupled per-stage `cost_usd` sub-field
+  (backward-compatible; the split-tier spread check makes the widening
+  record-internally checkable — the absolute-rate check is deferred to S3); the
+  `generated_by` description widening (admits the `tier:<tier>` label the merged S2
+  agent emits, with `tier:` as a reserved prefix); the grounding-path directory
+  sentinel documentation. State the change is backward-compatible and ships no S2
+  agent change.
+- [ ] `.claude-plugin/marketplace.json`: bump the `ai-literacy-superpowers`
+  `plugins[]` entry `version` and the top-level `plugin_version` to `0.43.0`; leave
+  top-level `version` at `0.4.0`.
+- [ ] `README.md`: bump the `ai-literacy-superpowers` badge `v0.42.0` → `v0.43.0`.
+- [ ] Verify version consistency:
+
+```bash
+python3 -c "
+import json
+pj = json.load(open('ai-literacy-superpowers/.claude-plugin/plugin.json'))
+m = json.load(open('.claude-plugin/marketplace.json'))
+entry = next(p for p in m['plugins'] if p['name']=='ai-literacy-superpowers')
+assert pj['version']=='0.43.0', pj['version']
+assert entry['version']=='0.43.0', entry['version']
+assert m['plugin_version']=='0.43.0', m['plugin_version']
+assert m['version']=='0.4.0', m['version']
+print('version consistency OK')
+"
+```
+
+---
+
+## Phase 4 — Verify and ship
+
+### Task 4: Local CI gate checks
+
+- [ ] Spec-first ordering — first commit on the `format-revision-per-stage-cost`
+  branch is the spec:
+
+```bash
+git log main..HEAD --reverse --oneline | head -1
+```
+
+- [ ] Reference ↔ scenario consistency — the three scenario files exist and assert
+  the edited reference content:
+
+```bash
+ls tdad_tests/scenarios/skills/cost-estimation/*.md
+```
+
+- [ ] Markdown lint, docs build, and the deterministic TDAD fast suite (Layers 0+1)
+  pass.
+
+### Task 5: Docs touch (confirm-or-update only)
+
+- [ ] Confirm `docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md`
+  (authored in S2) does not reference the old `generated_by` "model identifier"
+  wording in a way the widening now contradicts. Update only if it does; no new
+  page is required (the reference is the contract, and this is a format-detail
+  change, not a new command/skill/agent).
+
+### Task 6: Push, PR, CI, merge
+
+- [ ] Push the `format-revision-per-stage-cost` branch, open a PR against #377
+  (feature ceremony — `/diaboli` spec runs on this spec next; code-mode runs after
+  the code-reviewer PASS).
+- [ ] PR body states what ships (the three format changes + two extended scenarios
+  + one new backward-compat scenario + version bump) and what does NOT (S3–S6; **no
+  S2 agent change** — the format is widened to admit the merged agent's output; the
+  follow-on emitter enhancement is filed as a standalone issue at adjudication).
+- [ ] Watch CI green; merge `--squash --delete-branch`; sync the marketplace cache.
+
+### Task 7: File the deferred follow-on (at adjudication, per AGENTS.md)
+
+- [ ] File a standalone issue against the `cost-estimator` agent: "populate
+  per-stage `cost_usd` bands on cost-present records once a usable snapshot
+  exists." Do not leave it implicit in this slice's out-of-scope section (the
+  AGENTS.md "re-file, do not leave implicit" decision). Link it from #377.
+
+---
+
+## Out of scope (deferred)
+
+- The `/cost-estimate` command and its Output Validation Checkpoint that *runs* the
+  checklist against an on-disk record (S3, #370). This slice defines the checklist
+  line; it ships no runtime validator.
+- Orchestrator fold-in (S4, #371); the T0 ballpark (S5, #372); the calibration loop
+  (S6, #373). The `kind: calibration` grounding seam is untouched and the per-stage
+  sub-field is not a calibration input.
+- **The S2 agent enhancement to populate per-stage bands on cost-present records.**
+  Named in spec §12 and §7; filed as a standalone issue at adjudication (Task 7).
+  Not shipped here, to avoid re-creating the consumer/owner conflation this slice
+  exists to resolve.
+- Any change to the cost-derivation methodology (the binding table, the blended-rate
+  skew, the join key). This slice surfaces an already-computed widening as a field;
+  it does not change how the widening is computed.
+```
+

--- a/docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md
+++ b/docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md
@@ -1,0 +1,1055 @@
+# Cost Estimation — format-revision slice — per-stage `cost_usd`, `generated_by` wording, cost-snapshot grounding-path convention — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-11 |
+| Status | Draft |
+| Author | spec-writer (interactive session with russmiles) |
+| Slice | format-revision residue split out of S2 at its diaboli revision (a scoped residue of S2's diaboli — not a carpaccio slice) |
+| Owns | `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md` — this slice is its legitimate owner and MAY modify it |
+| Tracking issue | #377 |
+| Upstream (merged on main) | S1 (#—, merged): `cost-estimation` skill + estimate-record format reference; S2 (#369, merged): read-only `cost-estimator` agent |
+| Sibling slices | S3 (#370), S4 (#371), S5 (#372), S6 (#373) — all out of scope here |
+| Origin | The three concerns this slice resolves are deferred residues: O6 code-mode (per-stage `cost_usd`, deferred from S1), S2 round-2 O1 (`generated_by` wording), and S1 code-mode O7 / S2 §5.3 flag (cost-snapshot grounding path). |
+| Plugin version target | `ai-literacy-superpowers` v0.42.0 → v0.43.0 (format/schema change to a plugin reference file — minor bump). **Do NOT apply the bump at spec time** — it is an implementation-time step. |
+| Marketplace listing | Top-level `version` unchanged at v0.4.0; `plugin_version` 0.42.0 → 0.43.0 |
+| PR ceremony | feature — full `/diaboli` (spec + code) |
+| Governing decisions | AGENTS.md **"disclosure-of-derived-judgment"** decision (the `cost_usd` per-stage band is a machine-checkable form of the same derived-cost disclosure); the **"cross-cutting methodology lives in `skills/<name>/references/<contract>.md`"** decision (this slice edits that one canonical reference; consumers — the S2 agent, the future S3 checkpoint — reference it by path and inherit the change). |
+
+---
+
+## 1. Premise
+
+S1 shipped the **estimate-record format reference** — the stable contract an
+estimate-record must satisfy: the field table, the tier→model→$/token binding
+table, the four-part disclosure body, the closed-world **validation checklist** a
+consuming command's Output Validation Checkpoint runs, and two worked examples
+(one cost-omitted, one cost-present). S2 shipped the **emitter** — the read-only
+`cost-estimator` agent — as a **pure consumer** of that reference, forbidden from
+mutating it.
+
+Three concerns accumulated against the reference across the S1 and S2 reviews,
+and each was deliberately deferred to a slice that **owns** the contract rather
+than merely consumes it:
+
+1. **Per-stage `cost_usd` (S1 code-mode O6).** S1's split-tier widening (the
+   implementer's `Standard/Capable` priced low at `claude-sonnet-4`, high at
+   `claude-opus-4`) is demonstrated only in prose and a worked example — it is
+   **not machine-checkable on an emitted record**, because `tokens_by_stage[]`
+   carries no per-stage cost. A validator cannot assert the implementer band
+   reflects a genuine two-tier spread; it can only read the whole-record figure.
+   (The slice's resolution is a **record-internal spread invariant**, not an
+   absolute-rate check — see §4.4 for exactly what the validator CAN and CANNOT
+   assert.)
+2. **`generated_by` wording (S2 round-2 O1).** The field is documented as a
+   "model identifier", but the merged S2 agent honestly emits
+   `cost-estimator / tier:Standard` under `model: inherit`. The most common
+   record the merged agent emits carries a value the field's own description does
+   not recognise — with no validation signal that anything is off.
+3. **Cost-snapshot grounding-path convention (S1 code-mode O7 / S2 §5.3
+   flag).** The cost-omitted record's mandatory `grounding_sources` cost-snapshot
+   entry points at the **directory** `observability/costs/` when no snapshot file
+   exists. The field is documented as "the inputs the estimate was built from" —
+   a directory that grounded nothing strains that description, even though the
+   "at minimum a cost-snapshot entry" presence rule is satisfied.
+
+This slice **owns** `estimate-record-format.md` and resolves all three. Its
+load-bearing requirement is **demonstrated backward-compatibility**, not asserted:
+for **each** of the three changes, the spec states how the closed-world
+validation checklist treats **both** old (S1/S2-era) records **and** new records,
+and **demonstrates** — by tracing the actual checklist semantics — that both
+remain valid. This is the entire reason these concerns were split out of S2: a
+conditional sub-field coupled to top-level cost is *not* trivially additive against
+a closed-world validator (and its coupling must be expressed as a one-directional
+asymmetry, never an `iff` biconditional — see §4.1), so the claim must be shown, not
+stated.
+
+The slice is **format-only**. It is **not** the S3 command, **not** the S4
+orchestrator fold-in, and **not** the S6 calibration loop. It changes the
+reference file (and, where a change is unavoidable to keep the merged S2 agent
+conformant, the S2 agent and its scenarios), the TDAD scenarios that assert the
+reference's content and the backward-compat invariants, and the version-bump
+maintenance steps.
+
+## 2. Scope and non-goals
+
+### 2.1 In scope
+
+- **Edit `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`** — this slice owns the reference. Specifically:
+  - Add an **optional** `tokens_by_stage[].cost_usd` `{ low, high }` sub-field
+    under a **one-directional coupling**: sub-field present ⟹ top-level
+    `cost_usd` present (enforced); top-level `cost_usd` present ⟹ bands SHOULD be
+    populated by emitters but their absence does NOT invalidate the record (§4).
+  - Add **two** validation-checklist lines — a **"Per-stage cost coupling"** line
+    (the sub-field's one-directional coupling: present ⟹ top-level cost present)
+    and a **"Split-tier spread"** line (a split-tier stage's band must have a
+    strictly-positive ordered spread, `low < high`) — both written so they reject
+    **neither** old records (no sub-field) **nor** new cost-omitted records (no
+    sub-field), plus add the sub-field to the existing "Ranges well-formed"
+    enumeration, plus a §4.4.1 note stating what the validator CAN and CANNOT assert
+    about the widening (§4.4).
+  - **Update the cost-present worked example (Example 2)** to carry per-stage
+    `cost_usd` bands, demonstrating the implementer band spans
+    `claude-sonnet-4` low … `claude-opus-4` high (§4.5). Leave the cost-omitted
+    worked example (Example 1) **unchanged** (sub-field absent, still valid).
+  - **Widen the `generated_by` field description** to admit a `tier:<tier>`
+    routing-tier label when the concrete model is unavailable (§5).
+  - **Document the cost-snapshot grounding-path convention** — keep the directory
+    path `observability/costs/` and document it as the named cost-omitted
+    sentinel, so the merged S2 agent's behaviour and Example 1 stay conformant
+    (§6).
+- **The minimal S2-agent reconciliation, IF AND ONLY IF a change is unavoidable**
+  to keep the merged agent's emitted records conformant (§5.4, §6.3). The default
+  is **no S2 change** — the format is widened to *admit* the agent's existing
+  output. The spec states explicitly, per concern, whether an S2 change is needed
+  (it concludes: **no S2 agent change is required** for any of the three — see
+  §7).
+- **TDAD scenarios** that assert the reference's new content **and** the
+  backward-compat invariants, under `tdad_tests/scenarios/skills/cost-estimation/`
+  (§8). Decide per concern whether to **extend** the existing `format-and-contract`
+  / `cost-conditional` scenarios or **add** a new one (§8.1).
+- **The version bump** (0.42.0 → 0.43.0) and its maintenance tail (CHANGELOG,
+  marketplace `plugin_version`, README badge) — proposed here, applied at
+  implementation time (§9).
+
+### 2.2 Out of scope (deferred to S3–S6)
+
+- **S3 — the `/cost-estimate` command** (#370). No file under
+  `ai-literacy-superpowers/commands/`. The Output Validation Checkpoint that
+  *runs* the checklist against an on-disk record is the command's; this slice
+  only **defines** the checklist line, it does not implement a runtime validator.
+- **S4 — orchestrator fold-in** (#371). No change to
+  `agents/orchestrator.agent.md`; no gate added, moved, or re-weighted.
+- **S5 — T0 ballpark** (#372).
+- **S6 — calibration loop** (#373). No per-PR actuals capture; the
+  `kind: calibration` grounding seam is untouched. The per-stage `cost_usd`
+  sub-field is **not** a calibration input.
+- **Any change to the cost-derivation methodology itself.** This slice makes a
+  split-tier band's **non-collapsed (strictly-spread)** shape *record-internally
+  checkable* (`low < high`; it does **not** make the full widening machine-checkable
+  — the absolute-rate check is deferred to S3, §4.4.1); it does **not** alter how
+  the widening is computed (the S1 binding table, the blended-rate skew, the join
+  key all stand unchanged). The per-stage band is a **disclosure surface** for an
+  already-computed widening, not a new computation.
+- **A runtime validator binary or CI check.** The checklist is a specification a
+  future consumer (S3) runs; no executable validator ships here. The TDAD
+  scenarios assert the *reference's content* (the checklist line exists and reads
+  correctly) and the backward-compat *invariants* structurally, by inspection of
+  the reference and the worked examples.
+
+### 2.3 What this slice does NOT widen by accident
+
+The reference is a **stable contract** with merged consumers (the S2 agent; the
+future S3 checkpoint). This slice changes it deliberately and minimally. The
+guard rails:
+
+- The sub-field is **optional and one-directionally coupled** to the existing
+  top-level `cost_usd` (sub-field present ⟹ top-level present; not the reverse).
+  It introduces **no new top-level field**, **no new required field**, and **no
+  new grounding state**. The three grounding states (§ "three grounding states
+  for cost") are untouched.
+- The `generated_by` change is a **description widening**, not a new field or a
+  new validation rule. No checklist line keys on `generated_by` today; this slice
+  adds **none** (it does not introduce a `generated_by`-shape check that could
+  retroactively fail an old record).
+- The grounding-path change is a **documentation** of the existing convention
+  (Example 1 already uses the directory path). It adds **no** check that a `path`
+  must be a file, which would retroactively fail Example 1 and the merged S2
+  agent's day-one-default record.
+
+If a reviewer finds this slice adding a *required* field, a *new grounding
+state*, a `generated_by`-shape check, or a `path`-must-be-a-file check, that is
+scope creep that breaks backward-compatibility and must be cut.
+
+## 3. The closed-world validation checklist — the thing backward-compat is measured against
+
+The reference's **validation checklist** is the closed-world parser every
+backward-compat claim in this spec is measured against. Today it runs these
+checks (verbatim intent, `estimate-record-format.md` "Validation checklist"):
+
+- **Ranges well-formed** — every **present** range (`tokens`, each
+  `tokens_by_stage[].tokens`, `cost_usd` when present, `agent_compute_time`) has
+  `low ≤ high`.
+- **All four disclosure sections present** — Included, Excluded, Confidence
+  rationale, Failure direction.
+- **Per-axis confidence within cap** — each present `confidence` axis within the
+  `target_kind` ceiling for `tokens`/`time`; the `cost` axis present **iff**
+  `cost_usd` is present.
+- **Cost pairing** — `cost_usd` and `cost_basis` **both present or both absent**;
+  when absent, `Excluded` carries the cost-omission disclosure.
+- **Time split** — both time fields present and separate.
+- **No-verdict, field-absence layer** — no `recommendation`/`verdict`/`proceed`
+  field.
+- **No-verdict, positive-content layer** — the prose contains no imperative
+  recommendation or go/no-go language.
+
+**The closed-world property (load-bearing).** The checklist is a **closed
+enumeration**. It rejects a record **only** when one of its named checks fails; it
+does **not** reject a record for carrying a field the checklist does not mention.
+This is the property the "Cost pairing" check already relies on — it asserts an
+`iff` between two *named* fields and is silent about everything else. The
+backward-compat demonstrations in §4–§6 all turn on this: a new optional field is
+invisible to every check that does not name it, and the two new checks that do name
+it (the "Per-stage cost coupling" and "Split-tier spread" lines of §4.4) are each
+written to pass vacuously on its absence.
+
+## 4. Concern 1 — the per-stage `cost_usd` sub-field
+
+### 4.1 The decision (sub-field shape)
+
+Add an **optional** sub-field to each `tokens_by_stage[]` entry:
+
+| Sub-field | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `tokens_by_stage[].cost_usd` | range object `{ low, high }` | **optional, one-directionally coupled** — **present ⟹ top-level `cost_usd` present** (enforced); top-level `cost_usd` present ⟹ bands **SHOULD** be populated by emitters, but their **absence does NOT invalidate** the record | The per-stage dollar contribution. Makes the split-tier widening a machine-readable disclosure surface and a **record-internal** spread check: a validator can assert a split-tier stage's band has a strictly-positive ordered spread (`low < high`), consistent with the binding table's tier ordering. It **cannot** assert the absolute bounds equal the specific `claude-sonnet-4`/`claude-opus-4` rates — those live in the snapshot, not the record (see §4.4). |
+
+The coupling is **one-directional, not a biconditional** (this is the deliberate
+correction of the prior draft's `iff`, which a literal reader could tighten into a
+class-B-breaking mandate). It mirrors the *enforced direction* of the existing
+`cost_usd`/`cost_basis` pairing while leaving the reverse direction as an emitter
+SHOULD:
+
+- **Sub-field present ⟹ top-level `cost_usd` present** (state 3 — a usable
+  snapshot grounds cost). This direction is **enforced** by the checklist: a
+  per-stage band may never appear on a cost-omitted record.
+- **Top-level `cost_usd` present ⟹ bands SHOULD be populated** by emitters (so the
+  per-stage decomposition that produced the whole-record figure is surfaced), but a
+  cost-present record that omits them is **still valid** — this direction is an
+  emitter obligation, **not** a validation-rejection rule (§4.3, §4.4). This is the
+  asymmetry that keeps S1-era class-B records valid.
+- **Top-level `cost_usd` absent** (states 1 and 2 — cost-omitted) → **no**
+  `tokens_by_stage[]` entry carries a per-stage `cost_usd`. The sub-field is
+  absent everywhere, exactly as in the unchanged Example 1.
+
+The whole-record `cost_usd` band need **not** equal the arithmetic sum of the
+per-stage bands (stages may be correlated, and the widening is applied per stage),
+consistent with the existing same-rule for `tokens` vs `tokens_by_stage[].tokens`.
+When they differ the prose body says why — no **new** disclosure-body rule is
+added; the existing "when they differ the prose body must say why" rule already
+covers it.
+
+### 4.2 Why optional-and-one-directionally-coupled, not required
+
+A new **required** field would retroactively invalidate every old record and every
+cost-omitted record (which has no per-stage cost to carry) — the exact
+backward-compat break this slice exists to avoid. The **one-directional coupling**
+to top-level `cost_usd` (present ⟹ top-level present) makes the enforced check a
+function of an existing field, not a new mandate; the reverse direction (top-level
+present ⟹ bands present) is held as an emitter SHOULD, so no record that predates
+the sub-field is retroactively failed.
+
+### 4.3 Backward-compatibility — DEMONSTRATED, not asserted
+
+This is the defining requirement (S2 O2). The demonstration traces the **actual**
+closed-world checklist semantics against four record classes:
+
+| Record class | Has top-level `cost_usd`? | Has per-stage `cost_usd`? | Old checklist verdict | New checklist verdict | Why |
+| --- | --- | --- | --- | --- | --- |
+| **A. Old cost-omitted (S1/S2-era; Example 1, merged S2 day-one default)** | no | no | valid | **valid** | Every new per-stage check (§4.4) keys on the **presence of the sub-field**; with no sub-field present, each fires **vacuously**. No other check names the sub-field. Record unchanged, still valid. |
+| **B. Old cost-present (S1-era; Example 2 before this slice)** | yes | no | valid | **valid** — the coupling is one-directional, not a biconditional; see the critical note below | This is the load-bearing case. The check keys on sub-field presence, not top-level presence, so a cost-present record with no bands is never rejected. See §4.4. |
+| **C. New cost-omitted** | no | no | valid | valid | Identical to class A — the sub-field is absent, every new check fires vacuously. |
+| **D. New cost-present (Example 2 after this slice)** | yes | yes | n/a (sub-field did not exist) | valid | The new checks assert the enforced coupling holds (sub-field present ⟹ top-level present), each per-stage band has `low ≤ high`, and each **split-tier** stage's band has a strictly-positive ordered spread (`low < high`). Example 2's implementer band `{0.40, 5.00}` satisfies the spread rule (§4.5). |
+
+**The critical note on class B — the genuine backward-compat hazard.** A naive
+**biconditional** check stated as *"top-level `cost_usd` present ⟺ every stage
+carries a per-stage `cost_usd`"* would **reject class B** — an old cost-present
+record that has top-level cost but no per-stage bands. That would be a
+backward-compat break: S1's Example 2 (as merged) and any S1-era cost-present
+record an old consumer produced would suddenly fail validation. This is precisely
+the trap S2 O2 warned of — the prior draft of this spec **named the coupling
+`iff`** (a biconditional) in the field table, which a literal reader (the reference
+instructs readers to *parse*, not read loosely) would tighten into exactly this
+class-B-breaking mandate. This revision removes the `iff` from the field table and
+states the one-directional asymmetry there, so the field table and the §4.4 check
+now say the same thing.
+
+**The resolution.** The new check is written so the per-stage sub-field is
+**forward-optional**: its presence is *permitted-and-coupled*, not *mandated*, by
+top-level `cost_usd`. The exact checklist semantics (§4.4) are:
+
+> When per-stage `cost_usd` sub-fields are **present on a record**, the record's
+> **top-level `cost_usd` must also be present** (the sub-field never appears on a
+> cost-omitted record), **every present** per-stage `cost_usd` has `low ≤ high`,
+> and **every present split-tier** stage's band has a strictly-positive ordered
+> spread (`low < high`).
+
+Read carefully, this is a **one-directional** constraint keyed on the *presence of
+the sub-field*, not on the presence of top-level cost:
+
+- **Sub-field present, top-level absent** → **fail** (the genuinely incoherent
+  case the check must catch).
+- **Sub-field present, top-level present** → check `low ≤ high` on each, and
+  `low < high` on each split-tier stage → pass for well-formed bands (class D).
+- **Sub-field absent** → the check does not fire at all → pass (classes A, B, C).
+
+Class B (old cost-present, no sub-field) **passes** because the sub-field is
+absent, so the check does not fire. This is the demonstration: the constraint
+catches the incoherent shape (a per-stage band with no whole-record cost) without
+mandating the sub-field's presence on any record that predates it. The closed-world
+property (§3) guarantees no *other* check rejects class B for the missing
+sub-field, because no other check names it.
+
+#### 4.3.1 The SHOULD-populate obligation — its falsifiable home (O4)
+
+**The §4.1 "top-level cost present ⟹ bands SHOULD be populated" rule is an
+emitter obligation, NOT a validation-rejection rule.** This is the load-bearing
+distinction. The reference's *methodology prose* says a new emitter SHOULD populate
+per-stage bands whenever it emits a top-level cost (so the widening is surfaced);
+the *validation checklist* does **not** reject a record for omitting them, because
+doing so would reject class B.
+
+To keep this SHOULD distinguishable from a MAY (rather than aspirational
+free-text), the spec gives it a **falsifiable home**: the SHOULD is stated as a
+**requirement on the deferred follow-on emitter enhancement** (§12, the
+standalone issue filed against the `cost-estimator` agent at adjudication). That
+issue's acceptance criterion is "on a cost-present record, every exercised stage
+carries a per-stage `cost_usd` band, and each split-tier stage's band has a
+strictly-positive spread" — a falsifiable behavioural assertion a future Layer 3
+scenario will grade once a snapshot fixture exists.
+
+**Honest scope note for this slice.** No producer ships a cost-present record
+today (the merged S2 agent emits only cost-omitted records — empty
+`observability/costs/`). So within *this* format-only slice the obligation is
+**"the format admits the band; no producer yet populates it."** The only
+cost-present record carrying bands in this deliverable is the hand-authored
+Example 2. The SHOULD is real and has a named, falsifiable home — but it is
+honestly a documented obligation on a deferred enhancement, not a behaviour any
+shipped emitter exhibits today.
+
+#### 4.3.2 The inverse-rejection check guards a not-yet-producible shape (O8)
+
+The one genuinely new *rejection* rule this slice adds — "fail a per-stage
+`cost_usd` with no top-level `cost_usd`" — guards a shape **no consumer in
+existence can currently produce**. The merged S2 agent emits only cost-omitted
+records, which by construction carry no per-stage band; nothing today can create
+the incoherent inverse. The check is kept anyway as a **cheap guard rail for
+S3-era emitters** (a future buggy emitter could create it), and its enforcement
+surface is honestly stated here: it protects against a shape only a future emitter
+could create, while the *positive* obligation the slice cares about (bands
+present, split-tier spread) is the SHOULD of §4.3.1, not a rejection rule. Not a
+blocker; recorded so the slice's net-new enforcement surface is not overstated.
+
+### 4.4 The validation-checklist edit
+
+Three edits to the checklist, all backward-safe:
+
+1. **Extend the existing "Ranges well-formed" enumeration** to name the new range:
+   add `each tokens_by_stage[].cost_usd when present` to the bracketed list of
+   present ranges that must have `low ≤ high`. Because the enumeration is
+   guarded by "every **present** range", an absent sub-field is not checked —
+   classes A, B, C pass unchanged.
+2. **Add one new check line — "Per-stage cost coupling":**
+
+   > **Per-stage cost coupling** — if **any** `tokens_by_stage[].cost_usd` is
+   > present, the record's top-level `cost_usd` must also be present (per-stage
+   > cost bands never appear on a cost-omitted record). A record with **no**
+   > per-stage `cost_usd` sub-fields satisfies this check vacuously — **old
+   > records and cost-omitted records are not rejected.** This check does **not**
+   > mandate that a cost-present record carry per-stage bands; it only forbids the
+   > incoherent inverse (a per-stage band with no whole-record cost). Emitters
+   > SHOULD populate per-stage bands on cost-present records, but a cost-present
+   > record without them remains valid for backward-compatibility with S1-era
+   > records.
+
+3. **Add one new check line — "Split-tier spread" (asserts a non-collapsed
+   (strictly-spread) split-tier band — `low < high` — NOT that the band spans two
+   tiers; the absolute-rate check is deferred to S3 per §4.4.1):**
+
+   > **Split-tier spread** — for **every present** `tokens_by_stage[].cost_usd`
+   > whose `model_tier` is a **split tier**, the band must have a
+   > **strictly-positive ordered spread**: `low < high` (strict, not merely
+   > `low ≤ high`). A `model_tier` **is a split tier if and only if its label
+   > contains a `/`** (after the join-key whitespace normalisation); otherwise it
+   > is a single tier. A collapsed band (`low == high`) on a split-tier stage fails
+   > this check. **Single-tier** stages are exempt (they may carry `low == high`,
+   > governed only by "Ranges well-formed"). A record with no per-stage `cost_usd`
+   > satisfies this check vacuously.
+
+   **The split-tier trigger is a CLOSED rule.** A `model_tier` is a split tier
+   **iff its label contains a `/`** (after the join-key whitespace normalisation),
+   so `Standard/Capable` and `Standard / Capable` both classify identically and a
+   validator needs no enumerated set. No single (non-split) tier label contains a
+   slash — `MODEL_ROUTING.md` names exactly the single tiers `Most capable` and
+   `Standard` (neither contains `/`) plus the one complexity-dependent split
+   `Standard / Capable` — so "contains `/`" is a sound *total* classifier over
+   every tier label the reference admits.
+
+   **Emitter convention (methodology, NOT a checked invariant).** By convention a
+   split-tier stage prices its low bound at the **cheaper** representative model and
+   its high bound at the **dearer** one (per the binding table — for
+   `Standard / Capable`, `claude-sonnet-4` is the cheaper tier and `claude-opus-4`
+   the dearer), so a genuine widening produces a non-zero spread. The validator
+   **cannot** confirm which bound binds to which model from the record alone (it
+   sees two numbers and their order, never the per-model pricing); this cheaper-at-
+   low / dearer-at-high ordering is therefore an *emitter convention*, not a
+   checkable invariant, and lives here in the methodology prose. The only predicate
+   the checklist line tests on a present split-tier band is `low < high`.
+
+The new lines are **written into the reference** so the demonstration lives in the
+contract itself, next to the existing "Cost pairing" check they mirror. The TDAD
+scenario (§8) asserts the lines' presence and their backward-compat wording.
+
+#### 4.4.1 What the validator CAN and CANNOT assert (the O3 resolution)
+
+The slice's reason to exist is to make a split-tier band's **non-collapsed
+(strictly-spread)** shape record-internally checkable, not merely to add a place to
+put the band — and to be honest that this is a *floor*, not the full widening. The
+headline objection (O3) was that a `{ low: 99.0, high: 100.0 }` implementer band
+would pass a presence/pairing/`low ≤ high` check while bearing no relationship to
+the sonnet/opus rates the widening is defined by; the strict-spread check rejects
+the collapsed `{x, x}` case but, as stated below, a `{99.0, 100.0}` band still
+passes, so the check does not assert the band genuinely spans two tiers.
+
+**The snapshot-dependency, and why option (a) is rejected.** A stateless checklist
+parser reading **only the record** cannot know the **absolute** `claude-sonnet-4`
+and `claude-opus-4` `$/token` rates — those live in the snapshot, not in the
+emitted record. Option (a) — having the record carry the per-model rates it used
+(e.g. in `grounding_sources` or a derivation field) so the check is fully
+self-contained — is **rejected**: it adds data the merged S2 agent does not emit,
+which (i) breaks backward-compat against every S1/S2-era record that lacks the new
+field and (ii) re-introduces a new required field, the exact break §4.2 avoids.
+
+**The mechanism chosen — option (b): a record-internal spread invariant.** The
+"Split-tier spread" check above is the strongest **record-internal** invariant
+available without snapshot data: on a split-tier stage the band MUST have a
+strictly-positive ordered spread, and the binding table names which end is cheaper
+(`claude-sonnet-4`, low) and which dearer (`claude-opus-4`, high). This rejects the
+collapsed-band case (`{x, x}`) the widening cannot produce, turning the widening
+from a pure prose/worked-example assertion into a record-internal check.
+
+**State it plainly:**
+
+- The validator **CAN** assert: (1) presence/coupling — a per-stage band implies
+  top-level cost; (2) `low ≤ high` on every present band; (3) a strictly-positive
+  ordered spread (`low < high`) on every present **split-tier** band — i.e. that the
+  band is **non-collapsed (strictly spread)**. A `{ 99.0, 100.0 }` band still
+  *passes* `low < high`, so the check earns only the move from "any ordered band
+  (including a collapsed `{x, x}`)" to "a non-collapsed split-tier band". It does
+  **not** earn "the band spans two tiers": a non-collapsed band is necessary, but
+  not sufficient, for a genuine two-tier widening.
+- The validator **CANNOT** assert: that the band **spans two tiers** (a
+  `{99.0, 100.0}` band passes the strict-spread check while bearing no relationship
+  to the two rates), that the absolute `low`/`high` **equal** the specific
+  `claude-sonnet-4`/`claude-opus-4` rates, nor that the spread's magnitude is
+  *correct* for those rates — all three require the snapshot, which the record does
+  not carry. That absolute-rate falsification is a **runtime, snapshot-grounded
+  check** and lands with S3's Output Validation Checkpoint (which can read both the
+  record and the snapshot), not this format-only slice.
+
+So this slice delivers the **record-internal** half of the S1-O6 checkability (the
+spread invariant); the **absolute-rate** half is explicitly deferred to S3, where
+the snapshot is in scope. This is the honest boundary, stated rather than
+over-claimed.
+
+### 4.5 The worked-example edit
+
+- **Example 2 (cost-present) — UPDATE.** Add a `cost_usd: { low, high }` sub-field
+  to each of the three `tokens_by_stage[]` entries with the **concrete** values
+  derived below. The implementer entry's band, by the emitter convention, is priced
+  at the cheaper representative model (`claude-sonnet-4`) at its low bound and the
+  dearer (`claude-opus-4`) at its high bound. **Also update the whole-record
+  `cost_usd` to `{ 1.60, 7.60 }`** — the exact sum of the three re-derived per-stage
+  bands (the old `{ 0.95, 7.50 }` is replaced) — and update the Included prose: it
+  now says the per-stage bands are surfaced as fields, not only described, and any
+  dollar figure it cites for the whole-record band must read `$1.60–$7.60` (the
+  implementer's `$0.40–$5.00` band is unchanged).
+
+  **The three concrete bands (non-discretionary):**
+
+  | Stage | `model_tier` | tokens `{ low, high }` | per-stage `cost_usd` `{ low, high }` |
+  | --- | --- | --- | --- |
+  | spec-writer | Most capable (`claude-opus-4`) | `{ 50000, 100000 }` | **`{ 1.00, 2.00 }`** |
+  | tdd-agent | Standard (`claude-sonnet-4`) | `{ 50000, 150000 }` | **`{ 0.20, 0.60 }`** |
+  | implementer | Standard / Capable (split) | `{ 100000, 250000 }` | **`{ 0.40, 5.00 }`** |
+
+  **Derivation (reproducible from two fixed per-tier rates — every number is
+  traceable to the two rates below):**
+
+  1. **Fix two per-tier `$/token` rates**, ordered per the binding table
+     (`claude-opus-4` dearer than `claude-sonnet-4`):
+     - **sonnet (cheaper) = `4.0e-6` $/token**
+     - **opus (dearer) = `2.0e-5` $/token** (5× sonnet)
+
+     Every band below is one of these two rates applied to a token bound — nothing
+     is allocated to hit a sum envelope. The single-tier stages use a single rate
+     at both bounds; the split-tier implementer widens from the cheaper rate at its
+     low bound to the dearer rate at its high bound.
+  2. **Single-tier stages** = (that tier's rate) × (its token range, both bounds):
+     - **spec-writer** (Most capable → opus): low `2.0e-5 × 50000 = 1.00`,
+       high `2.0e-5 × 100000 = 2.00` → `{ 1.00, 2.00 }`.
+     - **tdd-agent** (Standard → sonnet): low `4.0e-6 × 50000 = 0.20`,
+       high `4.0e-6 × 150000 = 0.60` → `{ 0.20, 0.60 }`.
+  3. **Split-tier implementer** (the widening) = sonnet rate × low-tokens … opus
+     rate × high-tokens:
+     - low `4.0e-6 × 100000 = 0.40` (cheaper rate, low bound),
+       high `2.0e-5 × 250000 = 5.00` (dearer rate, high bound) → `{ 0.40, 5.00 }`.
+     This matches the example's existing Included prose ("its `$0.40–$5.00` cost
+     band") — the prose claim is now machine-checkable and rate-grounded.
+  4. **Whole-record `cost_usd` = the resulting per-stage sum** (set equal by
+     construction, the cleanest fix; the §4.4 correlation note permits the
+     whole-record band to differ from the sum, but here they are made equal):
+     - low `1.00 + 0.20 + 0.40 = 1.60`; high `2.00 + 0.60 + 5.00 = 7.60` →
+       whole-record `cost_usd = { 1.60, 7.60 }`.
+
+  **Every band satisfies the new checks AND an absolute-rate check (the deferred
+  S3 validator):** all three have `low ≤ high`; each single-tier stage's low and
+  high both equal its tier-rate × the respective token bound (so the band would
+  pass an absolute-rate check); the **split-tier** implementer band has a
+  strictly-positive spread (`0.40 < 5.00`), satisfying the §4.4 "Split-tier
+  spread" rule, and its bounds are the cheaper rate at low / dearer rate at high.
+  The whole-record `cost_usd` `{ 1.60, 7.60 }` is the exact sum of the three
+  per-stage bands.
+- **Example 1 (cost-omitted) — UNCHANGED.** No per-stage `cost_usd` appears. This
+  is the demonstration-by-example of class A/C validity: the reference's own
+  cost-omitted example still has no sub-field and still validates.
+
+## 5. Concern 2 — `generated_by` field wording
+
+### 5.1 The decision (widen the description)
+
+**Widen the field's documented description** to admit a `tier:<tier>`
+routing-tier label when the concrete model is unavailable. Do **not** reshape the
+provenance contract, and do **not** require an S2 agent change.
+
+The field description changes from:
+
+> `generated_by` — Agent name + model identifier (e.g. `"cost-estimator / claude-opus-4-8"`).
+
+to:
+
+> `generated_by` — Agent name plus **either** a concrete model identifier (e.g.
+> `"cost-estimator / claude-opus-4-8"`) **or** a `tier:<tier>` routing-tier label
+> when the concrete model is not available to the emitter at emit time (e.g.
+> `"cost-estimator / tier:Standard"` — an agent running `model: inherit` that is
+> not told its resolved model records the routing tier it reads from
+> `MODEL_ROUTING.md`). The value is **never** a guessed or hard-coded model string.
+>
+> **Recognised prefix grammar (so the two forms are mechanically
+> distinguishable).** `tier:` is a **reserved provenance prefix**. The provenance
+> token after the ` / ` separator is a **tier label** if and only if it begins with
+> the literal `tier:`; otherwise it is a **concrete model identifier**. A concrete
+> model id **never** begins with `tier:` (no model in `MODEL_ROUTING.md` or any
+> snapshot is named with a `tier:` prefix), so a consumer can mechanically decide
+> which form it holds by testing the `tier:` prefix — **without** any rejecting
+> check being added. This is a *grammar*, not a validator: the slice adds no
+> checklist line that rejects a malformed `generated_by`; it defines the prefix
+> reservation so the field's two structurally distinct meanings are no longer
+> ambiguous to a consumer splitting on the separator.
+
+### 5.2 Why widen, not reshape
+
+The merged S2 agent (`cost-estimator.agent.md`, "Provenance — `generated_by`")
+**already emits** `cost-estimator / tier:Standard` on the common path, by a
+deliberate two-branch convention the S2 review accepted as the honest least-bad
+option. Reshaping the provenance contract (e.g. splitting `generated_by` into
+`generated_by_agent` + `generated_by_model` + `generated_by_tier`) would:
+
+- **break the merged S2 agent** (it emits a single `generated_by` string) and
+  every S1/S2-era record;
+- introduce new required fields — a backward-compat break;
+- solve a wording mismatch with a schema change, which is disproportionate.
+
+Widening the description **admits the merged agent's existing output** with zero
+agent change. The honest `tier:` prefix the S2 agent already uses becomes the
+documented, recognised form rather than an undocumented convention.
+
+### 5.3 Backward-compatibility — DEMONSTRATED
+
+The checklist has **no** check on `generated_by` shape or content today (confirmed
+in S2 O1: "The validation checklist contains **no** check on the shape or content
+of `generated_by`"). This slice adds **none**.
+
+| Record class | `generated_by` value | Old checklist verdict | New checklist verdict | Why |
+| --- | --- | --- | --- | --- |
+| Old (Example 1/2, S1-era) | `cost-estimator / claude-opus-4-8` | valid (no check) | valid (no check) | No check fires on `generated_by`; the widened *description* admits both forms; no new check is added. |
+| Merged S2 day-one default | `cost-estimator / tier:Standard` | valid (no check, but **contradicts the description**) | **valid AND now description-conformant** | The widened description recognises the `tier:` form; the record was always valid, and is now also documentation-conformant. |
+
+The change is **description-only**, so it cannot reject any record — there is no
+machine check to fire. Its value is **honesty-of-documentation**: the field's
+description now matches what the merged emitter writes, closing the S2 O1
+spec↔contract gap. Adding a `generated_by`-shape *check* is explicitly **out of
+scope** (§2.3) — it would risk retroactively failing a record and is not needed to
+resolve the concern.
+
+**On the parse-ambiguity (O6).** Admitting the `tier:` form into a single
+free-text field would, without further structure, leave a consumer unable to tell
+a tier label from a concrete model id when splitting on the ` / ` separator. The
+slice does **not** add a rejecting check (that would risk retroactive failures),
+but it **does** close the ambiguity by defining `tier:` as a **reserved provenance
+prefix** (§5.1): a concrete model id never begins with `tier:`, so the prefix test
+is a total, mechanical discriminator. The field's content remains unvalidated *for
+rejection*, but it is no longer *ambiguous*: the grammar gives a consumer a
+deterministic rule to classify the value without a check. The merged S2 agent's
+`tier:Standard` output satisfies this grammar with no agent change.
+
+### 5.4 S2 agent change needed? — **No.**
+
+The S2 agent already emits the `tier:` form by design. Widening the description
+makes that output conformant. **No S2 agent edit is required for concern 2.**
+
+## 6. Concern 3 — cost-snapshot grounding-path convention
+
+### 6.1 The decision (keep the directory path, document it as the sentinel)
+
+**Keep the directory path `observability/costs/` and document it as the named
+cost-omitted sentinel.** Do **not** make the entry optional, and do **not**
+introduce a new sentinel token. The mandatory cost-snapshot entry stays present,
+its `path` carries the directory the emitter inspected (trailing slash marking it
+a directory, not a file), and the reference now **documents** this as the defined
+cost-omitted shape rather than leaving it as an undocumented Example-1 precedent.
+
+The reference's `grounding_sources` field description and the "three grounding
+states" section gain an explicit note:
+
+> When no snapshot **file** exists (states 1 and 2 — cost-omitted), the mandatory
+> `cost-snapshot` grounding entry's `path` is the **directory** the emitter
+> inspected, written with a trailing slash (`observability/costs/`). This is the
+> **defined cost-omitted sentinel**: the entry remains *present* (satisfying the
+> "at minimum a cost-snapshot entry" rule), and the directory path records what
+> the emitter actually read — the directory it inspected and found empty (or
+> without a usable snapshot). The `Excluded` prose names that the directory held
+> no usable snapshot. The entry is **never dropped** and **never given a
+> fabricated snapshot file path**. When a usable snapshot file exists (state 3),
+> the `path` is that **file** (e.g. `observability/costs/2026-08-15-costs.md`).
+>
+> **Consumer special-case (do not double-count).** Because the trailing-slash
+> directory path means *looked-and-found-nothing* rather than *grounded-in-a-
+> snapshot*, an aggregator that counts "how many records were grounded in a cost
+> snapshot" **must not** count a `cost-snapshot` entry whose `path` ends in `/` as
+> a grounding — it is a sentinel for the *absence* of a snapshot. Test the trailing
+> slash (directory) versus a file path to distinguish the two meanings.
+
+**This does not "resolve" the semantic tension — it entrenches an overloaded
+meaning, deliberately (O5).** The `grounding_sources` field now carries two
+meanings for a `cost-snapshot` entry depending on whether the `path` resolves to a
+**file** (grounded in that snapshot) or a **trailing-slash directory**
+(looked-and-found-nothing — the negative fact "no snapshot here"). The honest
+framing: the directory *is* the thing the emitter read to *determine* that no
+snapshot exists, so it is a real input in the weak sense — but naming it a
+`grounding_sources` entry widens "the inputs the estimate was built from" to admit
+"a location an input was looked for and not found." This slice chooses that
+entrenchment over a new sentinel token (§6.2) on backward-compat grounds (zero S2
+change, zero new parse case), and pays for it with the consumer special-case above.
+The strain is **named and accepted**, not eliminated.
+
+**Noted residual (O5).** The trailing-slash consumer special-case is
+**advisory/unenforced** — no validation-checklist line keys on `grounding_sources[].path`
+shape — so it externalises a **silent-miscount risk** onto every downstream counter
+(S3's checkpoint, any cost aggregator): nothing catches a consumer that counts a
+trailing-slash directory entry as a real grounding. This is an accepted residual of
+the deliberate keep-the-directory-sentinel trade, not a fix deferred to a later slice.
+
+### 6.2 Why keep, not make-optional or invent-a-sentinel
+
+- **Make the entry optional when omitted** — rejected. The S1 "at minimum a
+  cost-snapshot entry" rule is a deliberate honesty signal (the record always
+  shows it *looked* for a snapshot). Dropping the entry on cost-omission would
+  remove that signal and would **break the merged S2 agent**, which emits the
+  entry with the directory path and explicitly "never drops" it.
+- **Invent a new sentinel token** (e.g. `path: <none>` or a `kind: no-snapshot`)
+  — rejected. It introduces a new value the merged S2 agent does not emit (an S2
+  break) and a new enum/parse case for every consumer, to replace a directory
+  path that already works and already appears in Example 1.
+- **Keep the directory path and document it** — chosen. Zero S2 change, zero new
+  parse case, and it ratifies the existing Example-1 precedent as the named
+  convention. The only edit is **documentation** in the reference.
+
+### 6.3 Backward-compatibility — DEMONSTRATED
+
+| Record class | cost-snapshot `path` | Old checklist verdict | New checklist verdict | Why |
+| --- | --- | --- | --- | --- |
+| Old cost-omitted (Example 1, merged S2 default) | `observability/costs/` (directory) | valid | valid | No checklist line constrains `grounding_sources[].path` to be a file. The "at minimum a cost-snapshot entry" presence rule is satisfied by the present entry. The change is documentation only — it adds **no** path-shape check. |
+| Cost-present (Example 2) | `observability/costs/2026-08-15-costs.md` (file) | valid | valid | Unchanged; a file path was always conformant. |
+
+The demonstration: this slice adds **no** `path`-must-be-a-file check (which would
+retroactively fail Example 1 and the merged S2 default record). It documents the
+existing directory-path convention. The closed-world property (§3) means the
+absence of a path-shape check is what keeps every record valid; the change is
+purely additive documentation.
+
+### 6.4 S2 agent change needed? — **No.**
+
+The merged S2 agent already emits the directory path `observability/costs/` on the
+cost-omitted path ("An empty `observability/costs/` is NOT a refusal" section) and
+already notes in `Excluded` that the directory held no snapshot. Documenting the
+convention ratifies that behaviour. **No S2 agent edit is required for concern 3.**
+
+## 7. Does any S2 agent change ship in this slice? — **No.**
+
+The deliberate design of all three resolutions is to **widen / document the format
+to admit the merged S2 agent's existing output**, never to require the agent to
+change:
+
+| Concern | Resolution | S2 agent change? |
+| --- | --- | --- |
+| 1. Per-stage `cost_usd` | Add an optional, one-directionally coupled sub-field (present ⟹ top-level cost present; NOT an `iff`) with a split-tier spread check; **emitters SHOULD populate it on cost-present records** | **No change required for conformance.** The merged S2 agent emits cost-omitted records today (empty `observability/costs/`), which carry **no** per-stage band and stay valid (class A/C). The agent is **not broken** by the addition. A **follow-on enhancement** to have the S2 agent populate per-stage bands on cost-present records is **noted as a future emitter improvement**, NOT shipped here — it is out of scope and filed against the agent's own follow-up, because today the agent emits no cost-present records (no usable snapshot exists). |
+| 2. `generated_by` wording | Widen the description to admit `tier:<tier>` | **No.** The agent already emits the `tier:` form. |
+| 3. Grounding-path | Document the directory-path sentinel | **No.** The agent already emits the directory path. |
+
+**The conscious call recorded here (for diaboli scrutiny):** concern 1 introduces
+a sub-field the merged S2 agent does **not** emit. The spec chooses **not** to
+ship an S2 agent change in this slice, and justifies it: (a) the agent emits no
+cost-present records today (empty `observability/costs/`), so there is nothing for
+it to under-populate against a live snapshot; (b) the format's checklist does
+**not** mandate the sub-field on cost-present records (the §4.3 forward-optional
+rule), so the agent stays conformant when a snapshot eventually lands even before
+the follow-on; (c) bundling an emitter behaviour change with the format change
+would re-create the exact consumer/owner conflation that got this concern split
+out of S2 in the first place. The follow-on emitter enhancement is **named and
+deferred**, not orphaned — it is recorded in the spec's §11 watch-items and SHOULD
+be filed as a standalone issue against the `cost-estimator` agent at adjudication
+(per the AGENTS.md "a natural-home hand-off does not bind the next slice; re-file,
+do not leave implicit" decision).
+
+## 8. Component design (per component-design-with-tdad)
+
+- **Type**: a reference/format-contract edit — the deliverable is the modified
+  `estimate-record-format.md` (a `skills/<name>/references/<contract>.md` file per
+  the AGENTS.md cross-cutting-methodology decision) plus the scenarios that assert
+  it. Not a new skill, agent, or command.
+- **Justification**: the reference is the single canonical contract; editing it in
+  one place propagates to every consumer that references it by path (the merged S2
+  agent, the future S3 checkpoint). This is the exact idiom the AGENTS.md decision
+  prescribes.
+- **TDAD layers targeted**: `[structural]` only. Every assertion is mechanically
+  checkable by reading `estimate-record-format.md` and matching against the field
+  table, the validation checklist, and the two worked-example blocks. No
+  dispatchable side-effect ships in this slice (the S2 agent is unchanged; the S3
+  checkpoint is out of scope), so Layer 3 behavioural grading does not apply — the
+  same posture as the S1 `format-and-contract` scenario, which is structural for
+  the same reason. A future Layer 3 scenario (load the agent against a live
+  snapshot, assert the emitted cost-present record carries conformant per-stage
+  bands) is deferred to whichever slice wires a snapshot fixture (S6/calibration or
+  the follow-on emitter enhancement).
+- **What "demonstrated" means here vs what is deferred (O7 — honest framing).**
+  This slice's load-bearing claim is *demonstrated backward-compatibility*. Be
+  precise about what structural inspection delivers and what it does not:
+  - **Delivered here (structural).** Inspection of the reference establishes the
+    checklist **TEXT** (the "Per-stage cost coupling" and "Split-tier spread" lines
+    exist with their backward-safe wording), and the **four-class argument a human
+    traces** (§4.3 — that a faithful closed-world parser would accept classes A–D
+    and reject only the incoherent inverse). The scenarios assert the *content of
+    the contract* and the *coherence of the argument*, not the behaviour of a
+    parser. The new-scenario phrasings ("rejects the incoherent inverse", "no
+    `generated_by`-shape check exists", "no `path`-must-be-a-file check exists") are
+    assertions about the **checklist text** and the **absence of named checks in the
+    reference** — both directly readable — re-stated as the verdicts a faithful
+    parser *would* return, not the output of a parser actually run.
+  - **Deferred to S3 (runtime falsification).** An **actual closed-world parser run
+    over the four record classes** — the falsification that would turn the traced
+    argument into an executed demonstration — lands with S3's Output Validation
+    Checkpoint, which implements the runtime validator. This slice **defines** the
+    checklist; it does **not** run it. The claim here is therefore "the checklist
+    text and the four-class argument are demonstrated by structural inspection", not
+    "the closed-world behaviour is demonstrated by execution." The latter is honestly
+    S3's, and the spec does not over-claim it.
+- **Scenario vs finding**: scenario only — every assertion (the sub-field is in
+  the field table; the new checklist line exists and is backward-safe; Example 2
+  carries per-stage bands; Example 1 is unchanged; the `generated_by` description
+  admits `tier:`; the grounding-path sentinel is documented) is falsifiable by
+  inspection of the reference.
+
+### 8.1 Extend or add scenarios — the decision
+
+The existing S1 scenarios under `tdad_tests/scenarios/skills/cost-estimation/`
+assert the S1 reference content. This slice changes that content, so the existing
+scenarios must stay **consistent** with the edited reference, and new assertions
+are needed for the new content. The decision, per concern:
+
+- **`format-and-contract.md` — EXTEND.** It already asserts the field table, the
+  binding table, and the two worked examples. Extend its `Then` to assert: the
+  `tokens_by_stage[].cost_usd` sub-field is in the field table marked **optional and
+  one-directionally coupled** (sub-field present ⟹ top-level cost present; the
+  reverse is an emitter SHOULD, **not** an `iff`); the new "Per-stage cost coupling"
+  **and** "Split-tier spread" checklist lines are present with their backward-safe
+  wording; Example 2 carries the three concrete per-stage bands (spec-writer
+  `{1.00, 2.00}`, tdd-agent `{0.20, 0.60}`, implementer `{0.40, 5.00}`, summing to
+  the whole-record `{1.60, 7.60}`) with the
+  split-tier implementer band showing a strictly-positive spread; Example 1 carries
+  **no** per-stage band; the `generated_by` description admits the `tier:<tier>`
+  form and defines `tier:` as a **reserved prefix**; the grounding-path sentinel
+  (with its consumer special-case) is documented. Extending (not adding) keeps the
+  single structural contract for the reference in one scenario, consistent with
+  the corpus's one-scenario-per-contract shape.
+- **`cost-conditional.md` — EXTEND minimally.** It asserts the cost-omitted shape
+  and the three grounding states. Extend its `Then` to assert the cost-omitted
+  worked example (and the cost-omitted shape generally) carries **no** per-stage
+  `cost_usd` sub-field, and that the cost-snapshot grounding entry's directory-path
+  sentinel is the documented cost-omitted convention — locking the class-A/C
+  backward-compat invariant at the cost-conditional boundary where it belongs.
+- **Add ONE new scenario — `per-stage-cost-backward-compat.md`.** A dedicated
+  structural scenario whose entire job is the **backward-compatibility invariant**
+  (the load-bearing requirement of this slice). Per the O7 framing above, it is a
+  **structural** scenario: it asserts the **checklist text** and the **four-class
+  argument**, not the output of a parser actually run (that runtime falsification is
+  S3's). Its `Then` asserts that the checklist, **read as a closed-world parser**,
+  accepts **all four record classes** of §4.3 (old cost-omitted, old cost-present
+  without per-stage bands, new cost-omitted, new cost-present with per-stage bands);
+  **rejects** the incoherent inverse (a per-stage band with no top-level cost); and
+  **rejects** a collapsed split-tier band (`low == high` on a split-tier stage,
+  which the "Split-tier spread" rule forbids). It also asserts the **absence** of
+  two named checks in the reference — no `generated_by`-shape check and no
+  `path`-must-be-a-file check — both directly readable as the non-presence of those
+  lines. This isolates the demonstrated-not-asserted invariant into its own
+  falsifiable scenario, so a future edit that "tightens" the per-stage coupling into
+  a class-B-breaking mandate, or that drops the split-tier spread rule, fails this
+  scenario loudly.
+
+Three concerns, three scenario touches: two extensions of existing scenarios and
+one new backward-compat scenario. No scenario is deleted.
+
+## 9. Version bump and maintenance tail
+
+This slice edits a plugin reference file (a format/schema change), so it warrants
+a **minor** bump per the CLAUDE.md semver rules (a behavioural/format change to
+plugin files):
+
+- `ai-literacy-superpowers/.claude-plugin/plugin.json`: `version` 0.42.0 → 0.43.0.
+- `CHANGELOG.md` (repo root): new `## 0.43.0 — <implementation date>` heading with
+  entries for the per-stage `cost_usd` sub-field (optional, one-directionally
+  coupled, backward-compatible; split-tier spread check makes the widening
+  record-internally checkable), the `generated_by` description widening (with the
+  `tier:` reserved prefix), and the grounding-path sentinel documentation.
+- `.claude-plugin/marketplace.json`: bump the `ai-literacy-superpowers` entry
+  `version` and the top-level `plugin_version` to 0.43.0; leave top-level
+  `version` at 0.4.0.
+- `README.md`: bump the plugin badge 0.42.0 → 0.43.0.
+
+**Do NOT apply the bump at spec time** — it is an implementation-time step,
+recorded here for the plan. The validation checklist and the worked examples both
+live in the reference and **must stay mutually consistent** — the implementation
+must edit both (the new checklist line AND Example 2's per-stage bands) in the same
+change, and the `format-and-contract` scenario asserts that consistency.
+
+## 10. Functional requirements
+
+Numbered, testable, each traceable to a scenario in §8:
+
+- **FR-1** — `estimate-record-format.md` defines `tokens_by_stage[].cost_usd` as
+  an **optional** `{ low, high }` range sub-field under a **one-directional
+  coupling**, stated as such **in the field table** (not as an `iff`): sub-field
+  present ⟹ top-level `cost_usd` present (enforced); top-level `cost_usd` present
+  ⟹ bands SHOULD be populated by emitters but their absence does NOT invalidate the
+  record. The field table and the §4.4 check say the same thing.
+- **FR-2** — The field table / range rules name the per-stage `cost_usd` sub-field
+  in the "every present range has `low ≤ high`" enumeration (guarded by
+  *present*, so absence is not checked).
+- **FR-3** — The validation checklist carries a **"Per-stage cost coupling"** line
+  that (a) fails a record carrying a per-stage `cost_usd` with no top-level
+  `cost_usd`, (b) passes vacuously when no per-stage sub-field is present (old
+  records, cost-omitted records), and (c) does **NOT** mandate per-stage bands on
+  a cost-present record (so S1-era class-B records stay valid).
+- **FR-3b** — The validation checklist carries a **"Split-tier spread"** line that,
+  for every **present** per-stage `cost_usd` whose `model_tier` is a **split tier**,
+  requires a **strictly-positive ordered spread** (`low < high`) — rejecting a
+  collapsed band (`low == high`) on a split-tier stage. The split-tier trigger is a
+  **closed rule**: a `model_tier` is a split tier **iff its label contains a `/`**
+  (after the join-key whitespace normalisation), and no single (non-split) tier
+  label contains a slash, so "contains `/`" is a sound total classifier (§4.4).
+  Single-tier stages are exempt; an absent sub-field satisfies it vacuously. This is
+  the record-internal half of the S1-O6 checkability: the validator CAN assert a
+  split-tier band is **non-collapsed (strictly spread)** — `low < high` — but
+  CANNOT assert the band **spans two tiers** (a `{99.0, 100.0}` band passes) nor
+  that the bounds equal the absolute `claude-sonnet-4`/`claude-opus-4` rates (that
+  snapshot-grounded check is S3's, per §4.4.1). The cheaper-at-low / dearer-at-high
+  ordering is an **emitter convention** (methodology prose), not a checked invariant.
+- **FR-4** — The cost-present worked example (Example 2) carries the three concrete
+  per-stage `cost_usd` bands derived in §4.5 — spec-writer `{ 1.00, 2.00 }`,
+  tdd-agent `{ 0.20, 0.60 }`, implementer `{ 0.40, 5.00 }` — each re-derived from
+  two fixed per-tier rates (sonnet `4.0e-6`, opus `2.0e-5` $/token) applied to that
+  stage's tokens, so each single-tier band's low and high equal its tier-rate ×
+  the respective token bound (the band would pass an absolute-rate check); the
+  per-stage bands sum exactly to the whole-record `{ 1.60, 7.60 }` (set equal by
+  construction); the implementer split-tier band has a strictly-positive spread
+  and matches the Included prose's stated `$0.40–$5.00` band.
+- **FR-5** — The cost-omitted worked example (Example 1) carries **no** per-stage
+  `cost_usd` sub-field and remains valid (class A/C).
+- **FR-6** — The reference demonstrates (in a checklist note and by the two worked
+  examples) that all four §4.3 record classes validate and only the incoherent
+  inverse is rejected — the backward-compat invariant, shown not asserted.
+- **FR-7** — The `generated_by` field description admits **both** a concrete model
+  identifier **and** a `tier:<tier>` routing-tier label, defines **`tier:` as a
+  reserved provenance prefix** (a concrete model id never begins with `tier:`, so a
+  consumer can mechanically distinguish the two forms by the prefix without any
+  rejecting check), and states the value is never a guessed/hard-coded model.
+- **FR-8** — No validation-checklist line keys on `generated_by` shape (the
+  widening is description-only; no record is retroactively rejected).
+- **FR-9** — The reference documents the directory path `observability/costs/`
+  (trailing slash) as the **named cost-omitted sentinel** for the mandatory
+  cost-snapshot grounding entry; the entry is never dropped and never given a
+  fabricated file path; a snapshot file path is used in state 3.
+- **FR-10** — No validation-checklist line requires `grounding_sources[].path` to
+  be a file (the directory-path convention stays valid; no record is retroactively
+  rejected).
+- **FR-11** — No S2 agent change ships in this slice; the merged S2 agent's
+  emitted records (cost-omitted shape, `tier:Standard` provenance, directory
+  grounding-path) are all conformant against the edited reference. The follow-on
+  emitter enhancement (populate per-stage bands on cost-present records) is named
+  and deferred, not orphaned.
+- **FR-12** — The version bump (0.42.0 → 0.43.0) is proposed across the four
+  locations and applied only at implementation time; the checklist and worked
+  examples stay mutually consistent.
+
+### 10.1 FR → scenario map
+
+| FR | Covering scenario |
+| --- | --- |
+| FR-1 | `format-and-contract.md` (extended) |
+| FR-2 | `format-and-contract.md` (extended) |
+| FR-3 | `format-and-contract.md` (extended) + `per-stage-cost-backward-compat.md` (new) |
+| FR-3b | `format-and-contract.md` (extended) + `per-stage-cost-backward-compat.md` (new — rejects collapsed split-tier band) |
+| FR-4 | `format-and-contract.md` (extended) |
+| FR-5 | `cost-conditional.md` (extended) + `per-stage-cost-backward-compat.md` (new) |
+| FR-6 | `per-stage-cost-backward-compat.md` (new) |
+| FR-7 | `format-and-contract.md` (extended) |
+| FR-8 | `per-stage-cost-backward-compat.md` (new — asserts no `generated_by`-shape check exists) |
+| FR-9 | `format-and-contract.md` (extended) + `cost-conditional.md` (extended) |
+| FR-10 | `per-stage-cost-backward-compat.md` (new — asserts no path-shape check exists) |
+| FR-11 | (no scenario — an out-of-scope assertion; verified by the absence of any S2 agent edit in the module-touch list, checked at PR time) |
+| FR-12 | local version-consistency check (implementation-time) |
+
+## 11. User stories and acceptance scenarios
+
+### 11.1 Story — a split-tier band's non-collapsed spread is machine-checkable on a cost-present record
+
+**As** a future Output Validation Checkpoint (S3) author
+**I want** the per-stage `cost_usd` bands to be a field on the record, with a
+record-internal strictly-spread invariant on split-tier stages
+**So that** I can assert a split-tier band is non-collapsed (strictly spread,
+`low < high`) from the record alone, rather than trusting prose — and know exactly
+which absolute-rate check I must defer to my own snapshot-grounded validator.
+
+```gherkin
+Given ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+When I read the frontmatter field table and the cost-present worked example
+Then tokens_by_stage[].cost_usd is defined as an optional { low, high } range
+    under a one-directional coupling (sub-field present implies top-level cost
+    present; the reverse is an emitter SHOULD, not an iff)
+And the cost-present worked example (Example 2) carries a per-stage cost_usd on
+    each tokens_by_stage entry with the concrete bands spec-writer {1.00,2.00},
+    tdd-agent {0.20,0.60}, implementer {0.40,5.00}, re-derived from two fixed
+    per-tier rates (sonnet 4.0e-6, opus 2.0e-5 $/token)
+And the implementer entry (a split tier) has a strictly-positive ordered spread
+    (low < high), priced by the emitter convention at the cheaper representative
+    model (low) and the dearer (high) per the binding table, matching the Included
+    prose
+And the reference states the validator CAN assert the split-tier band is
+    non-collapsed (strictly spread) but CANNOT assert the band spans two tiers nor
+    that the bounds equal the absolute snapshot rates (that check is S3's)
+And the whole-record cost_usd band equals the per-stage sum {1.60,7.60} here (set
+    equal by construction), though the existing correlation note permits them to
+    differ in general
+```
+
+### 11.2 Story — old and new records both validate (backward-compat, demonstrated)
+
+**As** the owner of the stable format contract
+**I want** the new sub-field's validation to be demonstrated backward-compatible
+against the closed-world checklist
+**So that** neither S1/S2-era records nor new records are rejected, and only the
+incoherent inverse is caught.
+
+```gherkin
+Given the edited estimate-record-format.md validation checklist read as a
+    closed-world parser
+When I trace it against the four record classes
+Then an old cost-omitted record (no top-level cost, no per-stage band) is VALID
+And an old cost-present record with top-level cost but NO per-stage bands is VALID
+    (the per-stage coupling check does not mandate the sub-field)
+And a new cost-omitted record (no sub-field) is VALID
+And a new cost-present record with per-stage bands on every stage is VALID
+And a record carrying a per-stage cost_usd with NO top-level cost_usd is REJECTED
+    by the "Per-stage cost coupling" check
+And a record whose split-tier stage carries a collapsed band (low == high) is
+    REJECTED by the "Split-tier spread" check
+And the "Ranges well-formed" enumeration includes tokens_by_stage[].cost_usd
+    "when present", so an absent sub-field is never checked
+And no checklist line keys on generated_by shape and no checklist line requires
+    grounding_sources[].path to be a file (both readable as absent in the reference)
+```
+
+### 11.3 Story — the cost-omitted record is unchanged and still valid
+
+**As** a human running the estimator on today's repo (empty `observability/costs/`)
+**I want** the cost-omitted record shape unchanged by this slice
+**So that** the merged S2 agent's day-one-default output stays conformant.
+
+```gherkin
+Given the edited estimate-record-format.md
+When I read the cost-omitted worked example (Example 1)
+Then it carries no tokens_by_stage[].cost_usd sub-field on any stage
+And cost_usd and cost_basis remain absent with the omission disclosed in Excluded
+And the mandatory cost-snapshot grounding entry's path is the directory
+    "observability/costs/" (trailing slash), documented as the cost-omitted sentinel
+And the record validates against the edited checklist (class A/C)
+```
+
+### 11.4 Story — `generated_by` admits the merged agent's tier label
+
+**As** a reader or downstream consumer parsing `generated_by`
+**I want** the field's description to recognise the `tier:<tier>` form the merged
+S2 agent emits
+**So that** the most common record's provenance value is documentation-conformant,
+not a silent contradiction.
+
+```gherkin
+Given the edited estimate-record-format.md generated_by field description
+When I read it
+Then it admits both a concrete model identifier and a "tier:<tier>" routing-tier
+    label when the concrete model is unavailable
+And it defines "tier:" as a reserved provenance prefix, so a consumer can
+    mechanically distinguish a tier label from a concrete model id (which never
+    begins with "tier:") without any rejecting check
+And it states the value is never a guessed or hard-coded model string
+And no validation-checklist line keys on generated_by shape (no record is
+    retroactively rejected by the widening)
+And the merged S2 agent's "cost-estimator / tier:Standard" output is now
+    description-conformant with no S2 agent change
+```
+
+### 11.5 Story — the grounding-path directory sentinel is documented
+
+**As** a reader of the cost-omitted record
+**I want** the directory grounding-path documented as a named sentinel
+**So that** "the inputs the estimate was built from" reads coherently for the
+empty-snapshot case, and the merged S2 agent's behaviour is ratified.
+
+```gherkin
+Given the edited estimate-record-format.md grounding_sources description and
+    three-grounding-states section
+When I read them
+Then the directory path "observability/costs/" (trailing slash) is documented as
+    the cost-omitted sentinel for the mandatory cost-snapshot entry
+And the reference states this entrenches an overloaded meaning (file = grounded;
+    trailing-slash directory = looked-and-found-nothing) rather than resolving it
+And the reference carries a consumer special-case note: an aggregator counting
+    snapshot-grounded records must not count a trailing-slash directory path as a
+    grounding
+And the entry is never dropped and never given a fabricated snapshot file path
+And a usable snapshot (state 3) uses the snapshot file path instead
+And no validation-checklist line requires grounding_sources[].path to be a file
+    (no record is retroactively rejected)
+And the merged S2 agent's directory-path output stays conformant with no S2 change
+```
+
+## 12. Watch-items (named, not orphaned)
+
+- **Follow-on emitter enhancement (concern 1) — the falsifiable home of the
+  SHOULD (O4).** Have the `cost-estimator` agent populate per-stage `cost_usd`
+  bands on the cost-present records it emits once a usable snapshot exists. This is
+  the **emitter requirement that satisfies the §4.1/§4.3.1 SHOULD** — without it the
+  SHOULD would be indistinguishable from a MAY. Its acceptance criterion is
+  falsifiable: "on a cost-present record, every exercised stage carries a per-stage
+  `cost_usd` band, and each split-tier stage's band has a strictly-positive spread"
+  — gradable by a future Layer 3 scenario once a snapshot fixture exists. **Not
+  shipped here** (the agent emits no cost-present records today; bundling an emitter
+  change with the format change re-creates the consumer/owner conflation this slice
+  exists to avoid). **File as a standalone issue against the `cost-estimator` agent
+  at adjudication**, per the AGENTS.md "a natural-home hand-off does not bind the
+  next slice — re-file, do not leave implicit" decision. Until filed, it is recorded
+  here; within this slice the obligation is honestly "the format admits the band; no
+  producer yet populates it" (§4.3.1).
+- **A future Layer 3 behavioural scenario** that dispatches the agent against a
+  live snapshot fixture and asserts the emitted cost-present record's per-stage
+  bands conform — deferred to whichever slice wires a snapshot fixture (the
+  follow-on emitter enhancement or S6).

--- a/docs/superpowers/stories/format-revision-per-stage-cost-design.md
+++ b/docs/superpowers/stories/format-revision-per-stage-cost-design.md
@@ -1,0 +1,471 @@
+---
+spec: docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md
+date: 2026-06-11
+mode: spec
+cartographer_model: claude-opus-4-8[1m]
+stories:
+  - id: 1
+    lens: [patterns, alternatives]
+    title: Own-the-contract slice over in-place mutation
+    disposition: pending
+    disposition_rationale: null
+  - id: 2
+    lens: [forces, consequences]
+    title: Record-internal spread over absolute-rate binding
+    disposition: pending
+    disposition_rationale: null
+  - id: 3
+    lens: [patterns, forces]
+    title: One-directional coupling over biconditional iff
+    disposition: pending
+    disposition_rationale: null
+  - id: 4
+    lens: [forces, consequences]
+    title: Directory sentinel over a clean token
+    disposition: pending
+    disposition_rationale: null
+  - id: 5
+    lens: [patterns, defaults]
+    title: Reserved tier-prefix grammar without a check
+    disposition: pending
+    disposition_rationale: null
+  - id: 6
+    lens: [forces, consequences]
+    title: Whole-record cost set to per-stage sum
+    disposition: pending
+    disposition_rationale: null
+  - id: 7
+    lens: [alternatives, coherence]
+    title: Emitter enhancement deferred, not bundled
+    disposition: pending
+    disposition_rationale: null
+  - id: 8
+    lens: [patterns, consequences]
+    title: Widen-and-mark over reshape-and-validate
+    disposition: pending
+    disposition_rationale: null
+---
+
+## Story #1 — Own-the-contract slice over in-place mutation
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (Slice header, §1, §7)
+**Lens:** patterns / alternatives
+**Refs:** —
+
+**Context.** Three concerns accumulated against the merged S1 estimate-record
+format reference during the S1 and S2 reviews. Rather than letting S2 — a pure
+consumer of that reference — mutate the contract it consumes, the team carved
+the format change into its own slice (#377) that *owns* `estimate-record-format.md`
+and runs its own diaboli pass. This slice is the first worked instance of a
+boundary-discipline precedent the S2 cartographer named but did not yet exercise.
+
+**Forces.** Velocity (fold the three small fixes into S2 and move on) versus
+contract integrity (a shared kernel with merged consumers should not be edited
+by one of its consumers as a side-effect). A second, quieter force: adversarial
+coverage — a contract change folded into a consumer slice inherits that slice's
+diaboli pass, which is scoped to the consumer's behaviour, not the contract's
+backward-compatibility. Splitting buys the contract change a *dedicated*
+adversarial pass (it took two rounds, eight then five objections).
+
+**Options not taken.**
+- *Mutate the reference inside S2.* Lowest ceremony; conflates consumer and
+  owner roles and gives the contract change only S2's diaboli budget.
+- *Append the format fixes to a later sibling slice (S3, the command).* S3 owns
+  the runtime checkpoint, not the contract; the format change would again ride a
+  consumer's review.
+- *A single combined "format + emitter" slice.* Re-creates the consumer/owner
+  conflation in a different shape — see Story #7.
+
+**Choice as written.** The spec declares the slice the *legitimate owner* of the
+reference, the only slice that MAY modify it, and routes all three deferred
+residues here. Ownership is asserted in the slice header (`Owns:`) and enforced
+by the slice's whole structure.
+
+**Consequences.** Establishes a reusable pattern: contract changes get their own
+owning slice and their own adversarial pass, separate from any consumer. The cost
+is slice proliferation — a three-line documentation fix now carries a full
+feature-PR ceremony (spec + dual diaboli + scenarios + version bump). The team
+has decided that contract-change ceremony is worth more than the throughput it
+costs.
+
+**Pattern.** Shared Kernel with a single owning Bounded Context (Evans, DDD) —
+the reference is the kernel; the owning slice is its steward; consumers reference
+it by path and inherit changes. Also an instance of the codebase's
+"cross-cutting methodology lives in `skills/<name>/references/<contract>.md`"
+AGENTS.md decision, here paired with an explicit *ownership* boundary the
+decision implies but does not spell out.
+
+**Notes.** This is the first worked precedent of the S2 "consumer slice refuses
+to mutate its contract" decision. Strong promotion candidate: the ownership-plus-
+dedicated-diaboli rule is reusable beyond cost-estimation.
+
+## Story #2 — Record-internal spread over absolute-rate binding
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§4.4, §4.4.1)
+**Lens:** forces / consequences
+**Refs:** O3, #1
+
+**Context.** The slice exists to make S1's split-tier widening machine-checkable —
+S1 demonstrated it only in prose and a worked example. The headline decision (O3)
+is *what kind* of checkability to deliver now. The spec chose a record-internal
+strict-spread invariant (`low < high` on split-tier bands) deliverable in this
+format-only slice, and explicitly deferred the absolute-rate check (does the band
+equal the snapshot's sonnet/opus rates?) to S3, which owns the snapshot.
+
+**Forces.** Checkability-now versus checkability-complete. A stateless checklist
+parser reading only the record cannot know the absolute `$/token` rates — those
+live in the snapshot, out of scope here. The spec resolved toward delivering the
+strongest invariant the *record alone* can carry, and being honest in §4.4.1 that
+this is a floor: a `{99.0, 100.0}` band still passes the spread check while bearing
+no relation to a genuine two-tier widening.
+
+**Options not taken.**
+- *Make the record carry the per-model rates it used* (option (a), §4.4.1), so the
+  check is fully self-contained. Rejected: adds a field the merged S2 agent does
+  not emit, breaking backward-compat and re-introducing a required field.
+- *Defer all checkability to S3* and ship only "a place to put the band." Rejected
+  by round-1 O3's disposition: the slice must deliver real record-internal
+  checkability, not just a field.
+- *Over-claim the spread check as "makes the widening machine-checkable."* The
+  prior draft did exactly this in its headers and FRs; O3 forced every surface
+  down to the honest "non-collapsed (strictly spread)" floor.
+
+**Choice as written.** Deliver the record-internal half (strict-spread invariant)
+now; defer the absolute-rate half to S3 explicitly. §4.4.1 states plainly what the
+validator CAN assert (presence/coupling, `low ≤ high`, strict spread on split-tier
+bands) and CANNOT (spans-two-tiers, equals-the-rates, magnitude-correct).
+
+**Consequences.** The slice's value is genuine but partial, and the partition is
+now load-bearing on S3 honouring its half. A future S3 author must build the
+absolute-rate validator the deferred half names; if S3 forgets, the widening is
+forever only spread-checked. The honest §4.4.1 floor is the durable artefact — it
+tells the downstream author exactly which check is theirs to build.
+
+**Pattern.** A split invariant across a deferred boundary — necessary-but-not-
+sufficient checking, where the format owner proves the part it can and names the
+part it cannot. Sibling to Story #1's owner/consumer split: the same discipline
+that put the contract in its own slice also keeps the contract from claiming a
+check that needs a consumer's data.
+
+## Story #3 — One-directional coupling over biconditional iff
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§4.1, §4.2, §4.3)
+**Lens:** patterns / forces
+**Refs:** —
+
+**Context.** The new per-stage `cost_usd` sub-field is coupled to the existing
+top-level `cost_usd`. The prior draft expressed this as an `iff` biconditional in
+the field table. This revision splits the coupling into two directions of
+different strength: sub-field present ⟹ top-level present (enforced by the
+validator); top-level present ⟹ bands SHOULD be populated (an emitter obligation,
+not a rejection rule).
+
+**Forces.** Internal coherence of the format (a per-stage band with no whole-record
+cost is genuinely incoherent and should fail) versus backward-compatibility with
+S1-era cost-present records that have top-level cost but no per-stage bands
+(class B). A biconditional satisfies the first force and *breaks* the second — it
+would retroactively fail every S1-era cost-present record, including the merged
+Example 2. The asymmetry is the only resolution that holds both.
+
+**Options not taken.**
+- *Biconditional `iff`* (the prior draft). A literal reader — and the reference
+  instructs readers to parse, not read loosely — tightens it into a class-B-breaking
+  mandate.
+- *No coupling at all* — a per-stage band could appear on a cost-omitted record,
+  the incoherent inverse the slice means to forbid.
+- *Make the sub-field required when top-level cost is present.* Same class-B break
+  as the biconditional, stated imperatively.
+
+**Choice as written.** The enforced direction is the one that catches the
+incoherent inverse (sub-field ⟹ top-level); the SHOULD direction (top-level ⟹
+bands) is held as an emitter obligation with a falsifiable home in the deferred
+follow-on issue (§4.3.1). The field table and the §4.4 check are made to say the
+same thing.
+
+**Consequences.** Class B stays valid; the genuinely incoherent shape still fails.
+The cost is a SHOULD that no shipped emitter exhibits today (§4.3.1's honest scope
+note: "the format admits the band; no producer yet populates it") — its only home
+is a deferred issue's acceptance criterion (see Story #7). A reader who skims the
+field table must hold the asymmetry in mind; the symmetry of the old `cost_usd`/
+`cost_basis` pairing is deliberately *not* mirrored on the reverse direction.
+
+**Pattern.** Postel-flavoured asymmetry (liberal in what a record may omit, strict
+in the one shape that is incoherent) — and an instance of separating an emitter's
+SHOULD-populate obligation from a validator's MUST-reject rule, the same
+disclosure-vs-enforcement seam the codebase's disclosure-of-derived-judgment
+decision draws elsewhere.
+
+## Story #4 — Directory sentinel over a clean token
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§6.1, §6.2)
+**Lens:** forces / consequences
+**Refs:** O5, #1
+
+**Context.** When no cost snapshot file exists, the mandatory cost-snapshot
+grounding entry's `path` points at the directory `observability/costs/` (trailing
+slash). The field is documented as "the inputs the estimate was built from"; a
+directory that grounded nothing strains that description. The spec chose to keep
+the directory path and *document* it as the named cost-omitted sentinel, rather
+than invent a cleaner token.
+
+**Forces.** Semantic cleanliness (a directory path that grounded nothing overloads
+"the inputs the estimate was built from") versus backward-compatibility (the merged
+S2 agent already emits the directory path; Example 1 already uses it). The spec
+resolved toward zero S2 change and zero new parse case, and pays for it by naming
+the strain rather than removing it.
+
+**Options not taken.**
+- *Make the cost-snapshot entry optional when omitted.* Removes the deliberate "the
+  record always shows it looked" honesty signal and breaks the merged S2 agent,
+  which never drops the entry.
+- *Invent a new sentinel token* (`path: <none>`, `kind: no-snapshot`). Cleanest
+  semantically; introduces a value the S2 agent does not emit and a new enum/parse
+  case for every consumer.
+- *Keep the directory path and document it* — chosen. Zero S2 change, zero new
+  parse case, ratifies the Example-1 precedent.
+
+**Choice as written.** The reference now documents the trailing-slash directory as
+the defined cost-omitted sentinel and explicitly states this *entrenches* an
+overloaded meaning (file = grounded; trailing-slash directory =
+looked-and-found-nothing) — "named and accepted," not "resolved." It adds a
+consumer special-case: a snapshot-counting aggregator must not count a
+trailing-slash path as a grounding.
+
+**Consequences.** The overloaded field is now a deliberate, documented entrenchment.
+The accepted residual (O5): the consumer special-case is advisory prose with no
+checklist enforcement, so the same closed-world silence that proves backward-compat
+also guarantees nothing catches an aggregator that miscounts. The cost is
+externalised onto every downstream counter (S3, any cost aggregator) — a silent-
+miscount risk the slice does not control. This is the same own-the-contract trade
+as Story #1, seen from its cost side: ownership lets the slice choose entrenchment,
+but it cannot enforce the special-case it depends on without widening scope.
+
+**Pattern.** Overloaded sentinel value (a magic path encoding a negative fact) —
+the classic backward-compat-over-cleanliness trade, here made honest by naming the
+overload rather than hiding it.
+
+## Story #5 — Reserved tier-prefix grammar without a check
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§5.1, §5.3)
+**Lens:** patterns / defaults
+**Refs:** —
+
+**Context.** The merged S2 agent honestly emits `cost-estimator / tier:Standard`
+under `model: inherit` when it cannot resolve its concrete model — a value the
+field's "model identifier" description does not recognise. The spec widens the
+description to admit a `tier:<tier>` label and defines `tier:` as a *reserved
+provenance prefix* so a consumer splitting on the ` / ` separator can mechanically
+tell a tier label from a concrete model id — without adding any rejecting check.
+
+**Forces.** Mechanical distinguishability (a consumer must be able to classify the
+value deterministically) versus backward-compat (no new check may retroactively
+fail a record, and the checklist keys on `generated_by` nowhere today). A naive fix
+would add a `generated_by`-shape check; that risks retroactive failure. The spec
+resolved toward a *grammar* (a prefix reservation) that gives a consumer a total
+discriminator while the field stays unvalidated for rejection.
+
+**Options not taken.**
+- *Reshape `generated_by` into separate agent/model/tier fields.* Breaks the merged
+  S2 agent (single string), adds required fields, solves a wording mismatch with a
+  schema change.
+- *Add a `generated_by`-shape validation check.* Could retroactively fail an old
+  record; explicitly out of scope (§2.3).
+- *Widen the description with no prefix reservation.* Leaves the value ambiguous —
+  a consumer cannot tell `tier:Standard` from a model id when splitting on ` / `.
+
+**Choice as written.** Widen the description to admit both forms; reserve `tier:`
+as a prefix (a concrete model id never begins with `tier:`); add no check. A
+grammar, not a validator.
+
+**Consequences.** The most common record's provenance is now documentation-
+conformant with zero agent change. The reservation is enforced only by convention —
+nothing rejects a future model genuinely named `tier:...` (the spec argues none
+exists in `MODEL_ROUTING.md` or any snapshot, making the prefix a sound total
+discriminator *today*). A consumer that splits on the separator without testing the
+prefix still mis-classifies; the grammar enables correct parsing but does not compel
+it. Symmetric with Story #4: a parsing rule documented, not enforced.
+
+**Pattern.** Reserved prefix / sentinel namespace (cf. reserved identifiers in
+language grammars) — a discriminator carried in-band by convention rather than by a
+separate typed field. The default being widened here is the inherited "model
+identifier" framing from S1, which the merged S2 agent had already silently
+outgrown.
+
+## Story #6 — Whole-record cost set to per-stage sum
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§4.5)
+**Lens:** forces / consequences
+**Refs:** O1, #2
+
+**Context.** Example 2 (the cost-present worked example) is the reference's single
+demonstration of a correctly-priced widening. Round-2 O1 showed the prior bands were
+back-solved to hit a fixed whole-record envelope `{0.95, 7.50}`, so they could not
+be reproduced from two consistent per-tier rates. The fix re-derives all three bands
+from two fixed rates and sets the whole-record `cost_usd` to their exact sum
+`{1.60, 7.60}` by construction.
+
+**Forces.** Rate-groundedness (every band must be a fixed tier rate × a token bound,
+so the example would pass the absolute-rate validator S3 is told to build) versus
+sum-tidiness (a hand-author's instinct to make the per-stage figures add to a
+pre-chosen whole-record band). The §4.4 correlation note *permits* the whole-record
+band to differ from the sum — so the spec was free to let the sum land where the
+rates put it, and then chose to make the whole-record figure equal that sum rather
+than preserve the old envelope.
+
+**Options not taken.**
+- *Keep the old envelope `{0.95, 7.50}` and allocate bands to fit it* (the O1
+  defect) — produces per-token rates that contradict the example's own declared
+  rates; the canonical example would fail the deferred S3 validator.
+- *Let the whole-record band differ from the sum* (permitted by the correlation
+  note) — defensible, but leaves the example's two figures unrelated and invites a
+  reader to wonder why they differ.
+- *Set the whole-record band equal to the sum* — chosen, the cleanest fix: every
+  number traceable to one of two rates, and the two figures reconcile by
+  construction.
+
+**Choice as written.** Two fixed rates (sonnet `4.0e-6`, opus `2.0e-5`), each
+single-tier band = its rate × its token bounds, the split implementer band =
+cheaper rate at low / dearer rate at high, and the whole-record band = the exact
+sum. The worked example must itself pass the validator the slice defers to S3.
+
+**Consequences.** The canonical example is now rate-grounded and would survive the
+deferred absolute-rate check (Story #2) — the example that teaches the widening is
+no longer the example that breaks the deferred validator. The cost: the whole-record
+band is now *demonstrated* equal to the sum in the one canonical case, which a
+careless reader could over-generalise into "whole-record always equals the sum,"
+contradicting the correlation note that still permits divergence. The spec flags
+this ("set equal by construction... though the correlation note permits them to
+differ"); the example carries the weaker invariant only by construction, not as a
+rule.
+
+**Pattern.** Executable specification by exemplar — the worked example is held to
+the same check the contract defines, so the demonstration cannot drift from the
+checked invariant. This is the artefact-side counterpart to Story #2's deferred-
+check honesty: the example pre-satisfies the check that the format itself cannot yet
+run.
+
+## Story #7 — Emitter enhancement deferred, not bundled
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§7, §12, §4.3.1)
+**Lens:** alternatives / coherence
+**Refs:** #1, #3
+
+**Context.** Concern 1 adds a sub-field the merged S2 agent does not emit. A natural
+move is to also teach the S2 agent to populate per-stage bands on cost-present
+records. The spec explicitly does *not* ship that emitter change; it files it as a
+standalone follow-on issue against the `cost-estimator` agent, and ships only the
+format that *admits* the band.
+
+**Forces.** Completeness (a format field nothing populates feels half-finished)
+versus boundary discipline (an emitter behaviour change belongs to the emitter's
+slice, not the contract's). The decisive force is that bundling an emitter change
+into the format slice re-creates the exact consumer/owner conflation that got this
+slice split out of S2 in the first place — the slice would have to reason about both
+the contract and a consumer's behaviour in one diaboli pass.
+
+**Options not taken.**
+- *Bundle the emitter change here.* Re-conflates owner and consumer; the spec calls
+  this out directly (§7(c)).
+- *Drop the SHOULD entirely* and make per-stage bands a pure MAY. Loses the emitter
+  obligation that Story #3's asymmetry depends on; the SHOULD would be
+  indistinguishable from a MAY.
+- *Leave the follow-on implicit.* The AGENTS.md "a natural-home hand-off does not
+  bind the next slice — re-file, do not leave implicit" decision forbids this; an
+  unfiled hand-off is an orphaned obligation.
+
+**Choice as written.** No S2 agent change ships (§7). The emitter enhancement is
+named in §12 watch-items with a falsifiable acceptance criterion and is to be filed
+as a standalone issue at adjudication. The SHOULD of Story #3 gets its falsifiable
+home there.
+
+**Consequences.** The slice stays format-only and its diaboli pass stays scoped to
+the contract. The cost: the SHOULD has no shipped producer today — within this slice
+the obligation is honestly "the format admits the band; no producer yet populates
+it" (§4.3.1), and the only cost-present record carrying bands is the hand-authored
+Example 2. The whole construction is coherent only if the follow-on issue is
+actually filed; until it is, the SHOULD's falsifiable home is a watch-item, not a
+tracked issue. The re-application of Story #1's own discipline to its own residue is
+the coherence signal — the slice declines to do to S2 what it was created to stop S2
+doing to the contract.
+
+**Pattern.** Re-filing a hand-off as a tracked obligation (the AGENTS.md "re-file,
+do not leave implicit" decision) — and a recursive application of the
+owner/consumer boundary that created the slice (Story #1) to the slice's own
+emitter residue.
+
+## Story #8 — Widen-and-mark over reshape-and-validate
+
+**Source:** `docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md` (§2.3, §3, §5, §6)
+**Lens:** patterns / consequences
+**Refs:** #3, #4, #5
+
+**Context.** All three concerns share a single resolution strategy, made possible by
+the checklist's closed-world property (§3): the checklist rejects a record only when
+a *named* check fails, never for carrying a field it does not mention. Every fix is
+shaped to widen the format to admit existing output and mark new structure as
+optional — never to reshape the contract or add a rejecting check that could
+retroactively fail a record.
+
+**Forces.** Contract evolution versus backward-compat against merged consumers. The
+closed-world property is the lever: a new optional field is invisible to every check
+that does not name it, so additive widening is provably non-breaking, while
+reshaping (new required fields, new rejecting checks) is not. The spec resolved
+*every* concern toward additive widening and named the guard rails (§2.3): if a
+reviewer finds a required field, a new grounding state, a `generated_by`-shape
+check, or a `path`-must-be-a-file check, that is scope creep to be cut.
+
+**Options not taken.**
+- *Reshape the contract per concern* (split `generated_by`, a new snapshot token, a
+  required per-stage field) — each a backward-compat break, each rejected in its
+  own section (§4.2, §5.2, §6.2).
+- *Add rejecting checks to enforce the new semantics* (a `generated_by`-shape check,
+  a `path`-must-be-a-file check, a biconditional coupling) — each risks retroactive
+  failure; all declined.
+- *Treat backward-compat as asserted* rather than demonstrated. The slice's load-
+  bearing requirement is the opposite: trace the closed-world checklist against four
+  record classes and show, not state, that all pass.
+
+**Choice as written.** Widen-and-mark across all three concerns: an optional one-
+directionally-coupled sub-field (Story #3), a description widening plus a non-
+rejecting grammar (Story #5), documentation of an existing path convention (Story
+#4). The closed-world property carries every backward-compat demonstration.
+
+**Consequences.** Backward-compat is provable and proven; the merged S2 agent needs
+no change. The accepted cost is that the new semantics the slice cares about (the
+SHOULD-populate obligation, the trailing-slash special-case, the `tier:` prefix
+reservation) are all *conventions the checklist does not enforce* — the same closed-
+world silence that proves safety also guarantees nothing catches a consumer that
+ignores them. The strategy buys zero breakage at the price of zero enforcement on
+the new conventions; the slice records each unenforced convention's residual
+honestly (O5 for the path, §4.3.2 for the inverse-rejection scope) rather than
+implying enforcement it did not add.
+
+**Pattern.** Tolerant Reader / additive schema evolution over a closed-world
+validator — the unifying pattern beneath Stories #3, #4, and #5. The closed-world
+checklist is the enabling mechanism; widen-and-mark is the strategy it makes safe.
+
+---
+
+## Cross-references — resolved summary
+
+- **#1 → (none cited inward).** The owning-slice decision is the root; Stories #2,
+  #4, and #7 all reference it as the discipline they inherit or re-apply.
+- **#2 → O3, #1.** O3 forced the honest "non-collapsed (strictly spread)" floor that
+  this story records as the chosen checkability level; #1 is the owner/consumer split
+  whose discipline keeps the contract from claiming a snapshot-dependent check.
+- **#3 → (no objection — round-1 resolved).** The `iff` trap is confirmed-resolved in
+  the round-2 record's "Explicitly not objecting to" section, so no live O-id applies;
+  the story records the decision, not a residual risk.
+- **#4 → O5, #1.** O5 is the accepted residual (advisory consumer special-case, no
+  enforcement) that this story records as the cost of the entrenchment; #1 is the
+  ownership that licenses choosing entrenchment.
+- **#5 → (no objection — round-1 resolved).** The `tier:` reserved-prefix grammar is
+  confirmed-resolved (round-1 O6) in the not-objecting section; the story records the
+  grammar-not-validator decision.
+- **#6 → O1, #2.** O1 forced the re-derivation from two fixed rates (the defect that
+  made the prior bands envelope-fitted); #2 is the deferred absolute-rate check that
+  the re-derived example must pre-satisfy.
+- **#7 → #1, #3.** #1 is the owner/consumer boundary this story re-applies to the
+  emitter residue; #3 is the SHOULD whose falsifiable home is the deferred follow-on.
+- **#8 → #3, #4, #5.** This is the coherence story over the three widen-and-mark
+  fixes; it names the closed-world property as their shared enabling mechanism.

--- a/tdad_tests/scenarios/skills/cost-estimation/cost-conditional.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/cost-conditional.md
@@ -77,6 +77,45 @@ three snapshot grounding states is handled.
   usable snapshot lands — the same `cost_usd`/`cost_basis`/
   `confidence.cost` fields simply begin to appear.
 
+---
+
+### Format-revision slice (#377) additions
+
+The format-revision slice (spec
+`docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md`)
+adds two cost-conditional invariants that belong at this boundary. They
+fail against the S1-era reference and pass only once the slice's edits
+land.
+
+**Cost-omitted shape carries no per-stage `cost_usd` sub-field** (spec
+§4.3 class A/C, §4.5; FR-5):
+
+- The **cost-omitted worked example** (Example 1) carries **no**
+  `tokens_by_stage[].cost_usd` sub-field on any stage — the per-stage cost
+  band **never appears on a cost-omitted record** (top-level `cost_usd`
+  absent ⟹ no per-stage band anywhere).
+- This is the cost-conditional half of the class-A/C backward-compat
+  invariant: a cost-omitted record (today's day-one default) stays
+  **valid** under the edited checklist precisely because the sub-field is
+  absent and every new per-stage check fires vacuously.
+
+**Grounding-path directory sentinel is the documented cost-omitted
+convention** (spec §6, §6.1; FR-9):
+
+- The mandatory `cost-snapshot` grounding entry's `path` on the
+  cost-omitted record is the **directory** `observability/costs/`
+  (trailing slash), and the reference **documents** this as the **named
+  cost-omitted sentinel** — the entry is **present** (satisfying the "at
+  minimum a cost-snapshot entry" rule), **never dropped**, and **never
+  given a fabricated snapshot file path**.
+- The reference carries the **consumer special-case** note: an aggregator
+  counting snapshot-grounded records **must not** count a `cost-snapshot`
+  entry whose `path` ends in `/` as a grounding — the trailing-slash
+  directory is a sentinel for *looked-and-found-nothing*, not
+  *grounded-in-a-snapshot*.
+- A usable snapshot (state 3) uses the snapshot **file** path (e.g.
+  `observability/costs/2026-08-15-costs.md`) instead.
+
 ## Rubric
 
 Layer 1 structural: each assertion is verifiable by reading the
@@ -85,6 +124,13 @@ the cost-omitted worked example in the format reference. The scenario
 fails if the methodology describes a list-price fallback, treats the
 no-cost case as an error, collapses the three states into two, or if the
 cost-omitted worked example carries a `cost` axis or a `cost_usd` value.
+
+For the format-revision (#377) additions the scenario also fails if the
+cost-omitted worked example (Example 1) carries a
+`tokens_by_stage[].cost_usd` sub-field on any stage, or if the
+directory-path sentinel (`observability/costs/` trailing slash, with the
+consumer special-case that an aggregator must not count it as a grounding)
+is not documented as the cost-omitted convention.
 
 ## Notes
 

--- a/tdad_tests/scenarios/skills/cost-estimation/format-and-contract.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/format-and-contract.md
@@ -22,6 +22,16 @@ It ships exactly two artefacts and nothing else:
 This scenario fixes the structural contract both files must satisfy
 (spec §4, §5, §6, §8.1, §8.2; FR-1 through FR-11, FR-8a, FR-14).
 
+The **format-revision slice** (#377, spec
+`docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md`)
+extends this contract in place — this slice **owns** the reference. The
+additional `Then` assertions below (under "Format-revision slice (#377)
+additions") fix the per-stage `cost_usd` sub-field, the two new
+validation-checklist lines, the re-derived Example 2 bands, the
+`generated_by` reserved-prefix grammar, and the grounding-path sentinel
+(format-revision spec §4, §4.4, §4.4.1, §4.5, §5, §6; FR-1, FR-2, FR-3,
+FR-3b, FR-4, FR-7, FR-9).
+
 ## When
 
 The skill and its format reference are read directly from the
@@ -126,13 +136,162 @@ the S4 orchestrator fold-in — the consumers that parse this contract.
   two-layer no-verdict guarantee (the field-absence check **and** the
   positive-content scan of §5.3).
 
+---
+
+## Format-revision slice (#377) additions
+
+The following assertions are added by the format-revision slice. They
+fail against the S1-era reference and pass only once the slice's edits
+land. All are structural — verifiable by inspection of the field table,
+the validation checklist, the worked examples, and the field
+descriptions in `references/estimate-record-format.md`.
+
+**Per-stage `cost_usd` sub-field — field table** (`FR-1`):
+
+- The field table (or a sub-row note under `tokens_by_stage`) defines a
+  `tokens_by_stage[].cost_usd` sub-field as an **optional**
+  `{ low, high }` range object.
+- The sub-field is documented as **one-directionally coupled**, stated as
+  such **in the field table itself**: **sub-field present ⟹ top-level
+  `cost_usd` present** (enforced); **top-level `cost_usd` present ⟹ bands
+  SHOULD be populated by emitters but their absence does NOT invalidate
+  the record**.
+- The coupling is **NOT** stated as an `iff` / biconditional in the field
+  table — the word `iff` does not describe this sub-field's coupling (the
+  asymmetry is stated explicitly), so a literal reader cannot tighten it
+  into a class-B-breaking mandate.
+
+**Per-stage `cost_usd` sub-field — range enumeration** (`FR-2`):
+
+- The "Range representation" section's enumeration of **present**
+  quantitative ranges that must have `low ≤ high` names
+  `tokens_by_stage[].cost_usd` **when present** (so an absent sub-field is
+  never checked).
+
+**New validation-checklist line — "Per-stage cost coupling"** (`FR-3`):
+
+- The validation checklist carries a **"Per-stage cost coupling"** line
+  that: (a) **fails** a record carrying a per-stage `cost_usd` with no
+  top-level `cost_usd` (the incoherent inverse); (b) **passes vacuously**
+  when no per-stage sub-field is present (old records and cost-omitted
+  records are not rejected); (c) explicitly **does NOT mandate** per-stage
+  bands on a cost-present record (so S1-era class-B records stay valid),
+  while stating emitters SHOULD populate them.
+
+**New validation-checklist line — "Split-tier spread"** (`FR-3b`):
+
+- The validation checklist carries a **"Split-tier spread"** line
+  requiring, for **every present** `tokens_by_stage[].cost_usd` whose
+  `model_tier` is a **split tier**, a **strictly-positive ordered spread**
+  `low < high` (strict, not merely `low ≤ high`). A collapsed band
+  (`low == high`) on a split-tier stage **fails** this line. **Single-tier
+  stages are exempt**, and an absent sub-field satisfies the line
+  vacuously.
+- The split-tier trigger is stated as a **CLOSED rule**: a `model_tier`
+  **is a split tier if and only if its label contains a `/`** (after the
+  join-key whitespace normalisation), and the reference confirms no single
+  (non-split) tier label contains a slash (`Most capable`, `Standard`
+  contain none), so "contains `/`" is a sound **total** classifier — not
+  merely an example.
+- The cheaper-at-low / dearer-at-high pricing ordering is stated as an
+  **emitter convention in the methodology prose**, **NOT** as a predicate
+  the checklist line tests — the only predicate the line tests on a
+  present split-tier band is `low < high`.
+
+**The §4.4.1 CAN/CANNOT honest-floor note** (`FR-3b`):
+
+- The reference carries a note stating the validator **CAN** assert
+  presence/coupling, `low ≤ high` on every present band, and that a
+  split-tier band is **non-collapsed (strictly spread, `low < high`)**.
+- The same note states the validator **CANNOT** assert that the band
+  **spans two tiers** (a `{ 99.0, 100.0 }` band passes the strict-spread
+  check), nor that the bounds **equal** the absolute
+  `claude-sonnet-4`/`claude-opus-4` snapshot rates — that absolute-rate
+  check is **deferred to S3** (the snapshot-grounded Output Validation
+  Checkpoint), not this format-only slice.
+- The note records that **option (a)** — carrying the per-model rates in
+  the record so the check is fully self-contained — was **rejected**
+  (it would add data the merged S2 agent does not emit, re-introducing a
+  required field and breaking backward-compat).
+
+**Re-derived Example 2 (cost-present) bands** (`FR-4`):
+
+- Example 2's three `tokens_by_stage[]` entries each carry a `cost_usd`
+  sub-field with the concrete re-derived bands:
+  - **spec-writer** (`Most capable`): `{ low: 1.00, high: 2.00 }`
+  - **tdd-agent** (`Standard`): `{ low: 0.20, high: 0.60 }`
+  - **implementer** (`Standard/Capable`, split): `{ low: 0.40, high: 5.00 }`
+- Each band is **rate × tokens** from two fixed per-tier rates (sonnet
+  `4.0e-6`, opus `2.0e-5` $/token): each single-tier band's low and high
+  equal its tier-rate × the respective token bound; the split-tier
+  implementer band widens from the cheaper rate at low (`4.0e-6 × 100000 =
+  0.40`) to the dearer rate at high (`2.0e-5 × 250000 = 5.00`).
+- The split-tier implementer band has a **strictly-positive spread**
+  (`0.40 < 5.00`), satisfying the "Split-tier spread" line, and matches
+  the Included prose's `$0.40–$5.00`.
+- Example 2's whole-record `cost_usd` is updated to **`{ low: 1.60, high:
+  7.60 }`** — the exact sum of the three per-stage bands (the old
+  `{ 0.95, 7.50 }` is replaced) — and the Included prose, if it cites a
+  whole-record dollar figure, reads `$1.60–$7.60`.
+
+**Example 1 (cost-omitted) carries no per-stage band** (`FR-5`, locked
+here too; primarily asserted in `cost-conditional.md`):
+
+- Example 1's `tokens_by_stage[]` entries carry **no** `cost_usd`
+  sub-field on any stage.
+
+**`generated_by` reserved-prefix grammar** (`FR-7`):
+
+- The `generated_by` field description admits **both** a concrete model
+  identifier (e.g. `"cost-estimator / claude-opus-4-8"`) **and** a
+  `tier:<tier>` routing-tier label (e.g. `"cost-estimator / tier:Standard"`)
+  when the concrete model is unavailable to the emitter at emit time.
+- The description defines **`tier:` as a reserved provenance prefix**: the
+  provenance token after the ` / ` separator is a **tier label iff it
+  begins with the literal `tier:`**, otherwise it is a **concrete model
+  identifier** (a concrete model id never begins with `tier:`), so a
+  consumer can mechanically distinguish the two forms **without any
+  rejecting check** being added.
+- The description states the value is **never** a guessed or hard-coded
+  model string.
+
+**Grounding-path directory sentinel** (`FR-9`):
+
+- The `grounding_sources` description and/or the three-grounding-states
+  section documents the directory path **`observability/costs/` (trailing
+  slash)** as the **named cost-omitted sentinel** for the mandatory
+  `cost-snapshot` entry: the entry is **never dropped**, **never given a
+  fabricated file path**, and a **snapshot file path** is used in state 3.
+- The reference **names the entrenchment** — a `cost-snapshot` entry's
+  `path` carries two meanings (a **file** = grounded in that snapshot; a
+  **trailing-slash directory** = looked-and-found-nothing) — rather than
+  claiming the tension is resolved.
+- The reference carries the **consumer special-case** note: an aggregator
+  counting snapshot-grounded records **must not** count a trailing-slash
+  directory `path` as a grounding (it is a sentinel for the *absence* of a
+  snapshot).
+
 ## Rubric
 
 This is a Layer 1 structural scenario: every assertion is mechanically
 checkable by reading `SKILL.md` and `references/estimate-record-format.md`
 and matching against frontmatter, headings, the field table, the binding
 table, and the two worked example blocks. The scenario passes only when
-every assertion in `Then` can be verified by inspection of the two files.
+every assertion in `Then` — including every "Format-revision slice (#377)
+additions" assertion above — can be verified by inspection of the two
+files.
+
+A scenario reviewer checking the format-revision additions verifies: the
+field-table coupling is stated as a one-directional asymmetry and the word
+`iff` is **not** used for it; both new checklist lines are present with
+their backward-safe wording (coupling fails the inverse and passes
+vacuously; split-tier spread requires strict `low < high` with the closed
+`contains-/` trigger); the §4.4.1 note states both the CAN and the CANNOT
+honestly (record-internal spread, not absolute rates, S3-deferred);
+Example 2 carries exactly the three re-derived bands summing to
+`{ 1.60, 7.60 }`; the `generated_by` description admits `tier:<tier>` and
+reserves the `tier:` prefix; and the grounding-path directory sentinel
+(with entrenchment + consumer special-case) is documented.
 
 A future Layer 3 scenario could load the skill and ask a model to emit a
 record against the format, asserting the result validates — that

--- a/tdad_tests/scenarios/skills/cost-estimation/per-stage-cost-backward-compat.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/per-stage-cost-backward-compat.md
@@ -1,0 +1,140 @@
+---
+component: cost-estimation
+component_type: skill
+tier: structural
+---
+
+# Scenario: the per-stage `cost_usd` sub-field is backward-compatible — four record classes validate, only the incoherent inverse is rejected
+
+## Given
+
+The format-revision slice (#377, spec
+`docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md`)
+adds an **optional, one-directionally coupled** `tokens_by_stage[].cost_usd`
+sub-field to the estimate-record format
+(`ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`).
+
+The slice's **load-bearing requirement is demonstrated backward-compatibility,
+not asserted** (spec §1, §4.3): adding a conditional sub-field coupled to
+top-level cost is *not* trivially additive against the reference's
+**closed-world validation checklist**, so the claim must be **shown** by
+tracing the actual checklist semantics against every record class.
+
+This is a **structural** scenario. Per the spec's O7 honest framing (§8), it
+asserts the **checklist TEXT** and the **four-class argument a human traces** —
+not the output of a parser actually run. The runtime falsification (an actual
+closed-world parser executed over the four classes) lands with S3's Output
+Validation Checkpoint, which is out of scope here. The assertions below are
+therefore restated as the verdicts a faithful closed-world parser *would*
+return, each grounded in directly-readable text of the reference (the presence
+of named checklist lines and the absence of others).
+
+This scenario isolates the demonstrated-not-asserted backward-compat invariant
+into its own falsifiable file, so a future edit that "tightens" the per-stage
+coupling into a class-B-breaking `iff` mandate, or that drops the split-tier
+spread rule, fails this scenario loudly (FR-3, FR-3b, FR-5, FR-6, FR-8, FR-10).
+
+## When
+
+The edited reference's **validation checklist** is read as a closed-world
+parser (it rejects a record **only** when one of its named checks fails; it
+does **not** reject a record for carrying a field the checklist does not
+mention — spec §3), and traced against the four record classes of spec §4.3
+plus the two genuinely-rejected shapes.
+
+## Then
+
+**The four record classes all validate** (spec §4.3 classes A–D; FR-5, FR-6):
+
+- **Class A — old cost-omitted** (S1/S2-era; Example 1; merged S2 day-one
+  default): no top-level `cost_usd`, no per-stage `cost_usd` → **VALID**. Every
+  new per-stage check keys on the **presence of the sub-field**; with no
+  sub-field present, each fires **vacuously**, and the closed-world property
+  guarantees no other check names the sub-field.
+- **Class B — old cost-present without per-stage bands** (S1-era; Example 2
+  before this slice): top-level `cost_usd` present, **no** per-stage
+  `cost_usd` → **VALID**. This is the **load-bearing** case: the "Per-stage
+  cost coupling" check keys on **sub-field presence, not top-level presence**,
+  so a cost-present record with no bands is **never rejected**. The check does
+  **NOT** mandate per-stage bands on a cost-present record.
+- **Class C — new cost-omitted**: no top-level `cost_usd`, no per-stage
+  `cost_usd` → **VALID** (identical to class A — every new check fires
+  vacuously).
+- **Class D — new cost-present with per-stage bands** (Example 2 after this
+  slice): top-level `cost_usd` present, per-stage `cost_usd` on each stage →
+  **VALID**. The new checks confirm the enforced coupling holds (sub-field
+  present ⟹ top-level present), `low ≤ high` on each band, and a
+  strictly-positive ordered spread (`low < high`) on each **split-tier**
+  band — the implementer band `{ 0.40, 5.00 }` satisfies the spread rule.
+
+**The two genuinely-rejected shapes** (spec §4.3, §4.4; FR-3, FR-3b):
+
+- A record carrying a **per-stage `cost_usd` with NO top-level `cost_usd`**
+  (the incoherent inverse) is **REJECTED** by the **"Per-stage cost coupling"**
+  check. The reference also records that this inverse is a
+  **not-yet-producible shape** — the merged S2 agent emits only cost-omitted
+  records, so nothing today can create it; the check is kept as a **cheap guard
+  rail for S3-era emitters**, and the reference does not overstate its net-new
+  enforcement surface.
+- A record whose **split-tier stage carries a collapsed band** (`low == high`
+  on a `model_tier` whose label contains `/`) is **REJECTED** by the
+  **"Split-tier spread"** check, which requires a **strict** `low < high` on
+  every present split-tier band. **Single-tier** stages with `low == high` are
+  **not** rejected by this line (they are exempt, governed only by "Ranges
+  well-formed").
+
+**The present-guard keeps absence un-checked** (spec §4.4; FR-2):
+
+- The **"Ranges well-formed"** enumeration includes
+  `tokens_by_stage[].cost_usd` **"when present"**, so an **absent** sub-field
+  is **never** checked — classes A, B, and C pass this line unchanged.
+
+**No retroactively-failing checks were added** (spec §5.3, §6.3; FR-8, FR-10):
+
+- **No** validation-checklist line keys on the **shape or content of
+  `generated_by`** — readable as the **absence** of any `generated_by`-shape
+  check in the reference's checklist. The `generated_by` change is a
+  description widening only, so the `tier:<tier>` form (the merged S2 agent's
+  day-one default) is never retroactively rejected.
+- **No** validation-checklist line requires `grounding_sources[].path` to be a
+  **file** — readable as the **absence** of any `path`-must-be-a-file check in
+  the reference's checklist. The directory-path sentinel
+  (`observability/costs/`) on Example 1 and the merged S2 default record is
+  therefore never retroactively rejected.
+
+## Rubric
+
+This is a Layer 1 structural scenario. Every assertion is verifiable by reading
+the **validation checklist text** and the **field/range rules** in
+`references/estimate-record-format.md` and tracing the closed-world semantics —
+**not** by running a parser. The "rejects" and "no check exists" assertions are
+claims about the **checklist text** and the **non-presence of named checks**,
+both directly readable.
+
+The scenario passes only when: the two new checklist lines ("Per-stage cost
+coupling", "Split-tier spread") are present with backward-safe wording; the
+coupling is keyed on **sub-field presence** (not a top-level ⟺ per-stage
+biconditional), so class B (cost-present, no bands) is **not** rejected; the
+split-tier spread line requires a **strict** `low < high` on split-tier bands
+and exempts single-tier bands; the "Ranges well-formed" line carries the
+"when present" guard; and **neither** a `generated_by`-shape check **nor** a
+`path`-must-be-a-file check appears anywhere in the checklist.
+
+The scenario **fails** if a future edit tightens the per-stage coupling into a
+biconditional (`iff`) that would reject class B, drops or weakens the split-tier
+spread rule, removes the "when present" guard from the range enumeration, or
+adds a `generated_by`-shape or `path`-must-be-a-file check that would
+retroactively fail an S1/S2-era record.
+
+## Notes
+
+Scope is the format-revision slice (#377) only. This scenario asserts the
+**record-internal** half of the S1-O6 checkability (the strictly-spread
+split-tier invariant); the **absolute-rate** half — confirming a split-tier
+band's bounds equal the snapshot's `claude-sonnet-4`/`claude-opus-4` rates — is
+a **runtime, snapshot-grounded check explicitly deferred to S3** (spec §4.4.1),
+not asserted here. A `{ 99.0, 100.0 }` band passes the strict-spread check; the
+scenario does **not** claim the spread check proves a genuine two-tier widening.
+
+No S2 agent scenario is touched: this slice changes the format the agent
+consumes, not the agent (spec §7, FR-11).


### PR DESCRIPTION
The dedicated **format-revision slice** (#377) that owns and modifies the merged S1 estimate-record format reference — split out of S2 so the contract change gets its own adversarial pass.

## What it changes (`estimate-record-format.md`)
Resolves three concerns flagged across the S1/S2 reviews, all **backward-compatible** against the closed-world validator (demonstrated, not asserted, across four record classes):
1. **Per-stage `cost_usd` sub-field** — optional, **one-directionally coupled** (sub-field ⟹ top-level cost; *not* an `iff` — the class-B-trap fix). Two new checklist lines: per-stage coupling + a **split-tier strict-spread** check (closed `contains-/` trigger, tests `low < high`). A §4.4.1 **CAN/CANNOT honest floor**: the validator asserts a non-collapsed spread; absolute-rate checking is deferred to S3.
2. **`generated_by`** — widened to admit a **reserved `tier:` prefix** (makes the merged S2 agent's `tier:Standard` conformant; no rejecting check).
3. **Grounding-path** — the `observability/costs/` directory documented as the cost-omitted **sentinel** (entrenchment named, not "resolved").

Example 2 is **re-derived from two fixed rates** (sonnet 4.0e-6, opus 2.0e-5): each band = rate × tokens, whole-record `{1.60, 7.60}` = the exact sum — so the canonical example would pass S3's deferred absolute-rate validator.

## Built through the full pipeline
spec → **diaboli spec (2 rounds, 13 objections)** → cartographer (8 stories) → plan approval → tdd (3 scenarios) → implement → code-review (PASS) → **diaboli code (6 findings)**. All adjudicated: spec rounds drove the iff-fix and the rate-consistent Example 2; code round's O1/O3/O4 fixed (reference-precision notes), **O2 → #381** (S2 literal-form), O5/O6 noted residuals.

## Notes
- **Format-only** — the S2 agent is untouched; consumes the format as-merged. The emitter-populates-bands enhancement is deferred to **#380**.
- 3 TDAD scenarios under `tdad_tests/scenarios/skills/cost-estimation/` (incl. a 4-class backward-compat invariant).
- New format/schema → minor bump **0.42.0 → 0.43.0**.
- Choice-story dispositions `pending` (soft gate); **Story #1** a promote candidate (own-the-contract precedent).

Tests: `pytest tdad_tests/` → 218 passed, 31 skipped. Taxonomy guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
