### PR TITLE
docs: bring docs site current with the cost-estimation pipeline

### DIFF
--- a/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
@@ -77,8 +77,8 @@ The skill itself is **methodology and a format contract**. It describes
 how an estimate is derived and what an estimate record must contain — it
 does not dispatch an agent, write a file, or decide go/no-go. Emitting
 and validating a record is the job of downstream consumers (the
-read-only `cost-estimator` agent, a future `/cost-estimate` command, and
-an orchestrator fold-in) that inherit this contract.
+read-only `cost-estimator` agent, the `/cost-estimate` command, and a
+future orchestrator fold-in) that inherit this contract.
 
 ## The read-only emitter — the `cost-estimator` agent
 
@@ -124,8 +124,32 @@ Three behaviours make the emitter honest rather than confidently wrong:
   cost-omitted record, not a refusal**, because the token grounding is
   intact.
 
+## The dispatcher that persists — the `/cost-estimate` command
+
+The agent emits a string; the **`/cost-estimate` command** is the
+dispatcher that turns it into a file — and the only place a `Write`
+happens. It dispatches the agent on one target, runs the **Output
+Validation Checkpoint** against the format contract, surfaces a review
+summary, and writes the record **only after the human disposes**
+(`accept` / `edit` / `re-run` / `abort`). This is the other half of the
+dispose-then-write invariant: the human reviews a *validated* record and
+the write is unambiguously downstream of `accept`.
+
+The checkpoint is bounded at **structural-only vs derived-value**: it may
+fix a purely structural deviation in place (in practice, deleting a stray
+verdict field) and records the change as a diff, but it **aborts — never
+authors — on any derived-value defect** (a missing `cost_basis`, an
+out-of-cap confidence, a verdict phrased in prose). On a `REFUSED:` emit
+it surfaces the refusal verbatim and writes nothing. Records land in a
+new top-level `cost-estimates/` directory — deliberately **outside**
+`observability/`, because a forward-looking prediction is not telemetry
+and must never be co-located with captured actuals where a later scan
+could read it as fact.
+
 ## See also
 
+- [Estimate Task Cost](../how-to/estimate-task-cost.md) — the
+  `/cost-estimate` command walkthrough.
 - [Track AI Costs](../how-to/track-ai-costs.md) — the retrospective
   sibling capture workflow.
 - `ai-literacy-superpowers/skills/cost-estimation/SKILL.md` — the skill.
@@ -135,3 +159,4 @@ Three behaviours make the emitter honest rather than confidently wrong:
   — the read-only emitter's tool boundary and contract.
 - Skill spec: `docs/superpowers/specs/2026-06-10-cost-estimation-skill-design.md`.
 - Agent spec: `docs/superpowers/specs/2026-06-11-cost-estimator-agent-design.md`.
+- Command spec: `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md`.

--- a/docs/plugins/ai-literacy-superpowers/reference/output-validation.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/output-validation.md
@@ -28,6 +28,7 @@ This verification layer runs synchronously within the command, ensuring consiste
 | /assess | `assessments/YYYY-MM-DD-assessment.md` | `ai-literacy-assessment/references/assessment-template.md` | Required sections, parseable level number (1-5), discipline maturity table |
 | /reflect | `REFLECTION_LOG.md` (last entry) | Entry template in `commands/reflect.md` | 8 mandatory fields, 4 session metadata subfields, Signal enum validation |
 | /cost-capture | `observability/costs/YYYY-MM-DD-costs.md` | `cost-tracking/SKILL.md` | Period, total spend, model routing reference present |
+| /cost-estimate | `cost-estimates/YYYY-MM-DD-<slug>-estimate.md` | `cost-estimation/references/estimate-record-format.md` | Ranges well-formed, per-stage cost coupling, four disclosure sections, per-axis confidence within cap, time split, no-verdict (field + prose) |
 | /harness-constrain | `HARNESS.md` (new constraint block) | `templates/HARNESS.md` | Rule/Enforcement/Tool/Scope fields, enum values, governance fields if applicable |
 | /harness-init | `HARNESS.md` | `templates/HARNESS.md` | 4 top-level sections, subsections, Status fields, template version marker |
 | /superpowers-init | `CLAUDE.md`, `AGENTS.md`, `MODEL_ROUTING.md`, `REFLECTION_LOG.md` | Corresponding `templates/` files | Required sections per file |

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -3,7 +3,7 @@ title: Skills
 ---
 # Skills
 
-The plugin ships 31 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 34 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -36,6 +36,10 @@ Harness health snapshots and observability. Covers how to read a health snapshot
 ### harness-onboarding
 
 Generating human-readable onboarding documentation from harness state. Covers the three-source synthesis (HARNESS.md, AGENTS.md, REFLECTION_LOG.md), tone guidelines for writing for new contributors, section-by-section content mapping, and the validation checkpoint that verifies structural completeness.
+
+### harness-audit-engine
+
+The shared drift-detection layer that backs both `/harness-audit` (read-only) and `/harness-sync`. Produces a structured drift report covering convention files, ONBOARDING.md, snapshot staleness, template drift, constraint regressions, recurring reflection patterns, and HARNESS.md Status section accuracy.
 
 ---
 


### PR DESCRIPTION
Docs-only currency pass after the `/cost-estimate` command (#384) landed. No plugin files change — `chore` exemption, no version bump.

## Changes

- **`reference/output-validation.md`** — adds the `/cost-estimate` Output Validation Checkpoint row (it was added to the CLAUDE.md checkpoints list but missing from this reference table), next to its `/cost-capture` sibling.
- **`explanation/prospective-cost-estimation.md`** — the page was written at S1 and called `/cost-estimate` a *"future"* command; it has shipped (S2 agent + S3 command). Updates the wording, adds a "dispatcher that persists" section, the how-to + command-spec links, and reframes the orchestrator fold-in as the remaining future consumer.
- **`reference/skills.md`** — corrects the stale skill count (**31 → 34**, matching the README and the actual `SKILL.md` count) and adds the missing **`harness-audit-engine`** entry under Harness Core (a pre-existing gap surfaced by the count audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)