### PR TITLE
docs: document all five CI-enforced version-bump locations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,18 +63,37 @@ change warrants a bump:
 4. If the change is trivial (typo, whitespace, formatting-only fixes
    like adding code fence languages), no bump needed — add the
    `no-bump` label to the PR to skip the CI check
-5. When bumping, update all three locations:
-   - `ai-literacy-superpowers/.claude-plugin/plugin.json` (`"version"` field)
-   - `README.md` (Plugin version badge)
-   - `CHANGELOG.md` (version header on the current date section)
+5. When bumping, update **every version location the `Version Check` CI
+   enforces** — `.github/workflows/version-check.yml` is the source of
+   truth. For the `ai-literacy-superpowers` plugin that is **five**
+   CI-checked locations (not three):
+   - `ai-literacy-superpowers/.claude-plugin/plugin.json` (`"version"` — canonical)
+   - `README.md` — the shields.io **badge** (`ai--literacy--superpowers-vX.Y.Z`)
+   - `CHANGELOG.md` — the top `## X.Y.Z — YYYY-MM-DD` heading
+   - `.claude-plugin/marketplace.json` — the top-level `plugin_version`
+   - `.claude-plugin/marketplace.json` — the plugin's `plugins[].version`
+     entry (each plugin entry's version must equal its own `plugin.json`
+     version; the check enumerates every plugin)
+
+   Also update, for human-facing consistency (**not** CI-enforced): the
+   `README.md` plugin-table row cell (`| v0.X.Y |`). Before committing,
+   `grep -rn 'vX\.Y\.Z' README.md .claude-plugin/marketplace.json
+   ai-literacy-superpowers/.claude-plugin/plugin.json` for the **old**
+   version to surface every spot at once — cheaper than discovering a
+   missed location via red CI.
 
 ## Marketplace Versioning
 
 The marketplace listing (`.claude-plugin/marketplace.json`) is versioned
-independently from the plugin. It has two version fields:
+independently from the plugin. It carries three version fields:
 
 - `version` — the listing version (the contract with the platform)
 - `plugin_version` — pointer to the currently approved plugin release
+- `plugins[].version` — a per-plugin entry version. **Every plugin
+  entry's `version` must equal that plugin's own `plugin.json`
+  version**, and `Version Check` CI enforces this for every entry in the
+  `plugins` array (not just `ai-literacy-superpowers`). Bump it whenever
+  the corresponding plugin bumps.
 
 **When to update `plugin_version`:**
 


### PR DESCRIPTION
## Summary

Closes the documentation gap surfaced by the 2026-06-14 reflection: CLAUDE.md's "Semantic Versioning" said to "update all three locations", but `Version Check` CI actually enforces **five** — and the two marketplace fields plus the per-plugin entry sync were under-/un-documented. This cost two avoidable red-CI round-trips on the S4 bump. Docs-only; no plugin change, no version bump.

Verified against `.github/workflows/version-check.yml`, the enforced locations are:
1. `ai-literacy-superpowers/.claude-plugin/plugin.json` (`version` — canonical)
2. `README.md` shields.io **badge**
3. `CHANGELOG.md` top heading
4. `.claude-plugin/marketplace.json` `plugin_version`
5. `.claude-plugin/marketplace.json` `plugins[].version` (per-plugin, enumerated for every entry)

The README plugin-**table cell** I also bumped during the pipeline is **not** CI-enforced (the check greps only the badge) — now documented as consistency-only, so future bumps don't treat it as required.

## Changes

- **Semantic Versioning step 5** rewritten as the complete five-location checklist, naming `version-check.yml` as the source of truth, with a `grep` one-liner to surface every spot before committing.
- **Marketplace Versioning** field list gains `plugins[].version` (was missing) with its "must equal the plugin's own `plugin.json`" rule.

## Test plan

- Re-read CLAUDE.md Semantic Versioning + Marketplace Versioning; confirm the five locations match `version-check.yml` exactly.

Branch prefix `chore/` (root convention doc, outside the plugin directory).