### PR TITLE
Cost snapshot 2026-06-13 (first capture)

### DIFF
--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -26,6 +26,19 @@
 | code-reviewer | 50-100k tokens | >100k: too many files, batch |
 | integration-agent | 30-80k tokens | >80k: CI issues, investigate |
 
+## Observed Cost (2026-06-13)
+
+First cost capture — see `observability/costs/2026-06-13-costs.md` (a
+single-machine session sample, not a full billing aggregate). Observed pattern:
+cost is **cache-read + output dominated**, not fresh input. Opus 4.8 effective
+**blended ~$0.83/1M** across all token categories (vs the $5/$25 list card),
+because the bulk of tokens were cache reads at ~0.1×. Drivers: subagent-heavy
+sessions (~70% of usage) and >150k-context sessions (~67%). No tier re-route is
+warranted — the data shows an operational cost pattern, not a misrouted tier.
+The prospective `cost-estimator` reads the snapshot as its `$/token` ground; keep
+its `cost` confidence low/medium until a provider-dashboard snapshot replaces this
+sample.
+
 ## Sovereignty Considerations
 
 ### Data Classification

--- a/observability/costs/2026-06-13-costs.md
+++ b/observability/costs/2026-06-13-costs.md
@@ -1,0 +1,76 @@
+# Cost Snapshot — 2026-06-13
+
+> **Source & scope (read first).** These figures are from Claude Code's `/cost`
+> for **one multi-day local session** on a single machine (API time 6h 40m;
+> wall 3d 4h), captured 2026-06-13. `/cost` itself notes the data is
+> "approximate, based on local sessions on this machine — does not include other
+> devices or claude.ai." This is therefore a **single-session sample, not a full
+> provider-billing-period aggregate**. It is the **first** cost data in
+> `observability/costs/` (prior state: "Last cost capture: never"), so the
+> prospective `cost-estimator` can now ground a dollar figure — but its `cost`
+> confidence should stay **low/medium** until a full provider-dashboard snapshot
+> replaces it.
+
+## Provider Spend
+
+| Provider | Period | Spend | Tokens (input, incl. cache) | Tokens (output) |
+| --- | --- | --- | --- | --- |
+| Anthropic | single session, API 6h 40m (captured 2026-06-13) | $287.64 | ~343.3M | ~1.64M |
+
+## Model Breakdown
+
+The cost is **cache- and output-dominated**, not fresh-input — so the input
+column carries the full picture (uncached + cache-read + cache-write). Naively
+reading "uncached input" alone would yield a nonsensical rate; the effective
+blended rate below is what reflects reality.
+
+| Model | Input (uncached / cache-read / cache-write) | Output | Estimated cost | Effective blended $/1M (all tokens) |
+| --- | --- | --- | --- | --- |
+| claude-opus-4-8 | 120.8k / 329.4M / 12.9M | 1.6M | $286.52 | ~$0.83 |
+| claude-haiku-4-5 | 611.8k / 0 / 241.6k | 40.5k | $1.12 | ~$1.25 |
+
+Per-category list rates used as the cross-check (per 1M tokens): Opus 4.8 input
+$5.00 / output $25.00, with cache-read ~$0.50 (0.1×) and cache-write ~$6.25
+(1.25×); Haiku 4.5 input $1.00 / output $5.00. Cost reconciliation for Opus:
+1.6M out × $25 ≈ $40 + 329.4M cache-read × $0.50 ≈ $165 + 12.9M cache-write ×
+$6.25 ≈ $81 + 0.12M input × $5 ≈ $0.6 → ≈ $286.5, matching the observed $286.52.
+
+## Per-Project Estimate
+
+| Project/Repo | Estimated share | Rationale |
+| --- | --- | --- |
+| ai-literacy-superpowers | ~100% | The session's work was entirely in this repo (cost-estimator pipeline S4–S6, governance audit, docs). |
+
+## Observations
+
+- **`$/token` ground for the estimator.** The Opus effective blended rate of
+  **~$0.83/1M** (all token categories) is what the `cost-estimator` should treat
+  as the snapshot-derived rate for the dominant tier — far below the $5/$25 list
+  card because **329.4M of 344M tokens were cache reads** at ~0.1×. This is the
+  single most important reason the methodology forbids list-price as ground: list
+  price would over-state this session's effective rate by ~6×.
+- **Cost drivers (from `/cost`):** 70% of usage came from **subagent-heavy**
+  sessions (each subagent runs its own requests); 67% was at **>150k context**
+  (long sessions are expensive even when cached). Output ($40) + cache-write
+  ($81) + cache-read ($165) dominate; fresh input is negligible ($0.60).
+- **Not a pipeline-stage breakdown.** This session was **direct authoring plus a
+  single `governance-auditor` subagent**, not an orchestrator pipeline run, so it
+  carries **no** per-stage (spec-writer/tdd/implementer/code-reviewer/integration)
+  attribution. It grounds the **dollar rate**, not the per-stage **token** budgets
+  — the latter still come from `MODEL_ROUTING.md` until a real orchestrator run is
+  captured via the S6 per-PR actuals path.
+
+## Budget Status
+
+- Monthly budget: not set
+- Current monthly average: not tracked (first capture — no prior snapshot to trend)
+- Trend: n/a (baseline)
+- Action needed: no — but capture a full provider-dashboard snapshot next quarter
+  to replace this single-machine sample with a billing-grounded aggregate.
+
+## Model Routing
+
+`MODEL_ROUTING.md` updated 2026-06-13 with an observed-cost note pointing at this
+snapshot (cache-read + output dominate; subagent-heavy / high-context sessions
+drive cost). No tier re-routing made — the data does not indicate a misrouted
+tier, only an operational cost pattern.


