### PR TITLE
S6: calibration loop — per-PR actuals capture (#373)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.46.0",
+  "plugin_version": "0.47.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.46.0"
+      "version": "0.47.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.47.0 — 2026-06-12
+
+### Calibration loop — per-PR actuals capture (S6 of the cost-estimator pipeline)
+
+Closes the calibration seam S1 deliberately left open: the estimator now learns
+from **this repo's own history** instead of only the generic `MODEL_ROUTING.md`
+budgets. The final slice of the cost-estimator pipeline. New integration-agent
+responsibility + new actuals format + calibration ingestion — minor bump.
+
+- **Per-PR actuals format (new).** A single-task, structural sibling of the
+  quarterly provider snapshot, owned by the `cost-tracking` skill
+  (`references/per-pr-actuals-format.md`) and stored under
+  `observability/costs/per-pr/`. Captures which stages ran, review cycles, files
+  and languages touched, plus token/cost figures **when a human supplies them**.
+- **Integration-agent capture (new Step 1a).** At integration time — after the
+  CHANGELOG, before the commit, so the record **ships in the PR** and never
+  commits to `main` — the integration-agent auto-captures the structural facts and
+  records human-supplied `/cost` figures, marking them `unavailable` otherwise.
+  **Non-blocking and never fabricates a figure**: a subagent can't read per-PR
+  tokens programmatically, and the repo's no-fabrication rule forbids inventing
+  them, so `unavailable` is explicit and is never `0`.
+- **Calibration ingestion — token ranges only.** The `cost-estimation` methodology
+  and the `cost-estimator` agent now read accumulated per-PR records as a
+  `kind: calibration` grounding source to **narrow the per-stage token ranges**
+  (and may raise the `tokens` confidence) against repo history, disclosed in
+  `Confidence rationale`. The `$/token` ground stays the snapshot
+  (`cost_basis: snapshot-actuals`) — calibration refines tokens only.
+- **No estimate-record format change.** True to the S1 seam, calibration ships as
+  the already-permitted `kind: calibration` `grounding_sources[]` entry plus a
+  disclosure — no field added, removed, or retyped. Zero history degrades cleanly
+  to the pre-S6 generic-budget behaviour.
+- **Docs** — the prospective-cost-estimation concept page gains a calibration-loop
+  section; the cost-tracking skill documents its two actuals records (quarterly
+  snapshot + per-PR).
+
 ## 0.46.0 — 2026-06-12
 
 ### Orchestrator T0 pre-carpaccio ballpark (S5 of the cost-estimator pipeline)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.46.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.47.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-34-2E8B57?style=flat-square)](#skills-34)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.46.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 27 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.47.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 27 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/cost-estimator.agent.md
+++ b/ai-literacy-superpowers/agents/cost-estimator.agent.md
@@ -151,6 +151,32 @@ widen the **whole-record `cost_usd` band**. Disclose the widening in the prose
 body. You emit **no** machine-checkable per-stage cost band (that is a separate
 slice's deliverable); the widening lives in the whole-record band and the prose.
 
+### Calibration against per-PR history (S6 — token ranges only)
+
+Glob `observability/costs/per-pr/` for per-PR actuals records (format:
+`skills/cost-tracking/references/per-pr-actuals-format.md`). When records exist,
+**calibrate the per-stage token ranges against this repo's own history**:
+
+- For each stage, gather the **supplied** per-stage token actuals
+  (`tokens_by_stage[].tokens` that are numbers — ignore the literal
+  `unavailable`) across the records and narrow that stage's range toward their
+  central tendency. With enough records for a stage you **may raise** the `tokens`
+  confidence one tier, **never above** the `target_kind` ceiling.
+- A record whose figures are `unavailable` still contributes its **structural**
+  signal: its `stages_run` shows which stages this repo actually exercises, so you
+  may drop a never-run stage (disclosed in `Excluded`). `unavailable` is **not**
+  zero — it never lowers a token magnitude.
+- **Token ranges only.** Calibration never touches `cost_usd` or `cost_basis`;
+  the $/token ground stays the snapshot. Do **not** promote a per-PR dollar figure
+  to a rate.
+- When you calibrate, add a `kind: calibration` `grounding_sources[]` entry naming
+  the `observability/costs/per-pr/` directory, and disclose the basis in
+  `Confidence rationale` — how many records informed the narrowing and over what
+  date range, with the explicit note "cost unchanged — calibration refines tokens
+  only". **No estimate-record field is added** — this is the S1 seam, honoured.
+- An absent/empty `per-pr/` directory is the day-one state: no `calibration`
+  entry, no disclosure, generic `MODEL_ROUTING.md` budgets as before.
+
 ### Mechanical cost-omission (no salience judgment)
 
 When you compute a cost figure (state 3 — a usable snapshot exists), re-verify
@@ -329,8 +355,11 @@ omits human-gate latency leans `likely-underrun` on wall-clock unless the
 ## Grounding-source read policy
 
 Read `MODEL_ROUTING.md` (the two tables) and the latest `observability/costs/`
-snapshot if one exists. A `kind: calibration` grounding source is read **if one
-exists** (the S1 seam) but is never produced or required by you.
+snapshot if one exists. Also **Glob `observability/costs/per-pr/`** for per-PR
+actuals records (the S6 calibration loop, see Methodology → Calibration). When
+records exist you **produce** a `kind: calibration` `grounding_sources[]` entry;
+when the directory is absent or empty you produce none and behave exactly as a
+pre-S6 estimate.
 
 ## Output
 

--- a/ai-literacy-superpowers/agents/integration-agent.agent.md
+++ b/ai-literacy-superpowers/agents/integration-agent.agent.md
@@ -25,16 +25,51 @@ files were edited. Include the PR number in parentheses at the end of each bulle
 
 Date format: DD Month YYYY (e.g. 26 March 2026)
 
+### 1a. Capture per-PR actuals (calibration)
+
+Write a **per-PR actuals record** so the `cost-estimator` can calibrate future
+estimates against this repo's own history (slice S6). This runs **before** the
+commit so the record ships **in the PR** — never committed to `main`. It is
+**non-blocking**: it never gates the merge and it **never fabricates a figure**.
+
+Format reference (the single source of truth for the field set and the
+`unavailable` honesty rule):
+
+```text
+ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md
+```
+
+1. **Auto-capture structural facts** from the context object and git:
+   `date`, `branch`, `issue`, `task_summary`, `progressed_slice`, `stages_run`
+   (inferred from the context object — `spec_changes` ⇒ spec-writer ran,
+   `failing_tests` ⇒ tdd-agent, `review_result` ⇒ code-reviewer, etc.),
+   `review_cycles` (from `review_result`), `files_changed` and `languages`
+   (from `git diff --name-only main...HEAD`). Leave `pr` as `null` if the PR
+   does not exist yet; the record's provenance is the PR it ships in.
+2. **Invite figures, non-blocking.** Say once: "If you want token/cost actuals
+   captured for calibration, paste the session figures from `/cost`; otherwise
+   I'll record them as unavailable." If the human supplies figures, record them
+   into `tokens_by_stage`/`tokens_total`/`cost_usd` and set
+   `figures_source: human-supplied`. If nothing is supplied, set **every**
+   token/cost field to the literal `unavailable` and `figures_source: unavailable`.
+   **Never invent a number, never use `0` as a stand-in.** Do not wait or block on
+   a reply — absence means `unavailable` and you proceed.
+3. **Write** the record to
+   `observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md`
+   (`mkdir -p observability/costs/per-pr` first), conforming to the format
+   reference.
+
 ### 2. Commit
 
 Stage all changed files. Write a concise commit message describing what changed and
 why. The message ends when the description ends — no Co-Authored-By, no Generated
 with, no attribution lines of any kind.
 
-Stage specific files by name (never `git add -A`), then commit:
+Stage specific files by name (never `git add -A`) — **including the per-PR actuals
+record written in step 1a** — then commit:
 
 ```bash
-git add path/to/changed/file ...
+git add path/to/changed/file ... observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md
 git commit -m "MESSAGE"
 ```
 

--- a/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
@@ -164,8 +164,8 @@ knowable" is more informative than a low-confidence list-price range that
 says "we don't really know" in numeric clothing. **No format change is
 required when the first snapshot lands** — the same
 `cost_usd`/`cost_basis`/`confidence.cost` fields simply begin to appear.
-This is the seam the [calibration section](#the-calibration-seam-s6) also
-contemplates.
+This is the seam the [calibration loop](#the-calibration-loop-s6) now
+closes.
 
 ## The Disclosure / Confidence Contract
 
@@ -281,24 +281,50 @@ variance. The failure-direction prose must reference this: an estimate
 whose wall-clock omits human-gate latency is `likely-underrun` on
 wall-clock unless the human-gate caveat is read alongside it.
 
-## The Calibration Seam (S6)
+## The Calibration Loop (S6)
 
-Calibration (a per-PR actuals loop) is accepted in-scope for the
-capability but **ships later**. This skill's only obligation is to keep
-the seam open so a future actuals data source can be ingested **without a
-format change**:
+The calibration loop is **implemented** (slice S6). The integration-agent
+captures a **per-PR actuals record** at merge time — defined in
+[`cost-tracking/references/per-pr-actuals-format.md`](../cost-tracking/references/per-pr-actuals-format.md)
+and written to `observability/costs/per-pr/` — and this methodology reads the
+accumulated records to refine estimates against **this repo's own history**.
+True to the seam S1 promised, calibration ships with **no format change**: it is
+the already-permitted `kind: calibration` `grounding_sources[]` entry plus a
+disclosure, nothing more.
 
-- `grounding_sources[]` permits a `kind: calibration` entry. Today only
-  `model-routing` and `cost-snapshot` entries appear; tomorrow a
-  `calibration` entry can be added without altering the field set.
-- The methodology is written so that calibration data, when it exists,
-  **refines** the $/token and the per-stage token ranges — narrowing
-  ranges and potentially raising confidence — rather than introducing a
-  new field.
+**What calibration refines — token ranges only.** Calibration narrows the
+**per-stage token ranges** toward the observed history and, when enough records
+exist for a stage, **raises the `tokens` confidence** one tier (never above the
+`target_kind` ceiling). It does **not** touch `cost_usd` or `cost_basis`: the
+$/token ground stays the snapshot (`cost_basis: snapshot-actuals`), and a per-PR
+record's dollar figure — when present at all — is not promoted to a rate. This is
+the deliberate token-ranges-only reach.
 
-This skill does **not** implement calibration: no per-PR actuals format,
-no integration-agent change, no ingestion logic. It names calibration as
-a *future* grounding source and stops there.
+**How the records are read:**
+
+- Glob `observability/costs/per-pr/` for actuals records. For each stage, gather
+  the **supplied** per-stage token actuals (`tokens_by_stage[].tokens` that are
+  numbers, not the literal `unavailable`) across the accumulated records and use
+  their central tendency to narrow that stage's range.
+- A record whose figures are `unavailable` still contributes its **structural**
+  signal: its `stages_run` tells you which stages this repo actually exercises, so
+  a stage the repo never runs can be dropped (disclosed in `Excluded`).
+  `unavailable` is **not** zero — it never pulls a token magnitude down.
+- Add a `kind: calibration` `grounding_sources[]` entry naming the `per-pr/`
+  directory, and disclose the basis in `Confidence rationale` — how many records
+  informed the narrowing and over what date range (e.g. "token ranges narrowed
+  against 9 per-PR actuals, 2026-06 to 2026-08; cost unchanged — calibration
+  refines tokens only").
+
+**Zero history is the valid day-one state.** When `observability/costs/per-pr/` is
+absent or empty, the methodology behaves exactly as it did before S6: generic
+`MODEL_ROUTING.md` budgets, no `calibration` entry, no calibration disclosure. The
+loop degrades cleanly to the pre-S6 behaviour.
+
+**Calibration never overrides the disclosure contract.** A calibrated estimate is
+still a range with disclosed confidence and a stated failure direction.
+Calibration can narrow a range and raise its confidence; it can never collapse a
+range to a point or suppress the `Excluded`/`Confidence rationale` disclosures.
 
 ## Sibling Relationship to cost-tracking
 
@@ -321,9 +347,12 @@ capability should discover the other from either skill's description.
   record is a downstream command's job; this skill defines what such a
   record must contain.
 - **Does not wire into the orchestrator.** No gate is added, moved, or
-  re-weighted; the orchestrator fold-in is downstream.
-- **Does not implement calibration.** The calibration seam is named, not
-  built.
+  re-weighted by this skill; the orchestrator fold-in lives in the
+  orchestrator agent (T0/T1/T2).
+- **Does not capture calibration actuals.** This skill defines the
+  calibration *methodology* (how per-PR actuals refine token ranges), but
+  the per-PR actuals are written by the integration-agent and the format is
+  owned by `cost-tracking` — this skill only reads them.
 - **Does not decide go/no-go.** It emits ranges and disclosures for a
   human to dispose; it carries no verdict, recommendation, or
   recommendation prose.

--- a/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
@@ -300,14 +300,18 @@ risk onto every downstream counter; nothing catches a consumer that counts a
 trailing-slash directory entry as a real grounding. This is an accepted residual
 of the deliberate keep-the-directory-sentinel trade.
 
-## The calibration seam
+## The calibration seam (closed by S6)
 
 `grounding_sources[]` permits a `kind: calibration` entry alongside
-`model-routing` and `cost-snapshot`. Calibration data, when it exists,
-**refines** existing $/token and per-stage token ranges (narrowing ranges,
-potentially raising confidence) rather than introducing a new field. No
-per-PR actuals capture, format, or integration-agent change ships in this
-slice.
+`model-routing` and `cost-snapshot`. The S6 calibration loop now populates it:
+per-PR actuals records — captured by the integration-agent, format owned by
+[`cost-tracking/references/per-pr-actuals-format.md`](../../cost-tracking/references/per-pr-actuals-format.md)
+and stored under `observability/costs/per-pr/` — **refine the per-stage token
+ranges** (narrowing them, potentially raising the `tokens` confidence) against
+this repo's own history. Per the token-ranges-only decision, calibration leaves
+`cost_usd`/`cost_basis` untouched. True to this seam, that shipped with **no
+field-set change** — only the `kind: calibration` entry (already permitted here)
+and a `Confidence rationale` disclosure.
 
 ## Validation checklist
 

--- a/ai-literacy-superpowers/skills/cost-tracking/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-tracking/SKILL.md
@@ -28,6 +28,20 @@ With cost data:
 - Cost trends reveal whether AI adoption is efficient
 - Budget conversations have receipts
 
+## Two actuals records: the quarterly snapshot and the per-PR record
+
+This skill owns **two** actuals formats under `observability/costs/`:
+
+- **The quarterly snapshot** (below) — a **provider-level aggregate** of spend and
+  tokens across all work for a billing period, captured by `/cost-capture`.
+- **The per-PR actuals record** — a **single-task** structural footprint (which
+  stages ran, review cycles, files) plus human-supplied token/cost figures when
+  available, written by the integration-agent at merge time and read by the
+  `cost-estimator` as a `kind: calibration` source. It lives under
+  `observability/costs/per-pr/` and is defined in
+  [`references/per-pr-actuals-format.md`](references/per-pr-actuals-format.md).
+  The two never share a file or directory.
+
 ## The Cost Snapshot
 
 Cost data is captured in `observability/costs/YYYY-MM-DD-costs.md`.

--- a/ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md
+++ b/ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md
@@ -1,0 +1,149 @@
+# Per-PR Actuals Format
+
+The **per-PR actuals record** is the single-task, structural sibling of the
+quarterly provider snapshot. The integration-agent writes one at integration
+time; the `cost-estimator` agent reads accumulated records as a
+`kind: calibration` grounding source to narrow per-stage token ranges against
+**this repo's own history** (slice S6, spec
+`docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md`).
+
+It is **not** the quarterly snapshot. The quarterly
+`observability/costs/<YYYY-MM-DD>-costs.md` is a **provider-level aggregate**
+(spend and tokens across all work for a billing period). A per-PR actual is **one
+task's** structural footprint plus, when a human supplies them, that task's
+token/cost figures. The two never share a file or a directory.
+
+## Home
+
+```text
+observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md
+```
+
+The `per-pr/` subdirectory keeps single-task records separate from the quarterly
+snapshots in `observability/costs/`, so neither a human reader nor the estimator
+mistakes a per-PR actual for a provider aggregate. `<branch-slug>` is the feature
+branch name (always known at integration time); the PR number, known later, is
+recorded in the `pr` field rather than the filename.
+
+## The no-fabrication rule (the load-bearing honesty contract)
+
+A subagent cannot reliably read "tokens spent on this PR" programmatically. The
+record therefore splits cleanly:
+
+- **Structural fields are auto-captured** from the orchestrator context object and
+  git — always present, always observed.
+- **Token/cost figures are human-supplied or `unavailable`.** When a human pastes
+  session figures (e.g. from Claude Code's `/cost`), they are recorded with
+  `figures_source: human-supplied`. When nothing is supplied, **every** token/cost
+  field is the literal string `unavailable` and `figures_source: unavailable`.
+
+**`unavailable` is never `0` and is never inferred.** An unsupplied figure
+contributes structural signal only (which stages this repo exercises); it
+contributes nothing to numeric token narrowing. There is no `inferred`
+`figures_source` value — figures are observed-and-supplied or they are absent.
+
+## Field set
+
+YAML frontmatter:
+
+| Field | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `date` | string `YYYY-MM-DD` | auto | Integration date. |
+| `branch` | string | auto | The feature branch slug. |
+| `issue` | string \| null | auto | Linked issue number (e.g. `#373`), or `null`. |
+| `pr` | string \| null | auto | PR number/URL when known, else `null`. |
+| `task_summary` | string | auto | One sentence from the context object. |
+| `progressed_slice` | string \| null | auto | The slice id this PR delivered (e.g. `S6`), or `null`. |
+| `stages_run` | list of strings | auto | Pipeline stages that actually ran — a subset of `spec-writer`, `tdd-agent`, `implementer`, `code-reviewer`, `integration-agent` — inferred from the context object (`spec_changes` ⇒ spec-writer; `failing_tests` ⇒ tdd-agent; `review_result` ⇒ code-reviewer; etc.). |
+| `review_cycles` | integer | auto | Reviewer→implementer cycle count (from `review_result`). |
+| `files_changed` | integer | auto | From `git diff --name-only main...HEAD`. |
+| `languages` | list of strings | auto | Distinct languages/extensions touched. |
+| `tokens_by_stage` | list of objects | supplied \| `unavailable` | Each entry: `stage` (string, matching the estimate-record stage labels so the join key is identical) and `tokens` (integer actual, or `unavailable`). |
+| `tokens_total` | integer \| `unavailable` | supplied | Whole-task token actual. |
+| `cost_usd` | number \| `unavailable` | supplied | Whole-task dollar actual, if the human has it. |
+| `figures_source` | enum | auto | `human-supplied` \| `unavailable`. Never `inferred`. |
+
+Body: a short disclosure paragraph stating what was auto-captured versus supplied,
+and — when figures are `unavailable` — an explicit line to that effect.
+
+## Validation checklist
+
+1. Frontmatter present with every auto field populated (`date`, `branch`,
+   `stages_run`, `review_cycles`, `files_changed`, `languages`,
+   `figures_source`).
+2. `figures_source` is exactly `human-supplied` or `unavailable`.
+3. If `figures_source: unavailable`, **every** token/cost field is the literal
+   `unavailable` (no zeros, no blanks, no invented numbers).
+4. If `figures_source: human-supplied`, at least `tokens_total` or one
+   `tokens_by_stage[].tokens` is a number.
+5. `stages_run` entries are drawn from the five known stage labels.
+6. The body discloses the auto-vs-supplied split, and states the
+   figures-unavailable case explicitly when it applies.
+
+## Worked example — figures supplied
+
+```markdown
+---
+date: 2026-06-20
+branch: feature/widget-export
+issue: "#412"
+pr: "#418"
+task_summary: Add CSV export to the widget report view.
+progressed_slice: S2
+stages_run: [spec-writer, tdd-agent, implementer, code-reviewer, integration-agent]
+review_cycles: 1
+files_changed: 7
+languages: [go, markdown]
+tokens_by_stage:
+  - stage: spec-writer
+    tokens: 62000
+  - stage: tdd-agent
+    tokens: 88000
+  - stage: implementer
+    tokens: 141000
+  - stage: code-reviewer
+    tokens: 54000
+  - stage: integration-agent
+    tokens: 39000
+tokens_total: 384000
+cost_usd: 4.10
+figures_source: human-supplied
+---
+
+Structural fields auto-captured from the context object and git. Token and cost
+figures supplied by the human from `/cost` at integration time. These calibrate
+this repo's per-stage token magnitudes for the cost-estimator.
+```
+
+## Worked example — figures unavailable
+
+```markdown
+---
+date: 2026-06-21
+branch: fix/legend-overlap
+issue: "#420"
+pr: "#421"
+task_summary: Fix the legend overlapping the chart at narrow widths.
+progressed_slice: null
+stages_run: [implementer, code-reviewer, integration-agent]
+review_cycles: 2
+files_changed: 2
+languages: [typescript]
+tokens_by_stage:
+  - stage: implementer
+    tokens: unavailable
+  - stage: code-reviewer
+    tokens: unavailable
+  - stage: integration-agent
+    tokens: unavailable
+tokens_total: unavailable
+cost_usd: unavailable
+figures_source: unavailable
+---
+
+Structural fields auto-captured from the context object and git. Token and cost
+figures were not supplied at integration time, so they are recorded as
+unavailable — never fabricated. The structural facts (which stages ran, review
+cycles, files touched) still calibrate which stages this repo exercises; they
+contribute nothing to token-magnitude narrowing.
+```

--- a/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md
@@ -206,6 +206,33 @@ is non-blocking and carries no gate, no keypress, and no verdict; the
 orchestrator proceeds to carpaccio regardless, and an unavailable T0
 changes nothing about the run.
 
+## Closing the loop — calibration against this repo's history
+
+Everything above grounds in the **generic** `MODEL_ROUTING.md` token
+budgets — the same numbers for every repo. The **calibration loop** lets
+the estimator learn what work in *this* repo actually costs. At
+integration time the **integration-agent** writes a **per-PR actuals
+record** to `observability/costs/per-pr/`: which stages ran, how many
+review cycles, the files and languages touched — auto-captured — plus the
+task's token/cost figures **when a human supplies them** (e.g. from
+Claude Code's `/cost`). The estimator then reads the accumulated records
+as a `kind: calibration` grounding source and **narrows its per-stage
+token ranges** toward the observed history.
+
+Two honesty commitments shape the design. First, **no fabrication**: a
+subagent cannot read "tokens spent on this PR" programmatically, so when a
+human supplies no figures they are recorded as `unavailable` — never
+invented, never `0`. An `unavailable` record still calibrates *which
+stages this repo exercises*; it contributes nothing to the token
+magnitudes. Second, **token ranges only**: calibration narrows token
+ranges and may raise their confidence, but the dollar rate stays bound to
+the cost snapshot (`cost_basis: snapshot-actuals`). True to the seam the
+skill kept open from the start, the whole loop ships with **no change to
+the estimate-record format** — just the already-permitted
+`kind: calibration` entry and a `Confidence rationale` disclosure. With
+zero history (the day-one state), the estimator behaves exactly as it did
+before the loop existed.
+
 ## See also
 
 - [Estimate Task Cost](../how-to/estimate-task-cost.md) — the
@@ -222,3 +249,5 @@ changes nothing about the run.
 - Command spec: `docs/superpowers/specs/2026-06-11-cost-estimate-command-design.md`.
 - Orchestrator fold-in spec: `docs/superpowers/specs/2026-06-12-orchestrator-cost-fold-in-design.md`.
 - T0 ballpark spec: `docs/superpowers/specs/2026-06-12-orchestrator-t0-ballpark-design.md`.
+- Calibration loop spec: `docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md`.
+- Per-PR actuals format: `ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md`.

--- a/docs/superpowers/plans/2026-06-12-calibration-loop-per-pr-actuals.md
+++ b/docs/superpowers/plans/2026-06-12-calibration-loop-per-pr-actuals.md
@@ -1,0 +1,54 @@
+# Implementation Plan — S6 — Calibration loop (per-PR actuals capture)
+
+Companion to
+`docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md`.
+Tracking issue #373. Plugin version 0.46.0 → 0.47.0 (new integration-agent
+responsibility + new actuals format + calibration ingestion — minor bump).
+This is the **final slice** of the cost-estimator pipeline.
+
+## Approach
+
+Three deliverables: a per-PR actuals **format**, an integration-agent **capture
+step**, and the **feedback path** (methodology + agent ingestion). All honour two
+human decisions taken at spec time: the actuals source is **hybrid
+(auto-structural + human-supplied figures, else `unavailable`)**, and calibration
+reach is **token ranges only** (no estimate-record format change).
+
+## Steps
+
+1. **Spec + plan** (this PR; spec is the spec-only first commit) — done.
+2. **Per-PR actuals format** — new `cost-tracking/references/per-pr-actuals-format.md`:
+   field set, `observability/costs/per-pr/` home, the no-fabrication /
+   `unavailable` rule, two worked examples (supplied + unavailable), checklist.
+3. **cost-tracking SKILL pointer** — document the two actuals records (quarterly
+   snapshot + per-PR).
+4. **Integration-agent capture step** — new `### 1a` after CHANGELOG, before
+   commit; auto-capture structural facts, invite `/cost` figures non-blockingly,
+   write to `observability/costs/per-pr/`, stage it with the commit (ships in the
+   PR, never to `main`).
+5. **Feedback path** —
+   - cost-estimation SKILL: rewrite the calibration section from named to
+     implemented (token ranges only, no format change); fix the internal anchor
+     link and the stale "does NOT do" lines.
+   - cost-estimator agent: glob `per-pr/`, narrow per-stage token ranges, emit a
+     `kind: calibration` grounding entry + disclosure; absent dir → pre-S6
+     behaviour.
+   - estimate-record-format reference: update the calibration-seam note to point
+     at the shipped format; no field change.
+6. **Version ceremony** — plugin.json; README badge + table cell; marketplace
+   `plugin_version` + `plugins[]` entry; CHANGELOG 0.47.0.
+7. **Docs** — concept page calibration-loop section + See-also entries.
+8. **PR ceremony** — feature; spec-only first commit; full diaboli + cartograph;
+   CI green before merge.
+
+## Risks / watch-items
+
+- **No-fabrication is the load-bearing honesty contract.** A code-mode diaboli
+  should probe every path for a fabricated/zero token figure or a silent
+  inference. `unavailable` must stay explicit and non-numeric.
+- **No commit to main.** The capture writes before commit so the record ships in
+  the PR; verify no path commits the actuals record to `main`.
+- **No format change.** Calibration must not add an estimate-record field — only
+  the permitted `kind: calibration` entry and a disclosure.
+- **Clean degradation.** Zero/absent per-PR history must reproduce exact pre-S6
+  behaviour.

--- a/docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md
+++ b/docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md
@@ -1,0 +1,326 @@
+# Cost Estimation — S6 — Calibration loop (per-PR actuals capture) — Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-12 |
+| Status | Draft |
+| Author | spec-writer (interactive session with russmiles) |
+| Slice | S6 of the slicing record at `docs/superpowers/slices/cost-estimator-pipeline.md` |
+| Progressed slice | S6 (this spec) |
+| Upstream (merged on main) | S1 (skill + `estimate-record-format.md`, incl. the calibration **seam**); S2 (#369, the `cost-estimator` agent); S3 (#370, `/cost-estimate`); S4 (#371, T1/T2 fold-in); S5 (#372, T0 ballpark) |
+| Tracking issue | #373 |
+| Downstream slices | none — S6 is the final slice of the cost-estimator pipeline |
+| Plugin version target | `ai-literacy-superpowers` v0.46.0 → v0.47.0 (new integration-agent responsibility + new actuals format + calibration ingestion — minor bump) |
+| Marketplace listing | Top-level `version` unchanged at v0.4.0; `plugin_version` and the `plugins[]` entry both 0.46.0 → 0.47.0 |
+| PR ceremony | feature — full `/diaboli` (spec + code) and `/choice-cartograph` |
+| Governing decisions | AGENTS.md **"agent-emit + dispatcher-persist + human-disposes"**; AGENTS.md **"disclosure-of-derived-judgment"**; the S1 **calibration seam** (`kind: calibration` grounding source, **no format change**); the repo-wide **no-fabrication** contract. |
+
+---
+
+## 1. Premise
+
+S1 named a **calibration seam** and deliberately did not build it: the
+estimate-record format permits a `grounding_sources[]` entry of
+`kind: calibration`, and the methodology is written so calibration data, when it
+exists, **refines** the estimate "without a format change" — but S1 shipped "no
+per-PR actuals format, no integration-agent change, no ingestion logic." S6 is
+the slice that **closes that loop**.
+
+Today the only actuals in `observability/costs/` are the **quarterly,
+provider-level** snapshots written by `/cost-capture` (and at time of writing
+there are none — "Last cost capture: never"). The estimator therefore calibrates
+only against the **generic** `MODEL_ROUTING.md` token budgets, which are the same
+for every repo. S6 gives the estimator **this repo's own history** to learn from:
+the integration-agent captures a **per-PR actuals record** at integration time,
+and the estimation methodology reads accumulated per-PR records to **narrow the
+per-stage token ranges** against what work in *this* repo actually costs.
+
+The slice's in/out decision_focus — "in scope for v1 or recorded follow-on?" — was
+already resolved by the human on 2026-06-10 (**accepted in-scope**), which is why
+S1 kept the seam open. S6's remaining design decisions, dispositioned by the human
+at spec time (§8), are shaped by one hard constraint: **a subagent cannot
+reliably read "tokens spent on this PR" programmatically, and the repo's
+no-fabrication contract forbids inventing the number.** Two decisions follow:
+
+1. **Actuals source: hybrid — auto-structural + human-supplied figures.** The
+   integration-agent **always** auto-captures the structurally-observable per-PR
+   facts (which stages ran, review-cycle count, files & languages, dates, the
+   progressed slice) from the context object and git. It records **token/cost
+   figures only when a human supplies them** (e.g. pasted from Claude Code's
+   `/cost`), marking them explicitly **`unavailable`** otherwise. It **never
+   fabricates** a figure. The structural facts alone already calibrate *which
+   stages this repo exercises*; the supplied figures, when present, calibrate
+   *how many tokens each stage actually costs here*.
+2. **Calibration reach: token ranges only.** Accumulated per-PR actuals narrow
+   the **per-stage token ranges** (and may raise the `tokens` confidence) against
+   repo history. The **$/token rate stays bound to the snapshot** — `cost_basis`
+   remains `snapshot-actuals`. Calibration adds **no field** to the estimate-record
+   format: it is a `kind: calibration` `grounding_sources[]` entry (already
+   permitted) plus a disclosure in `Confidence rationale`. This honours the S1
+   seam's "no format change" promise.
+
+## 2. Scope and non-goals
+
+### 2.1 In scope (S6)
+
+- **A per-PR actuals format** — a new reference under the **`cost-tracking`**
+  skill (the retrospective/actuals skill that owns `observability/costs/`):
+  `ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md`.
+  It defines the per-PR record's field set, its on-disk home
+  (`observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md`), the
+  auto-captured-vs-supplied split, and the `unavailable` honesty discipline. It is
+  **distinct** from the quarterly provider snapshot (per-PR + structural +
+  single-task granularity vs provider-level aggregate).
+- **A new integration-agent responsibility** — a capture step (new `### 1a`,
+  after CHANGELOG and before the commit) that writes the per-PR actuals record,
+  auto-filling structural fields and recording supplied token/cost figures (or
+  `unavailable`), and stages it so it ships **in the PR** (avoiding any
+  commit-to-`main`). **Non-blocking**: it never gates the merge and never
+  fabricates a figure.
+- **The feedback path** — wiring the captured actuals back into estimation:
+  - `cost-estimation/SKILL.md` — the "Calibration Seam" section moves from
+    *named* to *implemented*: how accumulated per-PR records are read as a
+    `kind: calibration` grounding source to narrow per-stage token ranges, with
+    disclosed confidence and **no format change**.
+  - `cost-estimator` agent (S2) — reads per-PR actuals from
+    `observability/costs/per-pr/` when present, emits a `kind: calibration`
+    `grounding_sources[]` entry, and discloses the calibration basis in
+    `Confidence rationale`. Token-range refinement only; `cost_basis` untouched.
+  - `estimate-record-format.md` — the calibration-seam note updates from "no
+    per-PR actuals capture ships in this slice" to point at the now-shipped
+    format; **no field-set change**.
+- Version bump, CHANGELOG, marketplace `plugin_version` + `plugins[]` entry,
+  README badge + table cell, and docs (the concept page's calibration section).
+
+### 2.2 Out of scope (S6)
+
+- **Any change to the estimate-record format field set.** Calibration ships as a
+  permitted `kind: calibration` grounding-source entry and value-refinement only
+  (decision §8 — token ranges only). `cost_basis` stays `snapshot-actuals`; no
+  new enum value.
+- **Automatic/programmatic token capture.** No telemetry/OTEL integration is
+  assumed; figures are auto-captured **only** when structurally observable
+  (they are not, for tokens/cost) and **human-supplied otherwise**. No
+  fabrication, no diff-size proxy passed off as actuals.
+- **$/token calibration** from per-PR cost — explicitly deferred by the
+  token-ranges-only decision; the snapshot remains the cost ground.
+- **A new command.** Capture is an integration-agent responsibility, as the slice
+  scope directs — not a new `/cost-*` surface.
+- **Backfilling history.** S6 starts the loop; it does not reconstruct actuals for
+  past PRs. The estimator simply uses whatever per-PR records exist (zero is the
+  valid day-one state, identical to today's generic-budget behaviour).
+
+## 3. The per-PR actuals format
+
+Defined in full in
+`ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md`.
+Summary of the contract:
+
+- **Home:** `observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md`.
+  The `per-pr/` subdirectory keeps these single-task records separate from the
+  quarterly `observability/costs/<YYYY-MM-DD>-costs.md` snapshots, so a reader (and
+  the estimator) never confuses a per-PR actual with a provider aggregate.
+- **Frontmatter fields** (auto-captured unless noted):
+  - `date`, `branch`, `issue`, `pr` (the PR number/URL when known, else `null`),
+    `task_summary`, `progressed_slice` (from the context object).
+  - `stages_run` — the ordered list of pipeline stages that actually ran
+    (spec-writer, tdd-agent, implementer(s), code-reviewer, integration-agent),
+    inferred from the context object (e.g. `spec_changes` present ⇒ spec-writer
+    ran; `failing_tests` ⇒ tdd-agent; `review_result` ⇒ code-reviewer).
+  - `review_cycles` — the reviewer→implementer cycle count (from `review_result`).
+  - `files_changed`, `languages` — from `git diff --name-only main...HEAD`.
+  - `tokens_by_stage` — per-stage token actuals **when human-supplied**, else the
+    stage entries carry `tokens: unavailable`. The shape mirrors the
+    estimate-record `tokens_by_stage[]` stage labels so the join key is identical.
+  - `tokens_total`, `cost_usd` — **human-supplied or `unavailable`**.
+  - `figures_source` — `human-supplied` | `unavailable` (never `inferred` — there
+    is no inference path for figures).
+- **Body** — a short disclosure: what was auto-captured vs supplied, and an
+  explicit statement when figures are `unavailable` ("token/cost figures were not
+  supplied at integration time; structural facts stand"). This is the
+  no-fabrication contract made visible in the record itself.
+
+The format file carries two worked examples — one **figures-supplied** record and
+one **figures-unavailable** record — and a short validation checklist, matching
+the house style of `estimate-record-format.md`.
+
+## 4. The integration-agent capture step
+
+A new **`### 1a. Capture per-PR actuals (calibration)`** in
+`ai-literacy-superpowers/agents/integration-agent.agent.md`, placed **after**
+`### 1. Update CHANGELOG.md` and **before** `### 2. Commit`, so the record is
+staged and committed **with the PR** (never to `main`).
+
+1. **Auto-capture structural facts** from the context object and git: `date`,
+   `branch`, `issue`, `task_summary`, `progressed_slice`, `stages_run`,
+   `review_cycles`, `files_changed`, `languages`. The `pr` field is filled later
+   if known, else left `null` (the record's provenance is the PR it ships in).
+2. **Invite figures, non-blocking.** Surface a brief one-line invitation: "If you
+   want token/cost actuals captured for calibration, paste the session figures
+   from `/cost`; otherwise I'll record them as unavailable." Record supplied
+   figures into `tokens_by_stage`/`tokens_total`/`cost_usd` and set
+   `figures_source: human-supplied`; if nothing is supplied, set every figure to
+   `unavailable` and `figures_source: unavailable`. **Never fabricate.** This
+   invitation does **not** block the pipeline — absence of a reply means
+   `unavailable` and the agent proceeds.
+3. **Write** the record to
+   `observability/costs/per-pr/<YYYY-MM-DD>-<branch-slug>-actuals.md` (the agent
+   `mkdir -p`s the directory), conforming to the format reference.
+4. **Stage it with the commit.** Step 2's named-file staging list includes the
+   per-PR actuals record, so it ships in the PR. No commit to `main`, no amend,
+   no force-push — consistent with the agent's existing constraints.
+
+The capture is **purely additive**: it never blocks the merge, and a missing or
+`unavailable` figure set produces a valid structural-only record.
+
+## 5. The feedback path (ingestion)
+
+### 5.1 Methodology (`cost-estimation/SKILL.md`)
+
+The "Calibration Seam (S6)" section is rewritten from *named, not built* to
+*implemented*:
+
+- When per-PR records exist in `observability/costs/per-pr/`, they are a
+  `kind: calibration` grounding source. The methodology uses the **per-stage
+  token actuals** across the accumulated records to **narrow** that stage's token
+  range (e.g. toward the observed central tendency) and, when enough records
+  exist for a stage, **raise** the `tokens` confidence one tier — never above the
+  `target_kind` ceiling.
+- Records whose figures are `unavailable` still contribute their **structural**
+  signal: which `stages_run` this repo actually exercises (so the estimator can
+  drop a stage the repo never uses, disclosed in `Excluded`). They contribute
+  **nothing** to the numeric token narrowing — `unavailable` is not zero.
+- Calibration **never** touches `cost_usd`/`cost_basis` (token-ranges-only
+  decision). The $/token ground stays the snapshot.
+- **No format change.** Calibration adds the `kind: calibration` entry (already
+  permitted) and a `Confidence rationale` disclosure naming how many records
+  informed the narrowing and over what date range. The disclosure contract is
+  honoured: a calibrated range is still a range with disclosed confidence, and the
+  failure direction still stated.
+
+### 5.2 The `cost-estimator` agent (S2)
+
+- On any dispatch, **Glob** `observability/costs/per-pr/` for actuals records. If
+  present, ingest the per-stage token actuals per §5.1, add a `kind: calibration`
+  `grounding_sources[]` entry naming the directory, and disclose the calibration
+  basis in `Confidence rationale` ("token ranges narrowed against N per-PR
+  actuals, 2026-06-… to …; cost unchanged — calibration refines tokens only").
+- If the directory is **absent or empty** (today's state), behaviour is
+  **identical to pre-S6**: generic `MODEL_ROUTING.md` budgets, no `calibration`
+  entry, no calibration disclosure. The loop degrades cleanly to the current
+  behaviour with zero history.
+- The agent's read-only trust boundary is unchanged (`Read`, `Glob`, `Grep`); it
+  consumes calibration data, it never writes it. The integration-agent writes;
+  the estimator reads — the same emit/persist split the whole pipeline uses.
+
+### 5.3 The format reference note
+
+`estimate-record-format.md`'s calibration-seam note changes from "no per-PR
+actuals capture, format, or integration-agent change ships in this slice" to a
+pointer at the now-shipped per-PR actuals format and a one-line statement that a
+`kind: calibration` entry is populated when history exists. **No field is added,
+removed, or retyped.**
+
+## 6. Failure modes and honesty guarantees
+
+- **No history (zero per-PR records):** the day-one state. The estimator behaves
+  exactly as pre-S6 (generic budgets), with no `calibration` grounding entry. Not
+  a failure.
+- **Figures unavailable on a record:** the record is valid and structural;
+  it calibrates the stage set but not the token magnitudes. The `unavailable`
+  marker is explicit; nothing is fabricated.
+- **Integration-agent can't reach the context object / git data:** it writes the
+  fields it can and marks the rest `unavailable`; it never blocks the merge to
+  obtain a complete record.
+- **Calibration never overrides disclosure:** a calibrated estimate is still a
+  range with disclosed confidence and a stated failure direction. Calibration can
+  narrow and raise confidence, but it cannot turn a range into a point or suppress
+  the `Excluded`/`Confidence rationale` disclosures.
+
+## 7. Acceptance scenarios
+
+```gherkin
+Scenario: Integration-agent captures a per-PR actuals record in the PR
+  Given a pipeline run is at the integration stage with a populated context object
+  When the integration-agent runs the per-PR actuals capture step
+  Then it writes observability/costs/per-pr/<date>-<branch-slug>-actuals.md with the auto-captured structural fields (stages_run, review_cycles, files_changed, languages, progressed_slice)
+  And it stages the record so it ships in the PR, never committing to main
+  And it never blocks the merge to obtain the record
+
+Scenario: Supplied figures are recorded; absent figures are marked unavailable, never fabricated
+  Given the integration-agent reaches the actuals capture step
+  When the human supplies token/cost figures from /cost
+  Then the record carries those figures with figures_source: human-supplied
+  And when no figures are supplied the record sets every token/cost field to unavailable with figures_source: unavailable
+  And in neither case does the agent invent a token or cost number
+
+Scenario: The estimator narrows token ranges against per-PR history
+  Given observability/costs/per-pr/ holds per-PR actuals records with supplied per-stage token figures
+  When the cost-estimator estimates a target
+  Then it adds a kind: calibration grounding_sources entry naming the per-pr directory
+  And it narrows the per-stage token ranges toward the observed history and discloses the calibration basis in Confidence rationale
+  And cost_usd and cost_basis are unchanged (calibration refines tokens only)
+  And no field is added to the estimate-record format
+
+Scenario: Zero history degrades cleanly to pre-S6 behaviour
+  Given observability/costs/per-pr/ is absent or empty
+  When the cost-estimator estimates a target
+  Then it uses the generic MODEL_ROUTING budgets exactly as before S6
+  And it emits no kind: calibration entry and no calibration disclosure
+
+Scenario: Unavailable-figure records still calibrate the stage set
+  Given per-PR records exist but their figures are unavailable
+  When the cost-estimator estimates a target
+  Then it may use stages_run to refine which stages the repo exercises (disclosed in Excluded)
+  And it does not narrow token magnitudes from those records
+```
+
+## 8. Decisions taken (for the choice-cartographer and the record)
+
+- **Ship the calibration loop in v1** — settled 2026-06-10 (in-scope), which is
+  why S1 kept the seam open. S6 builds it.
+- **Actuals source: hybrid (auto-structural + human-supplied figures, else
+  `unavailable`)** — the only design that both captures real actuals and honours
+  the no-fabrication contract, given no programmatic per-PR token source exists.
+  *(Open decision, dispositioned by the human at spec time.)*
+- **Calibration reach: token ranges only** — narrows per-stage token ranges from
+  repo history; `$/token`/`cost_basis` stay snapshot-bound; **no estimate-record
+  format change**, honouring the S1 seam. *(Open decision, dispositioned by the
+  human at spec time.)*
+- **Capture lives in the integration-agent and ships in the PR** — written after
+  CHANGELOG, before commit, so it never commits to `main`; non-blocking, never
+  gating the merge.
+- **Per-PR actuals format owned by `cost-tracking`** — the retrospective/actuals
+  skill that already owns `observability/costs/`; `cost-estimation` consumes it as
+  calibration. Keeps the prospective/retrospective sibling symmetry.
+- **`unavailable` is explicit and is not zero** — an unsupplied figure contributes
+  structural signal only, never a fabricated or zero-valued magnitude.
+
+## 9. TDAD discipline note
+
+S6 **modifies** existing components (`integration-agent.agent.md`,
+`cost-estimator.agent.md`, `cost-estimation/SKILL.md`, `cost-tracking/SKILL.md`,
+`estimate-record-format.md`) and **adds one reference file** under an existing
+skill (`cost-tracking/references/per-pr-actuals-format.md`). It adds **no new
+skill, agent, or command artefact** — the TDAD-scenario requirement (which the
+`tdad-scenario-check` workflow scopes to new `SKILL.md` / `*.agent.md` /
+`commands/*.md` components) does not trigger. A new `references/` file under an
+existing skill is not a new component. The modifications follow the same
+forward-applies-to-additions exemption the orchestrator changes (S4/S5) relied on.
+
+## 10. Affected files
+
+| File | Change |
+| --- | --- |
+| `ai-literacy-superpowers/skills/cost-tracking/references/per-pr-actuals-format.md` | **New.** The per-PR actuals format contract + worked examples + checklist. |
+| `ai-literacy-superpowers/skills/cost-tracking/SKILL.md` | Add a pointer to the per-PR actuals format as the per-PR sibling of the quarterly snapshot. |
+| `ai-literacy-superpowers/agents/integration-agent.agent.md` | New `### 1a` capture step; add the record to step 2's staged-files list. |
+| `ai-literacy-superpowers/skills/cost-estimation/SKILL.md` | Rewrite "The Calibration Seam (S6)" from named to implemented (§5.1). |
+| `ai-literacy-superpowers/agents/cost-estimator.agent.md` | Ingest per-PR actuals as a `kind: calibration` source; disclose basis; token-range refinement only (§5.2). |
+| `ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md` | Update the calibration-seam note to point at the shipped format; no field change (§5.3). |
+| `ai-literacy-superpowers/.claude-plugin/plugin.json` | 0.46.0 → 0.47.0. |
+| `README.md` | Badge + table cell 0.46.0 → 0.47.0. |
+| `.claude-plugin/marketplace.json` | `plugin_version` + `plugins[]` entry 0.46.0 → 0.47.0. |
+| `CHANGELOG.md` | New 0.47.0 section. |
+| `docs/plugins/ai-literacy-superpowers/explanation/prospective-cost-estimation.md` | Add a "calibration loop" section (the seam, now closed). |
+| `docs/superpowers/plans/2026-06-12-calibration-loop-per-pr-actuals.md` | Implementation plan. |


### PR DESCRIPTION
Closes the calibration seam S1 deliberately left open: the estimator now learns from **this repo's own history** instead of only the generic `MODEL_ROUTING.md` budgets. The **final slice** of the cost-estimator pipeline (S1–S5 already merged). Slice S6 of `docs/superpowers/slices/cost-estimator-pipeline.md`.

## What changed

- **Per-PR actuals format (new).** A single-task, structural sibling of the quarterly provider snapshot — owned by the `cost-tracking` skill (`references/per-pr-actuals-format.md`), stored under `observability/costs/per-pr/`. Captures which stages ran, review cycles, files & languages touched, plus token/cost figures **when a human supplies them**.
- **Integration-agent capture (new Step 1a).** After the CHANGELOG and before the commit — so the record **ships in the PR** and never commits to `main` — the integration-agent auto-captures the structural facts and records human-supplied `/cost` figures, marking them `unavailable` otherwise. **Non-blocking; never fabricates.**
- **Calibration ingestion — token ranges only.** The `cost-estimation` methodology and the `cost-estimator` agent read accumulated per-PR records as a `kind: calibration` grounding source to **narrow the per-stage token ranges** (and may raise `tokens` confidence) against repo history, disclosed in `Confidence rationale`. The `$/token` ground stays the snapshot (`cost_basis: snapshot-actuals`).

## Design commitments (two human decisions at spec time)

- **Actuals source: hybrid** — auto-structural + human-supplied figures, else `unavailable`. The only design that captures real actuals *and* honours the no-fabrication contract, given no programmatic per-PR token source exists. `unavailable` is explicit and never `0`.
- **Calibration reach: token ranges only** — `$/token`/`cost_basis` stay snapshot-bound; **no estimate-record format change**, honouring the S1 seam (just a `kind: calibration` grounding entry + disclosure). Zero history degrades cleanly to pre-S6 behaviour.

See spec §8 for the full decision record.

## Spec

First commit (spec-only): `docs/superpowers/specs/2026-06-12-calibration-loop-per-pr-actuals-design.md` (+ plan in commit 2). TDAD-exempt: modifies existing components and adds one `references/` file under an existing skill — no new skill/agent/command (spec §9).

## Version

New integration-agent responsibility + new actuals format + calibration ingestion — `ai-literacy-superpowers` 0.46.0 → 0.47.0 (plugin.json, README badge + table cell, marketplace `plugin_version` + `plugins[]` entry, CHANGELOG). Listing `version` unchanged.

Closes #373