### PR TITLE
Add /cost-estimate command (S3 of the cost-estimator pipeline)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.43.0",
+  "plugin_version": "0.44.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.43.0"
+      "version": "0.44.0"
     },
     {
       "name": "model-cards",

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,10 @@ site/
 # cache (S4 spec §7.2 / O3).
 diagnostic-legibility/output/
 
+# Cost estimate records — derived, regenerable artefacts written by the
+# /cost-estimate command. An estimate references a moving target (an
+# unmerged spec, a since-renamed slice, changing task text), so it is
+# regenerated on demand, not committed. Never committed.
+cost-estimates/
+
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,17 @@
   `/diagnose` ships only accept/abort, a narrower disposition vocabulary than
   the named architecture's accept/edit/re-run/abort and the model-card
   precedent; if that narrowing recurs on the next command spec, the divergence
-  may warrant its own sub-rule.
+  may warrant its own sub-rule. **Resolved (S3 `/cost-estimate` story #1,
+  2026-06-12): the next command spec (`/cost-estimate`) shipped the FULL
+  accept/edit/re-run/abort vocabulary, so the narrowing did NOT recur —
+  `/diagnose`'s accept/abort was a one-off, not a convention, and the
+  contemplated sub-rule is not warranted. `/cost-estimate` is the fifth
+  production instance, ships the full vocabulary, and honours the dispose-then-
+  write ordering.**
   Source: `docs/superpowers/stories/model-cards-plugin-design.md` stories
   #7 and #8 (original promotion); `docs/superpowers/stories/dl-s4-diagnose-command-design.md`
-  story #1 (ordering-invariant sharpening).
+  story #1 (ordering-invariant sharpening); `docs/superpowers/stories/cost-estimate-command-design.md`
+  story #1 (watch-item resolution).
 
 - Decision: **an agent that DERIVES a judgment a human previously SUPPLIED
   carries a disclosure obligation** — the disclosure-of-derived-judgment
@@ -308,17 +315,30 @@
   concern-accretion debt**: by the time the chain's parent issue closes, the
   concern has no tracking home and falls through the gap. Rule: when a slice
   declines an inherited hand-off, either (a) absorb it, or (b) re-file it as a
-  standalone issue with its own lifecycle — never leave it implicit in a
-  closed slice's "out of scope" section. Worked instance: the
+  standalone issue with its own lifecycle **AND bind it to a *scheduled
+  deliverable* — a concrete slice that produces the concern's triggering event,
+  not an unscheduled precondition or a bare "filed somewhere"** — never leave it
+  implicit in a closed slice's "out of scope" section. **Sharpening (S3
+  `/cost-estimate` story #7): re-filing to an unbound issue whose trigger no
+  slice causes is itself a buck-pass — the home must be a deliverable the roadmap
+  schedules, not an event it never reaches.** Worked instance: the
   diagnostic-legibility invocation-persistence corpus for the Phase-C
   escalation trigger was deferred at S2b, pointed at S4 by S3 §8 as its
   "natural home", and declined by S4 — three consecutive deferrals with the
   parent (#327) closing. Re-filed as standalone issue #350 at S4 adjudication.
+  Second worked instance (S3 `/cost-estimate`): the #377-deferred absolute-rate
+  check was re-filed at S3 and bound to S6/#373 as a blocking required
+  deliverable, with S6 extended to own first-snapshot capture so the triggering
+  event (the first cost-present record) is actually scheduled — correcting a
+  draft that keyed the trigger on an unscheduled "first cost-present record"
+  event no slice produced.
   Alternative considered and rejected: trusting the §8 "out of scope" note to
   carry the concern forward — rejected because closing the parent removes the
   natural tracking issue and the note becomes archaeology no one re-reads.
   Source: `docs/superpowers/stories/dl-s4-diagnose-command-design.md` story #8
-  (promoted disposition); tracking issue #350.
+  (original promotion); `docs/superpowers/stories/cost-estimate-command-design.md`
+  story #7 (bind-to-a-scheduled-deliverable sharpening, 2026-06-12); tracking
+  issues #350, #373.
 
 ## TEST_STRATEGY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.44.0 — 2026-06-12
+
+### New command — `/cost-estimate` (S3 of the cost-estimator pipeline)
+
+Ships the standalone manual dispatcher for the read-only `cost-estimator` agent —
+the **prospective** sibling of the retrospective `/cost-capture`. New command —
+minor bump.
+
+- **`/cost-estimate <target> [--kind <target-kind>] [--out <dir>]`** — point it at
+  a slice, a spec, a slicing record, or pasted task text and it estimates the
+  target's tokens, agent-compute time, and (only when a cost snapshot grounds it)
+  cost, then writes the estimate record to disk. One target per invocation
+  (matching the agent's one-target-per-dispatch contract); path vs inline text
+  resolved by filesystem lookup; `--kind` forwards an explicit `target_kind` to the
+  agent; the `--near` sketch is dropped. The command is a **pure consumer** of the
+  S2 agent and the S1 format reference — it redefines neither.
+- **Dispose-then-write ordering** — the command owns the single `Write`; the agent
+  stays read-only. The human disposition (`accept` / `edit` / `re-run` / `abort` —
+  the full vocabulary) **precedes** the write. On `REFUSED:` the refusal is
+  surfaced verbatim with no checkpoint and no file.
+- **Output Validation Checkpoint** — reads the returned record back and checks it
+  against every line of `estimate-record-format.md`'s validation checklist
+  (including the #377 per-stage cost coupling and split-tier strict-spread checks),
+  **fixing only structural-only deviations in place** (routinely just deleting a
+  stray verdict field) and **aborting — never authoring — on any derived-value
+  defect**. The review summary surfaces a change-list of exactly what was altered,
+  flags a human-asserted `--kind` as asserted-not-inferred, and honours the
+  grounding-path trailing-slash sentinel in its own summary consumption. The `edit`
+  path is validate-and-report, never silently reverting a human edit.
+- **Output home** — default `cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md`,
+  a new top-level directory **outside** `observability/` (predictions are not
+  telemetry); `--out` overrides the directory; same-day collisions are
+  disambiguated under both, never silently overwritten. `cost-estimates/` is added
+  to `.gitignore` as a derived, regenerable artefact.
+- **Docs and discipline** — `/cost-estimate` joins the CLAUDE.md Output Validation
+  Checkpoints list; a how-to guide and a reference-page entry ship in the same PR.
+- **Code-mode adversarial hardening** — eight `advocatus-diaboli` code-mode
+  objections closed executor-latitude seams in the command prose: the
+  `<target-slug>` is sanitised to a single `[a-z0-9-]` path segment
+  (write-target-injection closed); `REFUSED:` detection is anchored to the
+  untrimmed first line; a pre-classification test routes a *stray verdict field*
+  to FIX and a *prose verdict* to ABORT (so the checkpoint never edits the agent's
+  judgment); the change-list is a diff of the retained original, not a narration;
+  the checkpoint takes an explicit `fix-in-place | validate-and-report` mode; and
+  the same-day collision is re-checked at write time (TOCTOU gap closed).
+
 ## 0.43.0 — 2026-06-11
 
 ### Format revision — per-stage `cost_usd`, `generated_by` grammar, grounding-path sentinel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ consumers must include a validation checkpoint step. The pattern:
 4. Fix deviations in place (do not re-dispatch the agent)
 
 Commands with checkpoints: `/harness-health`, `/assess`, `/reflect`,
-`/cost-capture`, `/harness-constrain`, `/harness-init`,
+`/cost-capture`, `/cost-estimate`, `/harness-constrain`, `/harness-init`,
 `/superpowers-init`, `/governance-audit`, `/harness-onboarding`.
 
 When adding a new command that writes structured markdown, add a

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.43.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.44.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-34-2E8B57?style=flat-square)](#skills-34)
 [![Agents](https://img.shields.io/badge/Agents-15-2E8B57?style=flat-square)](#agents-15)
-[![Commands](https://img.shields.io/badge/Commands-26-2E8B57?style=flat-square)](#commands-26)
+[![Commands](https://img.shields.io/badge/Commands-27-2E8B57?style=flat-square)](#commands-27)
 [![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-10-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.43.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 26 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.44.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 27 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -218,7 +218,7 @@ A coordinated team that handles the full development lifecycle.
 | carpaccio | Cadence governor — runs at orchestrator step 0 before spec-writer; slices the raw task description into thin, end-to-end-complete pieces; hard gate on slice dispositions; the third member of the decision-discipline triad alongside diaboli and choice-cartographer | Read only |
 | cost-estimator | Prospective-cost emitter — reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns an estimate-record string (token + time ranges, dollar cost only when grounded) for a dispatcher to persist after a human disposes; refuses rather than fabricating an ungroundable estimate | Read only |
 
-### Commands (26)
+### Commands (27)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -238,6 +238,7 @@ A coordinated team that handles the full development lifecycle.
 | `/convention-sync` | Sync HARNESS.md conventions to Cursor, Copilot, and Windsurf convention files |
 | `/portfolio-assess` | Multi-repo AI literacy assessment — aggregate across local repos, GitHub orgs, or topic tags |
 | `/cost-capture` | Capture AI tool cost data — record spend, compare to previous snapshot, update model routing |
+| `/cost-estimate` | Estimate a target's tokens, agent-compute time, and (when grounded) cost before it runs — dispatches the read-only `cost-estimator` agent, validates the record, and writes it to `cost-estimates/` after you dispose (the prospective sibling of `/cost-capture`) |
 | `/governance-constrain` | Guided governance constraint authoring with three-frame alignment check |
 | `/governance-audit` | Deep governance investigation — semantic drift, debt inventory, frame alignment |
 | `/governance-health` | Governance health pulse check and dashboard generation |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/cost-estimate.md
+++ b/ai-literacy-superpowers/commands/cost-estimate.md
@@ -1,0 +1,375 @@
+---
+name: cost-estimate
+description: Estimate a target's tokens, agent-compute time, and (when grounded) cost before it runs — the prospective sibling of /cost-capture. Dispatches the read-only cost-estimator agent, validates the returned record, and writes it after you dispose.
+---
+
+# /cost-estimate \<target\> [--kind \<target-kind\>] [--out \<dir\>]
+
+The human-facing manual dispatcher for the read-only `cost-estimator` agent —
+the **prospective** counterpart to the retrospective `/cost-capture`. Point it at
+a slice, a spec, a slicing record, or pasted task text and it estimates the
+target's **tokens**, **agent-compute time**, and (only when a cost snapshot
+grounds it) **cost**, then writes the estimate record to disk.
+
+The command **owns the single Write**; the agent stays read-only and only emits a
+string. The human disposition **precedes** the write — nothing is persisted until
+you return `accept` (the AGENTS.md **agent-emit + dispatcher-persist +
+human-disposes** decision and its **dispose-then-write ordering invariant**).
+
+## Signature
+
+```text
+/cost-estimate <target> [--kind <target-kind>] [--out <dir>]
+```
+
+- **`<target>`** (required, positional) — **one** target per invocation, matching
+  the `cost-estimator` agent's one-target-per-dispatch contract. It is **either**
+  a path (to a slicing-record file, a spec file, or a file holding a single slice)
+  **or** a quoted string of pasted task text. The command classifies which by
+  resolving the positional argument as a filesystem path first: if it resolves to
+  a **readable file**, it is a **path** target; otherwise it is **inline task
+  text**.
+- **`--kind <target-kind>`** (optional) — an explicit `target_kind` hint, one of
+  `task-text` | `slicing-record` | `slice` | `spec`. When supplied, the command
+  forwards it to the agent as the **explicit dispatch-stated kind** (the agent's
+  rule-1 path — no inference-basis line is then required). When absent, the agent
+  infers the kind and discloses its inference basis. This is the single flag that
+  lets you disambiguate a path the agent might otherwise infer wrongly (e.g. a
+  slice fragment that superficially reads as a spec).
+- **`--out <dir>`** (optional) — an output-**directory** override; the derived
+  `<YYYY-MM-DD>-<target-slug>-estimate.md` filename still applies beneath it
+  (§ Output path). The `--near` flag from the slice sketch is **dropped**: the
+  agent accepts exactly one target per dispatch, so there is no
+  primary-target-plus-neighbour shape; `--kind` replaces it as the disambiguation
+  affordance.
+
+The command does **not** itself classify the `target_kind` (that is the agent's
+job) and does **not** re-implement the estimation methodology (that is the S1
+`cost-estimation` skill, applied by the agent). It only distinguishes **path vs
+inline text** so it knows *how to pass* the target to the agent, and forwards any
+`--kind` hint as the explicit kind.
+
+## When to use
+
+- A human deciding **whether to run a piece of work through the pipeline at all** —
+  the pre-pipeline question the orchestrator gates cannot answer, because they only
+  fire once a branch and slicing already exist.
+- The cleanest end-to-end exercise of the `cost-estimation` skill + `cost-estimator`
+  agent without a full orchestrator run.
+- The prospective half of the `/cost-capture` ↔ `/cost-estimate` pair: one records
+  what *was* spent (`observability/costs/`); this predicts what *will be* spent.
+
+## Process
+
+The flow, in order. **The human disposition (step 6) precedes the single Write
+(step 7).**
+
+### 1. Parse args and resolve the target
+
+Distinguish **path vs inline text** by resolving the positional `<target>` as a
+filesystem path:
+
+- Resolves to a **readable file** → a **path** target (passed to the agent as a
+  path to read).
+- Does **not** resolve → **inline task text** (passed to the agent as an inline
+  string).
+
+Capture any `--kind` (the explicit kind) and any `--out` (the directory
+override).
+
+### 2. Dispatch the `cost-estimator` agent
+
+Dispatch the read-only `cost-estimator` agent (`agents/cost-estimator.agent.md`),
+passing the **one** target, the explicit `--kind` if supplied, and — if the
+command knows it — the resolved model id for the agent's `generated_by` branch
+(a). **Note:** a slash-command executor has **no** resolved model id to pass, so in
+practice **branch (b) is the live path** (the agent reads its routing tier from
+`MODEL_ROUTING.md` and records honest `tier:` provenance); branch (a) is reserved
+for an **orchestrator dispatcher** that supplies a concrete id. The agent reads its
+grounding sources (`MODEL_ROUTING.md`, the latest
+`observability/costs/` snapshot if one exists), applies the S1 methodology, and
+returns **either** the estimate-record content as a string **or** a `REFUSED:`
+string. The agent **does not write** anything.
+
+### 3. Handle `REFUSED:` (no write, no checkpoint)
+
+REFUSED detection uses an **exact, anchored** test, applied **before any
+reformatting** of the agent's output: the **untrimmed first line** of the agent's
+final message **starts with** the literal `REFUSED:` prefix (leading whitespace
+makes the test fail — a real refusal is emitted with no leading whitespace; the
+match is first-line-only, never a substring found anywhere in the body). If that
+test passes, the command:
+
+- surfaces the refusal reason, the target, and the grounding-read line to the user
+  **verbatim**;
+- runs **no** validation checkpoint (there is nothing conforming to validate);
+- writes **no** file;
+- aborts the flow.
+
+This is the dispatcher half of the agent's refusal convention: an
+authoritative-looking estimate record is never written for a target the agent
+could not honestly ground. **An empty `observability/costs/` is NOT a refusal** —
+the agent returns a valid, complete **cost-omitted** record (see step 5), which
+the command treats as a normal emit, not a failure.
+
+### 4. Output Validation Checkpoint
+
+**The checkpoint takes an explicit `mode` input on every invocation** — it is a
+structural parameter, never carried by executor memory of authorship:
+
+- **`mode: fix-in-place`** — the content is the **agent's fresh output** (this
+  step, on the dispatch and `re-run` paths). Structural-only deviations are
+  repaired in place per the boundary below.
+- **`mode: validate-and-report`** — the content is **human-edited** (the `edit`
+  path, step 6). The checkpoint **validates and reports** remaining deviations but
+  applies **no** fix-in-place — a human edit is never reverted unseen.
+
+This step runs in **`fix-in-place`** mode. The `edit` path (step 6) invokes the
+checkpoint in **`validate-and-report`** mode explicitly.
+
+Per the CLAUDE.md **Output Validation Checkpoints** convention, **read the
+returned record back** and check its structure against the validation checklist in
+the format reference, **referenced by path** (do not inline or mutate its
+definitions):
+
+```text
+ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+```
+
+Run **every** line of that file's "Validation checklist", including the #377
+additions:
+
+1. **Ranges well-formed** — every **present** range (`tokens`, each
+   `tokens_by_stage[].tokens`, each `tokens_by_stage[].cost_usd` when present,
+   `cost_usd` when present, `agent_compute_time`) has `low ≤ high`.
+2. **Per-stage cost coupling (#377)** — if **any** `tokens_by_stage[].cost_usd` is
+   present, the top-level `cost_usd` must also be present. A record with no
+   per-stage bands passes **vacuously**; the check forbids only the incoherent
+   inverse.
+3. **Split-tier strict-spread (#377)** — for **every present**
+   `tokens_by_stage[].cost_usd` whose `model_tier` **contains a `/`** (the closed
+   split-tier trigger, after join-key whitespace normalisation), the band must
+   have a strict ordered spread (`low < high`). A collapsed band on a split-tier
+   stage fails; single-tier stages are exempt; a record with no per-stage bands
+   passes vacuously.
+4. **All four disclosure sections present** — Included, Excluded, Confidence
+   rationale, Failure direction.
+5. **Per-axis confidence within cap** — each present `tokens`/`time` axis is within
+   the `target_kind` ceiling (`task-text`→`low`, `slicing-record`/`slice`→`medium`,
+   `spec`→`high`); the `cost` axis is present **iff** `cost_usd` is present and is
+   **not** capped by `target_kind`.
+6. **Cost pairing** — `cost_usd` and `cost_basis` are **both present or both
+   absent**; when absent, `Excluded` carries the cost-omission disclosure.
+7. **Time split** — both time fields present and separate: `agent_compute_time` a
+   `{ low, high }` range, `human_gate_time` a qualitative caveat string (not a
+   range).
+8. **No-verdict, field-absence layer** — no `recommendation`, `verdict`, or
+   `proceed` field in the frontmatter.
+9. **No-verdict, positive-content layer** — the disclosure prose contains no
+   imperative recommendation or go/no-go language (the format reference's tripwire
+   pattern list).
+
+The checkpoint **never re-dispatches the agent** and runs **before** the human
+disposes, so the human reviews a *validated* record.
+
+#### The fix-in-place boundary — structural-only, never authoring derived judgment
+
+"Fix in place" is bounded at **structural-only vs derived-value** so the checkpoint
+can never silently alter what the human disposes over:
+
+- **STRUCTURAL-ONLY → fix in place, and record the change.** The checkpoint MAY
+  repair a deviation that is purely *structural* and *unambiguous* — one whose
+  correction invents **no** value the agent did not emit. **In practice the only
+  routinely-fixed line is #8: delete a stray `recommendation`/`verdict`/`proceed`
+  field** — a pure removal that authors nothing. (Also permitted: a join-key
+  whitespace normalisation already defined by the format reference, or a
+  YAML-shape-only fix that does not change a number, a tier, or a confidence
+  label.) Every such fix is **recorded** and surfaced in the review summary's
+  change-list (step 5).
+
+  **Pre-classification test for the #8 FIX (apply BEFORE choosing FIX vs ABORT).**
+  The #8 deletion-fix is licensed **only** when the offender is a **top-level YAML
+  key in the frontmatter whose name is literally one of `recommendation`,
+  `verdict`, `proceed`** — a *frontmatter field*, not prose. A **verdict phrased
+  inside disclosure prose** (e.g. a go/no-go sentence inside `failure_direction`)
+  is line **#9**, and **ABORTS** — the checkpoint never edits the agent's prose.
+  Run the test explicitly: *"Is the offending verdict a top-level YAML key named
+  `recommendation`/`verdict`/`proceed`? If yes → FIX by deleting that key. If it
+  is anywhere in prose → ABORT."* This prevents a prose verdict ("…so do not
+  proceed") from routing into FIX and being edited away as if it were a stray
+  field.
+
+- **DERIVED-VALUE or AMBIGUOUS → ABORT, never author.** The checkpoint MUST
+  **abort without writing** for any deviation whose correction would **create or
+  change a derived judgment value**. It never authors a `cost_usd` band, a
+  `cost_basis`, a `tokens`/`time` range, a per-axis confidence tier, or a
+  `failure_direction`; it never edits disclosure prose to supply a missing
+  rationale; it never resolves an ambiguous structural defect by guessing.
+  Concretely — a **cost-present record missing `cost_basis`** ABORTS (inserting one
+  would author provenance the agent did not state); a **`low > high` range** ABORTS
+  (re-ordering or clamping changes a derived number); a **missing disclosure
+  section** ABORTS (the checkpoint cannot author the prose); a
+  **per-stage-coupling violation** ABORTS; a **collapsed split-tier band** ABORTS;
+  a **confidence axis above the ceiling** ABORTS; an **imperative-recommendation
+  tripwire hit** ABORTS.
+
+Per-checklist-line disposition on failure:
+
+| # | Checklist line | On failure |
+| --- | --- | --- |
+| 1 | Ranges well-formed (`low ≤ high`) | **ABORT** — re-ordering/clamping changes a derived number |
+| 2 | Per-stage cost coupling | **ABORT** — resolution alters a derived value |
+| 3 | Split-tier strict-spread | **ABORT** — widening authors a spread |
+| 4 | Four disclosure sections present | **ABORT** — checkpoint cannot author prose |
+| 5 | Per-axis confidence within cap | **ABORT** — lowering is a derived-judgment change |
+| 6 | Cost pairing (`cost_usd`/`cost_basis` together) | **ABORT** — supplying `cost_basis` authors provenance |
+| 7 | Time split (separate fields, right shapes) | **ABORT** — any time-field defect alters or omits a derived value |
+| 8 | No-verdict field-absence (stray `recommendation`/`verdict`/`proceed`) | **FIX** — *only* when it is a top-level YAML key of that name (apply the pre-classification test above); delete the forbidden field and record it |
+| 9 | No-verdict positive-content (imperative/go-no-go prose) | **ABORT** — checkpoint cannot rewrite the agent's prose |
+
+On any abort, surface the failing checklist line and the reason ("derived-value
+defect — the checkpoint does not author the agent's judgment") and write **no
+file**. The honest move on a derived-value defect is to surface it and let the
+human re-run or abort, **not** to silently complete the agent's record.
+
+### 5. Show the review summary
+
+Show a structured, human-readable summary of the **validated** record — what the
+human disposes over:
+
+- **Target + classified `target_kind`.** When the kind was **human-asserted via
+  `--kind`**, flag it **prominently as asserted-not-inferred** and state that the
+  asserted kind **raised the `tokens`/`time` confidence ceiling** (e.g. to `high`
+  for `--kind spec`) **with no agent inference basis**, and ask the human to
+  **re-confirm the ceiling they raised** before disposing. When the kind was
+  **agent-inferred**, carry the agent's inference-basis line as emitted
+  (`classified as <kind> by <signal>`) and show **no** human-asserted flag.
+- The **token range** and per-axis confidence.
+- The **agent-compute-time range** and the `human_gate_time` qualitative caveat.
+- Whether **`cost_usd` is present or omitted**, and — when omitted — the disclosed
+  cause. When the `cost-snapshot` grounding entry's `path` **ends in a trailing
+  slash** (the directory sentinel for *looked-and-found-nothing*), report it as
+  **"no snapshot — cost omitted (directory inspected, no snapshot found)"**, **not**
+  as a snapshot grounding. (The command is itself a downstream consumer of
+  `grounding_sources`, so it honours the trailing-slash special-case in its own
+  summary; it does **not** add a validation-checklist line keying on
+  `grounding_sources[].path` shape — that would be a consumer mutating the format
+  contract.)
+- The **`failure_direction`** with its driver.
+- **The resolved output path** (§ Output path) — so the human confirms both
+  *content* and *destination* before any write.
+- **The change-list (a diff, not a narration).** The command **retains the agent's
+  original emitted output** before the checkpoint touches it. When the checkpoint
+  changed anything at step 4, show a **diff of the retained original vs the altered
+  record** — exactly what the command changed, computed from the captured bytes,
+  **not** a self-reported summary of what was changed. (A narrated "I deleted the
+  verdict field" without the diff is insufficient: the human disposes over an
+  *observed* change, not a *claimed* one.) When the checkpoint changed nothing,
+  state **"no checkpoint changes — record as emitted by the agent"**.
+
+> **Residual (recorded):** every cost-omitted record this command persists carries
+> the `cost-snapshot` grounding entry with the **unguarded** trailing-slash
+> directory sentinel — no validation-checklist line keys on
+> `grounding_sources[].path` shape. Any **other** consumer (S4's orchestrator
+> fold-in, or a future aggregator counting "how many estimates were grounded in a
+> real snapshot") **will silently miscount** that entry as a real grounding unless
+> it applies the same trailing-slash test this command applies in its summary. The
+> structural fix (a checklist line) is the format-owning slice's deliverable; this
+> command records the residual and declines to mutate the contract from a consumer
+> seat.
+
+### 6. Ask for disposition
+
+Ask for a disposition from the **full** named vocabulary (not a narrowed
+accept/abort):
+
+- **`accept`** — proceed to the write (step 7).
+- **`edit`** — open the validated draft in `$EDITOR` (or `vi` if unset). On
+  return, **re-invoke the step-4 checkpoint with `mode: validate-and-report`**: it
+  **validates** the human-edited content and **reports** any remaining deviation in
+  the re-prompt, but applies **NO** fix-in-place to human-edited content (the mode
+  input — not executor memory — carries this). **A human edit is never reverted
+  without the human seeing and re-confirming it.** If the edited record still
+  deviates, the human decides (re-edit, accept where structurally valid, or abort)
+  — the human is the final author on the edit path. (The `fix-in-place` mode of
+  step 4 applies to the **agent's fresh output**; the edit path passes
+  `validate-and-report`, because the content is now the human's.)
+- **`re-run`** — **re-dispatch the agent** on the same target as a **full fresh
+  dispatch** that **re-reads the grounding sources afresh**, including the
+  now-populated `observability/costs/`. So a human who adds a cost snapshot and
+  then chooses `re-run` gets a record grounded in the newly-added snapshot. The
+  command then re-validates (step 4) and re-summarises (step 5).
+- **`abort`** — discard the draft; **no file written**.
+
+**Nothing is persisted until the human returns `accept`.** Steps 2–5 produce and
+validate a *returned string* and a *review summary*; the Write at step 7 is the
+only persistence and it is **downstream of** the human disposition.
+
+### 7. On `accept` (post-disposition): write once
+
+**Re-evaluate the same-day collision at write time** (not only at the step-5
+summary): immediately before the Write, re-check whether the resolved target now
+exists. If a file appeared after the step-5 summary — a concurrent
+`/cost-estimate` for the same target/day, or a manual drop — **re-disambiguate**
+(append the short disambiguator) and report the adjusted path. **Never overwrite an
+existing estimate**, even one that materialised during the human's deliberation;
+this closes the time-of-check/time-of-use gap between the step-5 snapshot and the
+Write.
+
+Then perform the command's **single Write** to the (re-checked) resolved output
+path (§ Output path), creating the directory if needed (`mkdir -p`), and confirm
+the full written path to the user.
+
+## Output path
+
+The default output home is a **new top-level `cost-estimates/` directory**,
+deliberately **outside** the `observability/` tree (the telemetry/actuals root) so
+a forward-looking *prediction* is never co-located with captured *actuals* where a
+future scan could read it as fact:
+
+```text
+cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md
+```
+
+- **`cost-estimates/`** — created if it does not exist (`mkdir -p`). It is
+  **gitignored by default** (an estimate is a derived, regenerable prediction
+  referencing a moving target).
+- **`<YYYY-MM-DD>`** — the date the estimate was produced.
+- **`<target-slug>`** — for a **path** target, the source filename with its date
+  prefix and `.md` extension stripped (e.g. `cost-estimator-pipeline`); for
+  **inline task text**, a short kebab-case slug of the first few words. **The slug
+  is sanitised to a single safe path segment before use**: lowercased, reduced to
+  `[a-z0-9-]` (every other character — path separators, `.`, `..`, whitespace —
+  collapsed to `-`), leading/trailing/repeated `-` trimmed, and length-capped
+  (≤ 50 chars). The slug is **never a path**: it cannot contain `/` or `..` and so
+  cannot move the write target out of the resolved output directory. This closes
+  the write-target-injection surface for adversarial inline text or path
+  basenames.
+
+**`--out <dir>` overrides the directory only** — the derived
+`<YYYY-MM-DD>-<target-slug>-estimate.md` filename still applies beneath it
+(mirroring `model-card create`'s `--out` semantics).
+
+**Same-day collision disambiguation applies under BOTH the default directory and
+`--out`.** When the derived filename would overwrite an existing same-day estimate,
+the command appends a short disambiguator and notes it in the confirm-before-write
+summary (step 5), **and re-checks at write time (step 7)** to catch a file that
+appeared after the summary. **The command never silently overwrites an existing
+estimate**, under the default directory or under `--out`.
+
+## Scope
+
+`/cost-estimate` is a **standalone manual surface** and a **pure consumer** of two
+merged contracts — it does **not** redefine either:
+
+- the `cost-estimator` agent (`agents/cost-estimator.agent.md`) — dispatched as
+  merged; the command does not re-classify the `target_kind` or duplicate the
+  methodology;
+- the format reference
+  (`skills/cost-estimation/references/estimate-record-format.md`) — its checklist is
+  referenced by path and implemented; the command adds no field and changes no
+  validation rule.
+
+It does **not** wire into the orchestrator pipeline, add or move a gate, or build
+the deferred snapshot-grounded absolute-rate check (a BLOCKING required deliverable
+of S6/#373, which also owns first-snapshot capture).

--- a/docs/plugins/ai-literacy-superpowers/how-to/estimate-task-cost.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/estimate-task-cost.md
@@ -1,0 +1,156 @@
+---
+title: Estimate a Task's Cost Before It Runs
+---
+# Estimate a Task's Cost Before It Runs
+
+Get a prospective estimate of a target's **tokens**, **agent-compute
+time**, and (when a cost snapshot grounds it) **cost** before you commit
+to running the work — the prospective counterpart to `/cost-capture`,
+which records what *was* spent.
+
+`/cost-estimate` dispatches the read-only `cost-estimator` agent, which
+reads your grounding sources and emits an estimate-record string. The
+command validates that record, summarises it, and — only after you
+dispose — writes it to disk. The agent never writes; the command owns
+the single write, and **your disposition precedes it**.
+
+---
+
+## Prerequisites
+
+- A `MODEL_ROUTING.md` file with its Token Budget Guidance and Agent
+  Routing tables (run `/harness-init` or copy from
+  `templates/MODEL_ROUTING.md` if you don't have one). Without it the
+  agent refuses — there is no honest token grounding to estimate from.
+- Optionally, a cost snapshot under `observability/costs/` (produced by
+  `/cost-capture`). With **no** snapshot you still get a valid
+  **cost-omitted** record — a grounded token + time estimate plus an
+  honest "cost not yet knowable", which is the default on most repos.
+
+---
+
+## 1. Run the command against a target
+
+```text
+/cost-estimate <target> [--kind <target-kind>] [--out <dir>]
+```
+
+`<target>` is **one** target per invocation. Pass either:
+
+- a **path** to a spec file, a slicing record, or a file holding a
+  single slice, or
+- a quoted string of **pasted task text**.
+
+The command decides which by resolving the argument as a filesystem
+path: a readable file is treated as a path; anything else is treated as
+inline task text.
+
+```text
+/cost-estimate docs/superpowers/specs/2026-06-11-my-feature-design.md
+/cost-estimate "Add a rate limiter to the public API with a config flag"
+```
+
+---
+
+## 2. Disambiguate the kind (optional)
+
+If a path might be mis-classified — for example a slice fragment that
+superficially reads as a full spec — assert the kind explicitly:
+
+```text
+/cost-estimate path/to/slice-fragment.md --kind slice
+```
+
+`--kind` accepts `task-text` | `slicing-record` | `slice` | `spec`.
+An asserted kind raises the tokens/time confidence **ceiling** and
+suppresses the agent's inference-basis line, so the review summary
+**flags it as human-asserted** and asks you to re-confirm the ceiling
+you raised. When you omit `--kind`, the agent infers the kind and
+discloses what it classified on.
+
+---
+
+## 3. Choose where the record lands (optional)
+
+By default the record is written to:
+
+```text
+cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md
+```
+
+`cost-estimates/` is a top-level directory **outside** `observability/`
+(an estimate is a prediction, not telemetry) and is **gitignored** as a
+derived, regenerable artefact. Pass `--out <dir>` to override the
+directory — the derived filename still applies beneath it, so you can
+drop an estimate next to a spec under review:
+
+```text
+/cost-estimate docs/superpowers/specs/2026-06-11-my-feature-design.md --out docs/superpowers/specs/
+```
+
+The command never silently overwrites a same-day estimate for the same
+target — under either the default directory or `--out` it appends a
+short disambiguator and notes it in the confirm-before-write summary.
+
+---
+
+## 4. Review and dispose
+
+Before anything is written, the command shows a review summary of the
+**validated** record: the target and classified kind (with the
+human-asserted flag when you used `--kind`), the token range and
+confidence, the agent-compute-time range and the `human_gate_time`
+caveat, whether cost is present or omitted, the `failure_direction`, the
+resolved output path, and — when the validation checkpoint changed
+anything — a change-list of exactly what it altered versus the agent's
+emitted record.
+
+Then it asks for a disposition:
+
+- **`accept`** — write the record to the resolved path and confirm it.
+- **`edit`** — open the draft in `$EDITOR`; on return the command
+  validates and reports any remaining deviation but never silently
+  reverts your edit (you are the final author on the edit path).
+- **`re-run`** — re-dispatch the agent on the same target as a fresh
+  read of the grounding sources. Use this after adding a cost snapshot
+  to `observability/costs/` so the re-run can ground a cost figure.
+- **`abort`** — discard the draft; nothing is written.
+
+Nothing is persisted until you respond `accept`.
+
+---
+
+## What the validation checkpoint does (and does not) do
+
+The command checks the returned record against every line of
+`skills/cost-estimation/references/estimate-record-format.md`'s
+validation checklist — including the #377 per-stage cost coupling and
+split-tier strict-spread checks. It **fixes only structural-only
+deviations** in place (in practice, just deleting a stray
+`recommendation`/`verdict`/`proceed` field) and records the change. It
+**aborts — never authors** — on any deviation that would create or
+alter a derived value: a missing `cost_basis`, a `low > high` range, a
+missing disclosure section, a confidence axis above the ceiling, or
+imperative go/no-go prose. The honest move on a derived-value defect is
+to surface it and let you `re-run` or `abort`, not to silently complete
+the agent's judgment.
+
+---
+
+## A REFUSED target writes nothing
+
+If the agent cannot honestly ground an estimate — an unreadable target,
+or a `MODEL_ROUTING.md` whose tables are absent or unparseable — it
+returns a `REFUSED:` string. The command surfaces the refusal reason
+verbatim, runs no checkpoint, and writes no file. An empty
+`observability/costs/` is **not** a refusal: you get a valid
+cost-omitted record instead.
+
+---
+
+## Related
+
+- [Track AI Costs](track-ai-costs.md) — the retrospective sibling,
+  `/cost-capture`.
+- [Commands reference](../reference/commands.md) — full signature and
+  flow for `/cost-estimate`.

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -3,7 +3,7 @@ title: Commands
 ---
 # Commands
 
-All 24 slash commands registered in `commands/`. Each command is
+All 27 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -277,6 +277,52 @@ cost snapshot, guides you through provider dashboards to collect
 current spend and token usage, records the data, compares against the
 previous period, and updates `MODEL_ROUTING.md` with observed cost
 trends.
+
+### /cost-estimate
+
+- **Skills read**: cost-estimation (via the dispatched agent)
+- **Agents dispatched**: cost-estimator (read-only)
+
+Estimate a target's tokens, agent-compute time, and (only when a cost
+snapshot grounds it) cost **before** it runs — the prospective sibling
+of `/cost-capture`. Signature:
+`/cost-estimate <target> [--kind <target-kind>] [--out <dir>]`.
+
+**Accepted targets** — exactly one per invocation, matching the
+`cost-estimator` agent's one-target-per-dispatch contract: pasted task
+text, a slicing-record path, a single-slice path, or a spec path. The
+command distinguishes path vs inline text by filesystem resolution and
+forwards any `--kind` (`task-text` | `slicing-record` | `slice` |
+`spec`) as the explicit dispatch-stated kind; it does not itself
+re-classify the `target_kind` or re-implement the methodology.
+
+**Flow** — parse/resolve target → dispatch the read-only
+`cost-estimator` agent → handle a `REFUSED:` return (surfaced verbatim,
+no checkpoint, no file) → **Output Validation Checkpoint** against
+`skills/cost-estimation/references/estimate-record-format.md` →
+review summary → disposition (`accept` / `edit` / `re-run` / `abort`)
+→ on `accept`, the single `Write`. The human disposition **precedes**
+the write (the dispose-then-write ordering invariant): the command owns
+the single `Write`; the agent only emits a string.
+
+**Output path** — default
+`cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md`, a top-level
+directory **outside** `observability/` (predictions are not telemetry),
+gitignored as a derived, regenerable artefact. `--out <dir>` overrides
+the directory; the derived filename still applies beneath it. Same-day
+collisions are disambiguated under both the default and `--out` — an
+existing estimate is never silently overwritten.
+
+**Validation checkpoint** — checks the returned record against every
+line of the format reference's validation checklist (including the #377
+per-stage cost coupling and split-tier strict-spread checks), fixing
+only **structural-only** deviations in place (routinely just deleting a
+stray verdict field) and **aborting — never authoring** — on any
+derived-value defect. The review summary surfaces a change-list of what
+the checkpoint altered, flags a human-asserted `--kind` as
+asserted-not-inferred, and reports a trailing-slash `cost-snapshot`
+grounding path as "no snapshot", not a grounding. The `edit` path is
+validate-and-report — a human edit is never silently reverted.
 
 ### /extract-conventions
 

--- a/docs/superpowers/objections/cost-estimate-command-design-code.md
+++ b/docs/superpowers/objections/cost-estimate-command-design-code.md
@@ -1,0 +1,364 @@
+---
+spec: docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md
+date: 2026-06-12
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: high
+    claim: "The command never specifies how <target-slug> is derived from inline task text or sanitised, so a crafted task string or a path with traversal/separators can produce an estimate written outside cost-estimates/ or to a surprising filename."
+    evidence: "cost-estimate.md:291-293 — '<target-slug> — for a path target, the source filename with its date prefix and .md extension stripped; for inline task text, a short kebab-case slug of the first few words.' No sanitisation, no length bound, no statement that the slug is confined to a single path segment."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Pin <target-slug> to a single sanitised path segment
+      (lowercase [a-z0-9-], separators and '..' stripped, length-capped); the
+      slug is never a path. Closes the write-target-injection surface.
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "REFUSED detection is specified only as 'begins with the stable REFUSED: prefix', with no anchoring discipline — the agent's REFUSED string interpolates attacker-influenceable free text, and the command never states the test runs against the untrimmed first line, so a literal executor could substring-match anywhere or miss a real refusal emitted with leading whitespace."
+    evidence: "cost-estimate.md:92 'If the agent's output begins with the stable REFUSED: prefix'; cost-estimator.agent.md:249-251 'REFUSED: <one-line reason>. Target: <target description>.' — target description is free text. The command never specifies first-line-only anchoring or leading-whitespace handling."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Anchor REFUSED detection to an exact prefix on the
+      UNTRIMMED FIRST LINE of the agent's final message, tested before any
+      reformatting — not substring-anywhere, not post-trim. State the anchor
+      precisely so neither failure direction (drop a record / persist a refusal)
+      is reachable by executor latitude.
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "The checkpoint's only FIX action is 'delete a stray recommendation/verdict/proceed field' (line 8); a verdict in failure_direction PROSE (line 9) must ABORT — but the two share the word 'verdict' and sit one table-row apart, so an executing LLM can misread a prose verdict as a 'stray verdict' and try to fix it by editing the agent's text, which is authoring."
+    evidence: "cost-estimate.md:144-148 lists line 8 (field-absence FIX) above line 9 (positive-content ABORT); the fix-boundary prose (158-166) names 'delete a stray recommendation/verdict/proceed field' as the routine fix. The field-vs-prose distinction is a conclusion, not a test the executor applies before choosing FIX vs ABORT. estimate-record-format.md:373-375's line-9 example is exactly a verdict in Failure-direction prose."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Add an explicit pre-classification test BEFORE FIX-vs-ABORT:
+      the stray-field FIX applies only when the offender is a top-level YAML key
+      whose name is literally in {recommendation, verdict, proceed}; any verdict
+      phrased inside prose (failure_direction etc.) ABORTS. The checkpoint never
+      edits the agent's prose — make that test executable, not a conclusion.
+  - id: O4
+    category: implementation
+    severity: medium
+    claim: "The change-list is permitted to be 'an explicit itemised list (or diff)' and the command never requires the executor to compute an actual before/after comparison, so a literal executor can narrate 'I deleted the verdict field' without surfacing the altered content — the human disposes over a claimed change, not an observed one."
+    evidence: "cost-estimate.md:227-231 — 'show an explicit itemised list (or diff) of exactly what the command altered vs the agent's emitted record'. 'or itemised list' lets the executor choose the weaker form; nothing binds the list to the retained pre-edit content."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Require the executor to retain the agent's original emitted
+      output and present the change-list as a DIFF of original-vs-altered; drop
+      the 'or itemised list' weaker form. The seam the human ratifies must be an
+      observed change, not a narrated one.
+  - id: O5
+    category: implementation
+    severity: medium
+    claim: "On the edit path the post-edit checkpoint is 'validate-and-report', but that mode lives only in the disposition prose while step 4 documents a single default (fix-in-place); the switch is carried by executor memory of authorship context, not a structural flag — a foreseeable failure where re-validation silently applies fix-in-place to human-edited content."
+    evidence: "cost-estimate.md:250-258 (edit → 'validate-and-report mode') vs 259-263 (re-run → 're-validates (step 4)'); step 4 (106-199) documents only fix-in-place. The validate-and-report variant is remote prose, not a parameter the checkpoint takes."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Make the checkpoint mode an explicit input on every
+      invocation (fix-in-place on fresh agent output | validate-and-report on
+      human-edited content), so the 'a human edit is never reverted unseen'
+      invariant is structural, not carried by executor memory of authorship.
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "Same-day collision disambiguation is bound to the step-5 summary, but the single Write is step 7 after disposition, with no re-check at write time — a file appearing between summary and accept (a concurrent invocation, a manual drop) is clobbered because the disambiguator was computed against a now-stale listing; a time-of-check/time-of-use gap."
+    evidence: "cost-estimate.md:299-303 — collision check + disambiguator at 'the confirm-before-write summary (step 5)'; '...never silently overwrites'. The Write is step 7 (270-274) with no restated existence check. The guarantee is only as strong as the step-5 snapshot."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Re-evaluate the collision at WRITE time (step 7) and
+      re-disambiguate if the target now exists; never overwrite even if a file
+      appeared after the step-5 summary. Closes the time-of-check/time-of-use gap
+      that widens with deliberation time.
+  - id: O7
+    category: scope
+    severity: medium
+    claim: "The commands reference page still asserts 'All 24 slash commands registered in commands/' while the directory now holds 27 command files including cost-estimate.md — the reference ships factually wrong on the day this command lands, the reference-staleness the spec's scope section commits to preventing."
+    evidence: "docs/.../reference/commands.md:6 'All 24 slash commands registered in commands/'; Glob of commands/*.md returns 27 files. The implementer added the ### /cost-estimate entry (commands.md:281) but left the count sentence stale."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Correct the reference page's 'All 24 slash commands' to the
+      actual count this PR ships (27). The number was stale before, but this PR
+      adds the command that makes it wrong by one and touches the file, so it is
+      this PR's to correct.
+  - id: O8
+    category: implementation
+    severity: low
+    claim: "The command tells the executor to pass 'the resolved model id for the agent's generated_by branch (a)' only 'if the command knows it', but never says how a slash-command executor would know it; in practice it has no resolved model id, so branch (a) is dead and every record takes branch (b) — harmless, but the spec presents (a) as a live path."
+    evidence: "cost-estimate.md:83-84 '— if the command knows it — the resolved model id for the agent's generated_by branch (a)'. No mechanism for the command to obtain the model id; the agent's branch (b) default (cost-estimator.agent.md:218-226) is what fires."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — note (no behavioural change). Add a one-line note that a
+      slash-command executor has no resolved model id, so branch (b) is the live
+      path; (a) is reserved for an orchestrator dispatcher that supplies one.
+      Retires the dead-conditional ambiguity without changing output.
+---
+
+## O1 — specification quality — high
+
+### Claim
+
+The command derives the on-disk filename from a `<target-slug>` but never
+specifies how that slug is sanitised. For inline task text it is "a short
+kebab-case slug of the first few words"; for a path target it is the filename
+with date prefix and `.md` stripped. Neither rule constrains the result to a
+single safe path segment, bounds its length, or strips path separators and
+`..`. An executing agent given a quoted task string containing `/` or `..`, or
+a path target whose basename is adversarial, can produce a write target that
+escapes `cost-estimates/` or lands at a surprising location.
+
+### Evidence
+
+> `cost-estimate.md:291-293` — "**`<target-slug>`** — for a **path** target,
+> the source filename with its date prefix and `.md` extension stripped …; for
+> **inline task text**, a short kebab-case slug of the first few words."
+
+"kebab-case slug" implies normalisation, but the command never states the slug
+is confined to `[a-z0-9-]` or to a single path component. The collision logic
+(`299-303`) reasons about "the derived filename" as if it is always a leaf name,
+but nothing enforces that.
+
+### Why this matters
+
+A slash command that writes files derived from arbitrary human-supplied text is
+a write-target-injection surface. If the executor takes "first few words"
+literally on a target like `"../../etc/notes spike"`, the slug can carry
+separators. Because the single `Write` + `mkdir -p` trust the derived path, an
+unsanitised slug turns the confirm-before-write gate into the only defence — and
+the human confirms a path the executor chose. The fix is one sentence pinning
+the slug to a single sanitised segment (`[a-z0-9-]`, length-capped); its absence
+is a real footgun in an instruction artefact whose failure mode is executor
+latitude.
+
+## O2 — implementation — high
+
+### Claim
+
+REFUSED detection is the load-bearing branch that prevents persisting a
+non-record, yet its match is specified only as "begins with the stable
+`REFUSED:` prefix" with no anchoring discipline. The agent's REFUSED string
+interpolates an attacker-influenceable `<target description>`, and the command
+does not state the prefix test runs against the untrimmed first line of the
+agent's final message (vs. anywhere in the output). A literal executor that
+substring-matches `REFUSED:` could misclassify a conforming record whose prose
+mentions the token; one that trims/reformats before testing could miss a real
+refusal emitted with a leading newline.
+
+### Evidence
+
+> `cost-estimate.md:92` — "If the agent's output **begins with** the stable
+> `REFUSED:` prefix".
+
+> `cost-estimator.agent.md:249-251` — "`REFUSED: <one-line reason>. Target:
+> <target description>. …`" — reason and target are free text.
+
+The command never specifies first-line-only anchoring, leading-whitespace
+handling, or that the test precedes any reformatting of the agent's output.
+
+### Why this matters
+
+This seam keeps a malformed/partial output off disk. If the match is ambiguous,
+two opposite failures are reachable: a record mis-read as a refusal is silently
+dropped, and a refusal mis-read as conforming gets written. For a branch whose
+whole job is "never persist a non-record", "begins with" deserves an explicit
+anchor (untrimmed, first line, exact prefix) rather than relying on the
+executor's judgement.
+
+## O3 — implementation — high
+
+### Claim
+
+The checkpoint's only FIX action is "delete a stray
+`recommendation`/`verdict`/`proceed` **field**" (line 8); every prose-verdict
+case (line 9) must ABORT because the checkpoint "cannot rewrite the agent's
+prose". But the two cases are adjacent and the operative distinction — a
+*frontmatter field literally named* `verdict` versus *a verdict phrased inside*
+`failure_direction` prose — is stated as a conclusion, not a test the executor
+applies before choosing FIX vs ABORT. An LLM executor that meets "failure
+direction: likely-overrun, so do not proceed" can read "verdict" and reach for
+FIX, editing the agent's prose — the authoring the boundary forbids.
+
+### Evidence
+
+> `cost-estimate.md:144-148` lists line 8 ("field-absence layer — no
+> `recommendation`, `verdict`, or `proceed` field") immediately above line 9
+> ("positive-content layer — … no imperative recommendation or go/no-go
+> language").
+
+> `cost-estimate.md:158-166` names "delete a stray
+> `recommendation`/`verdict`/`proceed` field" as "the only routinely-fixed
+> line". `estimate-record-format.md:373-375`'s line-9 example is precisely a
+> verdict in the Failure-direction prose — the case most likely to be confused
+> with a "stray verdict".
+
+### Why this matters
+
+The dispose-then-write architecture depends on the checkpoint *never silently
+authoring the agent's judgment*. The single permitted mutation (field deletion)
+and the single most dangerous forbidden mutation (prose-verdict rewrite) share
+the word "verdict" and sit one table-row apart. An executor that conflates them
+edits the agent's disclosure text and presents it as "validated", collapsing the
+provenance the change-list exists to keep transparent. The command needs an
+explicit pre-classification test ("is this a top-level YAML key whose name is in
+{recommendation, verdict, proceed}? → FIX by deletion; otherwise → ABORT") so a
+prose verdict cannot route into FIX.
+
+## O4 — implementation — medium
+
+### Claim
+
+The change-list is the mechanism that makes the one mutating fix transparent,
+but the command permits it to be "an explicit itemised list (**or diff**)" and
+never requires an actual before/after comparison. A literal executor can satisfy
+the prose by narrating "deleted a stray `verdict` field" without surfacing the
+altered content, so the human disposes over a claimed change, not an observed
+one.
+
+### Evidence
+
+> `cost-estimate.md:227-231` — "show an **explicit itemised list (or diff) of
+> exactly what the command altered vs the agent's emitted record**".
+
+The disjunction "list (or diff)" lets the executor choose the weaker form, and
+nothing binds the list to the actual pre-fix bytes — the executor that *made*
+the change also *reports* it, with no independent capture of the agent's
+original output to diff against.
+
+### Why this matters
+
+The change-list exists so `accept` ratifies a composite "the human can see the
+seams of". If the executor can self-report the change without showing it, the
+seam is opaque again. Lower severity than O3 (the only fixable case is a
+deletion) but it undercuts the same transparency guarantee and is cheap to close
+(retain the original agent output; make the change-list a diff of it).
+
+## O5 — implementation — medium
+
+### Claim
+
+The post-edit checkpoint is "validate-and-report", but that mode lives only in
+the `edit` disposition prose, while step 4 documents a single default:
+fix-in-place. The mode switch is carried by executor memory of authorship
+context, not a structural flag passed into the checkpoint. An executor that
+re-enters "the checkpoint" after an edit can apply the step-4 fix-in-place
+default to human-authored content, silently reverting a human edit — the precise
+failure validate-and-report was added to prevent.
+
+### Evidence
+
+> `cost-estimate.md:250-258` (edit → "validate-and-report mode") vs `259-263`
+> (re-run → "re-validates (step 4)"). Step 4 (`106-199`) describes only
+> fix-in-place; the validate-and-report variant is not represented in the
+> checkpoint section.
+
+### Why this matters
+
+"A human edit is never reverted without the human seeing and re-confirming it"
+is an explicit O3-resolution invariant. Encoding the exception as remote prose
+rather than a parameter the checkpoint takes (`mode: fix | report`) means the
+invariant holds only if the executor correctly attributes authorship every time
+it re-enters validation — brittle in an artefact whose failure mode is executor
+drift. Stating the checkpoint's mode as an explicit input on every invocation
+makes the seam structural rather than mnemonic.
+
+## O6 — risk — medium
+
+### Claim
+
+The "never silently overwrites" guarantee is anchored to the collision check at
+step 5 (summary time), but the actual `Write` is at step 7 after the human
+disposes. Nothing requires the existence check to re-run at write time. A file
+appearing between summary and `accept` — a concurrent `/cost-estimate` for the
+same target/day, or a manual drop — is clobbered, because the disambiguator was
+computed against a listing that is stale by the time the Write fires.
+
+### Evidence
+
+> `cost-estimate.md:299-303` — collision check + disambiguator at "the
+> confirm-before-write summary (step 5) … never silently overwrites".
+
+> `cost-estimate.md:270-274` (step 7) — the single Write, with no restated
+> existence check.
+
+### Why this matters
+
+The guarantee is the whole point of the O9 resolution (silent estimate loss is
+real data loss). Binding the check to step 5 makes it a time-of-check/time-of-use
+gap that widens with deliberation time. The fix is one clause — "re-evaluate the
+collision at write time and re-disambiguate if the target now exists". Medium
+because the window is small and the targets are gitignored regenerable artefacts.
+
+## O7 — scope — medium
+
+### Claim
+
+The commands reference page still opens with "All 24 slash commands registered
+in `commands/`", but `commands/` now contains 27 command files including the new
+`cost-estimate.md`. The page ships factually wrong on the day the command lands —
+the reference-staleness the spec's own scope section commits to avoiding.
+
+### Evidence
+
+> `docs/plugins/ai-literacy-superpowers/reference/commands.md:6` — "All **24**
+> slash commands registered in `commands/`."
+
+A Glob of `commands/*.md` returns 27 files. The implementer correctly added the
+`### /cost-estimate` entry (`commands.md:281`) but left the count at line 6
+unchanged.
+
+### Why this matters
+
+The CLAUDE.md "Docs Site Review" convention requires reference pages to be
+current when a feature changes the surface they describe; the spec puts the
+reference entry in scope. The number was likely stale before this PR, but this PR
+adds the command that makes it wrong by one more and touches this very file, so
+it is this PR's to correct.
+
+## O8 — implementation — low
+
+### Claim
+
+The command tells the executor to pass "the resolved model id for the agent's
+`generated_by` branch (a)" but only "if the command knows it", and never says how
+a slash-command executor would know it. In practice it has no resolved model id,
+so branch (a) never fires and every record takes branch (b)'s routing-tier
+default. The instruction presents (a) as a live path when it is effectively dead.
+
+### Evidence
+
+> `cost-estimate.md:83-84` — "and — **if the command knows it** — the resolved
+> model id for the agent's `generated_by` branch (a)".
+
+> `cost-estimator.agent.md:218-226` — branch (b) (read the tier from
+> `MODEL_ROUTING.md`) is the default when no id is supplied.
+
+### Why this matters
+
+Harmless to output (branch (b) produces honest `tier:` provenance), so `low`. But
+it is dead conditional prose: a future maintainer may build logic for a path that
+can never be exercised, or be misled that records can carry concrete model ids
+under this command. A one-line note ("the slash-command executor has no resolved
+model id, so branch (b) is the live path; (a) is reserved for an orchestrator
+dispatcher that does") retires the ambiguity.
+
+## Explicitly not objecting to
+
+- **The dispose-then-write ordering itself**: steps 5→6→7 place the single
+  `Write` unambiguously downstream of `accept`, and the REFUSED/abort/edit/re-run
+  branches each correctly write nothing — the core ordering invariant is sound;
+  O5/O6 are about mode and collision-timing seams, not the ordering.
+- **The `cost-estimates/` output home (outside `observability/`, gitignored)**:
+  the placement reasoning, the `.gitignore` entry matching the `/diagnose`
+  rationale, and the "predictions are not telemetry" decision are coherent and
+  correctly implemented across command, docs, and gitignore.
+- **Empty-snapshot-is-not-a-refusal**: command (`102-104`) and agent agree an
+  empty `observability/costs/` yields a valid cost-omitted record, and the
+  trailing-slash sentinel is honoured in the summary without mutating the format
+  contract.
+- **The #377 deferred absolute-rate check being out of scope**: the re-filing-to-S6
+  reasoning is an adjudicated spec-time decision; re-raising it would re-litigate
+  a resolved disposition.
+- **The checklist transcription**: the command's lines 1-9 faithfully transcribe
+  the format reference's validation checklist incl. the #377 additions; the
+  transcription is correct.

--- a/docs/superpowers/objections/cost-estimate-command-design.md
+++ b/docs/superpowers/objections/cost-estimate-command-design.md
@@ -1,0 +1,312 @@
+---
+spec: docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md
+date: 2026-06-12
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: medium
+    claim: "The §7.1a per-checklist-line table classifies line 7 (Time split) as a partial FIX ('fix-in-place only a pure structural mistyping with no value change'), but no such fixable case is constructible without touching a derived value, so the one non-trivial 'fix' the table admits beyond line 8 is undefined — the ambiguity O2 was meant to remove was relocated into line 7, not eliminated."
+    evidence: "§7.1a table row 7: 'ABORT if a value is missing/mistyped (authoring); fix-in-place only a pure structural mistyping with no value change.' The format reference defines agent_compute_time as a `{low, high}` range and human_gate_time as a qualitative string (estimate-record-format.md:364-366). A shape-mistyping of either either changes a value (range bounds) or is indistinguishable from a missing/wrong field — so 'pure structural mistyping with no value change' has no worked instance."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Collapse §7.1a row 7 (Time split) to a clean ABORT
+      (consistent with rows 1-6): any time-field defect aborts, since no
+      no-value-change time mistyping is constructible. Removes the relocated
+      ambiguity.
+  - id: O2
+    category: implementation
+    severity: low
+    claim: "The O1-fix (change-list) and the O2-fix (abort on all derived-value defects) interact so that the change-list can contain only one thing — a deleted stray verdict field (line 8) — making 'an explicit change-list of exactly what the command altered' a near-always-trivial or empty disclosure, and the two fixes therefore deliver far less transparency than their prose implies."
+    evidence: "§7.1a: 'In practice the only routinely-fixed line is #8 (delete a stray verdict field).' Every other table row is ABORT. §5 step 5 / FR-6a require a change-list 'when the checkpoint changed anything', and otherwise 'no checkpoint changes — record as emitted by the agent.' The union of fixable cases is {delete a stray recommendation/verdict/proceed field}."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted observation. The change-list is bounded to line-8
+      deletions given the structural-only boundary — but the disclosure
+      obligation is honest and worth keeping; recorded that the mechanism's yield
+      is narrow, not a defect. No change.
+  - id: O3
+    category: risk
+    severity: medium
+    claim: "`cost-estimates/` is a new committed top-level directory (the spec declines to mandate gitignoring it), so S3 begins committing prospective estimate records — files whose `target` may reference an unmerged spec or a since-deleted slice — into version control, with no decision on staleness, rotation, or what happens when the referenced target changes after the estimate is committed."
+    evidence: "§6.1: 'the spec does not mandate gitignoring them (they are inspectable artefacts), but flags it as a docs-reference note.' The existing .gitignore gitignores the analogous derived /diagnose output (diagnostic-legibility/output/) precisely because it is 'derived, regenerable'. An estimate is likewise a regenerable guess, yet S3 leaves it committed-by-default with no staleness story."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix. Gitignore cost-estimates/ by default (consistent with the
+      /diagnose derived-output convention) — estimates are derived, regenerable
+      guesses referencing moving targets. State it as a decision (gitignored by
+      default + add the .gitignore line in this slice), not a deferred docs-note.
+  - id: O4
+    category: scope
+    severity: medium
+    claim: "The O6-fix's 'blocking acceptance criterion' is keyed on an event no scheduled slice produces — 'the first slice that produces a cost-present estimate record' requires a usable observability/costs/ snapshot to first land, but landing a snapshot is not itself a scheduled deliverable of any slice (S6 is the calibration loop, not a snapshot-capture slice), so the criterion may never fire and the absolute-rate check can still be orphaned exactly as O6 feared."
+    evidence: "§7.2: 'the absolute-rate check becomes BLOCKING on — and is a required deliverable of — the first slice that produces a cost-present estimate record (equivalently, the first slice under which a usable observability/costs/ snapshot lands…). On today's roadmap that is S6 (#373).' But §7.2 also states the repo 'cannot produce' a cost-present record because observability/costs/ is empty, and no slice in S4-S6 is described as capturing a snapshot — S6 consumes actuals (calibration), it is not the slice that first makes a snapshot exist. The trigger is a soft pointer in an issue body, not a gate any CI or slicing record enforces."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted — fix the homing. Bind the absolute-rate check to a slice NUMBER
+      directly (or name the slice that captures the first snapshot) so the trigger
+      is reachable — don't leave it keyed on an event no scheduled slice produces.
+      The re-filed issue must name a concrete blocking slice, not a precondition
+      the roadmap never causes.
+  - id: O5
+    category: specification quality
+    severity: low
+    claim: "Five of the nine per-checklist-line classifications (lines 1, 2, 3, and the cost halves of 5 and 6) key on cost_usd / per-stage bands that no record the command can emit today carries — by the spec's own closed-world argument — so the §7.1a table spends five rows on ABORT paths unreachable until a snapshot lands, while the only live abort paths today are lines 4, 8, 9; the table reads as uniformly live when two-thirds of it is dormant."
+    evidence: "§7.2: 'every record S3 writes today is cost-omitted — it carries no cost_usd and no per-stage cost_usd band.' estimate-record-format.md:320-363: lines 2 (per-stage coupling), 3 (split-tier spread), and the cost axis of lines 5-6 'pass vacuously' on a cost-omitted record, so their ABORT branches are unreachable today."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted observation (cheap one-line flag welcome): mark in the
+      spec that, against today's cost-omitted-only records, the live checklist
+      surface is lines 4/8/9; the cost-band rows are dormant until a snapshot
+      lands — consistent with the absolute-rate-deferral closed-world reasoning.
+  - id: O6
+    category: specification quality
+    severity: low
+    claim: "The scenario set grew to eleven Gherkin blocks, several of which (10.4b's cost-present abort, 10.6b's re-run-into-a-cost-present-record) require fixtures pinning a cost-present world the command's real grounding never produces today, and the synthetic cost-present fixtures must hand-author the very split-tier bands the deferred absolute-rate check would validate — yet the flat FR-17 list does not distinguish runnable-today scenarios from synthetic-future ones."
+    evidence: "§10.4b 'Given a returned cost-present record'; §10.6b 'the re-validated record can now carry cost_usd'; §9 'pins … an empty or populated observability/costs/'; FR-17 lists all scenarios flat with no runnable-today vs synthetic-fixture split."
+    disposition: accepted
+    disposition_rationale: >
+      Accepted as a noted observation (cheap one-line flag welcome): mark which
+      scenarios are runnable-today (empty-snapshot, REFUSED) vs synthetic-
+      cost-present-fixture (10.4b, 10.6b), and that the synthetic fixtures
+      hand-author bands the deferred absolute-rate check would validate.
+---
+
+## O1 — specification quality — medium
+
+### Claim
+
+The round-1 O2 disposition asked for the fix-in-place boundary to be defined
+*per checklist line*. The revision delivers the table in §7.1a, and for eight of
+nine lines it is unambiguous (one FIX, the rest ABORT). But line 7 (Time split)
+carries a split classification — "ABORT if a value is missing/mistyped
+(authoring); **fix-in-place only a pure structural mistyping with no value
+change**" — and that fixable sub-case has no constructible instance. The two
+time fields are a numeric range and a qualitative string; any mistyping of
+either changes a value or is indistinguishable from a missing field. The line
+therefore re-opens, on a single row, the exact "what counts as structural-only"
+ambiguity the table was added to close.
+
+### Evidence
+
+> §7.1a table, row 7: "**ABORT** if a value is missing/mistyped (authoring);
+> fix-in-place only a pure structural mistyping with no value change"
+
+The format reference defines the shapes that make a no-value-change mistyping
+unconstructible: `agent_compute_time` a `{ low, high }` range, `human_gate_time`
+a qualitative caveat string (estimate-record-format.md:364-366). A YAML shape-fix
+to `agent_compute_time` touches its bounds (a derived number); a shape-fix to
+`human_gate_time` either changes the caveat text (authoring) or is a no-op. There
+is no third case.
+
+### Why this matters
+
+O2 was accepted specifically to stop two implementers drawing the structural/
+derived line differently. Eight rows now agree; row 7 leaves one implementer free
+to "fix" a time-field shape and another to abort. The fix is cheap — either
+collapse row 7 to a clean ABORT (consistent with rows 1-6), or supply the one
+worked instance of a no-value-change time mistyping that justifies keeping the
+FIX half. As written, the table relocated the ambiguity rather than removing it
+on this row.
+
+## O2 — implementation — low
+
+### Claim
+
+The O1-fix (a change-list of what the checkpoint altered) and the O2-fix (abort
+on every derived-value defect) interact so the change-list's content is bounded
+to a single possibility: a deleted stray `recommendation`/`verdict`/`proceed`
+field. The spec itself concedes line 8 is "the only routinely-fixed line." So the
+elaborate change-list machinery (FR-6a, §5 step 5, scenario 10.4a) discloses
+either nothing ("no checkpoint changes") or one deletion. The two accepted fixes
+are individually sound but together deliver far less transparency than their
+prose frames.
+
+### Evidence
+
+> §7.1a: "In practice the only routinely-fixed line is **#8 (delete a stray
+> verdict field)** — a pure removal that authors nothing. Every line that would
+> require the checkpoint to *supply* a derived value aborts."
+
+> FR-6a: "When the checkpoint changes anything at step 4, the review summary
+> surfaces an explicit change-list … when it changes nothing, the summary says
+> so."
+
+The union of fixable deviations across the nine lines is {line 8 deletions}
+(line 7's FIX half being unconstructible per O1).
+
+### Why this matters
+
+Not a correctness defect — the composite is honest — but it signals the two fixes
+may be over-engineered relative to their yield. A reviewer disposing O1/O2 should
+know that "transparent agent-vs-command composite" almost always means "the
+agent's record verbatim, or that record minus one forbidden field." If that is
+acceptable, the change-list could be a one-line note rather than a diff apparatus.
+Low because nothing is wrong; it flags the mechanism's cost may exceed the bounded
+fix-set's value.
+
+## O3 — risk — medium
+
+### Claim
+
+`cost-estimates/` is a new top-level directory, and the spec explicitly declines
+to mandate gitignoring it ("they are inspectable artefacts"). So S3's default
+behaviour commits prospective estimate records into version control. An estimate
+is a regenerable guess whose `target` field may point at an unmerged spec, a slice
+that is later renamed, or a task description that changes — yet the spec gives no
+staleness, rotation, or invalidation story for the committed corpus, and treats
+the gitignore question as a deferred docs-note rather than a decision.
+
+### Evidence
+
+> §6.1: "the spec does **not** mandate gitignoring them (they are inspectable
+> artefacts), but flags it as a docs-reference note."
+
+The repo's existing convention for the directly-analogous artefact points the
+other way: `.gitignore` excludes the `/diagnose` output "because it is derived,
+regenerable … Never committed." A `/cost-estimate` record is equally derived and
+regenerable, but S3 leaves it committed-by-default and undecided.
+
+### Why this matters
+
+Committing estimates creates a growing body of stale guesses that reference moving
+targets, with no rule for when a committed estimate becomes misleading (a spec is
+exactly the kind of target that mutates between estimate and merge). The spec
+already invokes O5/O7 reasoning that "predictions are not facts" to keep estimates
+out of `observability/`; the same reasoning argues for treating committed
+predictions as derived output (gitignored, regenerable) by default, consistent
+with `/diagnose`. Leaving it to a downstream "docs-reference note" defers a
+decision that shapes what the command does on its very first run.
+
+## O4 — scope — medium
+
+### Claim
+
+The O6-fix replaced a soft "most naturally S6" hand-off with a "blocking
+acceptance criterion." But the criterion is keyed on an event no scheduled slice
+is committed to produce. It fires on "the first slice that produces a cost-present
+record," which requires a usable `observability/costs/` snapshot to first exist —
+and *landing a snapshot* is not a deliverable of any slice in the roadmap. S6 is
+the calibration loop, which consumes a snapshot; nothing in S4-S6 is described as
+the slice that first *captures* one. So the trigger may never fire, and the
+absolute-rate check can stay orphaned for the same reason O6 named.
+
+### Evidence
+
+> §7.2: "the absolute-rate check becomes BLOCKING on — and is a required
+> deliverable of — the **first slice that produces a cost-present estimate
+> record** … On today's roadmap that is **S6 (#373)**."
+
+But the same section establishes the precondition is unmet and unscheduled:
+`observability/costs/` is empty so every record today is cost-omitted, and S6 is
+"the slice that closes the actuals loop" — a *consumer* of actuals, not the slice
+that captures the first snapshot. The criterion lives in a re-filed issue's body,
+not in a slicing record, a CI gate, or a contract any pipeline step checks.
+
+### Why this matters
+
+O6 was accepted to convert a hand-off into a committed home with a falsifiable
+trigger. The revision's trigger is falsifiable in principle but unreachable in
+practice on the stated roadmap: if no slice captures the first snapshot, no slice
+"produces the first cost-present record," and the blocking criterion never binds.
+The spec should either name the slice that captures the first snapshot (making the
+trigger reachable) or bind the check to a slice number directly, rather than to a
+precondition the roadmap does not schedule.
+
+## O5 — specification quality — low
+
+### Claim
+
+Five of the nine per-checklist-line classifications (lines 1, 2, 3, and the cost
+halves of 5 and 6) key on `cost_usd` / per-stage bands that no record the command
+can emit today carries — by the spec's own closed-world argument. So the §7.1a
+table devotes five rows to ABORT paths unreachable until a snapshot lands, while
+the only abort paths the command can actually hit today are lines 4 (missing
+disclosure section) and 9 (verdict prose), plus the line-8 fix. The table reads as
+complete, but most of its rows describe a world §7.2 says does not yet exist.
+
+### Evidence
+
+> §7.2: "every record S3 writes today is **cost-omitted** — it carries no
+> `cost_usd` and no per-stage `cost_usd` band."
+
+estimate-record-format.md:320-363: lines 2, 3, and the cost axis of 5-6 "pass
+vacuously" / are "both absent" on a cost-omitted record, so their ABORT branches
+never reach on today's producible records.
+
+### Why this matters
+
+This is the same closed-world condition O4/§7.2 use to defer the absolute-rate
+check — applied consistently, the cost-band abort rows are equally untestable
+today. The spec presents a nine-row table as uniformly live when two-thirds of it
+is dormant; a reviewer adjudicating checkpoint testability should know the live
+surface against today's records is lines 4, 8, 9 only. Low because the rows are
+correct once cost-present records exist.
+
+## O6 — specification quality — low
+
+### Claim
+
+The scenario set grew to eleven Gherkin blocks — one per accepted objection plus
+the originals — but several (10.4b's cost-present abort, 10.6b's re-run yielding a
+cost-present record) require fixtures pinning a cost-present world the command's
+real grounding never produces today. The synthetic cost-present fixtures must
+hand-author the very split-tier bands the absolute-rate check (deferred per O4)
+would otherwise validate. The flat FR-17 list does not distinguish runnable-today
+scenarios from synthetic-future ones.
+
+### Evidence
+
+> §10.4b "Given a returned **cost-present** record"; §10.6b "the re-validated
+> record **can now carry cost_usd**"; §9 "pins … an **empty or populated**
+> observability/costs/"; FR-17 lists all scenarios flat, "graded by the
+> deterministic oracles of §9," with no runnable-today vs synthetic split.
+
+### Why this matters
+
+The scenarios are individually sound and the fixture-driven approach is right. The
+gap is presentational-but-load-bearing: an implementer reading FR-17 cannot tell
+that 10.4b/10.6b will never be exercised by a real grounding read and exist only
+to pin future behaviour against a synthetic snapshot — and that those synthetic
+fixtures encode hand-authored cost bands the spec elsewhere declines to check.
+Flagging which scenarios are synthetic-future would let a reviewer see the
+cost-present test surface rests on hand-authored bands, not a grounded emit. Low
+because the scenarios are honest; the omission is which ones are reachable.
+
+## Explicitly not objecting to
+
+- **O1 round-1 (checkpoint silently edits before disposition) — confirmed
+  resolved.** §5 step 5, §7.1a, and FR-6a require the review summary to surface an
+  explicit change-list of exactly what the checkpoint altered, and to state "no
+  checkpoint changes" otherwise; the human disposes over a transparent composite.
+  (My O2 notes the change-list is near-trivial, but the disclosure obligation is
+  fully met.)
+- **O2 round-1 (unbounded "fix in place") — confirmed resolved, save one row.**
+  §7.1a draws the structural-only vs derived-value boundary per checklist line and
+  removes the inverted "insert a missing cost_basis" example, replacing it with an
+  explicit ABORT. Eight of nine rows are unambiguous; only line 7 (my O1) retains a
+  residual.
+- **O3 round-1 (edit path silently reverts) — confirmed resolved.** §7.1b and
+  FR-6b put the post-edit checkpoint into validate-and-report mode: "a human edit
+  is never reverted without the human seeing and re-confirming it."
+- **O4 round-1 (asserted `--kind` silently buys a higher ceiling) — confirmed
+  resolved.** §4.1, §5 step 5, FR-8a, and scenario 10.6a flag a human-asserted
+  kind as asserted-not-inferred with a raised, basis-free ceiling and ask the human
+  to re-confirm.
+- **O5 round-1 (estimates under `observability/`) — confirmed resolved.** §6.1
+  moves the default home to top-level `cost-estimates/` with a documented read of
+  every current `observability/` consumer showing none globs the tree wholesale.
+  (My O3 is a *new* concern about committing that directory, distinct from the
+  resolved location.)
+- **O7 round-1 (unguarded trailing-slash sentinel residual) — confirmed
+  resolved.** §7.3, FR-14a, scenario 10.5 record in the spec that S3 ships the
+  first records carrying the unguarded sentinel.
+- **O8 round-1 (re-run re-reading the snapshot) — confirmed resolved.** §5 step 6,
+  FR-8b, scenario 10.6b state re-run is a full fresh dispatch re-reading grounding
+  incl. the now-populated `observability/costs/`.
+- **O9 round-1 (`--out` collision) — confirmed resolved.** §6.2, FR-11a, scenario
+  10.6c apply same-day disambiguation under `--out`; never silently overwrites.
+- **The premise and pure-consumer discipline** — unchanged and still sound; §3
+  argues the standalone surface well, §2.2/§2.3 refuse to mutate the S1 format or
+  S2 agent from a consumer seat.

--- a/docs/superpowers/plans/2026-06-11-cost-estimate-command.md
+++ b/docs/superpowers/plans/2026-06-11-cost-estimate-command.md
@@ -1,0 +1,597 @@
+# Cost Estimation — S3 — `/cost-estimate` command — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship S3 of the cost-estimator capability — the human-facing
+**`/cost-estimate` command** at `ai-literacy-superpowers/commands/cost-estimate.md`.
+It is the manual dispatcher for the S2 `cost-estimator` agent: it parses a single
+target, dispatches the agent, handles a `REFUSED:` output (write nothing), runs an
+**Output Validation Checkpoint** against the S1 format reference's checklist
+(including the #377 per-stage coupling + split-tier strict-spread lines) under a
+**transparency-at-the-disposition-seat discipline** — it fixes only
+**structural-only** deviations in place, **records every change** it makes,
+**aborts (never authors)** on any derived-value defect, and on the `edit` path
+**validates-and-reports** rather than reverting the human's edit — shows a review
+summary of the **validated** record (with the change-list and, on a human-asserted
+`--kind`, an asserted-not-inferred ceiling flag), asks the human for a disposition
+(accept / edit / re-run / abort), and on `accept` performs its **single Write** to
+a top-level **`cost-estimates/`** directory (outside `observability/`) —
+**downstream of the human disposition** (the dispose-then-write ordering
+invariant). Plugin version bumps `0.43.0 → 0.44.0`.
+
+**Revised 2026-06-12** after the spec-mode advocatus-diaboli raised 9 objections,
+all accepted (record:
+`docs/superpowers/objections/cost-estimate-command-design.md`). The revisions:
+checkpoint transparency + structural-fix boundary (O1, O2); edit-path
+validate-and-report (O3); `--kind` asserted-ceiling flag (O4); output home moved
+outside `observability/` to top-level `cost-estimates/` (O5); absolute-rate check
+re-filed with a blocking acceptance criterion (O6); unguarded-sentinel residual
+recorded (O7); `re-run` re-reads the snapshot (O8); `--out` collision
+disambiguation (O9).
+
+**Round-2 diaboli (2026-06-12):** O1 (collapse checklist row 7 to a clean ABORT),
+O3 (gitignore `cost-estimates/` by default + add the `.gitignore` line this slice),
+and O4 (bind the absolute-rate check to a concrete slice — S6/#373, extended to own
+first-snapshot capture — so the trigger is reachable) are fixed; O5/O6 are
+one-line flags (live-checklist-surface note; runnable-today vs synthetic-fixture
+split); O2 needs no change.
+
+**This is slice 3 of a six-slice capability.** Upstream (merged on main): S1 (the
+skill + `estimate-record-format.md`, incl. the #377 per-stage `cost_usd`
+additions) and S2 (#369, the read-only agent). Downstream issues, **none ship
+here**: S4 #371 (orchestrator T1/T2 fold-in), S5 #372 (T0 ballpark), S6 #373
+(calibration loop). S3 is a **standalone manual surface** — it does **not** wire
+into the orchestrator.
+
+**Architecture:** A new command file — the **fifth production instance** of the
+AGENTS.md **agent-emit + dispatcher-persist + human-disposes** pattern (after
+`advocatus-diaboli`, `choice-cartographer`, `model-card-researcher`, `/diagnose`),
+and the first cost-record instance. It mirrors the `model-card create`
+dispose-then-write flow (dispatch → handle REFUSED → validate → review summary →
+disposition → single Write) and the `/cost-capture` sibling's structure/discipline
+(directory creation, mandatory validation step). The command is a **pure
+consumer** of the S2 agent and the S1 format reference: it dispatches the agent
+as-merged and validates against the format checklist as-merged, mutating neither.
+
+**Tech Stack:** Markdown. No new dependencies, no code.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md`
+
+---
+
+## Modules / files touched
+
+```
+ai-literacy-superpowers/
+├── .claude-plugin/plugin.json                          # MODIFIED: 0.43.0 → 0.44.0
+└── commands/
+    └── cost-estimate.md                                # NEW — manual dispatcher command
+#   NOTE: agents/cost-estimator.agent.md is NOT touched (S2, consumed as-merged).
+#   NOTE: skills/cost-estimation/references/estimate-record-format.md is NOT
+#         touched — S3 is a pure consumer of the format checklist (incl. #377).
+
+CLAUDE.md                                                # MODIFIED: add /cost-estimate to the Output Validation Checkpoints command list
+CHANGELOG.md                                             # MODIFIED: new 0.44.0 entry (repo root, not under the plugin dir)
+.gitignore                                               # MODIFIED: add cost-estimates/ (derived, regenerable; matches the /diagnose entry's rationale) (O3, FR-10a)
+
+tdad_tests/scenarios/commands/cost-estimate/
+├── command-structure.md                                # NEW — structural (frontmatter; flow order; checkpoint-by-path; structural-fix boundary; disposition vocab; cost-estimates/ default home)
+├── writes-record-on-accept.md                          # NEW — behavioural (accept → single Write at cost-estimates/ resolved path; cost-omitted today)
+├── dispose-precedes-write.md                            # NEW — behavioural (abort → no file; accept → exactly one Write after disposition)
+├── refused-not-persisted.md                             # NEW — behavioural (REFUSED → surfaced verbatim, no checkpoint, no file)
+├── checkpoint-fix-boundary.md                           # NEW — behavioural (O1/O2: structural-only fix + change-list; derived-value defect ABORTS, never authors)
+├── edit-validate-and-report.md                          # NEW — behavioural (O3: edit path validates-and-reports, never silently reverts the human)
+├── checkpoint-377-checks.md                             # NEW — behavioural (#377 coupling + split-tier strict-spread on pinned cost-present/cost-omitted fixtures)
+├── empty-snapshot-cost-omitted.md                       # NEW — behavioural (empty costs/ → written cost-omitted record, not refusal; trailing-slash summary; unguarded-sentinel residual)
+├── kind-assertion-flag.md                               # NEW — behavioural (O4: --kind asserted → asserted-not-inferred summary flag; no --kind → inference-basis line)
+├── rerun-rereads-snapshot.md                            # NEW — behavioural (O8: re-run re-dispatches and re-reads now-populated observability/costs/)
+└── signature-targets.md                                 # NEW — behavioural (path vs inline; --kind forwarded; --out overrides dir + collision disambiguation, O9)
+
+docs/plugins/ai-literacy-superpowers/
+├── how-to/estimate-cost-of-a-task.md                   # NEW — how-to guide (runnable command)
+└── reference/cost-estimate-command.md                   # NEW — command reference (signature, targets, cost-estimates/ output path, checkpoint)
+
+.claude-plugin/marketplace.json                          # MODIFIED: entry version + plugin_version 0.43.0 → 0.44.0
+README.md                                                # MODIFIED: plugin badge 0.43.0 → 0.44.0
+```
+
+Top-level marketplace `version` stays at `0.4.0`. No agent, skill, format
+reference, or orchestrator file touched.
+
+**Plus a re-filed tracking issue (not a file in this PR):** the #377-deferred
+**absolute-rate check** is re-filed as a standalone GitHub issue
+("estimate-record absolute-rate validation — snapshot-grounded per-stage cost
+falsification") per the AGENTS.md natural-home-hand-off decision, **bound to a
+concrete slice number: a BLOCKING required deliverable of S6/#373**. S6 is extended
+to also own **first-snapshot capture** so the trigger is reachable — S6 both
+captures the first `observability/costs/` snapshot and consumes it in the
+calibration loop, making it the slice under which the first falsifiable cost-present
+record exists (the earlier "first slice that produces a cost-present record" wording
+was unreachable because no scheduled slice produced that event — O4) (spec §7.2,
+O6, O4).
+
+---
+
+## Algorithm / key decisions (not pseudocode)
+
+- **Dispatcher-persist + dispose-then-write ordering (load-bearing).** The
+  command owns the **single Write**; the human disposition **precedes** it. The
+  flow order is fixed: parse → dispatch agent → handle REFUSED (no write) →
+  Output Validation Checkpoint → review summary → ask disposition
+  (accept/edit/re-run/abort) → **on accept, write once**. Nothing is persisted
+  until `accept`. This is the AGENTS.md ordering invariant honoured as **ordering**,
+  not merely the agent/command tool split (spec §5, FR-8/FR-9).
+- **Full disposition vocabulary (accept/edit/re-run/abort).** Ship the full named
+  vocabulary, not the narrowed accept/abort `/diagnose` used — the AGENTS.md watch
+  item flags that narrowing as a divergence to avoid recurring (spec §5 step 6,
+  FR-8).
+- **Checkpoint runs BEFORE the disposition.** Resolves the model-card "validate
+  between accept and write" ambiguity: the human disposes over a **validated**
+  record, then the Write follows `accept`. The checkpoint references the S1 format
+  reference **by path** and implements **every** checklist line incl. the #377
+  per-stage coupling and split-tier strict-spread checks; never re-dispatches
+  (spec §5 step 4, §7.1, FR-6/FR-7).
+- **Checkpoint transparency + structural-fix boundary (O1, O2 — load-bearing).**
+  The checkpoint fixes only **STRUCTURAL-ONLY** deviations in place (routinely
+  only the removal of a stray `recommendation`/`verdict`/`proceed` field — a pure
+  removal that authors nothing) and **records every change** it makes, surfacing it
+  in the review summary's change-list so the human disposes over a transparent
+  agent-content-vs-command-content composite. It **ABORTS, never authors**, on any
+  deviation that would create or alter a **derived value** — a missing `cost_basis`
+  on a cost-present record (inventing provenance), a `low > high` range, a missing
+  disclosure section, a per-stage-coupling violation, a collapsed split-tier band,
+  an over-ceiling confidence axis, an imperative-recommendation prose hit. The
+  earlier "insert a missing `cost_basis`" example is **removed** — it inverted the
+  rule. The per-checklist-line fix-vs-abort table is in spec §7.1a (spec §5 step 4,
+  §7.1a, FR-6/FR-6a).
+- **Edit path is validate-and-report, never silent-revert (O3).** Step-4
+  fix-in-place applies to the **agent's fresh output**. On the `edit` disposition
+  the content is the **human's**: the post-edit checkpoint **validates and
+  reports** remaining deviations but does not apply fix-in-place — a human edit is
+  never reverted without the human seeing and re-confirming it. The human is the
+  final author on the edit path (spec §5 step 6, §7.1b, FR-6b).
+- **`--kind` asserted-ceiling flag in the review summary (O4).** An explicit
+  `--kind` suppresses the agent's inference-basis line *and* raises the
+  `tokens`/`time` confidence ceiling. The command (which owns the summary, not the
+  classification) carries the disclosure the suppressed line would have: when
+  `target_kind` was human-asserted via `--kind`, the summary flags it
+  **asserted-not-inferred** with a raised ceiling and no agent inference basis, so
+  the human re-confirms the ceiling raised; when agent-inferred, the summary carries
+  the agent's inference-basis line as emitted (spec §4.1, §5, FR-8a).
+- **`re-run` re-reads the snapshot (O8).** `re-run` is a **full fresh dispatch**
+  that re-reads the grounding sources, including the now-populated
+  `observability/costs/`, so add-a-snapshot-then-re-run works as described (spec
+  §5 step 6, FR-8b).
+- **Pure consumer of S2 + S1 — mutates neither.** The command dispatches the S2
+  agent as-merged (does not re-implement methodology or re-classify `target_kind`)
+  and validates against the format checklist as-merged (inlines no field/checklist
+  definition, adds no checklist line). A genuine contract need would be a separate
+  owning slice, never folded into this consumer (spec §2.3, FR-4/FR-7).
+- **Signature: one target, `--kind`, `--out`.** `/cost-estimate <target>
+  [--kind <target-kind>] [--out <dir>]`. `--near` is **dropped** (the S2 agent
+  accepts exactly one target per dispatch — no second "nearby" target); `--kind`
+  is the disambiguation affordance, forwarded to the agent as the explicit
+  dispatch-stated kind (the agent's rule-1 path). The command distinguishes path
+  vs inline text by filesystem resolution; it does **not** itself classify the
+  `target_kind` (spec §4, FR-2/FR-3/FR-4).
+- **REFUSED handling.** A `REFUSED:`-prefixed agent output is surfaced verbatim;
+  no checkpoint runs and no file is written; the flow aborts. The dispatcher half
+  of the S2 refusal convention (spec §5.1, FR-5).
+- **Empty cost snapshot is NOT a refusal.** Per the S1 three grounding states, an
+  empty `observability/costs/` yields a valid **cost-omitted** record, which the
+  command validates, summarises, and (on accept) writes. The command never treats
+  a cost-omitted record as a failure (spec §5.2, FR-13).
+- **Output path: top-level `cost-estimates/`, OUTSIDE `observability/` (O5).**
+  Default `cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md` — a new top-level
+  directory deliberately **outside** the `observability/` telemetry/actuals tree,
+  so a forward-looking prediction is never co-located with captured actuals where
+  a future scan could read it as fact. **What was checked:** every current
+  `observability/` consumer — `harness-health.md` (reads `observability/costs/*-costs.md`
+  + `observability/snapshots/*-snapshot.md`), `cost-capture.md`
+  (`observability/costs/*-costs.md`), `observatory-verify.md` + the observatory
+  signal checklist (named subdirs, specific filename patterns, no `estimates/`
+  signal source), and the hook scripts — reads **named subdirectories by specific
+  filename patterns, not the tree wholesale**, so none would aggregate an
+  estimates sibling today; moving the home outside `observability/` removes the
+  conflation at the source rather than relying on a marker a future tree-wide scan
+  could miss. `--out` overrides the **directory** only (derived filename preserved,
+  mirroring `model-card create`); `mkdir -p` on write; same-day slug collision
+  disambiguated and noted in the summary **under both** the default and `--out`
+  (O9) (spec §6, FR-10/FR-11/FR-11a/FR-12).
+- **`cost-estimates/` gitignored by default (O3).** Estimate records are
+  **derived, regenerable** predictions referencing moving targets (an unmerged
+  spec, a since-renamed slice) — the same artefact-kind the repo already gitignores
+  for the `/diagnose` output (`diagnostic-legibility/output/`). This slice adds a
+  `cost-estimates/` line to `.gitignore` with a comment matching that entry's
+  "derived, regenerable artefacts … Never committed" rationale. The staleness
+  concern is moot — a regenerable artefact, not a committed corpus (spec §6.1,
+  FR-10a).
+- **Grounding-path trailing-slash special-case — honoured in the command's OWN
+  summary, NOT as a new checklist line.** The command tests the trailing slash
+  when it reports "grounded in a snapshot?" in the review summary, reporting a
+  `cost-snapshot` entry whose `path` ends in `/` as "no snapshot — cost omitted",
+  not a grounding. It adds **no** checklist line keying on
+  `grounding_sources[].path` shape (that would be a consumer mutating the
+  contract). S3 is itself a downstream consumer, so it must not be the consumer
+  that miscounts. **Residual recorded (O7):** S3 ships the first persisted estimate
+  records and every cost-omitted one carries the **unguarded** trailing-slash
+  sentinel (no checklist line keys on it), so any other consumer (S4/aggregators)
+  that does not apply the same trailing-slash test will silently miscount — a known
+  failure named in the spec, not left to cartographer archaeology (spec §7.3,
+  FR-14/FR-14a).
+- **#377-deferred absolute-rate check — DEFER FURTHER, recorded + re-filed with a
+  COMMITTED home (O6).** S3 does **not** build the snapshot-grounded absolute-rate
+  falsification check: it is dead against today's cost-omitted-only records,
+  materially different (re-reads the snapshot, recomputes per-model $/token, needs
+  its own adversarial pass on tolerance/re-derivation), and YAGNI against a
+  closed-world record set. Recorded reason in the spec; **re-filed as a standalone
+  tracking issue bound to a concrete slice number — a BLOCKING required deliverable
+  of S6/#373**. The earlier "first slice that produces a cost-present record"
+  trigger was unreachable: no scheduled slice produced that event (O4). Fixed by
+  **extending S6 to also own first-snapshot capture** — S6 both captures the first
+  `observability/costs/` snapshot and consumes it in the calibration loop, so it is
+  the slice under which the first falsifiable cost-present record exists. This makes
+  the hand-off a committed home bound to a named slice, not a precondition the
+  roadmap never causes (spec §7.2, FR-15; O6, O4).
+- **Joins the Output Validation Checkpoints discipline.** `/cost-estimate` is added
+  to the CLAUDE.md Output Validation Checkpoints command list (spec §7.4, FR-16).
+- **Behavioural grading by deterministic oracles.** The behavioural scenarios ride
+  a non-deterministic `model: inherit` agent dispatch, so they grade **on-disk
+  outcome properties**: file-exists-at-`cost-estimates/`-resolved-path on accept /
+  no-file on abort-or-REFUSED; frontmatter conformance parse; the #377 coupling +
+  split-tier-spread checks on pinned fixtures; the trailing-slash summary
+  reporting; the **structural-fix-boundary** oracle (stray-verdict-field → removed
+  + change-listed; missing-`cost_basis` → ABORT, no `cost_basis` authored, no
+  file); the **edit-validate-and-report** oracle (human edit preserved, not
+  silently reverted); the **`--kind` assertion-flag** oracle (asserted →
+  asserted-not-inferred summary flag; inferred → inference-basis line). Never exact
+  numbers or prose wording. A scenario no oracle can grade is descoped (spec §9,
+  FR-17).
+
+---
+
+## FR mapping table
+
+| FR | Requirement (abbrev) | Covering test case(s) |
+| --- | --- | --- |
+| FR-1 | Command file present; well-formed frontmatter | `command-structure.md` (structural) |
+| FR-2 | Signature `<target> [--kind] [--out]`; `--near` absent; `--kind` enum | `command-structure.md` + `signature-targets.md` |
+| FR-3 | One target per invocation; path vs inline by FS resolution | `signature-targets.md` |
+| FR-4 | Dispatches S2 agent; forwards `--kind`; no re-classify/re-implement | `command-structure.md` + `signature-targets.md` |
+| FR-5 | REFUSED → surfaced verbatim, no checkpoint, no file, abort | `refused-not-persisted.md` |
+| FR-6 | Checkpoint runs full checklist incl. #377 coupling + split-tier spread; structural-only fix; abort-never-author on derived defects | `checkpoint-fix-boundary.md` + `checkpoint-377-checks.md` |
+| FR-6a | Checkpoint surfaces a change-list of exactly what it altered (O1) | `checkpoint-fix-boundary.md` |
+| FR-6b | Edit path validate-and-report, never silent-revert (O3) | `edit-validate-and-report.md` |
+| FR-7 | Checkpoint references format reference by path; no inline/mutation | `command-structure.md` + `checkpoint-377-checks.md` |
+| FR-8 | Review summary + disposition (accept/edit/re-run/abort) BEFORE write | `command-structure.md` + `dispose-precedes-write.md` |
+| FR-8a | `--kind` asserted → asserted-not-inferred ceiling flag in summary (O4) | `kind-assertion-flag.md` |
+| FR-8b | `re-run` re-dispatches + re-reads now-populated `observability/costs/` (O8) | `rerun-rereads-snapshot.md` |
+| FR-9 | Single Write, on accept, downstream of disposition | `dispose-precedes-write.md` + `writes-record-on-accept.md` |
+| FR-10 | Default path `cost-estimates/<date>-<slug>-estimate.md` (outside observability/); mkdir -p | `writes-record-on-accept.md` |
+| FR-10a | `cost-estimates/` gitignored by default (derived, regenerable) — add the `.gitignore` line in this slice (O3) | local check (Task 5a) |
+| FR-11 | `--out` overrides directory; derived filename preserved | `signature-targets.md` |
+| FR-11a | Same-day collision disambiguation under default AND `--out`; never silent overwrite (O9) | `signature-targets.md` |
+| FR-12 | Resolved path shown in summary (confirm content + destination) | `dispose-precedes-write.md` |
+| FR-13 | Empty costs/ → written cost-omitted record, not failure | `empty-snapshot-cost-omitted.md` + `writes-record-on-accept.md` |
+| FR-14 | Trailing-slash special-case honoured in command's own summary; no new checklist line | `empty-snapshot-cost-omitted.md` |
+| FR-14a | Unguarded-sentinel residual recorded for S4/aggregators (O7) | (no S3 test — recorded residual; spec §7.3) |
+| FR-15 | Absolute-rate check deferred further; recorded + re-filed **bound to S6/#373** (a concrete slice number) which is extended to own first-snapshot capture so the trigger is reachable (O6, O4) | (no S3 test — re-filed issue; spec §7.2) |
+| FR-16 | `/cost-estimate` added to CLAUDE.md checkpoint list | local check (Task 4) |
+| FR-17 | TDAD structural + behavioural scenarios present, deterministic oracles | all scenario files exist |
+| FR-18 | Version bump 0.44.0 across four locations | local version-consistency check (Task 6) |
+| FR-19 | How-to guide + reference entry ship | docs check (Task 5) |
+
+---
+
+## Test case list
+
+(In the same form as the existing TDAD command/agent scenario corpus —
+`Given/When/Then` markdown scenarios under
+`tdad_tests/scenarios/commands/cost-estimate/`. The structural scenario is Layer 1
+($0, every PR); the behavioural scenarios are Layer 3 (nightly + label-gated),
+graded by the deterministic oracle strategy of spec §9 so they fail honestly
+against a non-deterministic dispatch. One structural + ten behavioural = eleven
+scenarios (the revision added `checkpoint-fix-boundary.md`,
+`edit-validate-and-report.md`, `kind-assertion-flag.md`, and
+`rerun-rereads-snapshot.md`, and split the old `checkpoint-validates-record.md`
+into the fix-boundary scenario plus `checkpoint-377-checks.md`). **No S2 agent or
+S1 format scenario is modified** — S3 is a pure consumer.)
+
+- `command-structure.md` (tier: structural) — frontmatter well-formed
+  (`name: cost-estimate`, description); the process documents the order dispatch →
+  REFUSED-handling → checkpoint → review-summary → disposition → write with the
+  disposition **before** the write; the checkpoint section references
+  `estimate-record-format.md` by path and enumerates the checklist lines incl. the
+  #377 per-stage coupling + split-tier strict-spread, and documents the
+  **structural-fix boundary** (fix structural-only + record; abort-never-author on
+  derived defects); the disposition vocabulary is accept / edit / re-run / abort;
+  the signature is `<target> [--kind <target-kind>] [--out <dir>]` with no `--near`;
+  the default home is top-level `cost-estimates/` (outside `observability/`).
+- `writes-record-on-accept.md` (tier: behavioural) — dispatched against a real
+  spec target with `MODEL_ROUTING.md` readable and `observability/costs/` empty;
+  on `accept`, exactly one file is written to
+  `cost-estimates/<date>-<slug>-estimate.md`; the written record parses
+  to the S1 field set; cost omitted with the `Excluded` disclosure; the full path
+  is confirmed. Graded by file-existence + conformance oracles.
+- `dispose-precedes-write.md` (tier: behavioural) — at the disposition step no
+  file exists yet and the resolved output path is shown in the summary; `abort` →
+  no file written; `accept` → exactly one Write, to the resolved path, **after**
+  the disposition. Graded by file-existence oracle (no-file-before-accept;
+  no-file-on-abort; one-file-on-accept).
+- `refused-not-persisted.md` (tier: behavioural) — an ungroundable fixture
+  (unreadable target / absent or tableless `MODEL_ROUTING.md`) yields a `REFUSED:`
+  agent output; the command surfaces it verbatim, runs no checkpoint, writes no
+  file, and aborts. Graded by REFUSED-prefix + no-file oracles.
+- `checkpoint-fix-boundary.md` (tier: behavioural, O1/O2) — a fixture with a
+  **stray `verdict` field** (structural-only) is fixed in place by deletion AND the
+  review summary's change-list names the deletion; a fixture where the checkpoint
+  changes nothing yields a "no checkpoint changes" summary; a **cost-present
+  fixture missing `cost_basis`** (derived-value defect) **ABORTS without writing**
+  and **no `cost_basis` is authored**; a `low > high` range fixture likewise
+  aborts. Graded by the structural-fix-boundary oracle (field-removed +
+  change-listed; no-file + no-authored-field on derived defects).
+- `edit-validate-and-report.md` (tier: behavioural, O3) — on the `edit` path the
+  human edit is preserved (not silently reverted) and any remaining deviation is
+  **reported** in the re-prompt; the post-edit checkpoint does not apply
+  fix-in-place to human-edited content. Graded by the edit-validate-and-report
+  oracle (edited value preserved; deviation surfaced, not auto-fixed).
+- `checkpoint-377-checks.md` (tier: behavioural) — a cost-present fixture with a
+  split-tier (`model_tier` contains `/`) per-stage band with `low == high`
+  **fails** the split-tier strict-spread check; a non-collapsed band
+  (`low < high`) **passes**; a per-stage band on a cost-omitted record **fails**
+  the coupling check; a record with no per-stage bands passes both vacuously.
+  Graded by the #377-check oracle on pinned fixtures.
+- `empty-snapshot-cost-omitted.md` (tier: behavioural) — empty
+  `observability/costs/` yields a written **cost-omitted** record (NOT a refusal)
+  at `cost-estimates/<date>-<slug>-estimate.md`; the `cost-snapshot` grounding
+  entry's path is the directory `observability/costs/` (trailing slash); the review
+  summary reports it as "no snapshot — cost omitted (directory inspected, no
+  snapshot found)", not a snapshot grounding; the written record carries the
+  **unguarded trailing-slash sentinel** (no checklist line keys on it — the
+  recorded O7 residual); cost_usd / cost_basis omitted with the `Excluded`
+  disclosure; tokens / agent_compute_time ranges present; human_gate_time the
+  qualitative caveat string. Graded by conformance + trailing-slash-summary
+  oracles.
+- `kind-assertion-flag.md` (tier: behavioural, O4) — `--kind spec` on a
+  slice-fragment target yields a review summary flagging `target_kind` as
+  **human-asserted (not agent-inferred)** with the raised ceiling and no inference
+  basis; with no `--kind`, the summary carries the agent's inference-basis line.
+  Graded by the `--kind` assertion-flag oracle.
+- `rerun-rereads-snapshot.md` (tier: behavioural, O8) — after a cost-omitted first
+  dispatch (empty `observability/costs/`), adding a usable snapshot and responding
+  `re-run` re-dispatches the agent, which re-reads the now-populated
+  `observability/costs/`; the re-summarised record can carry `cost_usd` grounded in
+  the added snapshot. Graded by the re-dispatch-re-reads oracle (cost-present after
+  snapshot-add-then-re-run).
+- `signature-targets.md` (tier: behavioural) — a positional target that resolves
+  to a readable file is passed as a path; one that does not resolve is passed as
+  inline task text; `--kind spec` is forwarded to the agent as the explicit
+  dispatch-stated kind; `--out <dir>` writes the derived
+  `<date>-<slug>-estimate.md` filename beneath `<dir>`, exactly one file, full path
+  confirmed; a same-day same-slug collision under `--out` is disambiguated, never
+  silently overwritten (O9). Graded by path-vs-inline routing + file-at-overridden-
+  dir + collision-disambiguation oracles.
+
+---
+
+## Phase 1 — The command
+
+### Task 1: Write the `/cost-estimate` command
+
+- [ ] Create `ai-literacy-superpowers/commands/cost-estimate.md`.
+- [ ] Frontmatter: `name: cost-estimate`; a `description` (prospective sibling of
+  `/cost-capture`; estimate a target's tokens/time/cost before it runs; dispatches
+  the read-only `cost-estimator` agent, validates, and persists after a human
+  disposes).
+- [ ] Body sections (mirroring `/cost-capture` discipline + `model-card create`
+  dispose-then-write flow):
+  - **Usage / signature** — `/cost-estimate <target> [--kind <target-kind>]
+    [--out <dir>]`; one target per invocation; the four target types; path vs
+    inline resolution; `--kind` as the agent's explicit-kind hint **and the
+    review-summary asserted-ceiling consequence (O4)**; `--out` as the directory
+    override with collision disambiguation (spec §4, §6.2; FR-2/FR-3/FR-11/FR-11a).
+  - **1. Parse args & resolve target** — distinguish path vs inline text; capture
+    `--kind`, `--out` (FR-3).
+  - **2. Dispatch the cost-estimator agent** — one target, explicit `--kind` if
+    supplied, resolved model id if known (agent `generated_by` branch a). Agent
+    returns a record string **or** a `REFUSED:` string (FR-4).
+  - **3. Handle REFUSED** — surface verbatim; no checkpoint; no file; abort (spec
+    §5.1, FR-5).
+  - **4. Output Validation Checkpoint** — read the record back; check against the
+    `estimate-record-format.md` validation checklist **referenced by path**,
+    enumerating every line incl. the #377 per-stage coupling + split-tier
+    strict-spread. **Fix only STRUCTURAL-ONLY deviations in place and record each
+    change** (routinely only deleting a stray verdict field); **ABORT, never
+    author**, on any derived-value defect (missing `cost_basis`, `low > high`,
+    missing disclosure section, coupling violation, collapsed split-tier band,
+    over-ceiling confidence, imperative prose) — per the §7.1a per-line table;
+    never re-dispatch (spec §7.1, §7.1a, §7.3; FR-6/FR-6a/FR-7/FR-14). Honour the
+    trailing-slash special-case **in the summary's grounding report**, add no
+    checklist line.
+  - **5. Review summary** — target + classified `target_kind` **with an
+    asserted-not-inferred flag when the kind was human-asserted via `--kind` (O4)**;
+    token range + per-axis confidence; agent-compute-time range + `human_gate_time`
+    caveat; cost present/omitted (+ disclosed cause, with the trailing-slash "no
+    snapshot" reporting); `failure_direction` + driver; **the resolved output
+    path**; and **the change-list of exactly what the checkpoint altered (O1)** (or
+    "no checkpoint changes" when none) (spec §5 step 5, §6.3; FR-8/FR-8a/FR-6a/FR-12).
+  - **6. Ask for disposition** — accept / edit / re-run / abort (full vocabulary)
+    **before** any write. `edit` runs the post-edit checkpoint in
+    **validate-and-report** mode (never silent-revert, O3); `re-run` is a **full
+    fresh dispatch that re-reads `observability/costs/`** (O8) (spec §5 step 6,
+    §7.1b; FR-8/FR-6b/FR-8b).
+  - **7. On accept: write once** — `mkdir -p` the output dir; single Write to the
+    resolved path under `cost-estimates/`; confirm full path. This is the only
+    persistence, downstream of the disposition (spec §5 step 7, §6; FR-9/FR-10).
+  - **Specification picks** — `--near` dropped (one-target contract); `--kind`
+    enum; `--out` directory-override semantics + collision disambiguation; default
+    path **top-level `cost-estimates/<date>-<slug>-estimate.md` (outside
+    `observability/`, O5)**; absolute-rate check deferred + re-filed with a blocking
+    acceptance criterion (spec §4.1, §6.1, §7.2; FR-10/FR-15).
+
+---
+
+## Phase 2 — Convention list + TDAD scenarios
+
+### Task 2: Add `/cost-estimate` to the CLAUDE.md checkpoint list
+
+- [ ] Add `/cost-estimate` to the CLAUDE.md "Output Validation Checkpoints"
+  convention's list of commands with checkpoints (spec §7.4, FR-16).
+
+### Task 3: Author the structural + behavioural scenarios
+
+- [ ] Create the eleven scenario files under
+  `tdad_tests/scenarios/commands/cost-estimate/` per the test case list and the
+  corpus format in `tdad_tests/README.md` (one structural, ten behavioural). Do
+  **not** modify any `cost-estimator` agent or `cost-estimation` skill scenario —
+  S3 is a pure consumer.
+- [ ] Each behavioural scenario pins its grounding fixtures (a target, a fixture
+  `MODEL_ROUTING.md`, an empty or populated `observability/costs/`) and is graded
+  by the deterministic oracles (spec §9): file-existence at the `cost-estimates/`
+  resolved path, frontmatter conformance parse, the #377 coupling +
+  split-tier-spread checks, the REFUSED-prefix + no-file outcome, the trailing-slash
+  summary reporting, the **structural-fix-boundary** oracle (fix + change-list vs
+  abort-never-author), the **edit-validate-and-report** oracle, and the **`--kind`
+  assertion-flag** oracle — never exact numbers or prose wording.
+
+---
+
+## Phase 3 — Docs
+
+### Task 4: How-to guide + reference entry
+
+- [ ] Add a how-to guide at
+  `docs/plugins/ai-literacy-superpowers/how-to/estimate-cost-of-a-task.md` —
+  task-oriented walkthrough of running `/cost-estimate` on a slice / spec / task
+  text, the disposition flow, and where the record lands (FR-19).
+- [ ] Add a reference entry at
+  `docs/plugins/ai-literacy-superpowers/reference/cost-estimate-command.md` —
+  the signature, accepted target types, the **top-level `cost-estimates/`
+  output-path convention (outside `observability/`, with a note on why predictions
+  are not filed under the telemetry root, and that `cost-estimates/` is gitignored
+  by default as a derived, regenerable artefact)**,
+  the `--out` override + collision disambiguation, the **`--kind` asserted-ceiling
+  consequence**, and the Output Validation Checkpoint **with its structural-fix
+  boundary + change-list transparency** (FR-19). Cross-link the `/cost-capture`
+  sibling and the S1 format reference.
+
+---
+
+## Phase 4 — Version bumps + gitignore
+
+### Task 5a: Gitignore `cost-estimates/` (O3, FR-10a)
+
+- [ ] Add a `cost-estimates/` line to the repo-root `.gitignore`, with a comment
+  matching the existing `/diagnose` entry's rationale (e.g. "Cost estimate records
+  — derived, regenerable artefacts written by the /cost-estimate command. Never
+  committed."). Place it near the `diagnostic-legibility/output/` entry so the two
+  derived-output exclusions sit together (spec §6.1, O3).
+
+### Task 5: Bump plugin.json, CHANGELOG, marketplace.json, README
+
+- [ ] `ai-literacy-superpowers/.claude-plugin/plugin.json`: `version` `0.43.0` →
+  `0.44.0`.
+- [ ] `CHANGELOG.md` (repo root): new `## 0.44.0 — 2026-06-12` heading with
+  entries for the new command (manual dispatcher; dispose-then-write ordering;
+  Output Validation Checkpoint incl. #377 lines **with the structural-fix boundary
+  + change-list transparency** — fix structural-only, abort-never-author on derived
+  defects; the `edit` validate-and-report path; the `--kind` asserted-ceiling flag;
+  REFUSED handling; default output home **top-level `cost-estimates/` outside
+  `observability/`** (and **gitignored by default** as a derived, regenerable
+  artefact) + `--out` with collision disambiguation; `re-run` re-reads the
+  snapshot; trailing-slash summary special-case + recorded unguarded-sentinel
+  residual; absolute-rate check deferred + re-filed **bound to S6/#373 as a
+  blocking required deliverable**), the CLAUDE.md checkpoint-list addition, the
+  `.gitignore` entry, and the docs.
+- [ ] `.claude-plugin/marketplace.json`: bump the `ai-literacy-superpowers`
+  `plugins[]` entry `version` and the top-level `plugin_version` to `0.44.0`;
+  leave top-level `version` at `0.4.0`.
+- [ ] `README.md`: bump the `ai-literacy-superpowers` badge `v0.43.0` → `v0.44.0`.
+- [ ] Verify version consistency:
+
+```bash
+python3 -c "
+import json
+pj = json.load(open('ai-literacy-superpowers/.claude-plugin/plugin.json'))
+m = json.load(open('.claude-plugin/marketplace.json'))
+entry = next(p for p in m['plugins'] if p['name']=='ai-literacy-superpowers')
+assert pj['version']=='0.44.0', pj['version']
+assert entry['version']=='0.44.0', entry['version']
+assert m['plugin_version']=='0.44.0', m['plugin_version']
+assert m['version']=='0.4.0', m['version']
+print('version consistency OK')
+"
+```
+
+---
+
+## Phase 5 — Verify and ship
+
+### Task 6: Local CI gate checks
+
+- [ ] Spec-first ordering — first commit on branch is the spec:
+
+```bash
+git log main..HEAD --reverse --oneline | head -1
+```
+
+- [ ] TDAD scenario presence — the new command ships with scenarios:
+
+```bash
+ls tdad_tests/scenarios/commands/cost-estimate/*.md
+```
+
+- [ ] Markdown lint, docs build, and the deterministic TDAD fast suite
+  (Layers 0+1) pass.
+
+### Task 7: Re-file the deferred absolute-rate check
+
+- [ ] Open a standalone GitHub issue ("estimate-record absolute-rate validation —
+  snapshot-grounded per-stage cost falsification"). The issue body MUST bind the
+  check to a **concrete slice number, not an unscheduled precondition** (O4): it is
+  a **BLOCKING required deliverable of S6/#373**. State plainly that **S6/#373 is
+  extended to also own first-snapshot capture** — capturing the first usable
+  `observability/costs/` snapshot — so the first falsifiable cost-present record
+  actually comes into existence under S6 (S6 both captures the snapshot and
+  consumes it in the calibration loop); the absolute-rate check is then a required
+  deliverable of that same slice. Do **not** key the trigger on "the first slice
+  that produces a cost-present record" (no scheduled slice produced that event —
+  the unreachable-trigger defect O4 names). **Reference the issue as a required,
+  blocking deliverable from S6/#373.** This is a committed home bound to a named
+  slice (spec §7.2, FR-15; O6, O4). Reference it in the PR body.
+
+### Task 8: Push, PR, CI, merge
+
+- [ ] Push the `cost-estimate-command` branch, open a PR against #370 (feature
+  ceremony — `/diaboli` spec runs on this spec next; code-mode runs after the
+  code-reviewer PASS; `/choice-cartograph` as applicable).
+- [ ] PR body states what ships (command + eleven scenarios + CLAUDE.md
+  checkpoint-list entry + docs + version bump) and what does NOT (S4–S6, issues
+  #371–#373; no orchestrator wiring; no S2/S1 change; no absolute-rate check —
+  re-filed with a blocking acceptance criterion). Link the re-filed absolute-rate
+  issue.
+- [ ] Watch CI green; merge `--squash --delete-branch`; sync the marketplace
+  cache.
+
+---
+
+## Out of scope (deferred to S4–S6)
+
+- **Orchestrator fold-in at T1 (Slice Adjudication) and T2 (Plan Approval)** (S4,
+  #371). `/cost-estimate` is standalone; no orchestrator change, no gate added or
+  re-weighted, no estimate fields surfaced inside the existing gates. The
+  orchestrator dispatching the same S2 agent at T1/T2 is a separate dispatcher
+  with its own spec.
+- **The T0 pre-carpaccio ballpark** (S5, #372). The command accepts a task-text
+  target, but the firing position and bonus-step wiring are S5's.
+- **The calibration loop** — per-PR actuals capture + integration-agent change
+  (S6, #373). The agent reads a `kind: calibration` source if one exists (S1
+  seam); the command neither produces nor requires one.
+- **The snapshot-grounded absolute-rate check** (#377-deferred). Re-filed as a
+  standalone issue **bound to a concrete slice number — a BLOCKING required
+  deliverable of S6/#373**, which is extended to also own first-snapshot capture so
+  the trigger is reachable (spec §7.2, O6, O4); not built here.
+- **Any change to the S2 agent or the S1 format reference.** S3 consumes both
+  as-merged. A genuine contract need would be its own owning slice, never folded
+  into this consumer.
+```

--- a/docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md
+++ b/docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md
@@ -1,0 +1,1176 @@
+# Cost Estimation — S3 — `/cost-estimate` command — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-11 (revised 2026-06-12 after spec-mode diaboli round 1, 9 objections accepted; further revised 2026-06-12 after round-2 diaboli — O1/O3/O4 fixed, O5/O6 flagged, O2 no-change) |
+| Status | Draft — revised (round-2 request-changes pass complete) |
+| Author | spec-writer (interactive session with russmiles) |
+| Slice | S3 of the slicing record at `docs/superpowers/slices/cost-estimator-pipeline.md` |
+| Progressed slice | S3 (this spec) |
+| Tracking issue | #370 |
+| Upstream (merged on main) | S1 (skill + `estimate-record-format.md`, incl. the #377 per-stage `cost_usd` additions); S2 (#369, the read-only `cost-estimator` agent) |
+| Downstream slices | S4 (#371), S5 (#372), S6 (#373) — all out of scope here |
+| Plugin version target | `ai-literacy-superpowers` v0.43.0 → v0.44.0 (new command — minor bump) |
+| Marketplace listing | Top-level `version` unchanged at v0.4.0; `plugin_version` 0.43.0 → 0.44.0 |
+| PR ceremony | feature — full `/diaboli` (spec + code) and `/choice-cartograph` |
+| Governing decisions | AGENTS.md **"agent-emit + dispatcher-persist + human-disposes"** trust architecture (with its **dispose-then-write ordering invariant**); AGENTS.md **"disclosure-of-derived-judgment"** decision; CLAUDE.md **Output Validation Checkpoints** convention. |
+
+---
+
+## 1. Premise
+
+S1 defined what an estimate record **is** (the `cost-estimation` skill +
+`estimate-record-format.md` reference). S2 (#369) shipped the **emitter** —
+the read-only `cost-estimator` agent that, given one target, reads its
+grounding sources, applies the S1 methodology, and **returns the estimate-record
+content as a string**. The agent holds `Read`, `Glob`, `Grep` only: it cannot
+write, cannot validate its own output, and returns a stable `REFUSED:` string
+rather than fabricating an ungroundable estimate.
+
+S2 deliberately left three things to a **dispatcher**: who **writes** the record
+to disk, **where** it lands, and the **Output Validation Checkpoint** that reads
+it back and checks it against the format reference. S3 is the first such
+dispatcher: the human-facing **`/cost-estimate` command**.
+
+This slice's load-bearing decision is the one the slicing record's
+`decision_focus` names: *should there be a standalone manual surface at all, and
+what does it accept?* A command usable only inside the orchestrator gates is a
+different product from one a human invokes ad hoc against any slice or spec. S3
+commits to the standalone surface — the prospective counterpart to the existing
+retrospective `/cost-capture` command — and locks four things:
+
+1. **The command signature and accepted target types** — exactly what a human
+   can point `/cost-estimate` at, reconciled with the S2 agent's
+   one-target-per-dispatch contract (§4).
+2. **The dispatch → checkpoint → dispose → write flow** — and specifically that
+   the **human disposition PRECEDES the write** (the dispose-then-write ordering
+   invariant), since the command owns the single `Write` the agent cannot
+   perform (§5).
+3. **Where the record is written** — the on-disk output-path convention, with a
+   `--out` override and a confirm-before-write gate. The default home is a new
+   top-level **`cost-estimates/`** directory — deliberately **outside**
+   `observability/`, the telemetry/actuals tree, so a forward-looking *prediction*
+   is never co-located with captured *actuals* where a future scan could read it as
+   fact (§6).
+4. **That the manual path carries its own Output Validation Checkpoint** against
+   the format reference's validation checklist — including the #377 per-stage
+   coupling and split-tier strict-spread checks — rather than relying on
+   orchestrator-only validation, and that the checkpoint operates under a **strict
+   transparency-at-the-disposition-seat discipline**: it may fix *structural-only*
+   deviations in place but **never authors derived judgment**, and it **surfaces
+   exactly what it changed** so the human disposes over a transparent
+   agent-vs-command composite (§7).
+
+S3 honours both governing AGENTS.md decisions and the CLAUDE.md checkpoint
+convention. It is the **fifth production instance** of the
+agent-emit/dispatcher-persist/human-disposes pattern (after `advocatus-diaboli`,
+`choice-cartographer`, `model-card-researcher`, and `/diagnose`) — and the first
+to honour the **dispose-then-write ordering invariant** on a *cost* record.
+
+## 2. Scope and non-goals
+
+### 2.1 In scope (S3)
+
+- A new command at `ai-literacy-superpowers/commands/cost-estimate.md` — the
+  human-facing manual dispatcher for the S2 `cost-estimator` agent, mirroring the
+  `/cost-capture` retrospective sibling and the `model-card create`
+  dispose-then-write flow.
+- The **command signature** and the **accepted target types** (§4), reconciled
+  with the S2 agent's one-target-per-dispatch contract.
+- The **dispatch → REFUSED-handling → checkpoint → review summary → disposition →
+  write** flow (§5), with the human disposition placed **before** the single
+  `Write`.
+- The **output-path convention**: a default location at top-level
+  `cost-estimates/` (outside `observability/`), a `--out <dir>` override, the
+  filename derivation, and same-day collision disambiguation **under both** the
+  default and `--out` (§6).
+- The **Output Validation Checkpoint** against
+  `skills/cost-estimation/references/estimate-record-format.md`'s validation
+  checklist — implementing each checklist line, **including** the #377 per-stage
+  cost coupling and split-tier strict-spread checks — under the **structural-fix
+  boundary** (fix structural-only deviations in place; abort, never author, on any
+  deviation that would create or alter a derived value) and the **change-disclosure
+  rule** (the review summary surfaces exactly what the checkpoint altered vs the
+  agent's emitted record) — plus an **explicit decision** on the #377-deferred
+  absolute-rate check and the grounding-path trailing-slash consumer special-case
+  (§7, §8).
+- The **`--kind` human-assertion flag** in the review summary: when `target_kind`
+  is human-asserted (suppressing the agent's inference-basis line and raising the
+  confidence ceiling), the summary **flags it as asserted-not-inferred** so the
+  human re-confirms the ceiling they raised (§4.1, §5).
+- A TDAD scenario set covering the command (structural + behavioural layers)
+  under `tdad_tests/scenarios/commands/cost-estimate/` (§9).
+- The plugin version bump (0.43.0 → 0.44.0), CHANGELOG entry, marketplace
+  `plugin_version` pointer, README badge, the command's entry in the CLAUDE.md
+  Output Validation Checkpoints list, and a docs touch (a how-to guide — the
+  command is runnable now — plus a reference entry) (§10).
+
+### 2.2 Out of scope (filed as separate issues)
+
+Only S3 ships here. The following are explicitly **not** in this PR:
+
+- **S4 — orchestrator fold-in at T1/T2** (#371). `/cost-estimate` is a
+  **standalone manual surface**; it does **not** wire into the orchestrator
+  pipeline, add or move a gate, or surface estimate fields inside the Slice
+  Adjudication or Plan Approval gates. The command dispatches the agent directly
+  and persists the result; the orchestrator dispatching the same agent at T1/T2
+  is a separate dispatcher with its own spec. (The command and the orchestrator
+  share the S2 agent and the S1 format; they do not share a dispatch surface.)
+- **S5 — T0 pre-carpaccio ballpark** (#372). No pre-step-0 touchpoint. The
+  command **accepts** raw task text as a target (so S5 can reuse the same agent
+  for a coarse whole-task ballpark), but the firing position and the bonus-step
+  wiring are S5's.
+- **S6 — calibration loop** (#373). No per-PR actuals capture, no
+  integration-agent change. The agent reads a `kind: calibration` grounding
+  source **if one exists** (the S1 seam); the command neither produces nor
+  requires one.
+- **Any change to the S2 agent or the S1 format reference.** S3 is a **pure
+  consumer** of both — it dispatches the agent as-merged and validates against the
+  format reference as-merged. If a reviewer finds this spec adding a field,
+  changing a charter, or widening the format, that is a defect to cut. (A genuine
+  contract-change need would be carved into its own owning slice per the AGENTS.md
+  consumer-never-mutates-the-contract decision — it would **not** be folded into
+  S3, a consumer.)
+- **A standalone runtime validator shipped as a separate artefact.** The Output
+  Validation Checkpoint is a **step in the command's process**, not a new file or
+  reusable component.
+
+### 2.3 What S3 consumes (do not redefine)
+
+S3 is a **pure consumer** of two merged contracts:
+
+- The **S2 agent** at `ai-literacy-superpowers/agents/cost-estimator.agent.md` —
+  its input contract (one target per dispatch; the `target_kind` classification;
+  the `REFUSED:` convention; that it **emits a string and never writes**). S3
+  dispatches it and reads its output. S3 does not redefine the agent's contract
+  and does not duplicate the agent's methodology.
+- The **S1 format reference** at
+  `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`
+  — the field set, range rules, time split, per-axis confidence, binding table,
+  three grounding states, the `generated_by` `tier:` grammar, the grounding-path
+  sentinel, the per-stage `cost_usd` coupling, and the **validation checklist**.
+  The command's checkpoint references this file **by path** (per the file's own
+  "A downstream command's Output Validation Checkpoint references this file by
+  path" note) and implements its checklist. S3 adds no field and changes no
+  validation rule in the reference.
+
+## 3. Premise of a standalone manual surface (the in/out decision)
+
+**Decision: ship the standalone manual surface.** The decision-focus question is
+whether `/cost-estimate` should exist independently of the orchestrator at all.
+It should, for the same reasons `/cost-capture` exists independently of any
+pipeline:
+
+- **Ad hoc reach.** A human wants a cost/token/time estimate on a slice, a spec,
+  or a pasted task *before deciding to run the pipeline at all* — exactly the
+  pre-pipeline question the orchestrator gates cannot answer because they only
+  fire once a branch and slicing already exist.
+- **End-to-end proof of S1+S2.** The command is the cleanest surface that
+  exercises the skill + agent end-to-end without an orchestrator run: dispatch →
+  validate → record on disk. It proves the emitter works before S4 folds it into
+  gates where a bug would be costlier to find.
+- **Discoverable symmetry.** `/cost-capture` (retrospective, writes
+  `observability/costs/…`) and `/cost-estimate` (prospective, writes an estimate
+  record) become a discoverable pair — a reader who finds one finds the other,
+  mirroring the S1 SKILL's own sibling framing.
+
+The alternative — *no manual surface, orchestrator-only* — was rejected: it ties
+the capability's only entry point to a full pipeline run, removes the
+pre-pipeline use case entirely, and breaks the `/cost-capture` symmetry. The
+manual surface is cheap (it dispatches an agent that already exists) and is the
+canonical first consumer.
+
+## 4. The command signature and accepted targets
+
+### 4.1 Signature
+
+```text
+/cost-estimate <target> [--kind <target-kind>] [--out <dir>]
+```
+
+- **`<target>`** (required, positional) — **one** target per invocation, matching
+  the S2 agent's one-target-per-dispatch contract. It is **either** a path (to a
+  slicing-record file, a spec file, or a file holding a single slice) **or** a
+  quoted string of pasted task text. The command classifies which by resolving
+  the positional argument as a filesystem path first; if it resolves to a
+  readable file, it is treated as a path target, otherwise as inline task text.
+- **`--kind <target-kind>`** (optional) — an explicit `target_kind` hint, one of
+  `task-text` | `slicing-record` | `slice` | `spec`. When supplied, the command
+  passes it to the agent as the **explicit dispatch-stated kind** (the agent's
+  rule-1 path — no inference-basis line is then required). When absent, the agent
+  infers the kind from the target's content and discloses the inference basis
+  (the agent's rules 2–3). This is the single flag that lets a human disambiguate
+  a path the agent might otherwise infer wrongly (e.g. a slice fragment that
+  superficially reads as a spec).
+
+  **The asserted kind must not silently buy a higher ceiling (O4).** An explicit
+  `--kind` suppresses the agent's inference-basis disclosure line *and* raises the
+  `tokens`/`time` confidence **ceiling** (`task-text`→`low`,
+  `slicing-record`/`slice`→`medium`, `spec`→`high`). A human who asserts
+  `--kind spec` on a file that is really a slice fragment thereby obtains a
+  `high`-ceiling estimate with **no disclosed inference basis** — exactly the
+  silent over-claim the agent's inference-disclosure contract exists to prevent.
+  The command is a pure consumer of the agent's classification (it does not
+  re-classify), but it **owns the review summary**, so it carries the disclosure
+  the suppressed inference-basis line would otherwise have carried: when
+  `target_kind` was **human-asserted via `--kind`**, the review summary (§5 step 5)
+  **flags it prominently as asserted-not-inferred** and states that an asserted
+  kind raised the confidence ceiling with no agent inference basis, so the human
+  **re-confirms the ceiling they raised** before disposing. When the kind was
+  agent-inferred, the summary instead carries the agent's inference-basis line as
+  emitted. This keeps the asserted-vs-inferred distinction visible at the
+  disposition seat.
+- **`--out <dir>`** (optional) — an output-directory override; see §6.
+
+The slice's loose sketch was
+`/cost-estimate "<task>" [--near <path>] [--out <dir>]`. The `--near` flag is
+**dropped**: the S2 agent accepts **exactly one target per dispatch**, with no
+"primary target plus a nearby grounding hint" shape. Honouring the agent's
+contract means one target, not a target-plus-neighbour. The `--out` flag is
+kept; the `--kind` flag replaces `--near` as the disambiguation affordance and
+maps cleanly onto the agent's explicit-kind rule.
+
+### 4.2 Accepted target types (reconciled with the S2 agent)
+
+The command accepts exactly the four target types the S2 agent accepts, supplied
+as follows:
+
+| Target | What it is | Supplied as |
+| --- | --- | --- |
+| Raw task text | Pasted prose description of work, before slicing or spec | A quoted string `<target>` that does not resolve to a readable file |
+| A slicing record | A carpaccio slicing-record file (the whole multi-slice record) | A path `<target>` |
+| A single slice | One slice extracted from a slicing record | A path `<target>` (optionally `--kind slice`) |
+| A spec | A design spec enumerating scenarios and files to touch | A path `<target>` |
+
+The command does **not** itself classify the `target_kind` (that is the agent's
+job, §4.2 of the S2 spec). It only distinguishes **path vs inline text** to know
+*how to pass* the target to the agent (a path to read vs an inline string), and
+forwards any `--kind` hint as the explicit kind. Classification semantics —
+inference, the confidence ceiling, the inference-basis disclosure — remain the
+agent's.
+
+## 5. The dispatch → checkpoint → dispose → write flow
+
+This is the load-bearing structural commitment of S3: the command owns the single
+`Write`, and the **human disposition PRECEDES it**. The flow, in order:
+
+1. **Parse args and resolve the target** — distinguish path vs inline text (§4),
+   capture any `--kind` and `--out`.
+2. **Dispatch the S2 `cost-estimator` agent** — passing the one target, the
+   explicit `--kind` if supplied, and (if the command knows it) the resolved
+   model id for the agent's `generated_by` branch (a). The agent returns **either**
+   the estimate-record content as a string **or** a `REFUSED:` string.
+3. **Handle `REFUSED:` (no write).** If the agent's output begins with the stable
+   `REFUSED:` prefix, the command **surfaces the refusal reason to the user
+   verbatim and aborts with no file written** (§5.1). A malformed or partial
+   record is never persisted on a refusal.
+4. **Output Validation Checkpoint** — read the returned record back, check it
+   against the format reference's validation checklist, and **fix only
+   structural-only deviations in place**, **recording every change it makes**
+   (never re-dispatch the agent) (§7). The checkpoint **never authors derived
+   judgment**: any deviation that would create or alter a derived value
+   (`cost_usd`, `cost_basis`, a range, a confidence tier, a `failure_direction`)
+   is **not** fixed — the command **aborts without writing** (§7.1a). The
+   checkpoint runs **before** the human disposes, so the human reviews a
+   *validated* record. If a deviation cannot be fixed within the structural-only
+   boundary (a structurally unrecoverable record, or a derived-value defect), the
+   command surfaces the failure and aborts without writing (§7.1a, §7.3).
+5. **Show the review summary** — a structured, human-readable summary of the
+   validated record: target + classified `target_kind` **and, when the kind was
+   human-asserted via `--kind`, a prominent asserted-not-inferred flag noting the
+   raised ceiling has no agent inference basis** (§4.1, O4); the token range and
+   per-axis confidence; the agent-compute-time range and the `human_gate_time`
+   caveat; whether `cost_usd` is present or omitted (and, when omitted, the
+   disclosed cause, **reporting a trailing-slash `cost-snapshot` grounding entry
+   as "no snapshot — directory inspected, no snapshot found", not a grounding** —
+   §7.3); the `failure_direction` with its driver; **the resolved output path**;
+   and — **when the checkpoint changed anything at step 4 — an explicit
+   change-list (a diff or itemised list) of exactly what the command altered vs
+   the agent's emitted record** (O1). The summary is what the human disposes over;
+   the change-list makes the agent-content-vs-command-content provenance
+   transparent, so the human's `accept` ratifies a composite it can see the seams
+   of. When the checkpoint changed nothing, the summary says so ("no checkpoint
+   changes — record as emitted by the agent").
+6. **Ask for disposition** — the **full** named vocabulary from the
+   agent-emit/dispatcher-persist architecture (not a narrowed accept/abort):
+   - **`accept`** — proceed to the write (step 7).
+   - **`edit`** — open the validated draft in `$EDITOR` (or `vi` if unset). On
+     return, run the checkpoint in **validate-and-report mode**: it **validates**
+     the human-edited content and **reports** any remaining deviation, but does
+     **NOT** silently fix human-edited content. **A human edit is never reverted
+     without the human seeing and re-confirming it** (O3). If the edited record
+     still deviates, the command surfaces the remaining deviation in the
+     re-prompt and lets the human decide (re-edit, accept-as-is where structurally
+     valid, or abort) — the human is the final author on the edit path. (The
+     fix-in-place of step 4 applies to the **agent's fresh output**; the edit path
+     is **validate-and-report**, because the content is now the human's.)
+   - **`re-run`** — **re-dispatch the agent** on the same target. The re-dispatch
+     **re-reads the grounding sources afresh** — including the (now-populated)
+     `observability/costs/` directory — so a human who adds a cost snapshot and
+     then chooses `re-run` gets a record grounded in the newly-added snapshot
+     (the add-a-snapshot-then-re-run use case works because re-run is a full fresh
+     dispatch, not a reuse of cached grounding) (O8). The command then re-validates
+     (step 4) and re-summarises (step 5).
+   - **`abort`** — discard the draft; **no file written**.
+7. **On `accept` (post-disposition): write once.** The command performs its
+   single `Write` to the resolved output path (§6), creating the directory if
+   needed, then confirms the full path to the user.
+
+**The ordering invariant, stated plainly:** nothing is persisted until the human
+returns `accept` at step 6. Steps 2–5 produce and validate a *returned string*
+and a *review summary*; the `Write` at step 7 is the only persistence and it is
+**downstream of** the human disposition. This is the AGENTS.md dispose-then-write
+invariant honoured as ordering, not merely as the agent/command tool split — and
+it deliberately ships the **full** accept/edit/re-run/abort vocabulary rather
+than the narrowed accept/abort `/diagnose` shipped (the AGENTS.md watch item flags
+that narrowing as a divergence to avoid recurring).
+
+### 5.1 REFUSED handling (no malformed record)
+
+The S2 agent returns a stable `REFUSED:` string when it cannot ground an estimate
+(an unreadable/unclassifiable target, an absent or tableless `MODEL_ROUTING.md`).
+The command detects the prefix at step 3 and:
+
+- surfaces the refusal reason, the target, and the grounding-read line to the
+  user **verbatim**;
+- **writes no file** and runs **no** validation checkpoint (there is nothing
+  conforming to validate);
+- aborts the flow.
+
+This is the dispatcher half of the S2 refusal convention: the *convention* is
+the agent's, the *check-and-decline-to-persist* is the command's. An
+authoritative-looking estimate record is never written for a target the agent
+could not honestly ground.
+
+### 5.2 The empty-snapshot case is NOT a refusal
+
+Per the S1 three grounding states and the S2 agent's contract, an empty
+`observability/costs/` yields a **valid, complete cost-omitted record**, not a
+`REFUSED:` string. The command treats that record as a normal emit: it validates
+it (the checkpoint's cost-pairing and grounding-path checks confirm the omission
+is well-formed), summarises it (showing `cost_usd: omitted` with the disclosed
+cause), and — on `accept` — writes it. The command must **not** treat a
+cost-omitted record as a failure; doing so would make the command unusable on
+today's repo, contradicting the S1 "no-cost case is honest, not a failure"
+decision.
+
+## 6. Where the record is written
+
+### 6.1 Default output path — top-level `cost-estimates/`, OUTSIDE `observability/`
+
+The command's single `Write` targets, by default:
+
+```text
+cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md
+```
+
+- **`cost-estimates/`** — a **new top-level directory**, deliberately **outside**
+  the `observability/` tree. The command creates it if it does not exist
+  (`mkdir -p`).
+- **`<YYYY-MM-DD>`** — the date the estimate was produced.
+- **`<target-slug>`** — derived from the target: for a path target, the source
+  filename with its date prefix and `.md` extension stripped (e.g.
+  `cost-estimator-pipeline`); for inline task text, a short kebab-case slug of the
+  first few words. When a slug collision would overwrite an existing same-day
+  estimate, the command appends a short disambiguator and notes it in the
+  confirm-before-write summary. **This collision disambiguation applies under both
+  the default directory and `--out`** — see §6.2.
+
+#### Why outside `observability/` (the O5 output-home decision)
+
+The earlier draft filed estimates under `observability/estimates/`, a sibling to
+`observability/costs/`, "for symmetry". That conflates two **different kinds of
+data**: `observability/` is the project's **telemetry / actuals** tree — captured
+snapshots, cost actuals, audit outputs that downstream tools scan **as ground
+truth**. An estimate record is a forward-looking **prediction (a guess)**. Filing
+predictions under the actuals root risks a future scan reading an estimate as an
+observed fact — the precise confusion the estimate-record format works to prevent
+(no list-price fallback; omit-when-ungrounded).
+
+**What was checked.** Every current consumer of the `observability/` tree was
+read for how it globs:
+
+- `commands/harness-health.md` (lines 22–24, 60–64) reads **two named
+  subdirectories** by specific patterns — `observability/costs/*-costs.md` (latest
+  cost snapshot) and `observability/snapshots/*-snapshot.md` (trend comparison).
+  It does **not** glob `observability/**` tree-wide.
+- `commands/cost-capture.md` (step 1) globs `observability/costs/*-costs.md` only.
+- `commands/observatory-verify.md` (step 2) and its checklist
+  `skills/harness-observability/references/observatory-signals.md` read **named
+  subdirectories** — `observability/snapshots/`, `observability/governance/` — by
+  specific filename patterns; there is **no** tree-wide glob and **no** signal
+  source for an `estimates/` sibling.
+- The hook scripts (`snapshot-staleness-check.sh`, `governance-drift-check.sh`,
+  `gc-rotate.sh`) and `update-health-badge.sh` likewise key on named
+  subdirectories with specific filename patterns.
+
+So **no current consumer would aggregate an `observability/estimates/` sibling as
+actuals today.** But "no consumer mis-reads it *today*" is a weaker guarantee than
+"the data lives where its kind belongs." A marker/guard inside
+`observability/estimates/` would depend on every *future* tree-wide scan honouring
+the marker — a standing obligation a new consumer could silently miss.
+
+**Decision: move the default home OUTSIDE `observability/`** to a top-level
+`cost-estimates/` directory. This removes the conflation at the source rather than
+guarding against it: predictions are not telemetry, so they do not live under the
+telemetry root, and no future `observability/` scan can read an estimate as an
+actual because no estimate is under `observability/` at all. The
+`/cost-capture` ↔ `/cost-estimate` discoverable pairing (a retrospective-cost and
+a prospective-cost command) is preserved by **naming** — `observability/costs/`
+(actuals) and `cost-estimates/` (predictions) read as siblings-by-name — without
+co-locating the two data kinds under one scanned root.
+
+**Decision: `cost-estimates/` is gitignored by default (O3).** An estimate record
+is a **derived, regenerable** prediction — its `target` may reference an unmerged
+spec, a since-renamed slice, or a task description that changes after the estimate
+is produced. This is the exact shape the repo's existing convention treats as
+not-committed: `.gitignore` already excludes the `/diagnose` output
+(`diagnostic-legibility/output/`) because it is "derived, regenerable artefacts …
+Never committed." An estimate is the same kind of artefact, so it inherits the
+same default. **This slice adds the `cost-estimates/` line to `.gitignore`** with a
+comment matching the `/diagnose` entry's "derived, regenerable" rationale (Task 5a,
+FR-10a). The staleness/rotation concern O3 raised is thereby moot: estimates are
+regenerable artefacts re-produced on demand, not a committed corpus of stale
+guesses that drifts from moving targets. A human who wants to retain a specific
+estimate can still commit it explicitly or write it elsewhere via `--out`.
+
+### 6.2 `--out <dir>` override (collision disambiguation applies here too)
+
+`--out <dir>` overrides the **directory** only; the
+`<YYYY-MM-DD>-<target-slug>-estimate.md` filename still applies beneath it
+(mirroring `model-card create`'s `--out` semantics — directory override, derived
+filename preserved). This lets a human drop an estimate next to a spec under
+review, or into a scratch directory, without losing the canonical filename shape.
+
+**Same-day collision disambiguation applies under `--out` exactly as under the
+default (O9).** A human deliberately co-locating estimates in one `--out`
+directory is the *most* likely place to hit a same-day same-slug collision, and a
+silent overwrite there is real data loss. So when the derived filename beneath
+`--out` would overwrite an existing same-day estimate, the command appends the
+same short disambiguator and notes it in the confirm-before-write summary. **The
+command never silently overwrites an existing estimate, under the default
+directory or under `--out`.**
+
+### 6.3 Confirm-before-write
+
+The resolved output path is shown in the **review summary** (step 5) and the
+write happens only on `accept` (step 6 → 7). The human therefore confirms both
+the *content* (the validated record) and the *destination* (the resolved path)
+**before** any persistence. This is the confirm-before-write gate the slice asks
+for, realised as part of the single dispose-then-write disposition rather than a
+second separate prompt.
+
+## 7. The Output Validation Checkpoint
+
+Per the CLAUDE.md Output Validation Checkpoints convention, the command **reads
+the returned record back, checks its structure against the format reference's
+validation checklist, and fixes deviations in place** (it does **not** re-dispatch
+the agent). The checkpoint references
+`skills/cost-estimation/references/estimate-record-format.md` by path and
+implements **every** line of that file's "Validation checklist", including the
+#377 additions.
+
+### 7.1 The checklist lines the checkpoint implements
+
+The command's checkpoint runs each of the format reference's checklist lines:
+
+1. **Ranges well-formed** — every present range (`tokens`, each
+   `tokens_by_stage[].tokens`, each `tokens_by_stage[].cost_usd` *when present*,
+   `cost_usd` *when present*, `agent_compute_time`) has `low ≤ high`.
+2. **Per-stage cost coupling (#377)** — if **any** `tokens_by_stage[].cost_usd`
+   is present, the top-level `cost_usd` must also be present (a per-stage band
+   never appears on a cost-omitted record). A record with no per-stage bands
+   passes vacuously; the check forbids only the incoherent inverse.
+3. **Split-tier strict-spread (#377)** — for **every present**
+   `tokens_by_stage[].cost_usd` whose `model_tier` **contains a `/`** (the
+   closed split-tier trigger, after join-key whitespace normalisation), the band
+   must have a strictly-positive ordered spread (`low < high`, strict). A
+   collapsed band on a split-tier stage fails; single-tier stages are exempt; a
+   record with no per-stage bands passes vacuously.
+4. **All four disclosure sections present** — Included, Excluded, Confidence
+   rationale, Failure direction.
+5. **Per-axis confidence within cap** — each present `tokens`/`time` axis is
+   within the `target_kind` ceiling (`task-text`→`low`,
+   `slicing-record`/`slice`→`medium`, `spec`→`high`); the `cost` axis is present
+   **iff** `cost_usd` is present and is **not** capped by `target_kind`.
+6. **Cost pairing** — `cost_usd` and `cost_basis` are both present or both
+   absent; when absent, `Excluded` carries the cost-omission disclosure.
+7. **Time split** — both time fields present and separate: `agent_compute_time`
+   a `{ low, high }` range, `human_gate_time` a qualitative caveat string (not a
+   range).
+8. **No-verdict, field-absence layer** — no `recommendation`, `verdict`, or
+   `proceed` field in the frontmatter.
+9. **No-verdict, positive-content layer** — the disclosure prose contains no
+   imperative recommendation or go/no-go language (the tripwire pattern list).
+
+When a check finds a deviation, whether the command fixes it in place or aborts is
+governed by the **structural-fix boundary** in §7.1a — not a vague
+"mechanically-recoverable" predicate. The checkpoint **never re-dispatches the
+agent**, and **never authors derived judgment**.
+
+### 7.1a The fix-in-place boundary — structural-only, never authoring derived judgment (O1, O2)
+
+"Fix in place" is bounded precisely so the checkpoint can never silently alter
+what the human disposes over. The boundary is drawn at **structural-only vs
+derived-value**:
+
+- **STRUCTURALLY-RECOVERABLE → fix in place, and record the change.** The
+  checkpoint MAY repair a deviation that is purely *structural* and *unambiguous* —
+  one whose correction invents **no** value the agent did not emit. Examples:
+  - **delete a stray `recommendation`/`verdict`/`proceed` field** (checklist line
+    8) — removal of a forbidden field, authoring nothing;
+  - **normalise a malformed-but-unambiguous structural field** where the intended
+    value is unarguable from the surrounding emitted content (e.g. a join-key
+    whitespace normalisation already defined by the format reference; a YAML
+    shape-only fix that does not change a number, a tier, or a confidence label).
+
+  Every such fix is **recorded** and surfaced in the review summary's change-list
+  (§5 step 5), so the human sees exactly what the command altered.
+
+- **DERIVED-VALUE or AMBIGUOUS → ABORT, never author.** The checkpoint MUST
+  **abort without writing** — it does **not** invent or alter — for any deviation
+  whose correction would **create or change a derived judgment value**. The
+  checkpoint never authors a `cost_usd` band, a `cost_basis`, a `tokens`/`time`
+  range, a per-axis confidence tier, or a `failure_direction`; it never edits
+  disclosure prose to supply a missing rationale; it never resolves an ambiguous
+  structural defect by guessing the intended value. Concretely:
+  - a **cost-present record missing `cost_basis`** (checklist line 6, "Cost
+    pairing") **ABORTS** — inserting `cost_basis: snapshot-actuals` would assert a
+    provenance the agent did not state, which is *authoring derived provenance*,
+    exactly what is forbidden. (This **removes** the earlier draft's "insert a
+    missing `cost_basis`" fix-in-place example, which inverted the rule.)
+  - a **`low > high` range** (line 1) ABORTS — re-ordering or clamping a band
+    changes a derived number;
+  - a **missing disclosure section** (line 4) ABORTS — the checkpoint cannot
+    author the Included/Excluded/Confidence/Failure-direction prose the agent owns;
+  - a **per-stage-coupling violation** (line 2: a per-stage band on a cost-omitted
+    record) ABORTS — the resolution (drop the band, or supply a top-level cost)
+    each alters a derived value;
+  - a **collapsed split-tier band** (line 3) ABORTS — widening it would author a
+    spread the agent did not emit;
+  - a **confidence axis above the ceiling** (line 5) ABORTS — lowering it is a
+    derived-judgment change;
+  - an **imperative-recommendation tripwire hit** (line 9) ABORTS — the checkpoint
+    cannot rewrite the agent's prose to remove a verdict without authoring prose.
+
+  On any abort, the command surfaces the failing checklist line and the reason
+  ("derived-value defect — the checkpoint does not author the agent's judgment")
+  and writes **no file**. The honest move on a derived-value defect is to surface
+  it and let the human re-run or abort, **not** to silently complete the agent's
+  record.
+
+**Per-checklist-line disposition.** The table below states, for each of the nine
+checklist lines (§7.1), whether a failure is structurally-recoverable (fix +
+record) or abort:
+
+| # | Checklist line | On failure |
+| --- | --- | --- |
+| 1 | Ranges well-formed (`low ≤ high`) | **ABORT** — re-ordering/clamping changes a derived number |
+| 2 | Per-stage cost coupling | **ABORT** — resolution alters a derived value |
+| 3 | Split-tier strict-spread | **ABORT** — widening authors a spread |
+| 4 | Four disclosure sections present | **ABORT** — checkpoint cannot author prose |
+| 5 | Per-axis confidence within cap | **ABORT** — lowering is a derived-judgment change |
+| 6 | Cost pairing (`cost_usd`/`cost_basis` together) | **ABORT** — supplying `cost_basis` authors provenance |
+| 7 | Time split (separate fields, right shapes) | **ABORT** — any time-field defect alters or omits a derived value (`agent_compute_time` is a `{low, high}` range; `human_gate_time` a qualitative string); no no-value-change mistyping is constructible |
+| 8 | No-verdict field-absence (stray `recommendation`/`verdict`/`proceed`) | **FIX** — delete the forbidden field; record it |
+| 9 | No-verdict positive-content (imperative/go-no-go prose) | **ABORT** — checkpoint cannot rewrite the agent's prose |
+
+In practice the only routinely-fixed line is **#8 (delete a stray verdict
+field)** — a pure removal that authors nothing. Every line that would require the
+checkpoint to *supply* a derived value aborts. This is the structural-fix boundary
+the disclosure-of-derived-judgment contract demands: a *second* actor (the
+command) never silently mutates the agent's judgment, and on the one class it does
+touch (forbidden-field removal) it records the change for the human.
+
+**Live-surface note (O5).** Against today's cost-omitted-only records (§7.2: no
+record the command can emit today carries `cost_usd` or a per-stage `cost_usd`
+band), the LIVE checklist surface is lines **4 / 8 / 9** only. The cost-band rows
+— lines 1–3 and the cost halves of lines 5–6 — are **dormant** until a snapshot
+lands: their ABORT branches pass vacuously on a cost-omitted record and are
+unreachable until `/cost-estimate` can emit a cost-present record. The table is
+stated in full so it is correct once cost-present records exist; two-thirds of it
+does not fire on today's producible records.
+
+### 7.1b The edit path is validate-and-report, not fix-in-place (O3)
+
+The fix-in-place boundary of §7.1a governs the checkpoint run at **step 4 on the
+agent's fresh output**. On the **`edit` disposition** (§5 step 6) the content is
+the **human's**, and the human is the **final author**. The post-edit checkpoint
+runs in **validate-and-report mode**: it validates the edited record and
+**reports** any remaining deviation in the re-prompt, but it does **NOT** apply
+fix-in-place to human-edited content — **a human edit is never reverted without
+the human seeing and re-confirming it.** If the edited record still deviates, the
+human decides (re-edit, accept where the record is structurally valid, or abort);
+the command does not silently un-edit the human. This reconciles step 4's
+fix-in-place (agent output) with the edit path (human authorship): the two are
+different runs with different authorship and therefore different rules.
+
+### 7.2 The #377-deferred absolute-rate check — DECISION: defer further, with a recorded reason
+
+The #377 format reference states (in "Per-stage cost — what the validator CAN and
+CANNOT assert") that the **absolute-rate falsification** — asserting a split-tier
+band's bounds actually **equal** the `claude-sonnet-4`/`claude-opus-4` rates, or
+that the band genuinely **spans two tiers** rather than merely being non-collapsed
+— is *"a runtime, snapshot-grounded check … deferred to S3's Output Validation
+Checkpoint (which can read both the record and the snapshot)"*.
+
+**Decision: S3 does NOT build the absolute-rate check in this slice; it is
+deferred further, with a recorded reason and a re-filed tracking home.** The
+reasoning:
+
+- **The check is only meaningful on a cost-present record, which today's repo
+  cannot produce.** `observability/costs/` is empty, so every record S3 writes
+  today is **cost-omitted** — it carries no `cost_usd` and no per-stage
+  `cost_usd` band, so there is nothing for an absolute-rate check to falsify. The
+  check would be dead code against every record the command can currently emit.
+- **It is a materially different kind of check** from the structural-conformance
+  checklist S3 ships: it requires the checkpoint to **re-read the snapshot**,
+  recompute per-model `$/token` from the Model Breakdown, and compare against the
+  record's bands within a tolerance. That is the same rate-derivation arithmetic
+  the agent performs — duplicating it in the validator re-introduces the
+  derivation surface the read-only/dispatcher split exists to keep in one place,
+  and it needs its own adversarial pass on the tolerance and the
+  re-derivation (a snapshot whose mix differs from emit time, rounding, the
+  blended-rate skew).
+- **Building it speculatively now is YAGNI against a closed-world record set.**
+  The honest first-version checkpoint is the structural-conformance one; the
+  absolute-rate check earns its place once a real snapshot exists and a real
+  cost-present record can be validated against it.
+
+**Recorded reason + re-filing with a COMMITTED home and a blocking acceptance
+criterion (O6, per the AGENTS.md natural-home-hand-off decision).** Because #377
+named "S3's Output Validation Checkpoint" as the absolute-rate check's natural
+home, and S3 declines it, the concern must **not** be left implicit in a closed
+slice — and re-filing it to a fresh issue that no slice is bound to build would be
+a second consecutive buck-pass (the objection O6 names) that risks permanent
+orphaning. So S3 does two things, not one:
+
+1. **Re-file with its own lifecycle.** S3 **re-files the absolute-rate check as a
+   standalone tracking issue** ("estimate-record absolute-rate validation —
+   snapshot-grounded per-stage cost falsification"), so it has a tracking home
+   regardless of which slice eventually picks it up.
+2. **Bind it to a concrete slice NUMBER, not to an unscheduled precondition
+   (O4).** The re-filed issue is **not** a soft "most naturally S6" suggestion, and
+   — critically — it is **not** keyed on an event the roadmap never schedules. The
+   earlier revision bound the trigger to "the first slice that produces a
+   cost-present record", but **no scheduled slice produces that event**: landing
+   the first usable `observability/costs/` snapshot is not a deliverable of any
+   slice as previously written (S6 was framed as *consuming* actuals, not capturing
+   the first snapshot), so the trigger was unreachable and the check could stay
+   orphaned exactly as O6 feared. The fix is to **make snapshot-capture an explicit
+   S6 deliverable and bind the check directly to S6/#373**:
+
+   > **S6 (#373, the calibration loop) owns first-snapshot capture.** S6's
+   > deliverables are extended to include **capturing the first usable
+   > `observability/costs/` snapshot** (the actuals it calibrates against must
+   > first exist for the loop to close), and — as a **required deliverable of the
+   > same slice** — **building the absolute-rate check**. The absolute-rate check
+   > is therefore a **BLOCKING required deliverable of S6/#373**, bound to a
+   > concrete slice number, not to a precondition the roadmap does not cause.
+
+   This makes the home **reachable**: S6 is the slice that both first makes
+   cost-present records possible (by capturing the snapshot) and consumes them (the
+   calibration loop), so binding the check to S6 is binding it to the exact slice
+   under which the first record it could falsify comes into existence. If a future
+   roadmap re-assigns first-snapshot capture to an earlier slice, the check travels
+   with snapshot-capture to *that* slice; but the binding is to a **named slice**,
+   not to an event no slice is committed to produce. **S6/#373 now owns the
+   absolute-rate check.**
+
+### 7.3 The grounding-path trailing-slash consumer special-case — DECISION: not enforced as a checklist line; honoured where S3 itself consumes the field
+
+The #377 reference adds a **consumer special-case**: an aggregator that counts
+"how many records were grounded in a cost snapshot" must **not** count a
+`cost-snapshot` grounding entry whose `path` ends in `/` (the directory sentinel
+for *looked-and-found-nothing*) as a real grounding. The reference explicitly
+flags this special-case as **advisory/unenforced** — *"no validation-checklist
+line keys on `grounding_sources[].path` shape"* — and names the residual
+silent-miscount risk it externalises onto every downstream counter.
+
+**Decision: S3 does NOT add a new validation-checklist line that keys on the
+`grounding_sources[].path` shape** — it follows the reference's as-merged
+checklist, which deliberately carries no such line, and it does **not** invent
+one (inventing one would be a consumer mutating the contract, which the AGENTS.md
+consumer-never-mutates decision forbids). **But S3 honours the special-case at
+the one point where the command *itself* consumes the field**: in the review
+summary (step 5), when the command reports whether the record is "grounded in a
+cost snapshot", it tests the trailing slash and reports a trailing-slash
+`cost-snapshot` entry as **"no snapshot — cost omitted (directory inspected, no
+snapshot found)"**, *not* as a snapshot grounding. The command is itself a
+downstream consumer of `grounding_sources`, so it must not be the consumer that
+miscounts; honouring the special-case in its own summary logic is the dispatcher
+half of the residual the reference named, even though no checklist line enforces
+it on the record. (S3 does not add the missing checklist line because that is a
+format change the format-owning slice would have to own; S3 simply does not
+*itself* fall into the trap.)
+
+#### Recorded residual: S3 ships the FIRST records carrying the unguarded sentinel (O7)
+
+Not mutating the contract is correct (the own-the-contract rule — adding the
+checklist line is the format-owning slice's job, not a consumer's). But the
+consequence must be **recorded in this spec as a known failure the records
+carry**, not left only to later cartographer archaeology: **S3 is the slice that
+ships the first body of estimate records persisted to disk, and every such record
+that is cost-omitted carries the `cost-snapshot` grounding entry with the
+**unguarded** trailing-slash directory sentinel** — unguarded because no
+validation-checklist line keys on `grounding_sources[].path` shape (the #377
+reference names this residual explicitly:
+`estimate-record-format.md` "Noted residual", lines ~296–301). The concrete,
+named consequence for downstream consumers:
+
+- **Every other consumer of these records** — S4's orchestrator fold-in, and any
+  future aggregator that counts "how many estimates were grounded in a real cost
+  snapshot" — **will silently miscount** a trailing-slash directory entry as a
+  real grounding **unless it applies the same trailing-slash test S3 applies in
+  its own summary.** The records do not carry a machine-enforced guard; the
+  protection is per-consumer and easy to omit.
+- **S3 makes this risk concrete** rather than hypothetical: before S3 there were
+  no persisted estimate records; after S3 there is a growing corpus of them, every
+  cost-omitted one bearing the unguarded sentinel.
+
+This is recorded here so S4 and any aggregator inherit the failure **named in the
+spec**: a downstream consumer that does not replicate the trailing-slash test
+miscounts, and the records themselves will not stop it. The structural fix (a
+checklist line keying on `grounding_sources[].path` shape) remains the
+format-owning slice's deliverable; S3 records the residual and declines to mutate
+the contract from a consumer seat.
+
+### 7.4 Why the checkpoint is mandatory on the manual path
+
+The slice's decision-focus asks whether the manual path carries its **own**
+validation checkpoint or relies on orchestrator-only validation. It carries its
+own: `/cost-estimate` writes structured markdown that downstream tools (and S4's
+fold-in) may parse, so the CLAUDE.md convention applies to it directly — and the
+manual path is precisely the one the orchestrator never sees. The command joins
+the CLAUDE.md Output Validation Checkpoints list (§10).
+
+## 8. The decisions the slice asked S3 to fix, summarised
+
+| Question (from the slice / constraints) | S3 decision |
+| --- | --- |
+| Standalone manual surface at all? | **Yes** — ship it; prospective sibling of `/cost-capture` (§3) |
+| Command signature | `/cost-estimate <target> [--kind <target-kind>] [--out <dir>]`; `--near` dropped, `--kind` added (§4.1) |
+| Accepted target types | task text / slicing-record path / spec path / slice — one per invocation, matching the agent (§4.2) |
+| Where the record is written | Default top-level `cost-estimates/<date>-<slug>-estimate.md`, **outside `observability/`** (O5-home); **gitignored by default** as a derived, regenerable artefact (O3); `--out` overrides the directory; collision disambiguation under both (§6) |
+| `--kind` raised ceiling | Review summary **flags a human-asserted kind** as asserted-not-inferred with a raised ceiling and no agent inference basis (O4) (§4.1, §5) |
+| Dispose-then-write ordering | Human disposition (accept/edit/re-run/abort) PRECEDES the single Write; confirm-before-write realised in the disposition (§5, §6.3) |
+| Checkpoint transparency | Fix **structural-only** in place + **record every change** in the review summary; **abort, never author** any derived-value defect (O1, O2) (§5, §7.1a) |
+| Edit path | **Validate-and-report**, not fix-in-place — a human edit is never silently reverted (O3) (§5, §7.1b) |
+| `re-run` re-reads snapshot | `re-run` is a full fresh dispatch that **re-reads `observability/costs/`**, so add-a-snapshot-then-re-run works (O8) (§5) |
+| REFUSED handling | Surface verbatim, write nothing, no checkpoint (§5.1) |
+| Own validation checkpoint | **Yes** — implements the full format checklist incl. #377 per-stage coupling + split-tier strict-spread (§7.1) |
+| #377-deferred absolute-rate check | **Deferred further** with a recorded reason; re-filed as a **BLOCKING required deliverable of S6/#373** — bound to a concrete slice number, with S6 extended to own first-snapshot capture so the trigger is reachable (O6, O4) (§7.2) |
+| Grounding-path trailing-slash special-case | **Not** a new checklist line; honoured in the command's own summary consumption; **residual recorded** — S3 ships the first records carrying the unguarded sentinel (O7) (§7.3) |
+
+## 9. Component design (per component-design-with-tdad)
+
+- **Type**: command — the deliverable is a human-invokable slash command that
+  dispatches an agent and persists its output. Not a skill (the methodology is
+  the S1 skill) and not an agent (the read-only emitter is S2).
+- **Justification**: S2 shipped the emitter that returns a string; S3 is the
+  dispatcher that writes and validates it. A command file is the canonical home
+  for a human-facing dispatch surface, and the `/cost-capture` /
+  `model-card create` precedents establish the shape.
+- **TDAD layers targeted**: `[structural, behavioural]`. Layer 1 (structural)
+  always — frontmatter well-formed; the process documents the dispatch →
+  REFUSED-handling → checkpoint → review-summary → disposition → write order with
+  the disposition **before** the write; the checkpoint section references the
+  format reference by path and enumerates the checklist lines incl. the #377
+  ones; the disposition vocabulary is accept/edit/re-run/abort. Layer 3
+  (behavioural) **applies** — a dispatch against a real target produces a written
+  record at the resolved path (or, on REFUSED, no file), validatable by
+  deterministic oracles. Layer 2 (trigger) does not apply — commands have no
+  description-vs-query match.
+- **Behavioural grading strategy.** Like the S2 agent, the command's behaviour
+  rides a non-deterministic `model: inherit` dispatch, so the behavioural
+  scenarios grade **deterministically-checkable properties of the on-disk
+  outcome**, not exact wording:
+  - **File-existence + path oracle.** Assert a file exists at the resolved output
+    path on `accept`, and that **no** file is written on `abort` or on a
+    `REFUSED:` fixture.
+  - **Conformance oracle.** Parse the written record's frontmatter and assert the
+    S1 field-set structural properties (required fields present, enums in range,
+    every present range `low ≤ high`, the four disclosure sections present, no
+    `recommendation`/`verdict`/`proceed` field).
+  - **#377-check oracle.** On a fixture that pins a cost-present record with a
+    split-tier per-stage band, assert the checkpoint's per-stage-coupling and
+    split-tier strict-spread checks hold (band `low < high` on the `/`-tier
+    stage); on a cost-omitted fixture, assert both checks pass vacuously and the
+    `cost-snapshot` grounding entry's trailing-slash path is reported as "no
+    snapshot" in the summary, not a grounding.
+  - **Structural-fix-boundary oracle (O1/O2).** On a fixture pinning a record with
+    a **stray `verdict` field** (a structural-only defect), assert the field is
+    removed AND the review summary's change-list names the removal (fix + record).
+    On a fixture pinning a **cost-present record missing `cost_basis`** (a
+    derived-value defect), assert the command **aborts without writing** and does
+    **not** insert a `cost_basis` (abort, never author). On a fixture where the
+    checkpoint changes nothing, assert the summary says "no checkpoint changes".
+  - **Edit-validate-and-report oracle (O3).** On the `edit` path with a fixture
+    where the human edit introduces a tolerated structural change, assert the
+    post-edit checkpoint **reports** rather than silently reverts — the edited
+    value is preserved and any remaining deviation is surfaced in the re-prompt,
+    not auto-fixed.
+  - **`--kind` assertion-flag oracle (O4).** On a fixture invoking
+    `--kind spec` on a slice-fragment target, assert the review summary contains a
+    human-asserted (asserted-not-inferred) flag naming the raised ceiling; on a
+    fixture with no `--kind` (agent-inferred), assert the summary instead carries
+    the agent's inference-basis line.
+  - **REFUSED oracle.** On an ungroundable fixture, assert the agent's `REFUSED:`
+    prefix is surfaced and **no** file is written.
+  - **Fixture-driven grounding.** Each behavioural scenario pins its inputs (a
+    fixture target, a fixture `MODEL_ROUTING.md`, an empty or populated
+    `observability/costs/`) so the input is deterministic even though the model
+    is not. A scenario no oracle can grade is descoped, not rubber-stamped.
+- **Modification or new?** new — `commands/cost-estimate.md`. No modification of
+  the S2 agent or the S1 format reference.
+- **Scenario vs finding**: scenario only — every assertion is falsifiable by one
+  of the deterministic oracles above.
+
+## 10. User stories and acceptance scenarios
+
+**Runnable-today vs synthetic-fixture flag (O6).** Most scenarios below are
+exercised by a real grounding read on today's repo (an empty `observability/costs/`
+yields a cost-omitted record): §10.1, §10.3 (REFUSED), §10.4 (cost-omitted paths),
+§10.5, §10.6 are **runnable-today**. Two scenarios pin a **synthetic cost-present
+world** the command's real grounding cannot produce until a snapshot lands —
+**§10.4b** (the cost-present abort path) and **§10.6b** (re-run yielding a
+cost-present record). These two **hand-author the split-tier cost bands** that the
+deferred absolute-rate check (§7.2) would otherwise validate; they exist to pin
+future behaviour, not to be exercised by a grounded emit on today's repo.
+
+### 10.1 Story — a human can ask for a cost estimate ad hoc, end to end
+
+**As** a human deciding whether to run a piece of work through the pipeline
+**I want** a standalone `/cost-estimate` command that estimates a target's
+tokens, agent-compute time, and (when grounded) cost, and writes the record to
+disk
+**So that** I get a prospective estimate without a full orchestrator run — the
+prospective counterpart to `/cost-capture`.
+
+```gherkin
+Given the /cost-estimate command dispatched against a real spec-file target
+And MODEL_ROUTING.md is readable and observability/costs/ is empty (today's default)
+When the command runs the agent, validates the returned record, summarises it,
+    and I respond "accept"
+Then a cost-omitted estimate record is written to
+    cost-estimates/<date>-<slug>-estimate.md (a top-level directory, outside observability/)
+And the written file conforms to the S1 estimate-record field set (parsed, not read loosely)
+And cost_usd and cost_basis are omitted, the omission disclosed in Excluded
+And the command confirms the full written path to me
+```
+
+### 10.2 Story — the human disposition precedes the write (the ordering invariant)
+
+**As** a human who must stay in the disposition seat
+**I want** the command to surface and let me dispose over the validated record
+*before* it writes anything
+**So that** no estimate is persisted without my disposition, honouring the
+dispose-then-write ordering invariant.
+
+```gherkin
+Given the /cost-estimate command has dispatched the agent and validated the returned record
+When the command reaches the disposition step
+Then it shows me a review summary of the validated record (target, target_kind,
+    token range + confidence, agent-compute-time range + human_gate_time caveat,
+    cost present/omitted, failure_direction) and the resolved output path
+And it offers the disposition vocabulary accept / edit / re-run / abort
+And NO file has been written yet
+
+When I respond "abort"
+Then no file is written
+
+When I respond "accept" instead
+Then exactly one Write occurs, to the resolved output path, after my disposition
+```
+
+### 10.3 Story — a REFUSED estimate is surfaced, never persisted
+
+**As** a human running the command on an ungroundable target
+**I want** the agent's refusal surfaced and no record written
+**So that** an authoritative-looking estimate is never produced for a target the
+agent could not honestly ground.
+
+```gherkin
+Given the /cost-estimate command dispatched against an unreadable target path
+    (or one where MODEL_ROUTING.md cannot be read, or reads but its tables are
+    missing/unparseable)
+When the agent returns a string beginning with "REFUSED:"
+Then the command surfaces the refusal reason, target, and grounding-read line to me verbatim
+And no validation checkpoint runs
+And no file is written
+And the flow aborts
+```
+
+### 10.4 Story — the manual path carries its own Output Validation Checkpoint, transparently
+
+**As** a downstream consumer (a human, or S4's fold-in) of the written record
+**I want** the command to validate the record against the format checklist before
+I dispose, fixing only structural-only deviations and surfacing exactly what it
+changed
+**So that** the manual path does not rely on orchestrator-only validation, the
+checkpoint never silently authors the agent's derived judgment, and I dispose over
+a transparent agent-vs-command composite.
+
+```gherkin
+Given the /cost-estimate command has received a record from the agent
+When it runs the Output Validation Checkpoint
+Then it checks the record against every line of the format reference's validation
+    checklist, including the #377 per-stage cost coupling and split-tier
+    strict-spread checks
+And it fixes only STRUCTURAL-ONLY deviations in place, without re-dispatching the agent
+And it presents the validated record (not the raw agent output) in the review summary
+
+Given a returned record carrying a cost-present split-tier per-stage cost band
+When the checkpoint runs the split-tier strict-spread check
+Then a split-tier (model_tier contains "/") per-stage band with low == high fails the check
+And a non-collapsed split-tier band (low < high) passes
+```
+
+#### 10.4a Scenario — the checkpoint surfaces exactly what it changed (O1)
+
+```gherkin
+Given a returned record carrying a stray "verdict" field (a structural-only defect)
+When the checkpoint fixes it in place by deleting the forbidden field
+Then the review summary includes a change-list naming the deletion (agent-content vs command-content)
+And I dispose over the validated record knowing exactly what the command altered
+
+Given a returned record the checkpoint did not need to change
+When it presents the review summary
+Then the summary states "no checkpoint changes — record as emitted by the agent"
+```
+
+#### 10.4b Scenario — the checkpoint aborts, never authors, on a derived-value defect (O2)
+
+```gherkin
+Given a returned cost-present record that is MISSING cost_basis (a derived-value defect)
+When the checkpoint runs the Cost-pairing check
+Then it does NOT insert a cost_basis (inventing provenance the agent did not state)
+And the command surfaces the failing checklist line and aborts without writing
+
+Given a returned record with a low > high range (a derived-number defect)
+When the checkpoint runs the Ranges-well-formed check
+Then it does NOT re-order or clamp the band
+And the command surfaces the failure and aborts without writing
+```
+
+### 10.5 Story — an empty cost snapshot produces a written cost-omitted record, not a refusal
+
+**As** a human running the command on today's repo (empty `observability/costs/`)
+**I want** a valid cost-omitted record written, not a refusal
+**So that** I get a grounded token + time estimate plus an honest "cost not yet
+knowable".
+
+```gherkin
+Given the /cost-estimate command dispatched against a valid spec target
+And MODEL_ROUTING.md is readable but observability/costs/ is empty
+When the agent returns a valid cost-omitted record (NOT a REFUSED string) and I accept
+Then a cost-omitted record is written to cost-estimates/<date>-<slug>-estimate.md
+And the cost-snapshot grounding entry's path is the directory "observability/costs/"
+    (trailing slash), and the review summary reports it as "no snapshot — cost
+    omitted (directory inspected, no snapshot found)", not as a snapshot grounding
+And the written record carries the UNGUARDED trailing-slash sentinel (no checklist
+    line keys on grounding_sources[].path shape) — a residual any other consumer
+    must apply the same trailing-slash test to avoid miscounting (recorded, O7)
+And cost_usd and cost_basis are omitted, the omission disclosed in Excluded
+And tokens and agent_compute_time are present as ranges and human_gate_time is the
+    qualitative caveat string
+```
+
+### 10.6 Story — the signature accepts one target, with an optional kind hint and out override
+
+**As** a human estimating different kinds of target
+**I want** `/cost-estimate <target> [--kind <kind>] [--out <dir>]` to accept a
+path or pasted task text, an explicit kind hint, and an output-directory override
+**So that** I can point it at a slice, a spec, a slicing record, or pasted text,
+disambiguate an ambiguous path, and choose where the record lands.
+
+```gherkin
+Given the /cost-estimate command
+When I pass a positional target that resolves to a readable file
+Then the command treats it as a path target and passes it to the agent as a path
+
+When I pass a positional target that does not resolve to a readable file
+Then the command treats it as inline task text and passes it to the agent as inline text
+
+When I pass --kind spec
+Then the command forwards "spec" to the agent as the explicit dispatch-stated kind
+And the agent uses it directly (no inference-basis line required)
+
+When I pass --out <dir>
+Then the record is written beneath <dir> with the derived
+    <date>-<slug>-estimate.md filename
+
+When I pass --out <dir> while the agent returns a cost-omitted record and I accept
+Then exactly one file is written, beneath <dir>, and the command confirms the full path
+```
+
+#### 10.6a Scenario — an asserted --kind is flagged in the review summary, not silently trusted (O4)
+
+```gherkin
+Given the /cost-estimate command invoked with --kind spec on a target that is really a slice fragment
+When the command summarises the validated record for disposition
+Then the review summary flags target_kind as HUMAN-ASSERTED (not agent-inferred)
+And it states that the asserted kind raised the tokens/time confidence ceiling to "high"
+    with no agent inference basis
+And it asks me to re-confirm the ceiling I raised before I dispose
+
+Given the /cost-estimate command invoked with NO --kind (the agent infers the kind)
+When the command summarises the validated record
+Then the summary carries the agent's inference-basis line as emitted (classified as <kind> by <signal>)
+And it does NOT show a human-asserted flag
+```
+
+#### 10.6b Scenario — re-run re-reads a newly-added snapshot (O8)
+
+```gherkin
+Given the /cost-estimate command has produced a cost-omitted record (observability/costs/ was empty)
+And I add a usable cost snapshot to observability/costs/ before disposing
+When I respond "re-run"
+Then the command re-dispatches the agent on the same target
+And the re-dispatch re-reads grounding afresh, including the now-populated observability/costs/
+And the re-validated, re-summarised record can now carry cost_usd grounded in the added snapshot
+```
+
+#### 10.6c Scenario — --out never silently overwrites an existing same-day estimate (O9)
+
+```gherkin
+Given a same-day estimate for the same target already exists beneath <dir>
+When I run /cost-estimate <same-target> --out <dir> on the same day and accept
+Then the command appends a short disambiguator to the derived filename
+And it notes the disambiguation in the confirm-before-write summary
+And the existing estimate is NOT overwritten
+```
+
+### 10.6d Story — a human edit is never silently reverted (O3)
+
+**As** a human who edits the draft on the `edit` disposition
+**I want** the post-edit checkpoint to validate and report, not silently fix my
+edit
+**So that** I remain the final author of the content I edited and no edit is
+reverted without my seeing and re-confirming it.
+
+```gherkin
+Given I chose "edit" and changed the validated draft in $EDITOR
+When the command runs the post-edit checkpoint in validate-and-report mode
+Then it does NOT apply fix-in-place to my edited content
+And if my edited record still deviates, it surfaces the remaining deviation in the re-prompt
+And it lets me decide (re-edit, accept where structurally valid, or abort)
+And no edit of mine is reverted without my seeing and re-confirming it
+```
+
+### 10.7 Story — the command joins the Output Validation Checkpoints discipline
+
+**As** a maintainer
+**I want** `/cost-estimate` listed in the CLAUDE.md Output Validation Checkpoints
+list and documented as a runnable command
+**So that** the checkpoint discipline is discoverable and the new command has a
+how-to guide and a reference entry.
+
+```gherkin
+Given the S3 change set
+When I read the CLAUDE.md Output Validation Checkpoints convention
+Then /cost-estimate appears in the list of commands with checkpoints
+
+And a how-to guide exists for /cost-estimate under
+    docs/plugins/ai-literacy-superpowers/how-to/
+And a reference entry documents the command signature, accepted targets, output
+    path, and validation checkpoint
+```
+
+## 11. Functional requirements
+
+| FR | Requirement |
+| --- | --- |
+| FR-1 | A new command file `ai-literacy-superpowers/commands/cost-estimate.md` exists with well-formed frontmatter (`name: cost-estimate`, a description) (§2.1, §9). |
+| FR-2 | The command signature is `/cost-estimate <target> [--kind <target-kind>] [--out <dir>]`; `--near` is not present; `--kind` accepts the four `target_kind` values (§4.1). |
+| FR-3 | The command accepts exactly one target per invocation, distinguishing path vs inline task text by filesystem resolution, matching the S2 agent's one-target-per-dispatch contract (§4.2). |
+| FR-4 | The command dispatches the S2 `cost-estimator` agent (it does not re-implement the methodology or re-classify the `target_kind`), forwarding any `--kind` as the explicit kind (§4.2, §5 step 2). |
+| FR-5 | On a `REFUSED:` agent output, the command surfaces the refusal verbatim, runs no checkpoint, writes no file, and aborts (§5.1). |
+| FR-6 | The command runs an Output Validation Checkpoint that checks the returned record against every line of the format reference's validation checklist — including the #377 per-stage cost coupling and split-tier strict-spread checks — fixing **only structural-only deviations** in place and **aborting (never authoring)** on any deviation that would create or alter a derived value (`cost_usd`, `cost_basis`, a range, a confidence tier, a `failure_direction`); it never re-dispatches the agent. The per-checklist-line disposition (fix vs abort) of §7.1a governs (§7.1, §7.1a). |
+| FR-6a | When the checkpoint changes anything at step 4, the review summary surfaces an explicit change-list (diff or itemised list) of exactly what the command altered vs the agent's emitted record; when it changes nothing, the summary says so. The human disposes over a transparent agent-content-vs-command-content composite (§5 step 5, §7.1a; O1). |
+| FR-6b | On the `edit` disposition the post-edit checkpoint runs in **validate-and-report** mode: it validates and reports remaining deviations but does NOT apply fix-in-place to human-edited content; a human edit is never reverted without the human seeing and re-confirming it (§5 step 6, §7.1b; O3). |
+| FR-7 | The checkpoint references `skills/cost-estimation/references/estimate-record-format.md` by path and does not inline or mutate its field/checklist definitions (§2.3, §7). |
+| FR-8 | The command shows a review summary of the validated record and asks for a disposition from the full vocabulary accept / edit / re-run / abort **before** any write (§5 steps 5–6). |
+| FR-8a | When `target_kind` was human-asserted via `--kind`, the review summary flags it prominently as asserted-not-inferred and states that the asserted kind raised the confidence ceiling with no agent inference basis, so the human re-confirms the ceiling raised; when the kind was agent-inferred, the summary carries the agent's inference-basis line as emitted (§4.1, §5 step 5; O4). |
+| FR-8b | The `re-run` disposition re-dispatches the agent as a full fresh dispatch that re-reads the grounding sources, including the now-populated `observability/costs/`, so the add-a-snapshot-then-re-run use case works (§5 step 6; O8). |
+| FR-9 | The command owns the single `Write`, performed only on `accept`, downstream of the human disposition (the dispose-then-write ordering invariant) (§5 step 7). |
+| FR-10 | The default output path is `cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md` — a top-level directory **outside `observability/`** (the telemetry/actuals tree); the command creates the directory if absent. No current `observability/` consumer would read it as an actual; the home is outside the telemetry root by design (§6.1; O5-home). |
+| FR-10a | `cost-estimates/` is gitignored by default: this slice adds a `cost-estimates/` line to `.gitignore` with a "derived, regenerable artefacts … Never committed" comment matching the existing `/diagnose` (`diagnostic-legibility/output/`) entry. Estimate records are derived, regenerable predictions, not a committed corpus (§6.1; O3). |
+| FR-11 | `--out <dir>` overrides the directory only; the derived filename still applies beneath it (§6.2). |
+| FR-11a | Same-day slug-collision disambiguation applies under both the default directory and `--out`; the command never silently overwrites an existing estimate (§6.1, §6.2; O9). |
+| FR-12 | The resolved output path is shown in the review summary so the human confirms content and destination before the write (§6.3). |
+| FR-13 | An empty `observability/costs/` produces a written cost-omitted record (not a refusal); the command never treats a cost-omitted record as a failure (§5.2, §10.5). |
+| FR-14 | The command honours the grounding-path trailing-slash consumer special-case in its OWN summary consumption (reporting a trailing-slash `cost-snapshot` entry as "no snapshot", not a grounding) without adding a new validation-checklist line to the format (§7.3). |
+| FR-14a | The spec records, as a named residual, that S3 ships the first persisted estimate records and that every cost-omitted one carries the **unguarded** trailing-slash sentinel — a known failure for any other consumer (S4/aggregators) that does not apply the same trailing-slash test (§7.3; O7). |
+| FR-15 | The #377-deferred absolute-rate check is **deferred further** with a recorded reason and re-filed as a standalone tracking issue **bound to a concrete slice number**: it is a **BLOCKING required deliverable of S6/#373**, which is extended to also own **first-snapshot capture** so the trigger is reachable (not keyed on an unscheduled "first cost-present record" event). S6 both captures the first `observability/costs/` snapshot and consumes it in the calibration loop, so it is the slice under which the first falsifiable cost-present record comes into existence (§7.2; O6, O4). |
+| FR-16 | `/cost-estimate` is added to the CLAUDE.md Output Validation Checkpoints command list (§7.4, §10.7). |
+| FR-17 | TDAD structural + behavioural scenarios exist under `tdad_tests/scenarios/commands/cost-estimate/`, graded by the deterministic oracles of §9 — including the structural-fix-boundary, edit-validate-and-report, and `--kind` assertion-flag oracles (§9). **Runnable-today vs synthetic-fixture split (O6):** scenarios exercised by a real grounding read on today's repo are the **runnable-today** ones (empty-snapshot cost-omitted §10.5, REFUSED §10.3, and the cost-omitted-record paths of §10.1/§10.4/§10.6); the **synthetic cost-present fixtures** are §10.4b (cost-present abort path) and §10.6b (re-run yielding a cost-present record), which pin a cost-present world the command's real grounding cannot produce until a snapshot lands and therefore **hand-author the very split-tier bands the deferred absolute-rate check (§7.2) would otherwise validate** (§9). |
+| FR-18 | The plugin version is bumped 0.43.0 → 0.44.0 across plugin.json, marketplace.json (entry + `plugin_version`), and the README badge, with a CHANGELOG entry; top-level marketplace `version` stays 0.4.0 (§2.1, §10). |
+| FR-19 | A how-to guide and a reference entry for `/cost-estimate` ship in the same PR (§10.7). |
+
+## 12. Open questions / ambiguities resolved
+
+- **`--near` vs the one-target contract.** The slice sketched
+  `[--near <path>]`, but the S2 agent accepts exactly one target per dispatch.
+  Resolved by **dropping `--near`** and adding `--kind` as the disambiguation
+  affordance (§4.1) — honouring the agent's contract rather than inventing a
+  second-target shape the agent cannot consume.
+- **Where checkpoint runs relative to the disposition.** `model-card create`
+  validates between `accept` and the write; the format reference says "fix
+  deviations in place". Resolved by running the checkpoint **before** the
+  disposition (§5 step 4) so the human disposes over a *validated* record, then
+  writing on `accept` — keeping the single Write downstream of the disposition.
+- **What "fix in place" may and may not do (O1, O2).** The phrase was
+  under-bounded. Resolved by the **structural-fix boundary** (§7.1a): the
+  checkpoint fixes **structural-only** deviations in place (routinely only the
+  removal of a stray verdict field) and **records every change** in the review
+  summary; it **aborts, never authors**, on any deviation that would create or
+  alter a derived value. The earlier "insert a missing `cost_basis`" example is
+  **removed** — inventing provenance is exactly what is forbidden, so a
+  cost-present record missing `cost_basis` now **aborts**.
+- **The edit path vs fix-in-place (O3).** Resolved by making the post-edit
+  checkpoint **validate-and-report** (§7.1b): step-4 fix-in-place applies to the
+  agent's fresh output; on the human-authored edit path the checkpoint reports but
+  never silently reverts.
+- **`--kind` raising the ceiling silently (O4).** Resolved by a review-summary
+  **asserted-not-inferred flag** (§4.1, §5) so a human-asserted kind that raised
+  the ceiling with no inference basis is surfaced for re-confirmation.
+- **The #377-deferred absolute-rate check (O6, O4).** #377 named S3 as its home.
+  Resolved by **deferring further with a recorded reason** (the check is dead
+  against today's cost-omitted-only records and needs its own adversarial pass on
+  re-derivation + tolerance) and **re-filing it bound to a concrete slice
+  number — a BLOCKING required deliverable of S6/#373**, per the AGENTS.md
+  natural-home-hand-off decision. The earlier revision keyed the trigger on "the
+  first slice that produces a cost-present record", but no scheduled slice produces
+  that event (O4); resolved by **extending S6 to also own first-snapshot capture**
+  so the trigger is reachable — S6 both captures the first `observability/costs/`
+  snapshot and consumes it, making it the slice under which the first falsifiable
+  cost-present record exists. S6/#373 now owns the absolute-rate check (§7.2).
+- **The grounding-path trailing-slash special-case (O7).** The reference flags it
+  as advisory/unenforced. Resolved by **not** adding a checklist line (a consumer
+  must not mutate the contract) while **honouring it where S3 itself consumes the
+  field** (the review summary), and **recording the residual** that S3 ships the
+  first records carrying the unguarded sentinel so S4/aggregators inherit a named
+  failure (§7.3).
+- **`re-run` and a mid-session snapshot (O8).** Resolved by stating that `re-run`
+  is a full fresh dispatch that re-reads `observability/costs/`, so adding a
+  snapshot and re-running picks it up (§5).
+- **Output directory (O5).** The earlier draft chose `observability/estimates/`
+  for symmetry with `/cost-capture`. Resolved by moving the default home to a
+  top-level **`cost-estimates/` directory, outside `observability/`** — predictions
+  do not belong under the telemetry/actuals root where a future scan could read
+  them as fact. Every current `observability/` consumer (harness-health,
+  cost-capture, observatory-verify + signal checklist, the hook scripts) was
+  checked and reads named subdirectories by specific filename patterns, not the
+  tree wholesale; moving the home outside `observability/` removes the conflation
+  at the source rather than relying on a marker a future scan could miss (§6.1).
+- **`--out` collision (O9).** Resolved by applying the same-day disambiguation
+  under `--out` too — the command never silently overwrites an existing estimate
+  (§6.2).
+- **Whether `cost-estimates/` is committed (O3).** The earlier draft left
+  gitignoring it a deferred docs-note. Resolved by **deciding it: gitignored by
+  default** — an estimate is a derived, regenerable prediction referencing a moving
+  target, the same artefact-kind as the `/diagnose` output the repo already
+  gitignores. This slice adds the `cost-estimates/` line to `.gitignore` (§6.1,
+  FR-10a). The staleness concern is moot once the corpus is regenerable rather than
+  committed.

--- a/docs/superpowers/stories/cost-estimate-command-design.md
+++ b/docs/superpowers/stories/cost-estimate-command-design.md
@@ -1,0 +1,543 @@
+---
+spec: docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md
+date: 2026-06-12
+mode: spec
+cartographer_model: claude-opus-4-8[1m]
+stories:
+  - id: 1
+    lens: [patterns, consequences]
+    title: Full vocabulary closes the /diagnose watch item
+    disposition: promoted
+    disposition_rationale: >
+      Promoted. S3 shipped the full accept/edit/re-run/abort vocabulary, so the
+      /diagnose accept/abort narrowing did NOT recur — the AGENTS.md agent-emit
+      decision's watch item is marked RESOLVED (the divergence was a one-off, not
+      a convention). A future reader should not re-litigate /diagnose's two-verb
+      form as the norm.
+  - id: 2
+    lens: [patterns, forces]
+    title: Checkpoint as a second derived-judgment discloser
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. The checkpoint as a second derived-judgment discloser
+      (structural-only fix, change-list, abort-on-author; edit = validate-and-
+      report) is a sound extension of disclosure-of-derived-judgment to a second
+      mutating actor in the same record.
+  - id: 3
+    lens: [forces, alternatives]
+    title: Predictions exiled from the actuals tree
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Filing predictions outside observability/ (the actuals tree)
+      removes the estimate-as-fact conflation at the source rather than via a
+      guard marker every future scan must remember.
+  - id: 4
+    lens: [defaults, alternatives]
+    title: Estimates inherit the /diagnose gitignore default
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Estimates gitignored by default, inheriting the /diagnose
+      derived-output convention; the staleness concern is moot once the corpus is
+      regenerable rather than committed.
+  - id: 5
+    lens: [forces, alternatives]
+    title: One target swallows the --near hint
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. --near dropped for --kind to honour the agent's one-target
+      contract rather than splice a composite input from the consumer seat; if
+      the nearby-grounding use case resurfaces it is an agent-contract change.
+  - id: 6
+    lens: [patterns, forces]
+    title: Asserted --kind buys disclosure, not silence
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. An asserted --kind is flagged in the review summary
+      (asserted-not-inferred, raised ceiling, no basis) — disclosure over a silent
+      ceiling-raise; the command discloses but never re-classifies (pure consumer).
+  - id: 7
+    lens: [patterns, consequences]
+    title: A deferred check bound to a deliverable, not a wish
+    disposition: promoted
+    disposition_rationale: >
+      Promoted. Sharpens the AGENTS.md re-file decision: re-filing a hand-off must
+      bind to a SCHEDULED deliverable (a slice that produces the triggering event),
+      not merely "filed somewhere" keyed on an unscheduled trigger —
+      re-file-to-an-unbound-issue is itself a buck-pass. Second worked instance
+      (after #350). Folded into the existing re-file ARCH_DECISION.
+  - id: 8
+    lens: [forces, consequences]
+    title: Honouring a special-case without enforcing it
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. Honouring the trailing-slash special-case only where the command
+      consumes the field (not adding a checklist line) correctly applies
+      own-the-contract; the residual is recorded in the spec for other consumers.
+  - id: 9
+    lens: [coherence]
+    title: Pure-consumer discipline as the spine
+    disposition: accepted
+    disposition_rationale: >
+      Accepted. The pure-consumer-discipline spine is the coherent organising
+      principle of the spec; recorded so a future change to S3 has a spine to be
+      evaluated against ("does this make the command mutate or re-derive a
+      contract it consumes?").
+---
+
+## Story #1 — Full vocabulary closes the /diagnose watch item
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§5 step 6, §1)
+**Lens:** patterns / consequences
+**Refs:** —
+
+**Context.** S3 is a command-surface dispatcher in the
+agent-emit/dispatcher-persist/human-disposes architecture — the first since
+`/diagnose`. The architecture's named disposition vocabulary is
+accept/edit/re-run/abort. `/diagnose` shipped only accept/abort, and AGENTS.md
+logged that narrowing as an explicit watch item: "if that narrowing recurs on
+the next command spec, the divergence may warrant its own sub-rule." S3 is that
+next command spec.
+
+**Forces.** Minimalism (two verbs is a smaller surface to specify, test, and
+explain) versus fidelity to the named architecture (the four-verb vocabulary is
+what makes the human a genuine author rather than a yes/no gate). `/diagnose`
+resolved toward minimalism and bought a watch item. S3 had the standing option
+to inherit the narrowed precedent and call it consistency.
+
+**Options not taken.**
+- *Inherit /diagnose's accept/abort* — treat the most recent precedent as the
+  living convention and narrow with it. This is the path the watch item was
+  written to detect.
+- *A different reduced set* (accept/re-run/abort, dropping edit) — plausible if
+  the record were considered too structured to hand-edit safely.
+- *Defer the vocabulary question to S4's orchestrator fold-in* — let the
+  standalone surface ship narrow and widen later.
+
+**Choice as written.** S3 ships the full accept/edit/re-run/abort vocabulary and
+says so against the watch item by name (§1, §5): it "deliberately ships the full
+accept/edit/re-run/abort vocabulary rather than the narrowed accept/abort
+`/diagnose` shipped." This is a decision that *closes* a watch item rather than
+opening one — the divergence does not recur, so the sub-rule the watch item
+contemplated is not provoked.
+
+**Consequences.** Each verb carries a downstream obligation the spec then has to
+honour: `edit` forces the validate-and-report reconciliation (Story #2), and
+`re-run` forces the fresh-grounding semantics that make add-a-snapshot-then-re-run
+work. The full vocabulary is not free — it is what makes those two seams
+load-bearing. The narrowed precedent could have ducked both. Choosing the full
+set means S3 owns the harder edit/re-run design rather than the simpler gate.
+
+**Pattern.** A worked instance of the agent-emit/dispatcher-persist/human-disposes
+architecture (AGENTS.md), specifically resolving toward the canonical vocabulary
+where the immediately prior instance diverged. The live question this instance
+answers is not "is this a pattern" but "does the pattern hold its full shape
+under the pull of the most recent narrower precedent."
+
+**Notes.** Promotion candidate: an explicit AGENTS.md note that the watch item is
+*resolved* (S3 did not narrow) would stop a future reader re-litigating whether
+`/diagnose`'s two-verb form is the convention.
+
+## Story #2 — Checkpoint as a second derived-judgment discloser
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§7.1a, §7.1b, §5 step 5)
+**Lens:** patterns / forces
+**Refs:** O1, O2
+
+**Context.** The disclosure-of-derived-judgment contract was written for the
+*agent* that derives a value a human once supplied. S3 introduces a second actor
+into the same record: the Output Validation Checkpoint, run by the command, may
+alter the agent's emitted record before the human disposes. The spec draws a
+boundary — the checkpoint may fix structural-only deviations in place but never
+authors a derived value, and it surfaces a change-list of exactly what it altered.
+
+**Forces.** Convenience of a self-healing checkpoint (silently fix the record so
+the human sees a clean draft) versus the integrity of what the human disposes
+over (the `accept` must ratify a composite whose seams are visible). A checkpoint
+that silently completes the agent's record would manufacture exactly the
+correctness risk the four-part disclosure exists to contain — only now a *third*
+party (the command) is the one over-reaching, invisibly. The spec resolves toward
+transparency: structural-only fixes, recorded; everything that would touch a
+derived value aborts.
+
+**Options not taken.**
+- *Self-healing checkpoint* — complete missing `cost_basis`, clamp inverted
+  ranges, widen collapsed bands. The spec explicitly removed its own earlier
+  "insert a missing `cost_basis`" example as the inversion of the rule.
+- *No fix at all — abort on every deviation* — simpler and unimpeachable, but
+  loses the cheap structural recovery (a stray verdict field) that costs nothing
+  to the human's judgment.
+- *Fix silently, no change-list* — the path that would have re-created the
+  pre-diaboli /diagnose ordering defect in a new disguise.
+
+**Choice as written.** The checkpoint is the disclosure contract applied to a
+second actor: it fixes only what authors nothing (routinely just deleting a
+forbidden field), records every change in the review summary, and aborts rather
+than author on any derived-value defect. The `edit` path inverts the rule by
+authorship (§7.1b): once the human edits, the content is theirs, so the
+post-edit run is validate-and-report — a human edit is never silently reverted.
+
+**Consequences.** As the diaboli noted (O2), the structural-only boundary
+collapses the change-list's reachable content to essentially one case — a deleted
+verdict field — so the elaborate diff apparatus discloses "nothing" or "one
+deletion" almost always. That is a recorded yield-versus-machinery tension, not a
+correctness defect; the disclosure obligation is honest even where its yield is
+thin. The forward consequence the cartographer adds: once cost-present records
+exist, the abort branches (currently dormant) become the dominant behaviour, and
+the change-list stays narrow precisely because the spec chose abort over author.
+
+**Pattern.** The disclosure-of-derived-judgment contract (AGENTS.md), extended
+from the deriving agent to a *second mutating actor* in the same artefact
+lifecycle. This is a genuinely new surface for the contract — prior instances
+disclosed an agent's own derivation; this discloses one actor's edits to
+another's derivation.
+
+**Notes.** O1 (round 2) sharpened the boundary by collapsing the time-split row
+to a clean abort, eliminating the one row where two implementers could have drawn
+structural-vs-derived differently. The boundary is now uniform across all nine
+checklist lines save the single fix line.
+
+## Story #3 — Predictions exiled from the actuals tree
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§6.1)
+**Lens:** forces / alternatives
+**Refs:** —
+
+**Context.** The earlier draft filed estimates under `observability/estimates/`,
+a sibling of `observability/costs/`, "for symmetry" with `/cost-capture`. S3
+moves the default home to a new top-level `cost-estimates/` directory,
+deliberately outside `observability/`, on the ground that `observability/` is the
+telemetry/actuals tree and an estimate is a forward-looking guess.
+
+**Forces.** Discoverable symmetry (a reader who finds `/cost-capture`'s output
+should find `/cost-estimate`'s next to it) versus data-kind integrity (a
+prediction filed under the actuals root invites a future scan to read a guess as
+an observed fact). The spec resolves the tension by *naming* rather than
+*co-location*: `observability/costs/` (actuals) and `cost-estimates/`
+(predictions) read as siblings-by-name without sharing a scanned root.
+
+**Options not taken.**
+- *`observability/estimates/` for symmetry* — the rejected earlier draft;
+  co-locates two different data kinds under one tree.
+- *`observability/estimates/` plus a guard marker* — keep the symmetry, add a
+  sentinel every tree-wide scan must honour. Rejected because the guarantee then
+  depends on every *future* consumer remembering the marker — a standing
+  obligation a new scan can silently miss.
+- *Bury it under an existing non-telemetry tree* (e.g. `docs/`) — loses the
+  retrospective/prospective pairing entirely.
+
+**Choice as written.** Move the home outside `observability/` and remove the
+conflation at the source: predictions are not telemetry, so they do not live
+under the telemetry root, and no `observability/` scan can misread an estimate
+because no estimate is under `observability/` at all. The spec backs this with a
+read of every current `observability/` consumer, confirming none globs the tree
+wholesale today — then argues that "no consumer mis-reads it today" is the weaker
+guarantee, and chooses the structural fix over the temporal one.
+
+**Consequences.** The discoverable pair now rests on a naming convention
+(`costs/` ↔ `cost-estimates/`) rather than directory adjacency, so a future
+reorganisation of `observability/` will not automatically carry the estimate home
+with it. The capability also acquires a *second* new top-level directory in the
+repo root, a small cost to root-level tidiness accepted in exchange for
+kind-integrity.
+
+**Pattern.** —
+
+## Story #4 — Estimates inherit the /diagnose gitignore default
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§6.1, FR-10a)
+**Lens:** defaults / alternatives
+**Refs:** O2, #3
+
+**Context.** Having moved the output home out of `observability/` (Story #3), S3
+faces a fresh question the earlier draft left as a deferred docs-note: is
+`cost-estimates/` committed to version control? S3 decides it explicitly —
+gitignored by default — and adds the `.gitignore` line in this slice.
+
+**Forces.** Inspectability (a committed estimate is reviewable in a PR, citable,
+durable) versus regenerability and staleness (an estimate's `target` may point at
+an unmerged spec or a since-renamed slice, so a committed corpus drifts into a
+body of stale guesses with no invalidation rule). The default chosen resolves
+toward regenerability.
+
+**Options not taken.**
+- *Committed by default* — the earlier draft's de-facto posture ("inspectable
+  artefacts"), which the diaboli flagged as committing a growing corpus of stale
+  guesses with no staleness or rotation story.
+- *Committed with a rotation/TTL policy* — keep the corpus but bound its
+  staleness; more machinery than a regenerable artefact warrants.
+- *Leave it a docs-note* — the deferred non-decision the spec explicitly
+  replaces with a decision.
+
+**Choice as written.** The default's source is named, which is the cheapest
+cognitive-debt payment available: the repo *already* gitignores the directly
+analogous `/diagnose` output (`diagnostic-legibility/output/`) as "derived,
+regenerable artefacts … Never committed," and an estimate is the same artefact
+kind. S3 does not invent a policy; it inherits an established one and says so.
+The staleness concern is thereby moot — regenerable-on-demand, not committed.
+
+**Consequences.** A human who wants a specific estimate retained must commit it
+explicitly or write it elsewhere via `--out` — retention becomes an opt-in act
+rather than the default. This forecloses any future workflow that assumes
+estimates are present in a fresh checkout (CI that reads the estimate corpus, a
+reviewer browsing committed estimates), but no such workflow exists today and S4
+is the slice that would introduce one.
+
+**Pattern.** An inherited default whose source is a sibling convention rather
+than a framework — the highest-value kind to name, because the source
+(`/diagnose`'s gitignore rationale) is non-obvious to a reader who has not met
+that entry. Builds on the home-relocation of #3: the gitignore default only makes
+sense once predictions are understood as derived/regenerable rather than as
+actuals.
+
+## Story #5 — One target swallows the --near hint
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§4.1, §12)
+**Lens:** forces / alternatives
+**Refs:** —
+
+**Context.** The slicing record sketched the signature as
+`/cost-estimate "<task>" [--near <path>] [--out <dir>]` — a primary target plus a
+"nearby grounding hint." The merged S2 agent accepts exactly one target per
+dispatch, with no target-plus-neighbour shape. S3 drops `--near` and adds
+`--kind` in its place.
+
+**Forces.** Fidelity to the slice sketch (the author imagined a nearby-context
+affordance) versus fidelity to the merged agent's contract (one target, no
+second-target slot). The command is a pure consumer of the agent; honouring the
+agent's contract means the signature cannot offer an input shape the agent cannot
+consume. The spec resolves toward the contract and treats the sketch as
+provisional.
+
+**Options not taken.**
+- *Keep `--near` and have the command splice the hint into the target* — would
+  make the command author a composite input, mutating the agent's
+  one-target contract from the consumer seat (the very thing §2.3 forbids).
+- *Keep `--near` and pass it as a second dispatch* — two dispatches per
+  invocation, a different cost and grounding model the agent was not designed for.
+- *Keep `--near` as a no-op* — honour the sketch's syntax while ignoring it; a
+  signature that lies about what it does.
+
+**Choice as written.** `--near` is dropped; `--kind` replaces it as the
+disambiguation affordance and maps cleanly onto the agent's explicit-kind rule.
+The reconciliation is explicit (§12): the sketch's two-input shape is rejected
+because the agent accepts one target, and the new flag is chosen *because* it
+lands on a rule the agent already has.
+
+**Consequences.** The "estimate this task, grounded in that nearby slice"
+use case the sketch implied has no home in S3 — a human who wants that must
+choose a single richer target instead. Whether that use case was real or an
+artefact of the sketch is now a closed question; if it resurfaces, it is a new
+agent-contract change owned by the agent's slice, not a command flag.
+
+**Pattern.** —
+
+## Story #6 — Asserted --kind buys disclosure, not silence
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§4.1, §5 step 5)
+**Lens:** patterns / forces
+**Refs:** O1, #2
+
+**Context.** An explicit `--kind` does two things: it suppresses the agent's
+inference-basis disclosure line (the human asserted the kind, so the agent infers
+nothing) *and* it raises the tokens/time confidence ceiling
+(`task-text`→`low` … `spec`→`high`). A human who asserts `--kind spec` on a file
+that is really a slice fragment thereby obtains a high-ceiling estimate with no
+disclosed inference basis. S3 makes the review summary flag the asserted kind as
+asserted-not-inferred.
+
+**Forces.** Ergonomics of a single disambiguation flag (let the human override
+the agent's classification cheaply) versus the integrity of the confidence
+ceiling (an override that silently raises the ceiling is exactly the silent
+over-claim the inference-disclosure contract exists to prevent). The flag's two
+effects pull apart: one is benign (telling the agent the kind), one is dangerous
+(buying a higher ceiling with no basis). The spec keeps the flag and neutralises
+the danger by disclosure rather than by removing the ceiling-raise.
+
+**Options not taken.**
+- *Trust the flag silently* — the pre-diaboli posture; an asserted kind buys the
+  ceiling with no flag, the silent over-claim.
+- *Let `--kind` set the kind but not raise the ceiling* — keep the
+  classification override, deny it the confidence benefit. Rejected implicitly:
+  the ceiling is a property of the kind, so asserting the kind asserts the
+  ceiling.
+- *Have the command re-classify to check the human* — would make the command
+  re-derive the agent's judgment, breaking the pure-consumer split (Story #9).
+
+**Choice as written.** The command is a pure consumer of the agent's
+classification (it does not re-classify), but it *owns the review summary*, so it
+carries the disclosure the suppressed inference-basis line would otherwise have
+carried: a prominent asserted-not-inferred flag stating the raised, basis-free
+ceiling and asking the human to re-confirm the ceiling they raised. The human
+disposes over a visible assertion, not a silent one.
+
+**Pattern.** The disclosure-of-derived-judgment contract again — here applied not
+to a derived value but to a *human-supplied override that suppresses* the agent's
+own derivation. The command becomes the discloser-of-last-resort precisely
+because the override silenced the agent's discloser. Same contract as #2, a
+distinct surface: #2 discloses a second actor's *edits*; this discloses a human's
+*assertion* standing in for the agent's inference.
+
+## Story #7 — A deferred check bound to a deliverable, not a wish
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§7.2, FR-15)
+**Lens:** patterns / consequences
+**Refs:** O1
+
+**Context.** The #377 format reference named "S3's Output Validation Checkpoint"
+as the natural home for the snapshot-grounded absolute-rate falsification check.
+S3 declines to build it (dead code against today's cost-omitted-only records) but
+does not leave the concern implicit — it re-files the check as a standalone issue
+and binds it to S6/#373 as a blocking required deliverable, extending S6 to also
+own first-snapshot capture so the trigger is reachable.
+
+**Forces.** YAGNI against a closed-world record set (the check is meaningless
+until a cost-present record exists, which today's empty `observability/costs/`
+cannot produce) versus the deferred-concern-accretion debt that accrues when a
+named home declines an inherited hand-off and the concern falls through the gap.
+The spec resolves both: defer the build (YAGNI) *and* commit the home
+(anti-orphaning).
+
+**Options not taken.**
+- *Build the absolute-rate check now* — dead code against every record the
+  command can currently emit, and it duplicates the agent's rate-derivation
+  surface the read-only/dispatcher split exists to keep in one place.
+- *Re-file to a fresh unbound issue* — a tracking home with no slice committed to
+  build it; the diaboli (round 2, O4) caught the earlier revision keying the
+  trigger on "the first cost-present record," an event no scheduled slice
+  produces — so the check could orphan exactly as feared.
+- *Leave it in S3's "out of scope" note* — the implicit-in-a-closed-slice path
+  the re-file rule explicitly forbids.
+
+**Choice as written.** Two acts, not one: re-file with its own lifecycle, *and*
+bind to a concrete slice number. Critically, the binding is made reachable by
+extending S6's deliverables to include capturing the first `observability/costs/`
+snapshot — so S6 is the slice under which the first falsifiable cost-present
+record comes into existence, and the check travels with snapshot-capture if the
+roadmap reassigns it. The trigger is a named slice, not an unscheduled event.
+
+**Consequences.** S6's scope grew: it now owns first-snapshot capture *and* the
+calibration loop *and* the absolute-rate check — three deliverables bound
+together because the check needs the snapshot the loop needs. If S6 later proves
+too large, the snapshot-capture deliverable is the natural split point, and the
+check follows it. The reachability fix trades a larger S6 for a trigger that
+actually fires.
+
+**Pattern.** The re-file-do-not-leave-implicit decision (AGENTS.md "natural-home
+hand-off does not bind slice N+1"), with the round-2 sharpening that re-filing to
+an *unbound* issue is itself a buck-pass — the home must be a deliverable the
+roadmap schedules, not a precondition it never causes. This is a second worked
+instance of that decision (after the #350 re-file), and it tightens the rule:
+"re-file with its own lifecycle" now means "bound to a slice that produces the
+triggering event," not merely "filed somewhere."
+
+**Notes.** Promotion candidate: the sharpening (re-file must bind to a
+*scheduled* deliverable, not an unscheduled trigger) is a refinement of the
+existing AGENTS.md decision worth folding back into it.
+
+## Story #8 — Honouring a special-case without enforcing it
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§7.3, FR-14, FR-14a)
+**Lens:** forces / consequences
+**Refs:** #7
+
+**Context.** The #377 reference adds an advisory, unenforced consumer
+special-case: a `cost-snapshot` grounding entry whose `path` ends in `/` is the
+directory sentinel for looked-and-found-nothing and must not be counted as a real
+grounding. No validation-checklist line keys on `grounding_sources[].path` shape.
+S3 neither adds such a line nor ignores the special-case — it honours the test in
+the one place the command itself consumes the field (the review summary).
+
+**Forces.** Completeness (add the missing checklist line so every record is
+machine-guarded) versus the own-the-contract discipline (a consumer that adds a
+validation rule is mutating the format it consumes). The spec resolves toward the
+discipline: it declines to add the line because that is the format-owning slice's
+job, while refusing to be the consumer that itself miscounts.
+
+**Options not taken.**
+- *Add the checklist line in S3* — guards every record, but mutates the merged
+  format from a consumer seat (forbidden by §2.3 / the consumer-never-mutates
+  decision).
+- *Ignore the special-case entirely* — the command's own summary would then
+  report a directory sentinel as a real snapshot grounding, making the command
+  the first consumer to fall into the trap it knows about.
+- *Add the line and file it as a separate format-owning slice in the same PR* —
+  conflates two slices' ceremony; the format change deserves its own adversarial
+  pass.
+
+**Choice as written.** S3 honours the special-case only at its own consumption
+point — reporting a trailing-slash entry as "no snapshot — directory inspected,
+no snapshot found," not a grounding — and records the residual (FR-14a): S3 ships
+the *first* persisted estimate records, every cost-omitted one carrying the
+unguarded sentinel, so any other consumer that omits the same trailing-slash test
+silently miscounts.
+
+**Consequences.** The protection is per-consumer and easy to omit: S4's
+orchestrator fold-in and any future aggregator inherit a named failure rather
+than a machine-enforced guard. The spec converts what would have been later
+cartographer archaeology into a recorded residual in the spec itself — the
+honest move, but one that accepts a standing per-consumer obligation until the
+format-owning slice adds the line. The choice is coherent only because S3 holds
+the pure-consumer line elsewhere too (Story #9); honouring-where-I-consume and
+declining-to-mutate are the same discipline applied to one field.
+
+**Pattern.** The consumer-never-mutates-the-contract decision (AGENTS.md), here
+producing the unusual posture of *honouring an obligation the consumer refuses to
+encode as a rule*. Pairs with #7: both are the own-the-contract discipline
+deciding what S3 may and may not do to a contract it consumes — #7 about a
+deferred check's home, this about an unenforced special-case.
+
+## Story #9 — Pure-consumer discipline as the spine
+
+**Source:** `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (§2.3, §4.2, §7, §7.2, §7.3)
+**Lens:** coherence
+**Refs:** #5, #6, #7, #8
+
+**Context.** S3 makes a dozen distinct decisions — signature, output home,
+gitignore, checkpoint boundary, asserted-kind disclosure, deferred-check homing,
+trailing-slash handling. Read individually they could look like a bag of
+independent choices. Read together they resolve along a single axis: S3 is a pure
+consumer of the S1 format and the S2 agent, and every contested decision is
+settled by asking what a consumer may and may not do.
+
+**Forces.** The recurring tension across the whole spec is consumer-reach versus
+contract-integrity. Each decision faced a tempting move that would have widened
+the command's reach by mutating or re-deriving a contract it consumes; each was
+declined on the same ground. The coherence question is whether the load-bearing
+reason behind the individual choices is one principle or several.
+
+**Options not taken (as a whole-document posture).**
+- *Treat the command as the capability's integration point* — let it splice a
+  `--near` neighbour (#5), re-classify the kind to check the human (#6), add the
+  missing checklist line (#8), build the absolute-rate check (#7). Each would have
+  made the command richer and the contracts dirtier.
+- *Settle each decision on its own local merits* — produce a coherent-looking
+  command with no spine, where the next change has nothing to be evaluated
+  against.
+
+**Choice as written.** The spec is coherent under one reading: S3 is a pure
+consumer, and the consumer-never-mutates-the-contract decision is the spine that
+settles the otherwise-independent choices. `--near` dropped because the agent
+takes one target (#5); the command never re-classifies, it only disambiguates and
+discloses (#6); the absolute-rate check is re-filed to the format/snapshot-owning
+slice rather than built here (#7); the trailing-slash line is honoured-where-
+consumed but not added to the format (#8). The checkpoint fixes structural-only
+and aborts on derived values for the same reason — it consumes the agent's
+judgment, it does not author it (#2). Each decision is the same principle applied
+to a different field.
+
+**Consequences.** The coherence is real and is the spec's chief virtue: a future
+change to S3 has a spine to be evaluated against ("does this make the command
+mutate or re-derive a contract it consumes?"). The cost the spine accepts is that
+several genuine improvements (the missing checklist line, the absolute-rate
+check) live elsewhere or later, so the capability is only complete once the
+owning slices act — S3 is deliberately not the place those land.
+
+**Pattern.** "Quality without a name" (Alexander) applied to decisions: the spec
+reads as one decision made repeatedly rather than many decisions made once. The
+named pattern underneath is the consumer-never-mutates-the-contract architecture
+(AGENTS.md), here operating as the organising principle of an entire spec rather
+than a single rule invoked once.
+
+**Notes.** This is the one coherence story in the set, emitted because the
+pure-consumer spine is genuinely visible across five or more otherwise-independent
+decisions — not because every set needs a sixth-lens entry.

--- a/tdad_tests/scenarios/commands/cost-estimate/checkpoint-377-checks.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/checkpoint-377-checks.md
@@ -1,0 +1,67 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-377-bands
+---
+
+# Scenario: the checkpoint enforces the #377 per-stage coupling and split-tier strict-spread checks
+
+## Given
+
+A fixture repository pinning the **agent's returned record** to several
+per-stage-cost shapes so the checkpoint's #377 checks (spec §7.1 lines 2–3) can
+be exercised deterministically:
+
+1. A **cost-present** record with a **split-tier** per-stage band — its
+   `model_tier` **contains a `/`** — whose band is **collapsed** (`low == high`).
+2. A cost-present record with a split-tier per-stage band that is **non-collapsed**
+   (`low < high`).
+3. A **cost-omitted** record carrying a **per-stage `cost_usd` band** while the
+   top-level `cost_usd` is **absent** (the incoherent per-stage-coupling inverse).
+4. A cost-omitted record with **no per-stage bands** at all.
+
+Shapes 1–3 are **synthetic cost-present / cost-band fixtures** — they hand-author
+the very split-tier bands the deferred absolute-rate check (spec §7.2) would
+otherwise validate; the command's real grounding cannot produce a cost-present
+band against today's empty `observability/costs/` (spec §10.4; FR-6).
+
+## When
+
+The command runs its Output Validation Checkpoint over each pinned record.
+
+## Then
+
+The **#377-check oracle** asserts:
+
+- **Shape 1 (collapsed split-tier band)** — the **split-tier strict-spread check
+  FAILS** (a `/`-tier per-stage band with `low == high` is not allowed); the
+  command aborts without writing (widening would author a spread — a
+  derived-value defect).
+- **Shape 2 (non-collapsed split-tier band)** — the split-tier strict-spread
+  check **PASSES** (`low < high` on the `/`-tier stage).
+- **Shape 3 (per-stage band on a cost-omitted record)** — the
+  **per-stage-coupling check FAILS** (a per-stage band requires a top-level
+  `cost_usd`); the command aborts without writing.
+- **Shape 4 (no per-stage bands)** — both checks **pass vacuously**.
+
+## Rubric
+
+Layer 3 behavioural, graded by the **#377-check oracle** on pinned fixtures
+(spec §9): the split-tier strict-spread check fails on a collapsed `/`-tier band
+and passes on a non-collapsed one; the per-stage-coupling check fails on a
+per-stage band atop a cost-omitted record and passes vacuously with no bands.
+Each band shape is fixture-pinned. The oracle never asserts exact cost numbers —
+only the pass/fail outcome of each check and the no-file consequence of the
+failing-check aborts.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner pins each per-stage-cost record shape as the agent's returned string,
+runs the checkpoint, and asserts the named check passes or fails as above, and
+that a failing #377 check aborts the flow with no file written.

--- a/tdad_tests/scenarios/commands/cost-estimate/checkpoint-fix-boundary.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/checkpoint-fix-boundary.md
@@ -1,0 +1,72 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-checkpoint-boundary
+---
+
+# Scenario: the checkpoint fixes structural-only + records it, and aborts (never authors) on a derived-value defect (O1/O2)
+
+## Given
+
+A fixture repository pinning the **agent's returned record** to several shapes so
+the checkpoint's structural-fix boundary (spec §7.1a) can be exercised
+deterministically. The grounding (`MODEL_ROUTING.md` tables, target) is held
+fixed; only the pinned record shape varies:
+
+1. A record carrying a **stray `verdict` field** in the frontmatter (a
+   structural-only defect — a forbidden field whose removal authors nothing).
+2. A **clean** record the checkpoint need not touch.
+3. A **cost-present** record that is **MISSING `cost_basis`** (a derived-value
+   defect — supplying `cost_basis` would assert provenance the agent did not
+   state).
+4. A record with a **`low > high` range** (a derived-number defect).
+
+Shapes 3 and 4 are **synthetic cost-present / derived-defect fixtures** — they
+hand-author a record shape the command's real grounding cannot produce against
+today's empty `observability/costs/`; they exist to pin the abort-never-author
+behaviour, not to be produced by a grounded emit (spec §10.4a, §10.4b; FR-6,
+FR-6a).
+
+## When
+
+The command runs its Output Validation Checkpoint over each pinned record.
+
+## Then
+
+The **structural-fix-boundary oracle** asserts:
+
+- **Shape 1 (stray `verdict`, structural-only)** — the `verdict` field is
+  **removed** from the validated record, AND the review summary's **change-list
+  names the deletion** (the agent-content-vs-command-content provenance is
+  surfaced). On `accept`, the written file carries no `verdict` field.
+- **Shape 2 (clean)** — the review summary states **"no checkpoint changes —
+  record as emitted by the agent"** (the change-list is empty).
+- **Shape 3 (cost-present missing `cost_basis`, derived-value)** — the command
+  **aborts without writing**: **no file** is written under the resolved path, and
+  the validated record has **no `cost_basis` authored** (the checkpoint did not
+  invent provenance). The failing checklist line (Cost pairing) is surfaced.
+- **Shape 4 (`low > high` range, derived-number)** — the command **aborts
+  without writing**: **no file** is written, and the range is **not** re-ordered
+  or clamped (no derived number is altered).
+
+## Rubric
+
+Layer 3 behavioural, graded by the **structural-fix-boundary oracle** (spec §9):
+field-removed + named-in-change-list for the structural-only defect; "no
+checkpoint changes" for the clean record; no-file + no-authored-field for each
+derived-value defect. Each record shape is fixture-pinned. The oracle never
+asserts the exact change-list prose — only that the named field was removed and
+listed, or that no file was written and no derived value was authored.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner pins each of the four record shapes as the agent's returned string,
+runs the checkpoint, and asserts: removal + change-list entry for shape 1; empty
+change-list ("no checkpoint changes") for shape 2; no-file + absent `cost_basis`
+for shape 3; no-file + unaltered range for shape 4.

--- a/tdad_tests/scenarios/commands/cost-estimate/command-structure.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/command-structure.md
@@ -1,0 +1,103 @@
+---
+component: cost-estimate
+component_type: command
+tier: structural
+---
+
+# Scenario: /cost-estimate ships as a dispose-then-write dispatcher — structure and flow
+
+## Given
+
+The `/cost-estimate` command is S3 of the cost-estimator capability
+(spec `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md`).
+It is the **human-facing manual dispatcher** for the read-only S2 `cost-estimator`
+agent: it parses one target, dispatches the agent, handles a `REFUSED:` output
+(writes nothing), runs an **Output Validation Checkpoint** against the S1 format
+reference, summarises the validated record for a human disposition, and performs
+its **single Write** only after the human returns `accept` — downstream of the
+disposition (the AGENTS.md dispose-then-write ordering invariant).
+
+This scenario fixes the structural contract the single command file must satisfy
+(spec §4, §5, §6, §7; FR-1, FR-2, FR-4, FR-6, FR-7, FR-8, FR-9, FR-10, FR-16).
+
+## When
+
+The command file at `ai-literacy-superpowers/commands/cost-estimate.md` is read
+directly from the filesystem.
+
+## Then
+
+**Frontmatter** (`FR-1`):
+
+- **YAML frontmatter present** with `name: cost-estimate` and a non-empty
+  `description` — required by the `All frontmatter has name and description`
+  HARNESS constraint. The description frames the command as the prospective
+  sibling of `/cost-capture` (estimate a target's tokens/time/cost before it
+  runs).
+
+**Signature** (`FR-2`):
+
+- The body documents the signature `/cost-estimate <target> [--kind <target-kind>]
+  [--out <dir>]` — one required positional `<target>`, an optional `--kind`, an
+  optional `--out`.
+- `--near` is **absent** — the S2 agent accepts exactly one target per dispatch,
+  so the slice's loose `--near` sketch is dropped.
+- `--kind` is documented as accepting the four `target_kind` values
+  (`task-text` | `slicing-record` | `slice` | `spec`).
+
+**Dispatch → checkpoint → dispose → write flow** (`FR-4`, `FR-8`, `FR-9`):
+
+- The process documents the flow in this order: **parse/resolve target →
+  dispatch the `cost-estimator` agent → handle REFUSED (no write) → Output
+  Validation Checkpoint → review summary → ask disposition → on accept, write
+  once**.
+- The body states the command **dispatches the S2 `cost-estimator` agent** and
+  does **not** re-implement the methodology or re-classify the `target_kind`
+  itself (it only distinguishes path vs inline text, and forwards any `--kind`).
+- The disposition vocabulary is the **full** `accept` / `edit` / `re-run` /
+  `abort` (not a narrowed accept/abort).
+- The body states the **single Write** occurs **only on `accept`** and
+  **after** the human disposition — the dispose-then-write ordering invariant,
+  with a cross-reference to the AGENTS.md agent-emit/dispatcher-persist decision.
+
+**Output Validation Checkpoint section** (`FR-6`, `FR-7`):
+
+- The checkpoint section **references**
+  `skills/cost-estimation/references/estimate-record-format.md` **by path** and
+  does **not** inline or mutate its field/checklist definitions.
+- It enumerates the format reference's validation checklist lines, **including
+  the #377 per-stage cost coupling and split-tier strict-spread checks**.
+- It documents the **structural-fix boundary**: the checkpoint fixes only
+  **structural-only** deviations in place (routinely only deleting a stray
+  `recommendation`/`verdict`/`proceed` field) and **records every change**;
+  it **aborts, never authors**, on any deviation that would create or alter a
+  derived value, and it **never re-dispatches** the agent.
+- It documents the **edit path** as **validate-and-report** (the post-edit
+  checkpoint validates the human's edit and reports remaining deviation but does
+  not silently revert it).
+
+**Output home** (`FR-10`):
+
+- The body states the default output home is a top-level **`cost-estimates/`**
+  directory (`cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md`),
+  deliberately **outside** `observability/`, with a `--out` directory override.
+
+## Rubric
+
+This is a Layer 1 structural scenario: every assertion is mechanically checkable
+by reading the command file and matching against its frontmatter and body
+headings. The scenario passes only when the frontmatter carries
+`name: cost-estimate` + a description; the signature is documented with `--kind`
+and `--out` and **no** `--near`; the flow documents dispatch → REFUSED-handling →
+checkpoint → review-summary → disposition (`accept`/`edit`/`re-run`/`abort`) →
+write with the write **after** the disposition; the checkpoint references the S1
+format reference by path, enumerates the checklist incl. the #377 lines, and
+documents the structural-fix boundary; and the default home is top-level
+`cost-estimates/` outside `observability/`.
+
+## Notes
+
+Scope is S3 only. This scenario asserts the command's structural shape; it does
+**not** assert anything about the S4 orchestrator fold-in, the S5 T0 ballpark,
+the S6 calibration loop, the S2 agent's internals, or the S1 format reference's
+content. S3 makes no change to the agent or the format reference.

--- a/tdad_tests/scenarios/commands/cost-estimate/dispose-precedes-write.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/dispose-precedes-write.md
@@ -1,0 +1,61 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-spec-target-empty-costs
+---
+
+# Scenario: the human disposition precedes the single Write (the ordering invariant) (runnable-today)
+
+## Given
+
+A fixture repository with a valid, readable **spec** target, a readable
+`MODEL_ROUTING.md` whose tables parse, an **empty** `observability/costs/`, and
+no pre-existing `cost-estimates/` directory.
+
+The command is run against the spec target and reaches the disposition step. This
+scenario exercises the dispose-then-write ordering invariant on both an `abort`
+and an `accept` path.
+
+**Runnable-today** — cost-omitted record from an empty `observability/costs/`
+(spec §10.2; FR-8, FR-9, FR-12).
+
+## When
+
+The command dispatches the agent, validates the returned record, shows the review
+summary, and reaches the disposition prompt.
+
+## Then
+
+The **file-existence oracle** asserts, across the disposition paths:
+
+- **At the disposition step, no file has been written yet** — nothing exists
+  under `cost-estimates/` (or the resolved output dir) before the human responds.
+- The review summary **shows the resolved output path** (so the human confirms
+  both content and destination before any write).
+- The summary offers the **full disposition vocabulary** — `accept` / `edit` /
+  `re-run` / `abort`.
+- On **`abort`**: **no file is written**.
+- On **`accept`** (the alternate run on the same fixture): **exactly one Write**
+  occurs, to the resolved output path, **after** the disposition.
+
+## Rubric
+
+Layer 3 behavioural, graded by the **file-existence oracle** (no-file-before-the-
+disposition; no-file-on-abort; exactly-one-file-on-accept at the resolved path),
+per spec §9. The fixture pins the grounding so the input is deterministic even
+though the dispatch is not. The oracle never asserts the summary's prose — only
+the on-disk state at each step and the presence of the resolved path in the
+summary.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner drives the command twice against the same fixture — once choosing
+`abort`, once choosing `accept` — and asserts no file exists at the disposition
+step in both, no file after `abort`, and exactly one file at the resolved path
+after `accept`.

--- a/tdad_tests/scenarios/commands/cost-estimate/edit-validate-and-report.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/edit-validate-and-report.md
@@ -1,0 +1,59 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-edit-path
+---
+
+# Scenario: the edit path validates-and-reports — a human edit is never silently reverted (O3)
+
+## Given
+
+A fixture repository where the command has produced a validated draft and the
+human chooses the **`edit`** disposition, then changes the draft in `$EDITOR`.
+The fixture pins a human edit that introduces a **tolerated structural change**
+(the kind step 4 would have fixed in place on the agent's fresh output) and,
+separately, a human edit that leaves a **remaining deviation**.
+
+This scenario exercises the edit-path rule that the content is now the **human's**
+and the post-edit checkpoint runs in **validate-and-report** mode, not
+fix-in-place (spec §10.6d; FR-6b).
+
+## When
+
+The command runs the **post-edit checkpoint** over the human-edited content.
+
+## Then
+
+The **edit-validate-and-report oracle** asserts:
+
+- The human's edited value is **preserved** — the post-edit checkpoint does
+  **not** apply fix-in-place to human-edited content, and the edit is **not
+  silently reverted** to the agent's original.
+- When the edited record **still deviates**, the command **reports** the
+  remaining deviation in the re-prompt (it surfaces it rather than auto-fixing
+  it) and lets the human decide (re-edit, accept where structurally valid, or
+  abort).
+- **No edit of the human's is reverted without the human seeing and
+  re-confirming it.**
+
+## Rubric
+
+Layer 3 behavioural, graded by the **edit-validate-and-report oracle** (spec §9):
+the edited value is preserved across the post-edit checkpoint, and any remaining
+deviation is surfaced in the re-prompt rather than auto-fixed. The edit content
+is fixture-pinned. The oracle never asserts the exact re-prompt prose — only that
+the human's edited value survives and that a remaining deviation is reported, not
+silently corrected.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner drives the `edit` disposition with a pinned human edit (simulating the
+`$EDITOR` return), runs the post-edit checkpoint, and asserts the edited value is
+unchanged by the checkpoint and that a remaining deviation, if any, appears in
+the re-prompt rather than being auto-corrected.

--- a/tdad_tests/scenarios/commands/cost-estimate/empty-snapshot-cost-omitted.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/empty-snapshot-cost-omitted.md
@@ -1,0 +1,74 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-spec-target-empty-costs
+---
+
+# Scenario: an empty cost snapshot produces a written cost-omitted record, not a refusal (runnable-today)
+
+## Given
+
+A fixture repository with a valid, readable **spec** target, a readable
+`MODEL_ROUTING.md` whose tables parse, and an **empty** `observability/costs/`
+directory (today's default — no snapshot file). No pre-existing `cost-estimates/`
+directory. The human responds **`accept`**.
+
+This is the crucial distinction the spec polices (§5.2): a missing **cost
+snapshot** is **not** an ungroundable target — the token grounding is intact, so
+the command writes a valid cost-omitted record rather than treating it as a
+failure.
+
+**Runnable-today** — exercised by a real grounding read against today's empty
+`observability/costs/` (spec §10.5; FR-13, FR-14).
+
+## When
+
+The command dispatches the agent, validates the returned cost-omitted record,
+summarises it, and the human responds `accept`.
+
+## Then
+
+The **conformance oracle** and the **trailing-slash-summary oracle** assert:
+
+- A **cost-omitted** record is written (NOT a refusal) at the default resolved
+  path `cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md`.
+- The record's `grounding_sources` list carries a `cost-snapshot` entry whose
+  `path` is the **directory** `observability/costs/` (with a **trailing slash**;
+  no snapshot file existed).
+- The **review summary reports that entry as "no snapshot — cost omitted
+  (directory inspected, no snapshot found)"**, **not** as a snapshot grounding —
+  the command honours the trailing-slash special-case in its **own** summary
+  consumption (it adds no validation-checklist line keying on
+  `grounding_sources[].path` shape).
+- The written record carries the **unguarded trailing-slash sentinel** — no
+  checklist line keys on it (the recorded O7 residual: any other consumer that
+  does not apply the same trailing-slash test will silently miscount).
+- `cost_usd` and `cost_basis` are **absent**, the omission disclosed in
+  `Excluded`.
+- `tokens` and `agent_compute_time` are **present as `{low, high}` ranges**, and
+  `human_gate_time` is **present and not a range** (the qualitative caveat
+  string — presence and non-range shape only, never the prose).
+
+## Rubric
+
+Layer 3 behavioural, graded by the **conformance oracle** (cost-omitted field
+shape: `cost_usd`/`cost_basis` absent, ranges present, `human_gate_time`
+present-and-not-a-range) and the **trailing-slash-summary oracle** (the
+trailing-slash `cost-snapshot` entry is reported as "no snapshot", not a
+grounding), per spec §9. The empty `observability/costs/` is fixture-pinned. The
+oracle never asserts token numbers or the caveat's prose — only the omission
+shape and the trailing-slash summary reporting.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner copies the fixture (readable `MODEL_ROUTING.md`, empty
+`observability/costs/`, a spec target), drives an `accept` disposition, asserts
+the written record is cost-omitted and conforming, that the `cost-snapshot`
+grounding entry's directory `path` is preserved with its trailing slash, and that
+the review summary reports it as "no snapshot" rather than a grounding.

--- a/tdad_tests/scenarios/commands/cost-estimate/kind-assertion-flag.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/kind-assertion-flag.md
@@ -1,0 +1,58 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-kind-assertion
+---
+
+# Scenario: an asserted --kind is flagged in the review summary, not silently trusted (O4) (runnable-today)
+
+## Given
+
+A fixture repository with a target that is really a **slice fragment** but reads
+superficially like a spec, a readable `MODEL_ROUTING.md` whose tables parse, and
+an empty `observability/costs/`. The command is run two ways:
+
+1. With **`--kind spec`** asserted on the slice-fragment target.
+2. With **no `--kind`** (the agent infers the kind from content).
+
+**Runnable-today** — both arms are exercised by a real grounding read on today's
+repo (spec §10.6a; FR-8a).
+
+## When
+
+The command summarises the validated record for disposition in each arm.
+
+## Then
+
+The **`--kind` assertion-flag oracle** asserts:
+
+- **Asserted arm (`--kind spec`)** — the review summary **flags `target_kind` as
+  HUMAN-ASSERTED (not agent-inferred)**, states that the asserted kind **raised
+  the tokens/time confidence ceiling** (to `high` for `spec`) **with no agent
+  inference basis**, and asks the human to **re-confirm the ceiling they raised**
+  before disposing.
+- **Inferred arm (no `--kind`)** — the summary instead **carries the agent's
+  inference-basis line as emitted** (classified by signal) and **does NOT** show
+  a human-asserted flag.
+
+## Rubric
+
+Layer 3 behavioural, graded by the **`--kind` assertion-flag oracle** (spec §9):
+the asserted arm carries an asserted-not-inferred flag naming the raised ceiling
+and no inference basis; the inferred arm carries the inference-basis line and no
+asserted flag. The target and `--kind` invocation are fixture-pinned. The oracle
+checks for the presence/absence of the named flag and the inference-basis line —
+never the exact summary prose.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner drives the command twice against the same slice-fragment target — once
+with `--kind spec`, once with no `--kind` — and asserts the asserted-not-inferred
+flag (with the raised-ceiling note) appears only in the asserted arm, and the
+agent's inference-basis line appears only in the inferred arm.

--- a/tdad_tests/scenarios/commands/cost-estimate/refused-not-persisted.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/refused-not-persisted.md
@@ -1,0 +1,54 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-ungroundable
+---
+
+# Scenario: a REFUSED estimate is surfaced verbatim and never persisted (runnable-today)
+
+## Given
+
+A fixture repository supporting an **ungroundable** dispatch — an unreadable
+target path, or a valid target where `MODEL_ROUTING.md` cannot be read or reads
+but its tables are missing/unparseable — so the S2 agent returns a string
+beginning with the stable `REFUSED:` prefix. No pre-existing `cost-estimates/`
+directory.
+
+**Runnable-today** — the REFUSED path is exercised by a real ungroundable
+grounding read (spec §10.3; FR-5).
+
+## When
+
+The command dispatches the agent and the agent returns a `REFUSED:` string.
+
+## Then
+
+The **REFUSED oracle** and the **no-file oracle** assert:
+
+- The command **surfaces the refusal reason, the target, and the grounding-read
+  line verbatim** (the agent's `REFUSED:` output is passed through, not
+  re-authored).
+- **No validation checkpoint runs** — there is nothing conforming to validate.
+- **No file is written** — nothing exists under `cost-estimates/` (or the
+  resolved output dir).
+- The flow **aborts**.
+
+## Rubric
+
+Layer 3 behavioural, graded by the **REFUSED-prefix oracle** (the surfaced
+output retains the `REFUSED:` prefix) and the **no-file oracle** (no file at the
+resolved path), per spec §9. The ungroundable input is fixture-pinned. The oracle
+never asserts the exact refusal wording — only that the `REFUSED:` content is
+surfaced and that no record is persisted.
+
+## Cleanup
+
+Remove the temporary fixture repository.
+
+## Implementation note
+
+The runner runs the command against the ungroundable fixture, asserts the
+surfaced output carries the `REFUSED:` prefix, and asserts no file exists under
+the default `cost-estimates/` path (and that no checkpoint-fix change-list is
+produced, since no checkpoint ran).

--- a/tdad_tests/scenarios/commands/cost-estimate/rerun-rereads-snapshot.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/rerun-rereads-snapshot.md
@@ -1,0 +1,58 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-rerun-snapshot-added
+---
+
+# Scenario: re-run re-dispatches and re-reads a newly-added snapshot (O8) (synthetic cost-present)
+
+## Given
+
+A fixture repository where the command has first produced a **cost-omitted**
+record (`observability/costs/` was empty at first dispatch). Before disposing,
+the human **adds a usable cost snapshot** to `observability/costs/`, then responds
+**`re-run`**.
+
+This is a **synthetic cost-present fixture** — it pins a snapshot world the
+command's first real grounding could not produce (today's repo ships an empty
+`observability/costs/`), so the added snapshot is hand-pinned to exercise the
+re-run-re-reads behaviour, not produced by a grounded emit on today's repo (spec
+§10.6b; FR-8b).
+
+## When
+
+The human responds `re-run` after adding the snapshot.
+
+## Then
+
+The **re-dispatch-re-reads oracle** asserts:
+
+- The command **re-dispatches the agent on the same target** (a full fresh
+  dispatch, not a reuse of cached grounding).
+- The re-dispatch **re-reads the grounding sources afresh, including the
+  now-populated `observability/costs/`**.
+- The re-validated, re-summarised record **can now carry `cost_usd` grounded in
+  the added snapshot** (the cost-present record the first dispatch could not
+  produce).
+
+## Rubric
+
+Layer 3 behavioural, graded by the **re-dispatch-re-reads oracle** (spec §9): the
+first dispatch (empty `observability/costs/`) yields a cost-omitted record; after
+a fixture-pinned snapshot is added and `re-run` is chosen, the re-summarised
+record is **cost-present** — the grounding was re-read, not cached. The snapshot
+add is fixture-pinned. The oracle never asserts exact cost numbers — only the
+cost-omitted → cost-present transition across the re-run.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner drives the command to a first cost-omitted summary, injects a usable
+snapshot into the fixture's `observability/costs/`, drives a `re-run`, and asserts
+the re-summarised record can carry a `cost_usd` grounded in the added snapshot —
+confirming the re-dispatch re-read the now-populated directory.

--- a/tdad_tests/scenarios/commands/cost-estimate/signature-targets.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/signature-targets.md
@@ -1,0 +1,77 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-signature-targets
+---
+
+# Scenario: path-vs-inline routing, --kind forwarding, and --out override with collision disambiguation (runnable-today)
+
+## Given
+
+A fixture repository with: a valid, readable **spec** target file; a quoted
+**inline task-text** target that does not resolve to a readable file; a readable
+`MODEL_ROUTING.md` whose tables parse; an empty `observability/costs/`; and a
+scratch `<dir>` used for `--out`. For the collision arm, a **same-day,
+same-target** estimate already exists beneath `<dir>`.
+
+This scenario exercises the signature semantics: path vs inline resolution,
+`--kind` forwarding, `--out` directory override, and same-day collision
+disambiguation (spec §10.6, §10.6c; FR-3, FR-4, FR-11, FR-11a).
+
+**Runnable-today** — exercised by real grounding reads against today's empty
+`observability/costs/` (cost-omitted records).
+
+## When
+
+The command is run across the following arms:
+
+1. A positional target that **resolves to a readable file**.
+2. A positional target that **does not resolve** to a readable file.
+3. `--kind spec` supplied.
+4. `--out <dir>` supplied, human responds `accept`.
+5. `--out <dir>` supplied while a same-day same-target estimate already exists
+   beneath `<dir>`, human responds `accept`.
+
+## Then
+
+The **path-vs-inline routing**, **file-at-overridden-dir**, and
+**collision-disambiguation** oracles assert:
+
+- **Arm 1 (resolvable)** — the target is treated as a **path** and passed to the
+  agent as a path.
+- **Arm 2 (non-resolvable)** — the target is treated as **inline task text** and
+  passed to the agent as an inline string.
+- **Arm 3 (`--kind spec`)** — `spec` is **forwarded to the agent as the explicit
+  dispatch-stated kind** (the command does not itself re-classify).
+- **Arm 4 (`--out <dir>`)** — **exactly one file** is written **beneath `<dir>`**
+  with the derived `<YYYY-MM-DD>-<target-slug>-estimate.md` filename (the
+  directory is overridden, the derived filename preserved), and the full path is
+  confirmed.
+- **Arm 5 (`--out` collision)** — the command **appends a short disambiguator**
+  to the derived filename, **notes the disambiguation in the confirm-before-write
+  summary**, and the **pre-existing estimate is NOT overwritten** (a second file
+  appears; the original is intact).
+
+## Rubric
+
+Layer 3 behavioural, graded by the **path-vs-inline routing oracle** (how the
+target reaches the agent), the **file-at-overridden-dir oracle** (one file
+beneath `<dir>` with the derived filename), and the **collision-disambiguation
+oracle** (a disambiguated second file, original preserved, never a silent
+overwrite), per spec §9. Targets, `--kind`, and `--out` are fixture-pinned. The
+oracle never asserts the exact disambiguator string — only that the original
+file survives and a distinct second file is written.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written estimate
+directories).
+
+## Implementation note
+
+The runner drives each arm against the fixture: it inspects how the target is
+passed to the agent (path vs inline), confirms `--kind` is forwarded as the
+explicit kind, asserts the `--out` arm writes one file beneath `<dir>` with the
+derived filename, and asserts the collision arm writes a disambiguated second
+file while leaving the pre-existing estimate untouched.

--- a/tdad_tests/scenarios/commands/cost-estimate/writes-record-on-accept.md
+++ b/tdad_tests/scenarios/commands/cost-estimate/writes-record-on-accept.md
@@ -1,0 +1,71 @@
+---
+component: cost-estimate
+component_type: command
+tier: behavioural
+fixture: cost-estimate-spec-target-empty-costs
+---
+
+# Scenario: /cost-estimate writes a conforming cost-omitted record on accept (runnable-today)
+
+## Given
+
+A fixture repository containing:
+
+- A real **design spec** target file (a spec header table, numbered `## N.`
+  sections, and a Gherkin acceptance-scenario block) at a known path.
+- A readable `MODEL_ROUTING.md` whose **Token Budget Guidance** and **Agent
+  Routing** tables parse, and which carries a `cost-estimator` routing row.
+- An **empty** `observability/costs/` directory (today's default — no snapshot
+  file present).
+- No pre-existing `cost-estimates/` directory.
+
+The command is run against the spec target. The human responds **`accept`** at
+the disposition step.
+
+**Runnable-today** — exercised by a real grounding read on today's repo; an empty
+`observability/costs/` yields a cost-omitted record (spec §10.1; FR-9, FR-10,
+FR-13).
+
+## When
+
+The command dispatches the agent, validates the returned record, summarises it,
+and the human responds `accept`.
+
+## Then
+
+The **deterministic oracles** assert:
+
+- **Exactly one file** is written, at the default resolved path
+  `cost-estimates/<YYYY-MM-DD>-<target-slug>-estimate.md` — a top-level
+  directory, **outside** `observability/` (the command created the directory).
+- The written record's **frontmatter conforms to the S1 estimate-record field
+  set** — parsed, not read loosely: required fields present, every enum in range,
+  every present `{low, high}` range has `low ≤ high`, and the four disclosure
+  sections (Included, Excluded, Confidence rationale, Failure direction) are
+  present.
+- `cost_usd` and `cost_basis` are **absent**, and the omission is disclosed in
+  the `Excluded` section.
+- The written record contains **no** `recommendation`, `verdict`, or `proceed`
+  field in the frontmatter.
+- The command **confirms the full written path** to the human.
+
+## Rubric
+
+Layer 3 behavioural, graded by the **file-existence + path oracle** (one file at
+the resolved `cost-estimates/` path) and the **conformance oracle** (frontmatter
+parse against the S1 field set), per spec §9. The grounding inputs are
+fixture-pinned so the input is deterministic even though the `model: inherit`
+dispatch is not. No LLM-as-judge is used; the exact token figures and exact
+disclosure wording are out of grading scope.
+
+## Cleanup
+
+Remove the temporary fixture repository (including any written
+`cost-estimates/` directory).
+
+## Implementation note
+
+The runner copies the fixture to a temp directory, runs the command's flow
+driving an `accept` disposition, then asserts a single file exists at the
+default `cost-estimates/` resolved path, parses its frontmatter for S1
+conformance, and checks the cost-omitted shape and the path-confirmation.


### PR DESCRIPTION
## What

Adds the **`/cost-estimate`** slash command — the standalone manual dispatcher for the read-only `cost-estimator` agent, and the **prospective** sibling of the retrospective `/cost-capture`. S3 of the cost-estimator pipeline.

Point it at a slice, spec, slicing record, or pasted task text; it dispatches the agent, runs the output validation checkpoint against the `estimate-record-format.md` checklist, surfaces a review summary, and writes once **after** the human disposes (`accept`/`edit`/`re-run`/`abort`). The command owns the single `Write`; the agent stays read-only (the **agent-emit + dispatcher-persist + human-disposes** decision and its **dispose-then-write ordering invariant**).

Output home: a new top-level `cost-estimates/<YYYY-MM-DD>-<slug>-estimate.md`, **outside** `observability/` (predictions are not telemetry), gitignored.

The command is a **pure consumer** of the S2 agent and the S1 format reference — it redefines neither.

## Spec-first

- Spec: `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md` (first commit on the branch).
- Adversarial pipeline run end-to-end: carpaccio → spec-writer → **spec-mode diaboli** → choice-cartographer → plan approval → tdd-agent → implement → code-reviewer (PASS) → **code-mode diaboli**.

## Adjudicated objections

**Code-mode** (`docs/superpowers/objections/cost-estimate-command-design-code.md`) — 8 objections, all accepted; O1–O7 fixed, O8 noted:

- **O1** (high) — `<target-slug>` sanitised to a single `[a-z0-9-]` path segment; write-target-injection surface closed.
- **O2** (high) — `REFUSED:` detection anchored to the untrimmed first line (exact prefix, pre-reformat).
- **O3** (high) — pre-classification test separates a *stray verdict field* (FIX by deletion) from a *prose verdict* (ABORT); the checkpoint never edits the agent's judgment.
- **O4** (med) — change-list is a **diff of the retained original**, not a narration.
- **O5** (med) — checkpoint takes an explicit `fix-in-place | validate-and-report` mode; a human edit is never reverted unseen.
- **O6** (med) — same-day collision re-checked at **write time** (TOCTOU gap closed).
- **O7** (med) — commands reference count corrected 26→27.
- **O8** (low) — noted that branch (b) is the live `generated_by` path for a slash-command executor.

## Stories promoted

- **#1** → AGENTS.md: `/diagnose` agent-emit watch-item resolved.
- **#7** → AGENTS.md: a re-file must bind to a **scheduled** deliverable, not an unscheduled trigger.

## Version

Minor bump **0.43.0 → 0.44.0** (new command). README badge + counts, plugin.json, CHANGELOG, and marketplace `plugin_version`/entry all updated. Ships a how-to guide and a reference-page entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)