### PR TITLE
Dispose #377 stories; promote the own-the-contract-slice rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,31 @@
   (original promotion); `docs/superpowers/stories/cost-estimator-agent-design.md`
   story #2 (Rule-of-Three confirmation, 2026-06-11).
 
+- Decision: **a change to a shared/merged contract gets its own owning slice
+  with its own adversarial pass — a consumer never mutates the contract it
+  consumes.** When a slice discovers it needs to change a merged contract a
+  reference, schema, or format that other slices depend on (e.g. a
+  `skills/<name>/references/<contract>.md`), carve the change into a dedicated
+  slice that **owns** that artefact and runs its own diaboli pass, rather than
+  mutating it in-place from a consumer slice. Reason: a contract change folded
+  into a consumer slice (a) conflates owner and consumer roles, and (b) inherits
+  only that consumer's adversarial budget, which is scoped to the consumer's
+  behaviour — **not** the contract's backward-compatibility, the property that
+  most needs scrutiny. Worked instance: the per-stage `cost_usd` format change
+  was split out of S2 (the `cost-estimator` agent, a pure consumer of the
+  estimate-record format) into its own slice #377, which owns
+  `estimate-record-format.md` and earned a dedicated two-round diaboli pass that
+  hammered the backward-compat demonstration (the `iff` trap; the rate-consistent
+  worked example) a consumer-scoped review would have missed. Cost accepted:
+  slice proliferation — a small contract fix carries full feature-PR ceremony.
+  Pairs with the agent-emit/dispatcher-persist boundary above: a consumer
+  neither *writes* the contract nor *edits* it. Watch item: this is the **first
+  worked instance** of the precedent the S2 cartographer named; confirm the rule
+  on the next contract-change slice (Rule of Three).
+  Source: `docs/superpowers/stories/cost-estimator-agent-design.md` story #5
+  (precedent named, accepted); `docs/superpowers/stories/format-revision-per-stage-cost-design.md`
+  story #1 (first worked instance, promoted 2026-06-11).
+
 - Decision: hook scripts never block, only warn. Reason: this is a
   plugin used across diverse projects — blocking hooks could break
   workflows the plugin authors cannot predict. Advisory messages let

--- a/docs/superpowers/stories/format-revision-per-stage-cost-design.md
+++ b/docs/superpowers/stories/format-revision-per-stage-cost-design.md
@@ -7,43 +7,72 @@ stories:
   - id: 1
     lens: [patterns, alternatives]
     title: Own-the-contract slice over in-place mutation
-    disposition: pending
-    disposition_rationale: null
+    disposition: promoted
+    disposition_rationale: >
+      Promoted to AGENTS.md ARCH_DECISIONS as the own-the-contract-slice rule: a
+      change to a shared/merged contract gets its own owning slice with its own
+      adversarial pass; a consumer never mutates the contract it consumes. This
+      is the FIRST WORKED INSTANCE of the precedent S2 Story #5 named (accepted
+      there) — watch for a third before treating it as a hard invariant (Rule of
+      Three).
   - id: 2
     lens: [forces, consequences]
     title: Record-internal spread over absolute-rate binding
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Record-internal spread now, absolute-rate check deferred to S3
+      (which owns the snapshot). The honest §4.4.1 CAN/CANNOT floor is the durable
+      artefact telling the S3 author which check is theirs to build.
   - id: 3
     lens: [patterns, forces]
     title: One-directional coupling over biconditional iff
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. One-directional coupling over a biconditional iff is the only
+      resolution that keeps S1-era cost-present records (class B) valid while
+      still rejecting the incoherent inverse.
   - id: 4
     lens: [forces, consequences]
     title: Directory sentinel over a clean token
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Keep-the-directory-sentinel over a clean token — backward-compat
+      over semantic cleanliness, with the entrenchment named (not "resolved") and
+      the unenforced consumer special-case recorded as an honest residual (O5/O6).
   - id: 5
     lens: [patterns, defaults]
     title: Reserved tier-prefix grammar without a check
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. The tier: reserved-prefix grammar gives consumers a mechanical
+      discriminator without a rejecting check — widen-and-mark over
+      reshape-and-validate, keeping the merged S2 agent conformant.
   - id: 6
     lens: [forces, consequences]
     title: Whole-record cost set to per-stage sum
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Whole-record cost set to the per-stage sum by construction so the
+      canonical example would pass the deferred S3 absolute-rate validator (the
+      round-2 O1 fix); the Example-2 prose flags this as by-construction, not a
+      must-sum rule (code-mode O1).
   - id: 7
     lens: [alternatives, coherence]
     title: Emitter enhancement deferred, not bundled
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Emitter enhancement deferred-and-filed (#380), not bundled —
+      re-applying the same consumer/owner discipline (#1) to this slice's own
+      residue rather than re-conflating them.
   - id: 8
     lens: [patterns, consequences]
     title: Widen-and-mark over reshape-and-validate
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Widen-and-mark over reshape-and-validate is the unifying strategy
+      the closed-world checklist makes safe (provably non-breaking additive
+      evolution); each unenforced new convention is recorded as an honest
+      residual rather than implying enforcement it lacks.
 ---
 
 ## Story #1 — Own-the-contract slice over in-place mutation


### PR DESCRIPTION
Disposes the 8 #377 format-revision choice stories (the soft gate left open when #382 merged) and acts on the flagged candidate.

- **7 accepted**, **1 promoted**.
- **Promoted Story #1** to AGENTS.md ARCH_DECISIONS as the **own-the-contract-slice rule**: a change to a shared/merged contract gets its own owning slice with its own adversarial pass — a consumer never mutates the contract it consumes. #377 (the format change split out of S2) is its **first worked instance** of the precedent the S2 cartographer named (S2 story #5, accepted there); watch for a third before treating it as a hard invariant (Rule of Three).

No plugin files change → no version bump. `chore`-labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
