### PR TITLE
cost-estimator: normalise split-tier model_tier literal (#381)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.48.0",
+  "plugin_version": "0.48.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.48.0"
+      "version": "0.48.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.48.1 — 2026-06-14
+
+### cost-estimator: normalise the split-tier model_tier literal
+
+- **Consistent `Standard/Capable` literal (#381).** The cost-estimator agent
+  charter referred to the split tier as `Standard / Capable` (spaced) in its
+  Split-tier widening note while the format reference binding table records the
+  literal as `Standard/Capable` (unspaced). Normalised the charter to the
+  unspaced form so an exact-string consumer of `model_tier` sees one emitted
+  shape. The whitespace-insensitive comparison note (which deliberately shows
+  both forms are equivalent) is unchanged. Doc-only; patch bump.
+
 ## 0.48.0 — 2026-06-14
 
 ### Reservoir warden — watching the verifier the harness cannot verify

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.48.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.48.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.48.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.48.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/cost-estimator.agent.md
+++ b/ai-literacy-superpowers/agents/cost-estimator.agent.md
@@ -143,7 +143,7 @@ Apply the S1 `cost-estimation` SKILL. Derive the per-stage and whole-record
 record conforming to `estimate-record-format.md` exactly as-merged.
 
 **Split-tier widening (priced into the whole-record band, disclosed in prose).**
-The implementer stage maps to the split tier `Standard / Capable` and carries the
+The implementer stage maps to the split tier `Standard/Capable` and carries the
 largest token budget, so its rate dominates any cost figure. Price its cost
 contribution across both ends of the split — the cheaper end
 (`claude-sonnet-4`, low) and the dearer end (`claude-opus-4`, high) — and let it


### PR DESCRIPTION
Closes #381.

The cost-estimator agent charter referred to the split tier as `Standard / Capable` (spaced) in its Split-tier widening note, while the format reference binding table records the literal as `Standard/Capable` (unspaced). The #377 Split-tier spread check normalises whitespace before testing, so conformance held — but an exact-string consumer of `model_tier` would diverge by emitted form.

Fix: normalise the charter to the unspaced `Standard/Capable`. The whitespace-insensitive comparison note (which deliberately shows `Standard/Capable` ↔ `Standard / Capable` are equivalent) is intentionally unchanged.

Doc-only; patch bump 0.48.1. `fix`-exempt from spec-first.