### PR TITLE
Reservoir warden: advisory watch on the human verifier (0.48.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.47.0",
+  "plugin_version": "0.48.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.47.0"
+      "version": "0.48.0"
     },
     {
       "name": "model-cards",

--- a/.github/prompts/reservoir.prompt.md
+++ b/.github/prompts/reservoir.prompt.md
@@ -1,0 +1,62 @@
+---
+name: reservoir
+description: Watch the human verifier the harness cannot verify — Read mode dispatches the reservoir-warden agent for a fuller cognitive-reservoir read; Tune mode helps you edit the HARNESS.md Cognitive reservoir block (thresholds and chronotype), proposing edits for you to confirm
+---
+
+# Reservoir
+
+An on-demand, read-only advisory on **you**, the verifier — not on the
+code. It counts observable proxies over the recent git window and, if a
+threshold is crossed, offers the single decide-your-stop-first
+recommendation. Advisory only: never blocks, never scores, never
+persists a record of your state.
+
+## Usage
+
+```text
+/reservoir [read | tune]
+```
+
+Mode defaults to `read`.
+
+## Read mode
+
+1. Confirm HARNESS.md contains a `Cognitive reservoir` block. If not (or
+   no HARNESS.md, or no git repo), say the project has not opted in and
+   offer Tune mode. Do not manufacture a read.
+2. Read `ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md` for
+   the four proxies, the `observed`/`inferred`/`asked` confidence
+   discipline, the default thresholds, the one firm principle, the
+   honesty rule, and the report format.
+3. Gather proxies with `git`/`date` only (read-only): continuous session
+   span, decision volume, context switches, wall-clock hour. A proxy that
+   matches nothing degrades to 0.
+4. Read tuned thresholds from the HARNESS.md block (defaults: window 8 h,
+   span 180 min, decision volume 8, context switches 4). Evaluate
+   disjunctively — any one crossing fires the recommendation.
+5. Produce the report: a proxy table (each line flagged), one or two
+   sentences of defeasible inferred risk tied to a robust basis
+   (vigilance decrement / switching cost), and — if crossed — the one
+   firm principle plus one concrete time-boxed option. No fatigue score.
+   No second nudge.
+6. Honesty gate: never assert ego depletion; never quote the
+   hungry-judges figure; frame every trigger as a precaution under
+   uncertainty. The late-hour band is `asked`/unverified unless a
+   `chronotype` is declared.
+
+## Tune mode
+
+1. Read the current `Cognitive reservoir` block (or propose adding one).
+2. Walk the tunable fields: `window_hours`, `span_minutes`,
+   `decision_volume`, `context_switches`, and the optional `chronotype`.
+3. Present the proposed block as a diff; confirm before writing. The user
+   owns this block — it records configuration only, never a claim about
+   their state.
+4. After writing, verify the `## Cognitive reservoir` marker is intact,
+   keys are recognised, numeric values are positive integers, and the
+   not-a-constraint note is present.
+
+## Not a gate
+
+Advisory-only and not a Constraint. Never fails CI, never blocks, writes
+no record of cognitive state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,34 @@
   Source: `REFLECTION_LOG.md` 2026-06-14 (Proposal #2); snapshot
   `observability/costs/2026-06-13-costs.md`; PR #391.
 
+- Decision: the verifier-watch (`cognitive-reservoir` skill,
+  `reservoir-warden` agent, `/reservoir` command, `reservoir-check` Stop
+  hook) is **advisory-only and is NOT a Constraint** — do not promote it
+  into a CI gate. Reason: the mechanism watches the *human verifier*, the
+  one actor every other enforcement surface trusts blindly. It counts
+  observable proxies (session span, decision volume, context switches,
+  wall-clock hour) and infers risk, but the inputs cannot support a
+  precise measurement of cognitive state. Constraints are gates with a
+  scope that can fail CI; wiring a human-state advisory into a blocking
+  gate would (a) defeat its purpose — the engineer's *prohairesis* must
+  stay theirs, the warden watches but never chooses — and (b) overclaim a
+  precision the proxies lack. So it lives in its own `Cognitive
+  reservoir` HARNESS.md block (opt-in, never the Constraints section),
+  never blocks a commit/merge/session, never exits non-zero, and
+  persists **no** record of the human's state to disk. This generalises
+  the existing "hook scripts never block, only warn" decision to a
+  stronger rule for human-state observation: such a mechanism must also
+  never be a fatigue *score* and must keep contested science (ego
+  depletion, the hungry-judges figure) out of its assertions — the
+  honesty rule is load-bearing, not flavour. A future contributor who
+  "promotes" the warden into a blocking gate or a single combined score
+  has broken the design, not improved it. Alternative considered:
+  modelling it as a soft (non-blocking) Constraint for visibility in
+  health snapshots (rejected — even a non-blocking Constraint frames it
+  as a measured gate and invites later hardening). Source: spec
+  `docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`
+  (Approach, FR-011); builds on the line-201 advisory-hook decision.
+
 ## TEST_STRATEGY
 
 <!-- How tests are structured in this project. Helps agents write consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.48.0 — 2026-06-14
+
+### Reservoir warden — watching the verifier the harness cannot verify
+
+The framework's first observability surface aimed at the **human verifier**
+rather than the session output. Every other enforcement mechanism checks what
+an agentic session produced; none checked the state of the human who approves
+it. This adds a read-only, advisory watch — opt-in per project, never a gate.
+New skill + agent + command + hook — minor bump.
+
+- **`cognitive-reservoir` skill (new).** The shared grounding: four observable
+  proxies (session span, decision volume, context switches, wall-clock hour),
+  the `observed`/`inferred`/`asked` confidence discipline, disjunctive default
+  thresholds (span 180 min, decision volume 8, context switches 4, window 8 h),
+  the one firm principle, six-level scaling, and the honesty rule that keeps
+  contested science (ego depletion, the hungry-judges study) out of the
+  mechanism's assertions while standing on the robust basis (vigilance
+  decrement, task-switching cost).
+- **`reservoir-warden` agent (new).** Read-only on the human (tools: Read,
+  Glob, Grep, Bash — no Write, no Edit). Counts the proxies via `git`/`date`,
+  reports each with a confidence flag, and offers the single
+  decide-your-stop-first recommendation when a threshold is crossed. Persists no
+  record of the human's state; produces no combined fatigue score. Routed to an
+  inexpensive tier in `MODEL_ROUTING.md`.
+- **`/reservoir` command (new) + Copilot prompt.** Read mode dispatches the
+  agent for a fuller read; Tune mode helps you edit the HARNESS.md block
+  (thresholds and an optional `chronotype`), proposing edits to confirm.
+- **`reservoir-check.sh` Stop hook (new).** Self-gates on an active
+  `## Cognitive reservoir` heading and a git repo, computes the proxies over the
+  recent window, and emits at most one `{"systemMessage": ...}` advisory.
+  Advisory-only: never blocks, never exits non-zero, never asserts ego depletion
+  or the hungry-judges figure.
+- **HARNESS template (updated).** Ships an optional, commented `Cognitive
+  reservoir` block (inert until uncommented) with the `chronotype` field and a
+  not-a-constraint note.
+- **AGENTS.md ARCH_DECISION (new).** Records that the verifier-watch is
+  advisory-only and must never be promoted into a CI gate or a single fatigue
+  score, so a future contributor does not "improve" it into one.
+- **Docs + TDAD.** New explanation and how-to pages, reference entries for the
+  new skill/agent/command/hook, and four TDAD scenarios (read-only boundary,
+  fires-on-long-session, silent-when-quiet, silent-when-not-opted-in); the test
+  runner gains hook-component discovery.
+
 ## 0.47.0 — 2026-06-12
 
 ### Calibration loop — per-PR actuals capture (S6 of the cost-estimator pipeline)

--- a/MODEL_ROUTING.md
+++ b/MODEL_ROUTING.md
@@ -15,6 +15,7 @@
 | code-reviewer | Most capable | Nuance, quality judgment |
 | integration-agent | Standard | Procedural workflow |
 | cost-estimator | Standard | Read-and-author against a fixed methodology and named grounding sources — applies the cost-estimation skill and emits a conforming record. Not deep adversarial judgment or design synthesis; it follows a defined derivation (like tdd-agent). |
+| reservoir-warden | Inexpensive | Counts observable proxies (`git`/`date`) against fixed thresholds and emits a templated advisory from the cognitive-reservoir skill. No deep reasoning, no design synthesis, no adversarial judgment — it counts and advises. The honesty discipline lives in the skill, not in model judgment. |
 
 ## Token Budget Guidance
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.47.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.48.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-34-2E8B57?style=flat-square)](#skills-34)
-[![Agents](https://img.shields.io/badge/Agents-15-2E8B57?style=flat-square)](#agents-15)
-[![Commands](https://img.shields.io/badge/Commands-27-2E8B57?style=flat-square)](#commands-27)
+[![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
+[![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
+[![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
 [![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-10-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.47.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **34 skills, 15 agents, 27 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.48.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (34)
+### Skills (35)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -195,8 +195,9 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | advocatus-diaboli | Adversarial spec review — six-category objection framework, evidence requirements, steel-manned challenge before plan approval |
 | choice-cartographer | Decision archaeology — six-lens map of implicit choices a spec has made (forces, alternatives, defaults, patterns, consequences, coherence); routing rule partitions findings between the Cartographer and the diaboli |
 | component-design-with-tdad | Design-time methodology for new plugin components — names the five design questions implied by the four-layer TDAD architecture (component type, layer targeting, scenario shape, new-vs-modification, scenario-vs-finding); loadable by spec-writer, tdd-agent, or human brainstorming |
+| cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
 
-### Agents (15)
+### Agents (16)
 
 A coordinated team that handles the full development lifecycle.
 
@@ -217,8 +218,9 @@ A coordinated team that handles the full development lifecycle.
 | choice-cartographer | Decision-archaeology mapper — runs after spec-mode diaboli dispositions are resolved; emits choice stories (Henney pattern stories) for each material implicit decision; soft gate at plan approval, merge-time HARNESS constraint enforces resolution | Read only |
 | carpaccio | Cadence governor — runs at orchestrator step 0 before spec-writer; slices the raw task description into thin, end-to-end-complete pieces; hard gate on slice dispositions; the third member of the decision-discipline triad alongside diaboli and choice-cartographer | Read only |
 | cost-estimator | Prospective-cost emitter — reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns an estimate-record string (token + time ranges, dollar cost only when grounded) for a dispatcher to persist after a human disposes; refuses rather than fabricating an ungroundable estimate | Read only |
+| reservoir-warden | Verifier-watch — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and offers the single decide-your-stop-first recommendation when a threshold is crossed; persists no record of the human's state | Read only (no Write/Edit) |
 
-### Commands (27)
+### Commands (28)
 
 | Command | What it does |
 | ------- | ------------ |
@@ -249,6 +251,7 @@ A coordinated team that handles the full development lifecycle.
 | `/diaboli` | Run the adversarial spec reviewer — produces objection record at `docs/superpowers/objections/<slug>.md` |
 | `/choice-cartograph` | Run the Choice Cartographer — produces choice-story record at `docs/superpowers/stories/<slug>.md` after spec-mode diaboli dispositions are resolved |
 | `/harness-affordance` | Manage the project's affordance inventory — `discover` scans config to produce a draft inventory; `add` and `review` planned |
+| `/reservoir` | Read-only advisory on you, the verifier — Read mode dispatches the `reservoir-warden` agent for a fuller cognitive-reservoir read; Tune mode helps you edit the HARNESS.md `Cognitive reservoir` block (thresholds, chronotype). Advisory-only, not a Constraint |
 
 ### Templates (11)
 
@@ -403,7 +406,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (34)                     Domain knowledge for agents
+│   └── Skills (35)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/reservoir-warden.agent.md
+++ b/ai-literacy-superpowers/agents/reservoir-warden.agent.md
@@ -1,0 +1,127 @@
+---
+name: reservoir-warden
+description: Use on demand via /reservoir to watch the human verifier the harness cannot verify — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and if a threshold is crossed offers the single decide-your-stop-first recommendation; read-only by design, never writes a record of the human's state
+tools: [Read, Glob, Grep, Bash]
+---
+
+# Reservoir Warden Agent
+
+You watch the one actor the harness has always trusted blindly: the
+human verifier who approves the output of an agentic session. You count
+what you can see, report it honestly with confidence flags, and — only
+if a threshold is crossed — offer exactly one recommendation. You do not
+diagnose. You do not score. You do not choose for the engineer.
+
+## Your first action
+
+Read the `cognitive-reservoir` skill in full:
+
+```
+ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
+```
+
+It is the authoritative source for the four proxies, the
+`observed`/`inferred`/`asked` confidence discipline, the default
+thresholds, the one firm principle, the honesty rule, the report format,
+and the anti-patterns. Inherit your grounding from it — do not
+re-derive it here.
+
+## Trust boundary
+
+You have **Read, Glob, Grep, and Bash only** — and Bash solely to run
+`git` and `date` to count proxies. You have **no Write and no Edit** by
+design (FR-003). This is not a limitation; it is the mechanism. You are
+watching the human, and the discipline of read-only-on-the-human means
+you **never persist a record of the human's state, breaks, or
+chronotype to disk** (FR-011). The human edits HARNESS.md themselves;
+your tuning suggestions are returned as text for them to apply.
+
+## Input
+
+You are dispatched by `/reservoir` (Read mode). You may receive the
+project root path. If thresholds or a chronotype are configured, they
+live in the `Cognitive reservoir` block of HARNESS.md — read them; do
+not invent them.
+
+## Process
+
+### 1. Read configuration
+
+Read HARNESS.md. From the `Cognitive reservoir` block extract any tuned
+values, defaulting per the skill where unset:
+
+- `window_hours` (default 8)
+- `span_minutes` (default 180)
+- `decision_volume` (default 8)
+- `context_switches` (default 4)
+- `chronotype` (default: **not declared** → late-hour band is `asked`)
+
+If there is no `Cognitive reservoir` block, the project has not opted in
+— say so and stop; do not manufacture a read.
+
+### 2. Gather proxies (observed)
+
+Use Bash with `git` and `date` only. Every pipeline is best-effort: a
+proxy that legitimately matches nothing degrades to **0**, never an
+error. Suggested commands (adapt to the repo):
+
+- **Continuous span** — first and last commit timestamps within the
+  window:
+  ```bash
+  git log --since="<window_hours> hours ago" --format=%ct
+  ```
+  Span = (last − first) / 60 minutes. Treat sub-idle gaps as continuous;
+  if 0 or 1 commits in the window, span is 0.
+- **Decision volume** — approval-like events in the window:
+  ```bash
+  git log --since="<window_hours> hours ago" --oneline | wc -l
+  ```
+  (commits + merges as the observable proxy for "times the human said yes").
+- **Context switches** — distinct streams touched. Prefer distinct
+  top-level directories changed plus reflog branch switches:
+  ```bash
+  git log --since="<window_hours> hours ago" --name-only --format= | awk -F/ 'NF{print $1}' | sort -u | wc -l
+  git reflog --since="<window_hours> hours ago" 2>/dev/null | grep -c 'checkout: moving' || true
+  ```
+  Combine conservatively; degrade to 0 on no match.
+- **Wall-clock hour** — `date +%H` (local). Map to a circadian band
+  **only if** `chronotype` is declared; otherwise mark `asked` /
+  unverified.
+
+### 3. Evaluate thresholds (inferred)
+
+Compare each proxy to its threshold. Thresholds are **disjunctive** —
+any one crossing fires the recommendation. Form the inferred risk by
+naming each crossed proxy to its **robust basis** (vigilance decrement
+for span, switching cost for context switches, sustained decision load
+for volume). Frame it as a **precaution under uncertainty**.
+
+**Honesty gate (FR-009):** do not assert ego depletion. Do not quote the
+hungry-judges figure. Every `inferred` claim must sit on an `observed`
+proxy — no bare risk.
+
+### 4. Produce the report
+
+Follow the report format in the skill exactly:
+
+- A proxy table: value, threshold, flag, crossed?
+- One or two sentences of inferred, defeasible risk, each tied to a
+  crossed proxy and its robust basis.
+- **No combined fatigue score.**
+- If any threshold crossed: the one firm principle (decide your stop
+  before the next session begins; do not negotiate with your tired self),
+  then **one** concrete time-boxed option, then "The choice to continue
+  is yours."
+- If nothing crossed: say so plainly; add no manufactured concern.
+
+### 5. Optional tuning note
+
+If the `/reservoir` invocation was Tune mode, return **proposed** edits
+to the HARNESS.md block as text for the human to confirm and apply
+themselves. Never edit the file — you have no Edit tool, and that is the
+point.
+
+## Output
+
+Return the report as your final message. The dispatching command
+presents it to the human; you persist nothing.

--- a/ai-literacy-superpowers/commands/reservoir.md
+++ b/ai-literacy-superpowers/commands/reservoir.md
@@ -1,0 +1,96 @@
+---
+name: reservoir
+description: Watch the human verifier the harness cannot verify — Read mode dispatches the reservoir-warden agent for a fuller cognitive-reservoir read; Tune mode helps you edit the HARNESS.md Cognitive reservoir block (thresholds and chronotype), proposing edits for you to confirm
+---
+
+# /reservoir [read | tune]
+
+An on-demand, read-only advisory on **you**, the verifier — not on the
+code. It counts observable proxies (session span, decision volume,
+context switches, wall-clock hour) over the recent git window and, if a
+threshold is crossed, offers the single decide-your-stop-first
+recommendation. It never blocks, never scores, never persists a record
+of your state.
+
+Mode defaults to `read`.
+
+## When to use
+
+- **Read mode** (default): mid-session, when you want a fuller read than
+  the automatic Stop-hook advisory gives — or any time you want to check
+  the proxies deliberately.
+- **Tune mode**: when the hook fires too often or too rarely, or when you
+  want to declare a chronotype so the late-hour band is honest. A cluster
+  of advisories you routinely ignore is a signal to tune thresholds —
+  **not** to weaken the honesty rule.
+
+## Read mode
+
+### 1. Check opt-in
+
+Confirm HARNESS.md contains a `Cognitive reservoir` block. If it does
+not (or there is no HARNESS.md, or no git repo), tell the user the
+project has not opted in and offer Tune mode to add the block. Do not
+manufacture a read.
+
+### 2. Dispatch the reservoir-warden agent
+
+Pass the project root. The agent reads the `cognitive-reservoir` skill,
+gathers proxies via `git`/`date`, evaluates the thresholds from the
+HARNESS.md block (or defaults), and returns the report.
+
+### 3. Present the report
+
+Show the agent's report verbatim. It contains the proxy table (each line
+flagged `observed`/`inferred`/`asked`), the defeasible inferred risk,
+and — if any threshold crossed — the one firm principle plus one
+concrete time-boxed option. Do not add a fatigue score, a second nudge,
+or a diagnosis. The choice to continue is the user's.
+
+## Tune mode
+
+### 1. Read the current block
+
+Read the `Cognitive reservoir` block from HARNESS.md if present;
+otherwise propose adding one from the template.
+
+### 2. Walk the tunable fields
+
+Help the user set, defaulting per the `cognitive-reservoir` skill:
+
+- `window_hours` (default 8)
+- `span_minutes` (default 180)
+- `decision_volume` (default 8)
+- `context_switches` (default 4)
+- `chronotype` — **optional**. Only when declared does the late-hour
+  band get labelled (optimal / dip / suboptimal); otherwise it stays
+  `asked` / unverified. Declaring it is the user's choice.
+
+### 3. Propose, do not impose
+
+Present the proposed block as a diff and ask the user to confirm before
+writing. The user owns this block — it is the one place the mechanism
+records anything, and it records only configuration, never a claim about
+the user's state.
+
+### 4. Validation checkpoint
+
+After writing, read the block back and verify:
+
+1. The heading is `## Cognitive reservoir` (case-insensitive marker the
+   Stop hook greps for is intact).
+2. Each present key is one of: `window_hours`, `span_minutes`,
+   `decision_volume`, `context_switches`, `chronotype`.
+3. Numeric values are positive integers; `chronotype`, if present, is a
+   recognised label.
+4. The not-a-constraint note is present so a future reader does not
+   promote the block into CI.
+
+Fix any deviation in place.
+
+## Not a gate
+
+This mechanism is advisory-only and is **not** a Constraint. It never
+fails CI, never blocks a commit/merge/session, and writes no record of
+your cognitive state. See the `cognitive-reservoir` skill for the
+honesty rule and the contested-vs-robust scientific grounding.

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, and governance drift check (Stop) close all feedback loops at session end; template currency check (SessionStart) nudges on plugin upgrade",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, and reservoir check (Stop) close all feedback loops at session end; template currency check (SessionStart) nudges on plugin upgrade",
   "hooks": {
     "PreToolUse": [
       {
@@ -60,6 +60,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/governance-drift-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/reservoir-check.sh",
             "timeout": 10
           }
         ]

--- a/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Reservoir check — runs at session end (Stop hook).
+#
+# An advisory watch on the human verifier the harness cannot verify.
+# Counts observable proxies (continuous session span, decision volume,
+# context switches, wall-clock hour) over the recent git window and, if
+# a tunable threshold is crossed, emits at most ONE {"systemMessage": ...}
+# advisory grounded in the cognitive-reservoir skill.
+#
+# Discipline (see skills/cognitive-reservoir/SKILL.md):
+#   - Advisory only. Never blocks, never exits non-zero, never gates CI.
+#   - Counts are `observed`; risk is `inferred`; anything about the human
+#     (chronotype) is `asked` and only used when declared.
+#   - Never a fatigue score. Never asserts ego depletion or the
+#     hungry-judges figure. Every trigger is a precaution under uncertainty.
+#   - Persists NO record of the human's state to disk.
+#
+# Opt-in: a project opts in by adding an active `## Cognitive reservoir`
+# heading to HARNESS.md. The template ships the block commented out (the
+# `<!--` sits on the heading line), so a freshly scaffolded project is
+# NOT opted in until the human uncomments it.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+HARNESS_FILE="${PROJECT_DIR}/HARNESS.md"
+
+# --- Self-gate (FR-006): silent exit 0 unless opted in and in a git repo ---
+[ -f "$HARNESS_FILE" ] || exit 0
+# Match an ACTIVE level-2..6 heading, not the commented template block.
+grep -qiE '^#{1,6}[[:space:]]+Cognitive reservoir' "$HARNESS_FILE" || exit 0
+git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# --- Read tunable thresholds from the Cognitive reservoir block (FR-008) ---
+read_key() {
+  # read_key <key> <default> — first matching `key: value` / `key = value`
+  local key="$1" def="$2" val
+  val=$(grep -iE "^[[:space:]]*[-*]?[[:space:]]*${key}[[:space:]]*[:=]" "$HARNESS_FILE" 2>/dev/null \
+        | head -1 \
+        | sed -E "s/.*[:=][[:space:]]*//" \
+        | tr -d '[:space:]' \
+        | tr -d '`' || true)
+  if [ -n "$val" ]; then printf '%s' "$val"; else printf '%s' "$def"; fi
+}
+
+WINDOW_HOURS=$(read_key 'window_hours' '8')
+SPAN_MIN=$(read_key 'span_minutes' '180')
+DECISION_VOL=$(read_key 'decision_volume' '8')
+CTX_SWITCHES=$(read_key 'context_switches' '4')
+CHRONOTYPE=$(read_key 'chronotype' '')
+
+# Guard against non-numeric tuning (degrade to defaults rather than abort).
+case "$WINDOW_HOURS" in ''|*[!0-9]*) WINDOW_HOURS=8 ;; esac
+case "$SPAN_MIN" in ''|*[!0-9]*) SPAN_MIN=180 ;; esac
+case "$DECISION_VOL" in ''|*[!0-9]*) DECISION_VOL=8 ;; esac
+case "$CTX_SWITCHES" in ''|*[!0-9]*) CTX_SWITCHES=4 ;; esac
+
+SINCE="${WINDOW_HOURS} hours ago"
+
+# --- Gather proxies (observed). Every pipeline degrades to 0 (FR-007) ---
+
+# Continuous span (minutes): newest - oldest commit timestamp in the window.
+span_min=0
+commit_ts=$(git -C "$PROJECT_DIR" log --since="$SINCE" --format=%ct 2>/dev/null || true)
+if [ -n "$commit_ts" ]; then
+  newest=$(printf '%s\n' "$commit_ts" | head -1)
+  oldest=$(printf '%s\n' "$commit_ts" | tail -1)
+  if [ -n "$newest" ] && [ -n "$oldest" ] && [ "$newest" -ge "$oldest" ]; then
+    span_min=$(( (newest - oldest) / 60 ))
+  fi
+fi
+
+# Decision volume: approval-like events (commits/merges) in the window.
+decisions=$(git -C "$PROJECT_DIR" log --since="$SINCE" --oneline 2>/dev/null | wc -l | tr -d '[:space:]' || true)
+case "$decisions" in ''|*[!0-9]*) decisions=0 ;; esac
+
+# Context switches: max(distinct top-level dirs touched, reflog branch switches).
+dirs=$(git -C "$PROJECT_DIR" log --since="$SINCE" --name-only --format= 2>/dev/null \
+       | awk -F/ 'NF{print $1}' | sort -u | grep -c . || true)
+case "$dirs" in ''|*[!0-9]*) dirs=0 ;; esac
+branch_switches=$(git -C "$PROJECT_DIR" reflog --since="$SINCE" 2>/dev/null \
+                  | grep -c 'checkout: moving' || true)
+case "$branch_switches" in ''|*[!0-9]*) branch_switches=0 ;; esac
+ctx=$dirs
+[ "$branch_switches" -gt "$ctx" ] && ctx=$branch_switches
+
+# Wall-clock hour (local). Band applied only when chronotype declared (FR-010).
+hour=$(date +%H)
+hour=$((10#$hour))
+band="unverified"
+hour_suboptimal=0
+if [ -n "$CHRONOTYPE" ]; then
+  case "$CHRONOTYPE" in
+    early|lark|morning)
+      if [ "$hour" -ge 20 ] || [ "$hour" -lt 6 ]; then band="suboptimal"; hour_suboptimal=1
+      elif [ "$hour" -ge 14 ] && [ "$hour" -lt 16 ]; then band="dip"
+      else band="optimal"; fi ;;
+    late|owl|evening)
+      if [ "$hour" -lt 9 ]; then band="suboptimal"; hour_suboptimal=1
+      else band="optimal"; fi ;;
+    *)
+      if [ "$hour" -ge 22 ] || [ "$hour" -lt 6 ]; then band="suboptimal"; hour_suboptimal=1
+      elif [ "$hour" -ge 13 ] && [ "$hour" -lt 15 ]; then band="dip"
+      else band="optimal"; fi ;;
+  esac
+fi
+
+# --- Evaluate disjunctive thresholds (FR-008). Build the observed lines. ---
+crossed_count=0
+crossed_lines=""
+add_cross() {
+  crossed_lines="${crossed_lines}- ${1}
+"
+  crossed_count=$((crossed_count + 1))
+}
+
+[ "$span_min" -ge "$SPAN_MIN" ]   && add_cross "continuous span ${span_min} min (threshold ${SPAN_MIN})"
+[ "$decisions" -ge "$DECISION_VOL" ] && add_cross "decision volume ${decisions} (threshold ${DECISION_VOL})"
+[ "$ctx" -ge "$CTX_SWITCHES" ]    && add_cross "context switches ${ctx} (threshold ${CTX_SWITCHES})"
+if [ "$hour_suboptimal" -eq 1 ]; then
+  add_cross "wall-clock hour ${hour}:00 in your ${band} circadian band (chronotype: ${CHRONOTYPE})"
+fi
+
+# Below all thresholds → say nothing (Scenario B).
+[ "$crossed_count" -gt 0 ] || exit 0
+
+# --- Compose the single advisory (precaution under uncertainty) ---
+message="Reservoir advisory — a precaution under uncertainty, not a diagnosis.
+
+Observed in the last ${WINDOW_HOURS}h:
+${crossed_lines}
+Inferred (defeasible): the robust basis is sustained time-on-task (vigilance decrement) and task-switching cost (attention residue) — not ego depletion, and no 'hungry judges' figure is claimed. The instrument that would notice fatigue runs on the same capacity being spent, so this watch is external by design.
+
+Decide your stop BEFORE the next session begins, while the judgment making the call is still one you would trust — do not negotiate the boundary with your tired self. One option: re-review today's last approvals tomorrow morning on a full reservoir.
+
+The choice to continue is yours. Run /reservoir for a fuller read or to tune the thresholds."
+
+# JSON-encode: escape backslash and quote, then join lines with \n (valid JSON).
+encoded=$(printf '%s' "$message" \
+  | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+  | awk 'BEGIN{ORS=""} {if (NR>1) printf "\\n"; printf "%s", $0}')
+
+printf '{"systemMessage": "%s"}\n' "$encoded"
+
+exit 0

--- a/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Reservoir check — runs at session end (Stop hook).
+set -euo pipefail
 #
 # An advisory watch on the human verifier the harness cannot verify.
 # Counts observable proxies (continuous session span, decision volume,
@@ -19,8 +20,6 @@
 # heading to HARNESS.md. The template ships the block commented out (the
 # `<!--` sits on the heading line), so a freshly scaffolded project is
 # NOT opted in until the human uncomments it.
-
-set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 HARNESS_FILE="${PROJECT_DIR}/HARNESS.md"

--- a/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
+++ b/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: cognitive-reservoir
+description: Use when watching the human verifier rather than the output — defines the observable proxies, the observed/inferred/asked confidence discipline, the default thresholds, the one firm principle, six-level scaling, and the honesty rule that the reservoir-warden agent and the reservoir-check Stop hook both inherit
+---
+
+# Cognitive Reservoir
+
+You are watching the one actor the harness has always trusted blindly:
+the human who says *yes, this belongs in our system*. Every other
+enforcement mechanism in the framework checks the **output** of a
+session — constraints, mutation tests, convention-drift GC, the
+advocatus diaboli. None checks the **state of the verifier** who
+approves that output. A green checkmark at 09:00 and a green checkmark
+at 21:00 are the same colour in the merge log and carry the same
+authority, but they were not necessarily produced by the same quality
+of verification.
+
+This skill is the shared grounding for two surfaces:
+
+- the **`reservoir-check.sh` Stop hook** — fires automatically at
+  session end and emits at most one advisory;
+- the **`reservoir-warden` agent** — gives a fuller on-demand read via
+  `/reservoir`.
+
+Both inherit the proxies, the confidence discipline, the thresholds,
+and the honesty rule from here. Neither re-derives them.
+
+> The warden watches; it never chooses. The governance of one's own
+> cognitive state is the one thing the framework cannot do for the
+> engineer — the *prohairesis*, the capacity for reasoned choice,
+> remains theirs.
+
+## The instrument problem
+
+The intuitive control — "stop when you feel tired" — fails, because the
+metacognition that would notice the fatigue draws on the same capacity
+being spent. By the time a human *feels* they should stop, the judgment
+making that call is already the judgment that should not be trusted to
+make it.
+
+That is why this mechanism is **external and count/time-based**, not
+judgment-based. It does not ask the human how they feel; it counts what
+it can see and offers a precaution. The conclusion does not rest on any
+contested "willpower reservoir" model — it follows from the robust
+time-on-task vigilance decrement plus the well-documented unreliability
+of self-assessment under fatigue.
+
+## Honesty rule (the hard requirement)
+
+The scientific grounding is deliberately conservative, and this honesty
+is a hard requirement (FR-009), **not editorial flavour**. Two contested
+pillars of the popular "decision fatigue" narrative MUST NOT be asserted
+as established fact by any artefact in this mechanism:
+
+- **Ego depletion** — the strong "willpower is a finite resource that
+  drains with use" model (Baumeister). The 2016 multi-lab Registered
+  Replication Report (Hagger et al., 23 labs, N ≈ 2,141) found d = 0.04
+  with a 95% CI crossing zero. *"The reservoir empties"* is a useful
+  **metaphor**, not a measured mechanism. The name of this skill is that
+  metaphor; the skill does not claim the mechanism.
+- **The hungry-judges study** (Danziger, Levav & Avnaim-Pesso, 2011).
+  The headline result depends on random case ordering, challenged by
+  Weinshall-Margel & Shapard (2011) — unrepresented prisoners were
+  typically heard last — and Glöckner (2016) showed the magnitude, if
+  real, was overestimated. The "65% → near 0%" figure MUST NOT be quoted
+  as established.
+
+What the design stands on instead — **all robust**:
+
+| Basis | What it is | What it grounds |
+| --- | --- | --- |
+| **Task-switching cost / attention residue** (Leroy, 2009) | Switching between unfinished streams leaves residual activation that degrades the next decision; cost scales with *switching*, not agent count | the context-switch proxy |
+| **Vigilance decrement** | Sustained time-on-task reliably degrades performance | the session-span proxy |
+| **Circadian / time-of-day variation** | The daily performance curve (sleep inertia, late-morning peak, post-lunch dip, evening decline) is well established but **strongly chronotype-dependent** | the late-hour band — unverified-by-default |
+| **Ericsson's deliberate-practice ceiling** | Expert sustained deep work converges around 4–5 h/day | corroborating context for the span default — *suggestive, not prescriptive* |
+
+Every output of this mechanism is framed as a **precaution under
+uncertainty**, never a diagnosis.
+
+## Confidence-flag discipline
+
+Reusing the framework's existing confidence vocabulary, every statement
+the mechanism emits carries exactly one flag:
+
+- **`observed`** — counted directly from git/clock. The proxies are
+  `observed`. These are facts about activity, not about the human.
+- **`inferred`** — risk read off the proxies. Always defeasible. An
+  `inferred` claim MUST have an `observed` proxy beneath it; a bare
+  `inferred` risk with no count under it is a defect, not a reading.
+- **`asked`** — anything about the *human*: chronotype, whether breaks
+  were real rest, whether a long span was deep work or idle-with-editor-
+  open. Never assumed. If it has not been declared in HARNESS.md, it is
+  `asked` / unverified, not asserted.
+
+The mechanism **never combines proxies into a single "fatigue score."**
+That would manufacture precision the inputs cannot support. Report each
+proxy on its own line with its own flag.
+
+## Observable proxies
+
+Only four, all `observed`, all counted from git and the clock over the
+last `WINDOW_HOURS`:
+
+1. **Continuous session span** (minutes) — wall-clock from the first to
+   the last commit in the window, where gaps below the idle cut are
+   treated as continuous. Grounds in the **vigilance decrement**.
+2. **Decision volume** — count of approval-like events in the window
+   (commits + merges as the observable proxy for "times the human said
+   yes"). Grounds in sustained decision load.
+3. **Context switches** — distinct work streams touched: branch
+   switches in the reflog, distinct top-level directories touched, or
+   distinct branches committed to. Grounds in **task-switching cost /
+   attention residue** — the cost scales with the switching.
+4. **Wall-clock hour** — the current local hour, mapped to a circadian
+   band **only when a `chronotype` is declared**; otherwise reported as
+   `asked` / unverified (FR-010).
+
+A proxy that legitimately matches nothing (e.g. reflog branch-switch
+parsing on a single-branch session) degrades to **0** — it is not an
+error and must not abort the read.
+
+## Default thresholds
+
+Disjunctive — **any one** crossing fires the advisory (FR-008). All
+tunable in the HARNESS.md `Cognitive reservoir` block:
+
+| Proxy | Default threshold | HARNESS key |
+| --- | --- | --- |
+| Continuous session span | **180 min** | `span_minutes` |
+| Decision volume | **8** | `decision_volume` |
+| Context switches | **4** | `context_switches` |
+| Window | **8 h** | `window_hours` |
+
+The span default is corroborated by Ericsson's 4–5 h/day ceiling, cited
+as suggestive. Thresholds are a starting point, not a measurement: a
+cluster of advisories the human routinely ignores is a signal to **tune
+the thresholds**, not to weaken the honesty rule.
+
+## The one firm principle
+
+When a threshold is crossed, surface the proxies and the inferred risk
+with caveats, then offer the article's only non-negotiable move:
+
+> Decide your stop **before the next session begins**, while the
+> judgment making the decision is still the kind you would trust. Do not
+> negotiate the boundary with your tired self.
+
+Then offer exactly **one** concrete, time-boxed option — for example,
+*"re-review today's last two approvals tomorrow morning on a full
+reservoir"* — and stop. No lecture, no second nudge, no score. The
+choice to continue is the human's; say so.
+
+## Report format (agent)
+
+The `reservoir-warden` agent produces this shape. The hook emits a
+compressed single-line version of the same content.
+
+```text
+## Reservoir read — <local date/time>
+
+Window: last <window_hours> h
+
+| Proxy | Value | Threshold | Flag | Crossed? |
+| --- | --- | --- | --- | --- |
+| Continuous span | <n> min | 180 min | observed | yes/no |
+| Decision volume | <n> | 8 | observed | yes/no |
+| Context switches | <n> | 4 | observed | yes/no |
+| Wall-clock hour | <hh> (<band or "unverified — no chronotype declared">) | — | asked | — |
+
+Inferred risk (defeasible): <one or two sentences, each tied to a
+crossed proxy above and named to its robust basis — time-on-task or
+switching cost; never ego depletion, never the hungry-judges figure>.
+
+[If any threshold crossed:]
+Recommendation: <the one firm principle, then one concrete time-boxed option>.
+
+The choice to continue is yours.
+```
+
+If **no** threshold is crossed, the agent says so plainly and adds no
+manufactured concern.
+
+## Six-level scaling
+
+How heavily a team leans on the warden tracks AI-literacy maturity. The
+mechanism is the same at every level; what changes is how it is used.
+
+| Level | Posture toward the warden |
+| --- | --- |
+| **0 — Awareness** | Not yet relevant — no agentic verification load to watch. |
+| **1 — Prompting** | Optional. Single-stream work rarely crosses thresholds; the hook stays quiet. |
+| **2 — Verification** | The natural entry point. The verifier is now the bottleneck the framework trusts; opt in and let the hook surface long spans. |
+| **3 — Habitat Engineering** | Tune thresholds into the HARNESS.md block; declare a chronotype to turn on the circadian band honestly. |
+| **4 — Specification Architecture** | Multi-agent orchestration makes the *context-switch* proxy the load-bearing one — switching cost scales with parallel streams. This is the "Depletable Collaborator" signal: spec decomposition accounts for human energy, not just modularity. |
+| **5 — Sovereign Engineering** | The warden is one observability surface among many; the team reads its advisories as data and tunes rather than obeys. |
+
+## Anti-patterns
+
+- **A combined fatigue score.** Forbidden. The inputs cannot support it.
+- **Asserting ego depletion or the hungry-judges figure as fact.**
+  Forbidden (FR-009). Frame as precaution under uncertainty.
+- **A bare `inferred` claim** with no `observed` proxy beneath it.
+- **Assuming the late-hour band** when no chronotype is declared — it is
+  `asked`, not depletion (FR-010).
+- **Blocking, persisting, or gating.** The mechanism is advisory-only,
+  is not a Constraint, writes no record of the human's state to disk,
+  and never fails CI (FR-011). The human edits HARNESS.md themselves.
+- **A second nudge.** One advisory, then silence.
+- **Manufactured concern on a quiet session.** Below all thresholds →
+  say nothing.

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -420,6 +420,42 @@ honour the values declared here when reading.
 
 ---
 
+<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
+
+Advisory watch on the human verifier the harness cannot verify. Opt in
+by uncommenting this block so the `## Cognitive reservoir` heading
+becomes active — the reservoir-check Stop hook and the /reservoir agent
+only run when the heading is uncommented.
+
+NOT a Constraint. This is advisory-only: it never gates CI, never blocks
+a commit/merge/session, and never records a claim about your cognitive
+state to disk (you edit this block yourself). Do not promote it into a
+blocking gate — that would defeat its purpose and overclaim a precision
+the proxies cannot support.
+
+The proxies, the observed/inferred/asked confidence discipline, the
+default thresholds, and the contested-vs-robust scientific grounding
+(it does NOT assert ego depletion or the hungry-judges figure) all live
+in `skills/cognitive-reservoir/SKILL.md`.
+
+Thresholds are disjunctive — any one crossing fires a single session-end
+advisory. Tune to taste; a cluster of advisories you routinely ignore is
+a signal to raise a threshold, not to distrust the honesty rule.
+
+- window_hours: 8       # how far back the proxies look
+- span_minutes: 180     # continuous session span (min) before the span proxy fires
+- decision_volume: 8    # approval-like events (commits/merges) in the window
+- context_switches: 4   # distinct work streams touched in the window
+- chronotype:           # optional: early | late | intermediate. Only when
+                        #   declared is the late-hour circadian band labelled
+                        #   (optimal / dip / suboptimal); otherwise the hour is
+                        #   reported as asked/unverified.
+
+Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
+-->
+
+---
+
 ## Status
 
 <!-- Auto-updated by /harness-audit — do not edit manually -->

--- a/docs/plugins/ai-literacy-superpowers/explanation/watching-the-verifier.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/watching-the-verifier.md
@@ -1,0 +1,118 @@
+---
+title: Watching the Verifier
+---
+# Watching the Verifier
+
+Every enforcement mechanism in the plugin checks the **output** of an
+agentic session — commit and PR constraints, mutation tests,
+convention-drift garbage collection, the advocatus diaboli. None of them
+checks the state of the **human who approves that output**. A green
+checkmark at 09:00 and a green checkmark at 21:00 are the same colour in
+the merge log and carry the same authority, but they were not
+necessarily produced by the same quality of verification. The faculty
+that says *yes, this belongs in our system* runs on a finite human and
+has, until now, been unobserved by the harness that trusts it.
+
+The `cognitive-reservoir` skill, the `reservoir-warden` agent, the
+`/reservoir` command, and the `reservoir-check` Stop hook together close
+that gap. They are the framework's honest-confidence principle applied
+reflexively: the framework finally observes the one actor it has always
+trusted blindly, and does so without pretending to a precision it lacks.
+
+## Why "stop when you feel tired" fails
+
+The intuitive control fails because the metacognition that would notice
+the fatigue draws on the same capacity being spent. By the time a human
+*feels* they should stop, the judgment making that call is already the
+judgment that should not be trusted to make it. The corrective therefore
+has to be **external and count/time-based**, not judgment-based — it
+counts what it can see rather than asking the human how they feel.
+
+## Observable proxies, never a diagnosis
+
+The mechanism counts only four **observable** proxies over a recent git
+window:
+
+- **continuous session span** — the vigilance decrement says sustained
+  time-on-task reliably degrades performance;
+- **decision volume** — approval-like events (commits/merges) as the
+  proxy for "times the human said yes";
+- **context switches** — distinct work streams touched; task-switching
+  cost / attention residue says the cost scales with the *switching*,
+  not the agent count, which is exactly what multi-agent orchestration
+  accumulates invisibly;
+- **wall-clock hour** — mapped to a circadian band only when a
+  chronotype is declared.
+
+Every statement carries one confidence flag. Counts are `observed`. Risk
+read off the counts is `inferred` and always defeasible. Anything about
+the human — chronotype, whether a break was real rest — is `asked` and
+never assumed. The mechanism **never combines the proxies into a single
+fatigue score**: that would manufacture a precision the inputs cannot
+support.
+
+## Honest about contested science
+
+The popular "decision fatigue" narrative rests on two contested pillars
+that this mechanism deliberately **does not assert as fact**:
+
+- **Ego depletion** — the strong "willpower is a finite resource that
+  drains with use" model. A 2016 multi-lab Registered Replication Report
+  (23 labs, N ≈ 2,141) found an effect of d = 0.04 with a confidence
+  interval crossing zero. *"The reservoir empties"* is a useful
+  **metaphor** — and the name of the skill — but not a measured
+  mechanism.
+- **The hungry-judges study** — the headline "65% → near 0%" figure
+  depends on case ordering that later work challenged. It must not be
+  quoted as established.
+
+What the design stands on instead is robust: task-switching cost,
+vigilance decrement, chronotype-dependent circadian variation, and (as
+suggestive context) Ericsson's 4–5 h/day deliberate-practice ceiling.
+Every output is framed as a **precaution under uncertainty**, never a
+diagnosis. This honesty is a hard requirement of the design, not
+editorial flavour.
+
+## Advisory only, never a gate
+
+The mechanism is **opt-in per project** via a `Cognitive reservoir` block
+in `HARNESS.md`, which doubles as the marker the Stop hook greps for. It
+is deliberately **not** modelled as a Constraint. Constraints are gates
+with a scope that can fail CI; wiring a human-state advisory into a
+blocking gate would both defeat its purpose and overclaim a measurement
+the proxies cannot support. So it never blocks a commit, merge, or
+session, never fails CI, and never persists a record of the human's
+state to disk — the human edits the `HARNESS.md` block themselves.
+
+When a threshold is crossed it surfaces the proxies and the inferred
+risk with caveats, then offers the one firm principle:
+
+> Decide your stop **before the next session begins**, while the
+> judgment making the decision is still the kind you would trust. Do not
+> negotiate the boundary with your tired self.
+
+It pairs that with one concrete, time-boxed option — "re-review today's
+last two approvals tomorrow morning on a full reservoir" — and then goes
+silent. No lecture, no second nudge, no score.
+
+## The prohairesis stays with the engineer
+
+The lineage is the *Twentieth Watt* essay and Epictetus: the governance
+of one's own cognitive state is the one thing the framework cannot do
+for the engineer. The *prohairesis* — the capacity for reasoned choice —
+remains theirs. The warden watches; it never chooses. A cluster of
+advisories a human routinely ignores is a signal to tune the
+`HARNESS.md` thresholds, not to weaken the honesty rule — and certainly
+not to take the decision out of human hands.
+
+## See also
+
+- The [how-to guide](../how-to/watch-your-cognitive-reservoir.md) for
+  opting in, reading, and tuning.
+- The `reservoir-warden` agent and `reservoir-check` hook entries in the
+  [Agents](../reference/agents.md) and [Hooks](../reference/hooks.md)
+  reference.
+- The [Decision Discipline Triad](decision-discipline-triad.md) — the
+  carpaccio / diaboli / cartographer agents that protect the human's
+  decision budget at the *input* side, complementary to the warden's
+  watch on the verifier at the *output* side.

--- a/docs/plugins/ai-literacy-superpowers/how-to/watch-your-cognitive-reservoir.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/watch-your-cognitive-reservoir.md
@@ -1,0 +1,90 @@
+---
+title: Watch Your Cognitive Reservoir
+---
+# Watch Your Cognitive Reservoir
+
+Opt in to an advisory watch on **you**, the verifier the harness cannot
+verify. Once opted in, a Stop-hook advisory fires automatically at
+session end when a threshold is crossed, and you can ask for a fuller
+read any time with `/reservoir`. It is advisory-only: it never blocks,
+never scores, and records no claim about your cognitive state.
+
+For the concepts and the honest-confidence grounding behind this, see
+[Watching the Verifier](../explanation/watching-the-verifier.md).
+
+---
+
+## 1. Opt in
+
+The mechanism is off until your project's `HARNESS.md` contains an
+**active** `## Cognitive reservoir` heading. New projects scaffolded
+from the template ship the block commented out (the `<!--` sits on the
+heading line), so you are not opted in by default.
+
+To opt in, open `HARNESS.md`, find the commented `Cognitive reservoir`
+block near the Status section, and remove the surrounding `<!--` / `-->`
+markers so the heading becomes a real section:
+
+```markdown
+## Cognitive reservoir
+
+- window_hours: 8       # how far back the proxies look
+- span_minutes: 180     # continuous session span (min) before the span proxy fires
+- decision_volume: 8    # approval-like events (commits/merges) in the window
+- context_switches: 4   # distinct work streams touched in the window
+- chronotype:           # optional: early | late | intermediate
+```
+
+The block is **not** a Constraint — do not move it into the Constraints
+section and do not wire it into CI. That would defeat its purpose and
+overclaim a precision the proxies cannot support.
+
+## 2. Let the Stop hook advise you
+
+With the block active, `reservoir-check.sh` runs at session end. It
+counts the four proxies over the last `window_hours` of git activity and
+— only if a disjunctive threshold is crossed — emits a single advisory:
+the crossed counts (`observed`), the inferred risk framed as a precaution
+under uncertainty, and the one firm principle:
+
+> Decide your stop before the next session begins, while the judgment
+> making the call is still one you would trust.
+
+A quiet session produces no output. The hook never blocks and never
+fails CI.
+
+## 3. Ask for a fuller read on demand
+
+Run `/reservoir` (Read mode) mid-session to dispatch the
+`reservoir-warden` agent for a fuller read: a proxy table with each line
+flagged `observed` / `inferred` / `asked`, the defeasible inferred risk,
+and — if a threshold is crossed — the single recommendation. The report
+contains no combined fatigue score, and the choice to continue is always
+yours.
+
+## 4. Tune the thresholds
+
+If the hook fires too often or too rarely, **tune the thresholds — do
+not distrust the honesty rule.** Run:
+
+```text
+/reservoir tune
+```
+
+The command walks you through `window_hours`, `span_minutes`,
+`decision_volume`, `context_switches`, and the optional `chronotype`,
+and proposes the edited block as a diff for you to confirm. Declaring a
+`chronotype` (`early`, `late`, or `intermediate`) is what turns the
+late-hour circadian band from `asked` / unverified into a labelled
+band — without it, the mechanism will not assert anything about the
+hour.
+
+You own this block. It is the one place the mechanism records anything,
+and it records only configuration — never a claim about your state.
+
+## 5. Read the advisories as data
+
+A cluster of advisories you routinely ignore is a signal to raise a
+threshold, not a failure of discipline. The quality bar is not how often
+the warden fires; it is whether, when it fires, it tells the truth about
+its own confidence and leaves the choice with you.

--- a/docs/plugins/ai-literacy-superpowers/index.md
+++ b/docs/plugins/ai-literacy-superpowers/index.md
@@ -126,6 +126,7 @@ Practical guides for specific tasks.
 
 - [Track AI Costs](how-to/track-ai-costs.md)
 - [Enforce Human Pace](how-to/enforce-human-pace.md)
+- [Watch Your Cognitive Reservoir](how-to/watch-your-cognitive-reservoir.md)
 - [Write Literate Code](how-to/write-literate-code.md)
 
 ### Reference — exact details
@@ -162,6 +163,7 @@ from first principles to the complete system:
 - [The Decision-Discipline Triad](explanation/decision-discipline-triad.md) — how carpaccio, advocatus-diaboli, and choice-cartographer relate
 - [Decision Archaeology](explanation/decision-archaeology.md) — the choice-cartographer's role; intent debt and cognitive debt
 - [Adversarial Review](explanation/adversarial-review.md) — the advocatus-diaboli's role and the human-cognition gate
+- [Watching the Verifier](explanation/watching-the-verifier.md) — the reservoir-warden's advisory watch on the human the harness cannot verify
 - [Progressive Hardening](explanation/progressive-hardening.md) — the promotion ladder from unverified to agent to deterministic
 - [Determinacy Calibration](explanation/determinacy-calibration.md) — the bidirectional review practice that uses the ladder over time
 - [The Three Enforcement Loops](explanation/three-enforcement-loops.md) — inner, middle, and outer loops operating at different timescales

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -3,7 +3,7 @@ title: Agents
 ---
 # Agents
 
-The plugin ships 15 agents organised into three groups: the
+The plugin ships 16 agents organised into three groups: the
 **spec-first pipeline** that coordinates feature work end to end,
 the **harness agents** that verify and maintain infrastructure
 conventions, and the **assessor** that measures AI literacy.
@@ -333,6 +333,32 @@ governance analysis requires nuanced judgement about meaning.
 
 ---
 
+## Cognitive Reservoir
+
+### reservoir-warden
+
+- **Tools**: Read, Glob, Grep, Bash
+- **Model**: inherit (routed to an inexpensive tier — see `MODEL_ROUTING.md`)
+- **Dispatched by**: `/reservoir`
+- **Trust boundary**: Read-only (on the human)
+
+Watches the one actor the harness cannot verify: the human verifier who
+approves a session's output. Reads the `cognitive-reservoir` skill, then
+gathers observable proxies via `git`/`date` — continuous session span,
+decision volume, context switches, wall-clock hour — and reports each
+with an `observed` / `inferred` / `asked` flag. If a disjunctive
+threshold is crossed it offers the single decide-your-stop-first
+recommendation and stops; otherwise it says so plainly.
+
+Has **no Write and no Edit** by design: the read-only-on-the-human
+discipline means it never persists a record of the human's state,
+breaks, or chronotype. It produces no combined fatigue score, and it
+never asserts ego depletion or the hungry-judges figure — every trigger
+is a precaution under uncertainty. See the
+[Watching the Verifier](../explanation/watching-the-verifier.md) page.
+
+---
+
 ## Tool Summary
 
 | Agent | Read | Write | Edit | Glob | Grep | Bash | Agent | WebFetch | Trust |
@@ -352,6 +378,7 @@ governance analysis requires nuanced judgement about meaning.
 | harness-gc | x | x | x | x | x | x | | | read-write |
 | assessor | x | x | x | x | x | x | | | read-write |
 | governance-auditor | x | x | x | x | x | x | | | read-write (limited) |
+| reservoir-warden | x | | | x | x | x | | | read-only |
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -3,7 +3,7 @@ title: Commands
 ---
 # Commands
 
-All 27 slash commands registered in `commands/`. Each command is
+All 28 slash commands registered in `commands/`. Each command is
 invoked as `/command-name` in a Claude Code session.
 
 ---
@@ -490,6 +490,29 @@ Manage git worktrees for parallel agent isolation. Three modes:
   the current branch.
 - **`/worktree clean [name]`** — Remove the named worktree and its
   branch.
+
+### /reservoir
+
+- **Skills read**: `cognitive-reservoir`
+- **Agents dispatched**: `reservoir-warden` (Read mode)
+
+An on-demand, read-only advisory on **you**, the verifier — not on the
+code. Two modes:
+
+- **`/reservoir [read]`** (default) — dispatch the `reservoir-warden`
+  agent for a fuller read than the automatic Stop-hook advisory: a proxy
+  table (continuous span, decision volume, context switches, wall-clock
+  hour), each line flagged `observed` / `inferred` / `asked`, and — if a
+  threshold is crossed — the single decide-your-stop-first
+  recommendation.
+- **`/reservoir tune`** — help you edit the `Cognitive reservoir` block
+  in `HARNESS.md` (thresholds and an optional `chronotype`), proposing
+  edits for you to confirm.
+
+Advisory-only and **not** a Constraint: it never blocks, never scores,
+and records no claim about your cognitive state. See the
+[Watching the Verifier](../explanation/watching-the-verifier.md) concept
+page and the [how-to guide](../how-to/watch-your-cognitive-reservoir.md).
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -155,6 +155,28 @@ staleness. Also flags when governance constraints exist in
 HARNESS.md but no audit has ever been run. Nudges
 `/governance-audit` or `/governance-health`.
 
+### Reservoir check (command)
+
+- **Event**: Stop
+- **Matcher**: `*`
+- **Type**: command
+- **Script**: `hooks/scripts/reservoir-check.sh`
+- **Timeout**: 10s
+
+An advisory watch on the human verifier the harness cannot verify.
+Self-gates: silent exit 0 unless `HARNESS.md` contains an **active**
+`## Cognitive reservoir` heading (the opt-in marker — the commented
+template block stays inert) and the directory is a git repo. When opted
+in, it counts observable proxies over the recent git window — continuous
+session span, decision volume, context switches, and wall-clock hour —
+and emits at most one `{"systemMessage": ...}` advisory if a disjunctive
+threshold is crossed. Advisory-only: never blocks, never exits non-zero,
+records no claim about the human's state. Every trigger is framed as a
+precaution under uncertainty; it does not assert ego depletion or the
+hungry-judges figure. See the `cognitive-reservoir` skill and the
+[Watching the Verifier](../explanation/watching-the-verifier.md)
+concept page.
+
 ---
 
 ## SessionStart Hooks

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -3,7 +3,7 @@ title: Skills
 ---
 # Skills
 
-The plugin ships 34 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 35 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -40,6 +40,10 @@ Generating human-readable onboarding documentation from harness state. Covers th
 ### harness-audit-engine
 
 The shared drift-detection layer that backs both `/harness-audit` (read-only) and `/harness-sync`. Produces a structured drift report covering convention files, ONBOARDING.md, snapshot staleness, template drift, constraint regressions, recurring reflection patterns, and HARNESS.md Status section accuracy.
+
+### cognitive-reservoir
+
+The shared grounding for the reservoir-warden agent and the reservoir-check Stop hook — the framework's watch on the one actor it cannot verify, the human verifier. Defines the four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed` / `inferred` / `asked` confidence discipline, the disjunctive default thresholds, the one firm principle (decide your stop before the next session begins), the six-level scaling guidance, and the honesty rule that keeps the contested science (ego depletion, the hungry-judges study) separate from the robust basis (vigilance decrement, task-switching cost). Advisory-only; never a fatigue score, never a gate.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-14-reservoir-warden-design.md
+++ b/docs/superpowers/specs/2026-06-14-reservoir-warden-design.md
@@ -1,0 +1,292 @@
+---
+name: reservoir-warden
+description: Spec for the depletable-collaborator agent — a read-only, advisory watch on the human verifier the harness cannot verify
+date: 2026-06-13
+status: draft
+---
+
+# Reservoir Warden — Watching the Verifier
+
+## Problem
+
+### 1. The harness verifies the output; nothing verifies the verifier
+
+Every enforcement mechanism in the plugin — commit/PR constraints,
+mutation tests, convention-drift GC, the advocatus diaboli — checks the
+*output* of an agentic session. None of them checks the state of the
+human who approves that output. A green checkmark at 09:00 and a green
+checkmark at 21:00 are the same colour and carry the same authority in
+the merge log, but they were not necessarily produced by the same
+quality of verification. The faculty that says *yes, this belongs in our
+system* runs on a finite human and is unobserved by the harness that
+trusts it.
+
+### 2. The instrument that would detect depletion is itself depleted
+
+The intuitive control — "stop when you feel tired" — fails, because the
+metacognition that would notice the fatigue draws on the same capacity
+being spent. By the time a human feels they should stop, the judgment
+making that call is already the judgment that should not be trusted to
+make it. This conclusion does not depend on any contested "willpower
+reservoir" model (see Intellectual Foundations); it follows from the
+robust time-on-task vigilance decrement plus the well-documented
+unreliability of self-assessment under fatigue. The corrective must
+therefore be **external and count/time-based**, not judgment-based.
+
+### 3. Parallel orchestration hides its own cost
+
+The plugin actively encourages multi-agent orchestration. The literature
+on attention residue and task-switching cost says that switching between
+unfinished work streams leaves residual cognitive activation that
+degrades the next decision — and that the cost scales with the
+*switching*, not merely the agent count. An orchestrator running many
+streams accumulates this cost invisibly while producing impressive
+activity metrics. The harness currently celebrates the metrics and is
+silent on the cost.
+
+## Approach
+
+A read-only **observability-and-advice loop on the human**, surfaced two
+ways: a Stop-hook advisory that fires automatically at session end, and
+an on-demand `reservoir-warden` agent that gives a fuller read via
+`/reservoir`.
+
+The mechanism counts only **observable proxies** — continuous session
+span, approval-like event volume, distinct streams touched, wall-clock
+hour — and never claims to measure cognitive state. Every statement it
+emits carries a confidence flag (`observed` / `inferred` / `asked`,
+reusing the framework's existing confidence vocabulary). Counts are
+`observed`; risk is `inferred` and always defeasible; anything about the
+human (chronotype, whether breaks were real rest) is `asked` and never
+assumed.
+
+It is **advisory only**. It has no Write/Edit tools by design, never
+blocks a commit/merge/session, never persists a record about the human's
+state, and never combines proxies into a single "fatigue score" — that
+would manufacture precision the inputs cannot support. When a time/count
+threshold is crossed it offers exactly one recommendation, grounded in
+the one firm principle below, and then goes silent.
+
+The mechanism is **opt-in per project** via a `Cognitive reservoir` block
+in HARNESS.md, which also serves as the marker the Stop hook greps for.
+It is deliberately **not** modelled as a Constraint: constraints are
+gates with a scope that can fail CI, and wiring a human-state advisory
+into a blocking gate would both defeat its purpose and overclaim a
+measurement the proxies cannot support.
+
+### The one firm principle
+
+When a threshold is crossed, the warden surfaces the proxies and the
+inferred risk with caveats, then offers the article's only
+non-negotiable move:
+
+> Decide your stop **before the next session begins**, while the judgment
+> making the decision is still the kind you would trust. Do not negotiate
+> the boundary with your tired self.
+
+It then offers a concrete, time-boxed option (e.g. "re-review today's
+last two approvals tomorrow morning on a full reservoir") and stops. No
+lecture, no second nudge, no score.
+
+## Intellectual Foundations
+
+The source is the *Twentieth Watt* essay (softwareenchiridion.com) and
+Epictetus: the governance of one's own cognitive state is the one thing
+the framework cannot do for the engineer — the *prohairesis*, the
+capacity for reasoned choice, remains theirs. The warden watches; it
+never chooses for them.
+
+The scientific grounding is deliberately conservative, and this honesty
+is itself a hard requirement (FR-009), not editorial flavour. The
+popular "decision fatigue" narrative rests on two contested pillars that
+this spec **does not assert as fact**:
+
+- **Ego depletion** — the strong "willpower is a finite resource that
+  drains with use" model (Baumeister). The 2016 multi-lab Registered
+  Replication Report (Hagger et al., 23 labs, N ≈ 2,141) found
+  d = 0.04 with a 95% CI crossing zero. "The reservoir empties" is a
+  useful metaphor, not a measured mechanism.
+- **The hungry-judges study** (Danziger, Levav & Avnaim-Pesso, 2011).
+  Its headline result depends on random case ordering, challenged by
+  Weinshall-Margel & Shapard (2011) — unrepresented prisoners were
+  typically heard last — and Glöckner (2016) showed the magnitude, if
+  real, was overestimated. The "65% → near 0%" figure must not be quoted
+  as established.
+
+What the design stands on instead, all robust:
+
+- **Task-switching cost / attention residue** (Leroy, 2009, on a deep
+  task-switching literature) — the real basis for the context-switch
+  proxy.
+- **Circadian / time-of-day variation** — the daily performance curve
+  (sleep inertia, late-morning peak, post-lunch dip, evening decline) is
+  well established but **strongly chronotype-dependent**, which is why the
+  late-hour band is unverified-by-default rather than assumed.
+- **Vigilance decrement** — sustained time-on-task reliably degrades
+  performance; the basis for the session-span proxy.
+- **Ericsson's deliberate-practice ceiling** — expert sustained deep work
+  converges around 4–5 hours/day; corroborating context for the span
+  threshold default, cited as suggestive rather than prescriptive.
+
+Every output of the mechanism is therefore framed as a **precaution
+under uncertainty**, never a diagnosis.
+
+## Acceptance Scenarios
+
+### Scenario A — Long session crosses a threshold (hook)
+
+**Given** a project whose HARNESS.md contains a `Cognitive reservoir`
+block, and a git history showing a continuous activity span ≥ the
+configured session-span threshold within the window,
+**When** the Stop hook `reservoir-check.sh` runs at session end,
+**Then** it emits a single `{"systemMessage": ...}` JSON advisory that
+(a) states the crossed threshold(s) as `observed` counts, (b) frames the
+risk as `inferred` and a precaution under uncertainty, (c) names the
+robust basis (time-on-task / switching cost) and does **not** assert ego
+depletion or the hungry-judges figure, and (d) restates the
+decide-your-stop-first principle and that the choice to continue is the
+human's.
+
+### Scenario B — Quiet session stays silent (hook)
+
+**Given** the same opt-in project but a session with activity below all
+thresholds,
+**When** the Stop hook runs,
+**Then** it produces no output and exits 0 — no manufactured concern.
+
+### Scenario C — Not opted in (hook)
+
+**Given** a project whose HARNESS.md has no `Cognitive reservoir` block
+(or no HARNESS.md, or no git repo),
+**When** the Stop hook runs,
+**Then** it exits 0 silently and changes nothing.
+
+### Scenario D — On-demand read (agent)
+
+**Given** a user invokes `/reservoir` mid-session,
+**When** the `reservoir-warden` agent runs,
+**Then** it reads the `cognitive-reservoir` skill first, reports each
+proxy with an `observed`/`inferred`/`asked` flag, evaluates thresholds,
+and — if any is crossed — gives the single recommendation; and its report
+contains **no** combined fatigue score and **no** `inferred` claim that
+lacks an `observed` proxy beneath it.
+
+### Scenario E — Chronotype honesty (agent + hook)
+
+**Given** no `chronotype` is declared in the HARNESS.md block,
+**When** the current wall-clock hour falls in the naive late band,
+**Then** the late-hour signal is marked `asked` / unverified rather than
+asserted as depletion; **and** when a `chronotype` *is* declared, the
+band is labelled (optimal / dip / suboptimal) accordingly.
+
+### Scenario F — Read-only trust boundary (agent)
+
+**Given** the `reservoir-warden` agent definition,
+**When** its frontmatter `tools` list is inspected,
+**Then** it contains no `Write` or `Edit` tool, and the agent writes no
+file recording the human's state anywhere in its process.
+
+## Functional Requirements
+
+- **FR-001** A `cognitive-reservoir` skill SHALL define the observable
+  proxies, the confidence-flag discipline, the default thresholds, the
+  six-level scaling guidance, and the honesty rule; the agent and hook
+  SHALL inherit grounding from it rather than re-deriving it.
+- **FR-002** A `reservoir-warden` agent SHALL gather proxies via Bash
+  (git/date) and Grep only, report each with `observed`/`inferred`/
+  `asked`, and produce the report format in the skill.
+- **FR-003** The agent's `tools` SHALL be exactly `Read, Glob, Grep,
+  Bash` — no `Write`, no `Edit`.
+- **FR-004** A Stop hook `reservoir-check.sh` SHALL compute span,
+  decision volume, context switches, and wall-clock hour from the last
+  `WINDOW_HOURS` (default 8) of git activity, and emit at most one
+  advisory.
+- **FR-005** The hook SHALL be advisory-only: it never exits non-zero on
+  a triggered or untriggered path, never blocks, and outputs only the
+  `{"systemMessage": "..."}` JSON contract when triggered.
+- **FR-006** The hook SHALL self-gate: silent exit 0 unless HARNESS.md
+  contains a case-insensitive `Cognitive reservoir` marker and the
+  directory is a git repo.
+- **FR-007** The hook SHALL use `set -euo pipefail`; best-effort proxy
+  pipelines that legitimately match nothing (e.g. branch-switch reflog
+  parsing on a single-branch session) SHALL degrade to 0 without
+  aborting the script.
+- **FR-008** Thresholds SHALL be disjunctive (any one crossing fires the
+  advisory) and tunable in the HARNESS.md block; defaults: span 180 min,
+  decision volume 8, context switches 4, window 8 h.
+- **FR-009** No artefact SHALL assert ego depletion or the hungry-judges
+  magnitude as established fact; the contested/robust distinction SHALL
+  be visible in the skill, and the agent/hook copy SHALL frame triggers
+  as precaution under uncertainty.
+- **FR-010** The late-hour circadian band SHALL be applied only when a
+  `chronotype` is declared in the HARNESS.md block; otherwise the band is
+  reported as `asked`/unverified.
+- **FR-011** The mechanism SHALL NOT be modelled as a Constraint and
+  SHALL NOT be wired into any CI gate; it lives in its own HARNESS.md
+  block. No artefact SHALL persist a record of the human's claimed state,
+  breaks, or chronotype to disk (the human edits HARNESS.md themselves).
+- **FR-012** A `/reservoir` command SHALL offer a Read mode (dispatch the
+  agent) and a Tune mode (help the human edit the HARNESS.md block,
+  including declaring a chronotype), proposing edits for the human to
+  confirm.
+
+## Expected Outcome
+
+A project that opts in receives, at session end, an occasional honest
+advisory that names what it can see and is candid about what it cannot —
+and can ask for a fuller read any time via `/reservoir`. The quality bar
+is not whether the warden fires often; it is whether, when it fires, it
+tells the truth about its own confidence and leaves the choice with the
+engineer. A cluster of advisories the human routinely ignores is a signal
+to tune the HARNESS.md thresholds, not to weaken the honesty rule.
+
+The deeper outcome is that the framework finally observes the one actor
+it has always trusted blindly: the verifier. It does so without
+pretending to a precision it lacks, which is itself the framework's
+honest-confidence principle applied reflexively to the framework.
+
+## Artefacts
+
+1. `skills/cognitive-reservoir/SKILL.md` — proxies, confidence-flag
+   discipline, default thresholds, honesty rule, six-level scaling,
+   anti-patterns (FR-001, FR-009).
+2. `agents/reservoir-warden.agent.md` — read-only agent (tools: Read,
+   Glob, Grep, Bash), proxy-gathering process, report schema (FR-002,
+   FR-003).
+3. `commands/reservoir.md` — `/reservoir` Read + Tune modes (FR-012).
+4. `.github/prompts/reservoir.prompt.md` — Copilot CLI equivalent.
+5. `hooks/scripts/reservoir-check.sh` — Stop-hook advisory, `chmod +x`,
+   `set -euo pipefail`, self-gating, JSON `systemMessage` contract
+   (FR-004 – FR-008, FR-010).
+6. `hooks/hooks.json` — register `reservoir-check.sh` in the `Stop`
+   array (timeout 10).
+7. `templates/HARNESS.md` — add an (optional, commented) `Cognitive
+   reservoir` block for new projects, including the `chronotype` field
+   and the not-a-constraint note (FR-011).
+8. TDAD scenarios derived from the acceptance scenarios above:
+   `tdad_tests/scenarios/agents/reservoir-warden/read-only-boundary.md`
+   (Scenario F), `.../hooks/reservoir-check/fires-on-long-session.md`
+   (A), `.../hooks/reservoir-check/silent-when-quiet.md` (B),
+   `.../hooks/reservoir-check/silent-when-not-opted-in.md` (C) — per the
+   "new components ship with a TDAD scenario" constraint.
+9. `docs/plugins/ai-literacy-superpowers/` — a reference page and an
+   explanation page (per the reference-page-entry and docs-propagation
+   constraints).
+10. `MODEL_ROUTING.md` — route `reservoir-warden` to an inexpensive tier
+    (it counts and advises; no deep reasoning needed).
+11. `README.md`, `plugin.json`, `marketplace.json`, `CHANGELOG.md` —
+    version 0.48.0; counts Agents 15 → 16, Skills 34 → 35,
+    Commands 27 → 28.
+12. `AGENTS.md` — ARCH_DECISION: the verifier-watch is advisory-only and
+    never a gate; record the rationale so a future contributor does not
+    "promote" it into CI.
+
+## Exemptions
+
+None. The mechanism is opt-in by construction — a project that does not
+add the `Cognitive reservoir` block to its HARNESS.md is unaffected, so
+no pre-existing-work exemption is required. Naming is provisional:
+`reservoir-warden` (a warden watches but does not control, mirroring the
+read-only-on-the-human discipline); `twentieth-watt` and
+`sustainable-pace` are register-faithful alternatives, a find-replace
+across artefacts 1–7 if preferred.

--- a/tdad_tests/runner/plugin.py
+++ b/tdad_tests/runner/plugin.py
@@ -211,6 +211,26 @@ def list_commands(plugin_path: Path) -> Iterator[Component]:
         )
 
 
+def list_hooks(plugin_path: Path) -> Iterator[Component]:
+    """Yield every Stop/PreToolUse/SessionStart hook script in the plugin.
+
+    Hooks are bash scripts under ``hooks/scripts/`` with no frontmatter,
+    so the component name is the file stem (e.g. ``reservoir-check``).
+    They are deliberately *not* part of the ``all_components`` inventory
+    used by the frontmatter checks — a ``.sh`` file has none — but they
+    are addressable targets for behavioural scenarios.
+    """
+    hooks_dir = plugin_path / "hooks" / "scripts"
+    for file in sorted(hooks_dir.glob("*.sh")):
+        yield Component(
+            name=file.stem,
+            component_type="hook",
+            path=file,
+            frontmatter={},
+            parse_error=None,
+        )
+
+
 def find_component(
     plugin_path: Path,
     name: str,
@@ -226,6 +246,7 @@ def find_component(
         "agent": list_agents,
         "skill": list_skills,
         "command": list_commands,
+        "hook": list_hooks,
     }
     if component_type not in listings:
         raise ValueError(

--- a/tdad_tests/scenarios/agents/reservoir-warden/read-only-boundary.md
+++ b/tdad_tests/scenarios/agents/reservoir-warden/read-only-boundary.md
@@ -1,0 +1,68 @@
+---
+component: reservoir-warden
+component_type: agent
+tier: structural
+---
+
+# Scenario: reservoir-warden is read-only on the human — tool boundary and charter
+
+## Given
+
+The `reservoir-warden` agent (spec
+`docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`) watches the
+one actor the harness cannot verify: the human verifier. It counts observable
+proxies and, if a threshold is crossed, returns a single advisory. It is
+**advisory-only** and **read-only on the human**: the discipline is that it
+never persists a record of the human's state.
+
+This scenario fixes the structural contract the agent file must satisfy
+(Scenario F; FR-002, FR-003, FR-011).
+
+## When
+
+The agent file at
+`ai-literacy-superpowers/agents/reservoir-warden.agent.md` is read directly
+from the filesystem.
+
+## Then
+
+**Frontmatter** (FR-003):
+
+- YAML frontmatter present with `name: reservoir-warden` and a non-empty
+  `description`.
+- The `tools` declaration is **exactly** `Read, Glob, Grep, Bash` — and
+  contains **no** `Write` and **no** `Edit`. This is the load-bearing
+  trust-boundary decision: the agent cannot persist a record of the human's
+  state, so the read-only-on-the-human discipline is enforced by the tool
+  list, not by good intentions.
+
+**Charter / body** (FR-002, FR-011):
+
+- The body instructs the agent to read the `cognitive-reservoir` skill
+  (`ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md`) **first** and
+  to inherit its grounding rather than re-derive it.
+- The body states the agent gathers proxies via `git`/`date` (Bash) and Grep
+  only, and reports each proxy with an `observed` / `inferred` / `asked` flag.
+- The body states the agent **never persists a record of the human's state,
+  breaks, or chronotype to disk**, and that tuning suggestions are returned as
+  text for the human to apply themselves.
+- The body states the report contains **no combined fatigue score** and that
+  every `inferred` claim sits on an `observed` proxy.
+- The honesty gate is present: the agent does **not** assert ego depletion and
+  does **not** quote the hungry-judges figure; triggers are framed as a
+  precaution under uncertainty.
+
+## Rubric
+
+Layer 1 structural scenario: every assertion is mechanically checkable by
+reading the agent file and matching against its frontmatter `tools` list and
+its body headings. The scenario passes only when the tool boundary is exactly
+`Read, Glob, Grep, Bash` (no Write, no Edit), the agent reads the
+`cognitive-reservoir` skill first, the no-persistence and no-fatigue-score
+disciplines are stated, and the honesty gate is present.
+
+## Notes
+
+Scope is the agent's structural shape only. Behavioural assertions about the
+proxy values it computes are covered by the hook scenarios (the hook and agent
+share the skill's proxy definitions).

--- a/tdad_tests/scenarios/commands/reservoir/read-and-tune-modes.md
+++ b/tdad_tests/scenarios/commands/reservoir/read-and-tune-modes.md
@@ -1,0 +1,56 @@
+---
+component: reservoir
+component_type: command
+tier: structural
+---
+
+# Scenario: /reservoir offers Read and Tune modes and is never a gate
+
+## Given
+
+The `/reservoir` command (spec
+`docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`, FR-012) is the
+on-demand entry point to the verifier-watch. It dispatches the read-only
+`reservoir-warden` agent (Read mode) or helps the human edit the HARNESS.md
+`Cognitive reservoir` block (Tune mode).
+
+## When
+
+The command file at `ai-literacy-superpowers/commands/reservoir.md` is read
+directly from the filesystem.
+
+## Then
+
+**Frontmatter**:
+
+- YAML frontmatter present with `name: reservoir` and a non-empty
+  `description`.
+
+**Modes** (FR-012):
+
+- A **Read mode** section: checks the project has opted in (an active
+  `## Cognitive reservoir` block), dispatches the `reservoir-warden` agent, and
+  presents its report verbatim — no fatigue score, no second nudge added.
+- A **Tune mode** section: walks the tunable fields (`window_hours`,
+  `span_minutes`, `decision_volume`, `context_switches`, and the optional
+  `chronotype`), and **proposes edits for the human to confirm** before writing
+  — the human owns the block.
+
+**Validation checkpoint**:
+
+- A validation step that, after a Tune-mode write, reads the block back and
+  verifies the `## Cognitive reservoir` marker is intact, the keys are
+  recognised, numeric values are positive integers, and the not-a-constraint
+  note is present (per the Output Validation Checkpoints convention).
+
+**Not a gate**:
+
+- The command states the mechanism is **advisory-only and not a Constraint** —
+  it never blocks, never scores, and records no claim about the human's state.
+
+## Rubric
+
+Layer 1 structural scenario: every assertion is mechanically checkable by
+reading the command file and matching its section headings. The scenario passes
+only when both modes, the propose-then-confirm Tune flow, the validation
+checkpoint, and the not-a-gate statement are present.

--- a/tdad_tests/scenarios/hooks/reservoir-check/fires-on-long-session.md
+++ b/tdad_tests/scenarios/hooks/reservoir-check/fires-on-long-session.md
@@ -1,0 +1,59 @@
+---
+component: reservoir-check
+component_type: hook
+tier: behavioural
+fixture: opted-in-long-session
+---
+
+# Scenario: reservoir-check fires a single honest advisory on a long session
+
+## Given
+
+A project whose `HARNESS.md` contains an **active** `## Cognitive reservoir`
+heading (the opt-in marker), inside a git repository whose recent history
+shows activity that crosses at least one configured threshold within the
+window. The hook is `ai-literacy-superpowers/hooks/scripts/reservoir-check.sh`
+(spec `docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`, Scenario
+A; FR-004, FR-005, FR-008, FR-009).
+
+The fixture seeds enough commits across more than one top-level directory that
+the disjunctive thresholds (defaults: span 180 min, decision volume 8, context
+switches 4) — or values tuned lower in the block — are crossed.
+
+## When
+
+The Stop hook runs at session end with `CLAUDE_PROJECT_DIR` pointed at the
+fixture:
+
+```bash
+CLAUDE_PROJECT_DIR="$FIXTURE" bash ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+```
+
+## Then
+
+- The script exits **0** (advisory-only — never non-zero, FR-005).
+- It emits **exactly one** line of output, and that line is a valid JSON object
+  with a single `systemMessage` key (FR-004, FR-005). Parsing it with a strict
+  JSON parser succeeds.
+- The `systemMessage` value:
+  - (a) states the crossed threshold(s) as **observed** counts (e.g.
+    `continuous span N min (threshold ...)`, `decision volume N (threshold ...)`);
+  - (b) frames the risk as **inferred** / defeasible and a **precaution under
+    uncertainty**, not a diagnosis;
+  - (c) names the **robust basis** — time-on-task / vigilance decrement and/or
+    task-switching cost — and does **not** contain the strings "ego depletion"
+    asserted as fact nor any "hungry judges" figure (FR-009);
+  - (d) restates the decide-your-stop-before-the-next-session principle and that
+    **the choice to continue is the human's**.
+- The output contains **no** combined fatigue score (no single number claiming
+  to summarise cognitive state).
+
+## Rubric
+
+Deterministic behavioural scenario (no LLM). Run the script in the fixture and
+assert on exit code and the parsed JSON `systemMessage` string. The honesty
+assertions (c) are checkable as substring presence/absence.
+
+## Cleanup
+
+Remove the temporary fixture repository.

--- a/tdad_tests/scenarios/hooks/reservoir-check/silent-when-not-opted-in.md
+++ b/tdad_tests/scenarios/hooks/reservoir-check/silent-when-not-opted-in.md
@@ -1,0 +1,47 @@
+---
+component: reservoir-check
+component_type: hook
+tier: behavioural
+fixture: not-opted-in
+---
+
+# Scenario: reservoir-check stays silent when the project has not opted in
+
+## Given
+
+One of the following non-opted-in situations (spec
+`docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`, Scenario C;
+FR-006):
+
+1. A project whose `HARNESS.md` has **no** active `## Cognitive reservoir`
+   heading — including the case where the heading appears only inside the
+   commented template block (`<!-- ## Cognitive reservoir ... -->`), which must
+   remain inert.
+2. A project directory with **no** `HARNESS.md` at all.
+3. A directory that is **not** a git repository (even if it has a HARNESS.md
+   with the marker).
+
+## When
+
+The Stop hook runs at session end in each situation:
+
+```bash
+CLAUDE_PROJECT_DIR="$FIXTURE" bash ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+```
+
+## Then
+
+- The script produces **no output** in every situation.
+- The script exits **0** and changes nothing on disk.
+
+## Rubric
+
+Deterministic behavioural scenario covering the three self-gate branches
+(FR-006). The commented-template sub-case is the important one: the gate matches
+an **active** heading (`^#{1,6}\s+Cognitive reservoir`), so a freshly scaffolded
+project that copied the template verbatim is **not** opted in. Asserts empty
+stdout and exit 0 for all three fixtures.
+
+## Cleanup
+
+Remove the temporary fixture repositories.

--- a/tdad_tests/scenarios/hooks/reservoir-check/silent-when-quiet.md
+++ b/tdad_tests/scenarios/hooks/reservoir-check/silent-when-quiet.md
@@ -1,0 +1,40 @@
+---
+component: reservoir-check
+component_type: hook
+tier: behavioural
+fixture: opted-in-quiet-session
+---
+
+# Scenario: reservoir-check stays silent on a quiet session
+
+## Given
+
+An opt-in project (its `HARNESS.md` has an active `## Cognitive reservoir`
+heading) inside a git repository whose recent activity is **below all
+thresholds** — a short span, few commits, a single work stream (spec
+`docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`, Scenario B;
+FR-005, FR-008).
+
+## When
+
+The Stop hook runs at session end:
+
+```bash
+CLAUDE_PROJECT_DIR="$FIXTURE" bash ai-literacy-superpowers/hooks/scripts/reservoir-check.sh
+```
+
+## Then
+
+- The script produces **no output** (empty stdout) — no manufactured concern.
+- The script exits **0**.
+
+## Rubric
+
+Deterministic behavioural scenario. The thresholds are disjunctive, so the
+silence assertion only holds when **none** is crossed; the fixture must keep
+span, decision volume, and context switches all under their (default or tuned)
+thresholds. Asserts empty stdout and exit 0.
+
+## Cleanup
+
+Remove the temporary fixture repository.

--- a/tdad_tests/scenarios/skills/cognitive-reservoir/defines-proxies-and-honesty-rule.md
+++ b/tdad_tests/scenarios/skills/cognitive-reservoir/defines-proxies-and-honesty-rule.md
@@ -1,0 +1,63 @@
+---
+component: cognitive-reservoir
+component_type: skill
+tier: structural
+---
+
+# Scenario: cognitive-reservoir defines the proxies, the confidence discipline, and the honesty rule
+
+## Given
+
+The `cognitive-reservoir` skill (spec
+`docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`) is the shared
+grounding that both the `reservoir-warden` agent and the `reservoir-check` Stop
+hook inherit from rather than re-derive (FR-001, FR-009).
+
+## When
+
+The skill file at
+`ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md` is read directly
+from the filesystem.
+
+## Then
+
+**Frontmatter**:
+
+- YAML frontmatter present with `name: cognitive-reservoir` and a non-empty
+  `description`.
+
+**Content** (FR-001):
+
+- Defines the **four observable proxies**: continuous session span, decision
+  volume, context switches, and wall-clock hour.
+- Defines the **confidence-flag discipline** with all three flags — `observed`
+  (the counts), `inferred` (defeasible risk), `asked` (anything about the
+  human, e.g. chronotype) — and states that every `inferred` claim must sit on
+  an `observed` proxy.
+- States the **default thresholds** — span 180 min, decision volume 8, context
+  switches 4, window 8 h — and that they are **disjunctive** and tunable.
+- States the **one firm principle**: decide your stop before the next session
+  begins; do not negotiate the boundary with your tired self.
+- Provides **six-level scaling** guidance across the framework's literacy
+  levels (0–5).
+- Lists **anti-patterns**, including that the mechanism never produces a
+  combined fatigue score and is never a gate.
+
+**Honesty rule** (FR-009):
+
+- The skill makes the **contested-vs-robust distinction visible**: it names ego
+  depletion (and the 2016 multi-lab replication, d = 0.04) and the
+  hungry-judges study as **contested** and explicitly **not asserted as fact**,
+  while standing on the **robust** basis — task-switching cost / attention
+  residue, vigilance decrement, chronotype-dependent circadian variation, and
+  (as suggestive) Ericsson's deliberate-practice ceiling.
+- States that every output is framed as a **precaution under uncertainty**,
+  never a diagnosis.
+
+## Rubric
+
+Layer 1 structural scenario: every assertion is mechanically checkable by
+reading the skill and matching against its section headings and key phrases.
+The scenario passes only when the four proxies, the three confidence flags, the
+disjunctive thresholds, the one firm principle, the six-level scaling, the
+anti-patterns, and the contested-vs-robust honesty rule are all present.


### PR DESCRIPTION
Closes #395.

Implements `docs/superpowers/specs/2026-06-14-reservoir-warden-design.md` (committed as the first commit on this branch).

## What this adds

The framework's first observability surface aimed at the **human verifier** rather than the session output. Every other enforcement mechanism checks what an agentic session produced; none checked the state of the human who approves it. This adds a read-only, advisory watch — opt-in per project, never a gate.

- **`cognitive-reservoir` skill** — four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed`/`inferred`/`asked` confidence discipline, disjunctive default thresholds, the one firm principle, six-level scaling, and the honesty rule separating contested science (ego depletion, the hungry-judges study) from the robust basis (vigilance decrement, task-switching cost).
- **`reservoir-warden` agent** — read-only on the human (tools: Read, Glob, Grep, Bash — no Write/Edit). Persists no record of the human's state; produces no combined fatigue score.
- **`/reservoir` command + Copilot prompt** — Read mode dispatches the agent; Tune mode helps edit the HARNESS.md block (thresholds + optional chronotype).
- **`reservoir-check.sh` Stop hook** — self-gates on an active `## Cognitive reservoir` heading + git repo; emits at most one `{"systemMessage": ...}` advisory. Advisory-only: never blocks, never exits non-zero.
- **HARNESS template** — optional, commented `Cognitive reservoir` block (inert until uncommented; the `<!--` sits on the heading line so freshly-scaffolded projects are not opted in).
- **AGENTS.md ARCH_DECISION** — the verifier-watch is advisory-only and must never be promoted into a CI gate or a single fatigue score.

## Design notes for review

- **Opt-in is honest.** The hook gates on an *active* `## Cognitive reservoir` heading (`^#{1,6}\s+Cognitive reservoir`), not the bare phrase, so the commented template block stays inert. Verified.
- **Not a Constraint.** Lives in its own HARNESS.md block, not the Constraints section — recorded as an ARCH_DECISION so a future contributor doesn't harden it into a gate.
- **Test runner** gains `list_hooks` so the new `component_type: hook` scenarios resolve a real component (outside the plugin dir — no bump implication).

## Validation

- Hook tested across Scenarios A/B/C (fires / silent-quiet / silent-not-opted-in) + commented-template inertness; emits valid JSON; `bash -n` clean; `set -euo pipefail`, bash-3.2-safe.
- Version 0.48.0 consistent across all 5 CI-checked locations; counts 35 skills / 16 agents / 28 commands.
- Offline TDAD suite green (Layer 0 + Layer 1, 17 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)