### PR TITLE
Governance audit 2026-06-13

### DIFF
--- a/observability/governance/audit-2026-06-13.md
+++ b/observability/governance/audit-2026-06-13.md
@@ -1,0 +1,303 @@
+# Governance Audit — 2026-06-13
+
+## Governance Summary
+
+- Total constraints: 1
+- Falsifiable: 0 (with verification criteria)
+- Vague: 0 (lacking operational meaning)
+- Falsifiability ratio: 0%
+- Semantic drift stage: 3/5
+- Drift velocity: increasing
+- Governance debt items: 1
+- Aggregate debt score: 6 (sum of severity x blast radius)
+- Frame alignment score: 0%
+
+This audit covers the one governance constraint in HARNESS.md
+(**Release traceability** — the only constraint carrying a
+`Governance requirement` field). Since the previous audit
+(2026-04-15), the plugin grew from 0.19.2 to 0.47.0, a third
+marketplace plugin (`diagnostic-legibility`) shipped five versions,
+and a full prospective cost-estimation pipeline landed. The audit
+finds that the Release traceability constraint, scored **Falsifiable**
+with **no drift** at the last audit, has now drifted to **Stage 3**:
+its universal "every plugin in this marketplace" promise is enforced
+by a per-plugin allowlist that the new `diagnostic-legibility` plugin
+silently falls outside of. **Governance health: At Risk.**
+
+## Scope Note — Cost-Estimation Pipeline
+
+The context for this audit flagged the cost-estimation pipeline
+(S1–S6: `cost-estimation` skill, `cost-estimator` agent,
+`/cost-estimate` command, orchestrator T0/T1/T2 fold-ins, per-PR
+actuals calibration) as a candidate source of new governance
+constraints or drift.
+
+**Finding: the cost-estimation pipeline introduced no
+governance-flagged constraints into HARNESS.md.** A scan for
+governance language and for `Governance requirement` fields confirms
+that no constraint with cost-disclosure, estimate-accuracy, or
+spend-accountability framing was added. The pipeline is governed by
+ordinary (non-governance) constraints — output-validation
+checkpoints, TDAD scenarios, reference-page parity, spec-first
+ordering — none of which carry a `Governance requirement` field, so
+none fall in this audit's scope.
+
+This is itself worth flagging for human review (see Recommendation 3):
+a prospective cost estimator that produces `cost_usd` figures
+consumed downstream, plus a per-PR actuals-calibration loop, is a
+plausible *candidate* for a governance constraint around estimate
+provenance and disclosure of derived judgment. It is not governance
+debt today (there is no institutional requirement being silently
+mis-encoded), but it is an un-promoted governance surface. Flagged,
+not scored.
+
+## Constraint Assessment
+
+### Release traceability
+
+> Every version of every plugin in this marketplace must have a
+> matching `## X.Y.Z — YYYY-MM-DD` heading in that plugin's CHANGELOG
+> and a corresponding git tag. Per-plugin tag conventions: bare
+> `vX.Y.Z` for ai-literacy-superpowers, `<plugin-name>-vX.Y.Z` for
+> sister plugins. "Future sister plugins follow the same shape."
+
+#### Falsifiability scoring
+
+| Question | Answer |
+| --- | --- |
+| What do you verify? | (1) Changelog heading matches plugin.json version at PR time. (2) A tag exists for every published version of *every* plugin, using the per-plugin convention. |
+| What counts as evidence? | CI check output from version-check.yml, the per-plugin git tag list, auto-tag run logs, release-tag-completeness GC run logs. |
+| What happens on failure? | PR blocked (changelog mismatch); tag auto-created (auto-tag workflow or GC finding). |
+
+**Score: Partially operationalised (regressed from Falsifiable).**
+
+At the 2026-04-15 audit this constraint scored Falsifiable: all three
+questions had concrete answers and the verification machinery matched
+the constraint's promise. It no longer does. The constraint's promise
+is *universal* ("every version of every plugin in this marketplace")
+but its verification is an *enumerated allowlist* covering exactly two
+plugins. The third plugin's published versions have no answer to "what
+happens on failure" — nothing watches them. Question 1 (verify) and
+question 3 (failure action) are now unanswerable for one of the three
+governed plugins. A constraint that cannot answer its own
+falsifiability questions for a third of its declared scope is not
+fully falsifiable.
+
+The constraint is scored **neither Falsifiable nor Vague** for the
+Summary counts — it is the middle band, *partially operationalised*.
+Per the field-computation rules, it therefore contributes to neither
+the Falsifiable count (it lacks complete verification criteria for its
+full declared scope) nor the Vague count (it is rich in operational
+detail and is far from vague). This is the honest reading: the
+constraint is well-written but its enforcement has fallen behind its
+scope.
+
+#### Drift detection
+
+**Drift stage: 3 — Implementation from a different frame.**
+
+The five-stage model maps cleanly onto what happened:
+
+- **Stage 1 (Coinage):** "Every version of every plugin must have a
+  tag" was coined when the marketplace held one, then two plugins. The
+  per-plugin convention table (bare `vX.Y.Z`; `model-cards-vX.Y.Z`)
+  enumerated the plugins that existed.
+- **Stage 2 (Adoption without frame):** "Future sister plugins follow
+  the same shape" entered the constraint as a *prose promise* without
+  an operational hook. There is no rule that says "when a plugin is
+  added to `marketplace.json`, an auto-tag workflow and a GC
+  completeness step must be added for it." The universal language was
+  adopted; the frame that would make it self-extending was not.
+- **Stage 3 (Implementation from a different frame):** When
+  `diagnostic-legibility` shipped (0.1.0 → 0.5.0, five versioned
+  CHANGELOG entries), the engineering frame implemented release
+  governance as it always had — by *editing the two existing
+  enumerated checks*. No new auto-tag workflow was created
+  (`auto-tag-diagnostic-legibility.yml` does not exist), and no third
+  step was added to the release-tag-completeness GC in `gc.yml` (which
+  still hard-codes exactly two steps). The constraint *says* "every
+  plugin"; the implementation *does* "the two plugins I enumerated."
+  This is the textbook Stage 3 gap — form satisfied in the
+  engineering frame (the named checks pass), substance absent in the
+  governance frame (a published plugin's releases are untracked).
+
+The constraint's own text contains the fingerprint of the drift: the
+**Verification method** field reads "release-tag-completeness GC
+(periodic, **both** plugins)" — the word "both" silently caps the
+universal "every plugin" rule at two. The constraint was never
+re-operationalised when the marketplace went from two plugins to
+three.
+
+**Reality table:**
+
+| Plugin | CHANGELOG versions | Expected tag convention | Tags present | Auto-tag workflow | GC completeness step |
+| --- | --- | --- | --- | --- | --- |
+| ai-literacy-superpowers | up to 0.47.0 (73 headings) | bare `vX.Y.Z` | 73 (latest `v0.46.0`; `v0.47.0` pending post-merge auto-tag) | `auto-tag.yml` ✓ | yes ✓ |
+| model-cards | 0.1.0 | `model-cards-vX.Y.Z` | `model-cards-v0.1.0` ✓ | `auto-tag-model-cards.yml` ✓ | yes ✓ |
+| diagnostic-legibility | 0.1.0–0.5.0 (5 headings) | `diagnostic-legibility-vX.Y.Z` | **0 — none exist** | **none** | **none** |
+
+The `v0.47.0` gap on the primary plugin is *not* drift — it is the
+expected post-merge timing window (0.47.0 merged in the latest commit;
+auto-tag runs on merge to main and the GC backstop would catch it on
+the next run). The `diagnostic-legibility` gap *is* drift: five
+published versions with zero tags and no mechanism that will ever
+create them.
+
+#### Three-frame alignment check
+
+| Frame | Interpretation | Status |
+| --- | --- | --- |
+| Engineering | CI blocks mismatched changelog headings; auto-tag creates tags on merge; GC backstops completeness. **For diagnostic-legibility, none of these three layers run** — no auto-tag workflow, no GC step. | **Divergent** |
+| Compliance | Every published version has an auditable changelog entry and an immutable git tag, providing complete release history. **diagnostic-legibility has changelog entries but no tags — the immutable release record the compliance frame relies on does not exist for one plugin.** | **Divergent** |
+| AI system | All checks are deterministic, no judgement required. **True only for the two enumerated plugins; for diagnostic-legibility there is no check at all, deterministic or otherwise.** | **Divergent** |
+
+**Frame alignment: NOT aligned (significant divergence).** All three
+frames described the same operational meaning at the last audit. They
+no longer do — each frame is satisfied for two of three plugins and
+silently empty for the third. Because the constraint's declared scope
+is "every plugin in this marketplace" and one plugin is wholly
+outside all three frames, this constraint is counted as **not
+aligned** for the frame-alignment score. Aligned constraints: 0 of 1.
+
+#### Verification results
+
+- plugin.json (ai-literacy-superpowers): 0.47.0
+- CHANGELOG.md (root) headings: 73 versions; top heading `0.47.0 — 2026-06-12`
+- ai-literacy-superpowers bare tags: 73; latest `v0.46.0`; `v0.47.0` not yet tagged (post-merge window)
+- model-cards: CHANGELOG top `0.1.0`; tag `model-cards-v0.1.0` present — aligned
+- diagnostic-legibility: plugin.json `0.5.0`; CHANGELOG headings 0.1.0–0.5.0 (5); **`diagnostic-legibility-v*` tags: 0**
+- Auto-tag workflows present: `auto-tag.yml`, `auto-tag-model-cards.yml` — **no `auto-tag-diagnostic-legibility.yml`**
+- `gc.yml` release-tag-completeness: two hard-coded steps (ai-literacy-superpowers, model-cards) — **no diagnostic-legibility step**
+- version-check.yml: present (changelog-match PR gate)
+
+## Governance Debt Inventory
+
+| # | Description | Severity | Blast radius | Score | Affected constraints | Recommended action |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Release traceability promises "every version of every plugin in this marketplace" has a git tag, but the enforcement is a two-plugin enumerated allowlist. `diagnostic-legibility` (5 published versions) has no auto-tag workflow, no GC completeness step, and zero tags. The constraint's own Verification-method field says "both plugins," capping a universal rule at two. | 2 — Moderate (right intent; verification does not match current process — passes its own audit while missing the risk it was designed for: an untracked published plugin) | 3 — Systemic (the "every plugin in this marketplace" assumption is foundational to the multi-plugin release-governance framework; it interlocks with the Marketplace plugin version sync constraint and the "Every marketplace plugin appears in the docs index pages" whole-repo invariant — the same "every plugin" universal that this one fails to operationalise) | 6 — High | Release traceability (directly); Marketplace plugin version sync and Every-marketplace-plugin-in-docs-index (share the "every plugin" universal pattern) | Add `auto-tag-diagnostic-legibility.yml` and a third release-tag-completeness step in `gc.yml`; backfill the five missing `diagnostic-legibility-v0.x.0` tags; **then** rewrite the constraint so it is self-extending — replace the enumerated convention table with a rule keyed off `marketplace.json` `plugins[]` (every entry must have a matching auto-tag workflow and GC step), and delete the word "both" from the Verification-method field. Remediate within two weeks (High). |
+
+**Aggregate debt score: 6** (severity 2 × blast radius 3).
+
+Per the staleness thresholds, a single debt item keeps the inventory
+size "Fresh" (0–2 items), but the score-6 (High) severity and the
+falsifiability-ratio collapse (0% < 0.50, "Critical" band) put overall
+governance health at risk.
+
+## Debt Cycle Analysis
+
+**Early-stage four-debt reinforcement detected — not yet a full
+cycle, but the first link is live.**
+
+- **Governance debt → intent debt:** The constraint reads as if it
+  governs the whole marketplace ("every plugin"). A reader forms the
+  belief that all three plugins are tag-protected. That belief is
+  false for `diagnostic-legibility`. The governance language now
+  obscures the actual purpose-coverage — the classic
+  governance-debt-to-intent-debt step.
+- **Intent debt → cognitive debt:** The 2026-05-29 snapshot states
+  diagnostic-legibility "shipped" v0.1.0–v0.3.0 and lists tags
+  created — but those tags do not exist. The team's recorded mental
+  model already diverges from reality. That is cognitive debt forming
+  on top of the intent gap.
+- **Cognitive debt → technical debt:** Because the mental model says
+  "release governance is handled," no one built the third auto-tag
+  workflow or GC step. The missing automation is the technical-debt
+  manifestation.
+- **Technical debt → governance debt (closing the loop):** Each new
+  diagnostic-legibility release widens the gap between the
+  constraint's "every plugin" language and the untracked reality —
+  feeding the governance debt that started the cycle.
+
+The cycle is not yet self-sustaining (only five untracked versions, no
+real-world harm), but all four links are now identifiable. This is
+exactly the pattern the quarterly "Governance debt cycle check" GC
+rule is meant to surface — note that GC rule is currently commented
+out in HARNESS.md (see Recommendation 4).
+
+## Prioritised Recommendations
+
+1. **(High — within two weeks) Close the diagnostic-legibility
+   release-governance gap.** Create
+   `.github/workflows/auto-tag-diagnostic-legibility.yml`, add a third
+   release-tag-completeness step to `gc.yml`, and backfill the five
+   missing `diagnostic-legibility-v0.1.0`…`v0.5.0` tags at their
+   introducing commits. This restores the constraint's promise for the
+   third plugin and clears debt item #1's technical manifestation.
+
+2. **(High — same change) Make Release traceability self-extending so
+   it cannot silently regress on the next plugin.** Replace the
+   enumerated per-plugin convention table with a rule keyed off
+   `marketplace.json` `plugins[]`: every listed plugin must have a
+   matching auto-tag workflow and a GC completeness step. Delete the
+   word "both" from the Verification-method field. This converts the
+   Stage-3 drift back toward Stage 1 by giving the universal language
+   an operational hook. (Humans own the HARNESS.md edit — this audit
+   only recommends it.)
+
+3. **(Medium — this quarter) Decide whether the cost-estimation
+   pipeline warrants a governance constraint.** The prospective
+   estimator emits `cost_usd` figures with `generated_by` provenance
+   and a per-PR actuals-calibration loop. If the project (or any
+   downstream consumer) treats those figures as a basis for budget or
+   spend decisions, an estimate-provenance / disclosure-of-derived-
+   judgment governance constraint may be warranted. Flagged for human
+   decision — not scored as debt, because no institutional requirement
+   is currently being mis-encoded.
+
+4. **(Medium — this quarter) Activate the governance GC rules.** The
+   three governance GC rules (constraint freshness, semantic-drift
+   early warning, debt-cycle check) are present but commented out in
+   HARNESS.md. The drift surfaced in this audit existed silently for
+   weeks precisely because no periodic governance check was running.
+   Uncommenting them would have surfaced debt item #1 at Stage 2
+   instead of Stage 3.
+
+5. **(Low — next audit) Correct the snapshot record.** The 2026-05-29
+   snapshot reports diagnostic-legibility tags as created. They are
+   not. The next `/harness-health` run should reconcile the snapshot's
+   "Tags created" line with the actual tag list.
+
+## Notes — Comparison with Previous Audit (2026-04-15)
+
+| Dimension | 2026-04-15 (revised) | 2026-06-13 |
+| --- | --- | --- |
+| Governance constraints | 1 | 1 |
+| Falsifiable | 1 | 0 (regressed to partially operationalised) |
+| Falsifiability ratio | 100% | 0% |
+| Drift stage | 1/5 (no drift) | 3/5 (implementation from a different frame) |
+| Drift velocity | stable | increasing |
+| Governance debt items | 0 | 1 |
+| Aggregate debt score | 0 | 6 |
+| Frame alignment | 100% | 0% |
+| Plugin version (primary) | 0.19.2 | 0.47.0 |
+| Marketplace plugins | 1 (governed) | 3 (1 ungoverned by tags) |
+| Governance health | Healthy | At Risk |
+
+The previous audit's Recommendation 3 was prescient: it warned that if
+the project ever separated "published" from "in plugin.json," the
+"published plugin versions" terminology could become Stage-1 drift.
+The actual drift took a different but related shape — not the
+published/plugin.json gap, but a *scope* gap: the universal "every
+plugin" promise outran the enumerated enforcement when a third plugin
+arrived. The lesson generalises: universal governance language needs a
+self-extending operational hook, or each new entity that enters scope
+becomes silent debt.
+
+## Governance Metrics Block (for harness health snapshot)
+
+```text
+## Governance
+
+- Last governance audit: 2026-06-13
+- Governance constraints: 1
+- Falsifiable: 0 | Partially operationalised: 1 | Vague: 0
+- Falsifiability ratio: 0%
+- Semantic drift stage: 3/5 (implementation from a different frame)
+- Drift velocity: increasing
+- Governance debt items: 1 (aggregate score 6 — High)
+- Frame alignment score: 0%
+- Governance health: At Risk
+- Top action: close the diagnostic-legibility release-governance gap
+  (no auto-tag workflow, no GC step, 5 untagged published versions);
+  then make Release traceability self-extending off marketplace.json
+```

--- a/observability/snapshots/2026-05-29-snapshot.md
+++ b/observability/snapshots/2026-05-29-snapshot.md
@@ -103,6 +103,25 @@ Code-mode:
 - Budget status: not set
 - Cost trend: unknown (no `observability/costs/` directory yet)
 
+## Governance
+
+<!-- Metrics from /governance-audit 2026-06-13 (audit dated after this
+     snapshot; block backfilled so the latest snapshot carries current
+     governance state). Source: observability/governance/audit-2026-06-13.md -->
+
+- Last governance audit: 2026-06-13
+- Governance constraints: 1
+- Falsifiable: 0 | Partially operationalised: 1 | Vague: 0
+- Falsifiability ratio: 0%
+- Semantic drift stage: 3/5 (implementation from a different frame)
+- Drift velocity: increasing
+- Governance debt items: 1 (aggregate score 6 — High)
+- Frame alignment score: 0%
+- Governance health: At Risk
+- Top action: close the diagnostic-legibility release-governance gap
+  (no auto-tag workflow, no GC step, 5 untagged published versions);
+  then make Release traceability self-extending off marketplace.json
+
 ## Sustainable Pace
 
 - PRs merged in the last 7 days: 5 (#337, #341, #342 today; #336, #334 within the dl-s2 cluster) — within healthy range


### PR DESCRIPTION
## Summary

Quarterly governance audit (dispatched via `/governance-audit`). Observability output only — no plugin code change, no version bump.

- **One governance constraint** (Release traceability) regressed **Healthy → At Risk** since the 2026-04-15 audit.
- **Stage 3 semantic drift, velocity increasing.** The constraint promises "every version of every plugin in this marketplace" has a git tag, but enforcement is a **two-plugin enumerated allowlist**. `diagnostic-legibility` (5 published versions, v0.1.0–v0.5.0) has **zero tags, no auto-tag workflow, and no GC completeness step** — verified against the repo.
- **1 debt item, aggregate score 6 (High).** Early four-link debt cycle identified (governance → intent → cognitive → technical), not yet self-sustaining.
- **Summary metrics:** 1 constraint · falsifiability 0% · drift 3/5 · velocity increasing · 1 debt item (score 6) · frame alignment 0%.

## Files

- `observability/governance/audit-2026-06-13.md` — full report (Governance Summary verified against the Observatory contract)
- `observability/snapshots/2026-05-29-snapshot.md` — governance metrics block backfilled

## Top recommendations (for human action — the auditor reports, humans action)

1. **(High, 2 weeks)** Add `auto-tag-diagnostic-legibility.yml` + a third `gc.yml` completeness step; backfill the 5 missing tags.
2. **(High, same change)** Rewrite Release traceability to be self-extending off `marketplace.json` `plugins[]` so the next plugin can't silently fall out of scope; delete "both" from the Verification-method field.
3. **(Medium)** Decide whether the new cost-estimation pipeline (prospective `cost_usd` + actuals calibration) warrants an estimate-provenance governance constraint.
4. **(Medium)** Activate the three commented-out governance GC rules — they'd have caught this at Stage 2.

## Test plan

- Confirm `observability/governance/audit-2026-06-13.md` `## Governance Summary` has the exact heading and nine ordered fields.
- Confirm the snapshot governance block reflects the audit.

Branch prefix `chore/` (observability output outside the plugin dir).