### PR DESCRIPTION
## Summary

The first cost data in `observability/costs/` (prior state: "Last cost capture: never"). Real per-model actuals from Claude Code's `/cost` for one multi-day session — this **grounds the prospective `cost-estimator`'s dollar figure** across T0/T1/T2, which until now omitted `cost_usd` with a "not grounded — no snapshot" disclosure. Observability only — no plugin change, no version bump.

- **Total: $287.64** (Anthropic; API 6h 40m). Opus 4.8 $286.52, Haiku 4.5 $1.12.
- **Cache- and output-dominated.** 329.4M of ~344M tokens were cache reads at ~0.1×, so the Opus **effective blended rate is ~$0.83/1M** — ~6× below the $5/$25 list card. This is the concrete reason the methodology forbids list-price as ground; the snapshot carries the full input (incl. cache) so the derived rate is real, and the cost reconciliation matches the observed total.
- **Honest scope.** `/cost` is a single-machine session sample, not a billing-period aggregate — so the snapshot says the estimator's `cost` confidence should stay **low/medium** until a provider-dashboard snapshot replaces it.

## Why a snapshot, not a per-PR actuals record

Seeing the data changed the plan. `/cost` is per-**model** tokens + cost (snapshot Model-Breakdown shape), and this session was **direct authoring + one governance-auditor subagent**, not an orchestrator pipeline run — so it has no per-stage (spec-writer/tdd/implementer/code-reviewer/integration) attribution. A per-PR S6 calibration record would have every stage `unavailable` and calibrate nothing. The snapshot is the correct, higher-value home: it grounds the dollar rate. Per-stage token calibration still comes from `MODEL_ROUTING.md` until a real pipeline run is captured via the S6 per-PR path.

## Files

- `observability/costs/2026-06-13-costs.md` — the snapshot (validation checkpoint passed: Period, Total spend, Model-routing reference all present).
- `MODEL_ROUTING.md` — observed-cost note linking the snapshot; no tier re-route (data shows an operational cost pattern, not a misrouted tier).

## Test plan

- Confirm `observability/costs/2026-06-13-costs.md` parses (Provider Spend + Model Breakdown tables, Period, Total spend).
- Confirm MODEL_ROUTING.md observed-cost note references the snapshot.

Branch prefix `chore/` (observability + root config, outside the plugin directory).