### PR TITLE
cost-estimator: populate per-stage cost_usd bands on cost-present records (#380)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.48.1",
+  "plugin_version": "0.49.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.48.1"
+      "version": "0.49.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.49.0 — 2026-06-14
+
+### cost-estimator: populate per-stage cost_usd bands on cost-present records
+
+- **Per-stage `cost_usd` bands (#380).** Now that the repo has a usable cost
+  snapshot (`observability/costs/2026-06-13-costs.md`), the cost-estimator
+  emitter honours the #377 §4.3.1 SHOULD obligation: on a **cost-present**
+  record it populates a `tokens_by_stage[].cost_usd` `{ low, high }` band on
+  every exercised stage (stage `tokens` × tier `$/token`), with split-tier
+  stages priced cheaper-at-low / dearer-at-high so the spread is strictly
+  positive (`low < high`). Cost-omitted records are unchanged (no per-stage
+  band; the one-directional coupling forbids a band without the whole-record
+  `cost_usd`). The pricing convention is referenced from the format spec, not
+  redefined; no format change and no new validation-rejection rule. Behaviour
+  change to a shipped agent — minor bump. Spec:
+  `docs/superpowers/specs/2026-06-14-per-stage-cost-bands-emitter-design.md`.
+
 ## 0.48.1 — 2026-06-14
 
 ### cost-estimator: normalise the split-tier model_tier literal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.48.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.49.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.5.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.48.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.49.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.5.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/cost-estimator.agent.md
+++ b/ai-literacy-superpowers/agents/cost-estimator.agent.md
@@ -148,8 +148,24 @@ largest token budget, so its rate dominates any cost figure. Price its cost
 contribution across both ends of the split — the cheaper end
 (`claude-sonnet-4`, low) and the dearer end (`claude-opus-4`, high) — and let it
 widen the **whole-record `cost_usd` band**. Disclose the widening in the prose
-body. You emit **no** machine-checkable per-stage cost band (that is a separate
-slice's deliverable); the widening lives in the whole-record band and the prose.
+body.
+
+**Per-stage `cost_usd` bands (cost-present records only).** When you emit a
+**cost-present** record (S1 grounding state 3 — a usable snapshot Model
+Breakdown exists), also populate a `tokens_by_stage[].cost_usd` `{ low, high }`
+band on **every exercised stage**: the stage's `tokens` range × its tier's
+`$/token` rate from the snapshot. A **split-tier** stage prices its `low` bound
+at the cheaper representative model and its `high` bound at the dearer one (per
+the binding table), giving a strictly-positive spread (`low < high`). Follow the
+format reference's **"Per-stage band pricing convention"** and **"Deriving a
+per-model rate from a snapshot"** sections
+(`skills/cost-estimation/references/estimate-record-format.md`) — do **not**
+redefine the convention here. This is an **emitter obligation**, not a new
+validation rule: absence of bands does not invalidate a record, and the only
+checked predicate on a present split-tier band is `low < high`. On a
+**cost-omitted** record (states 1 and 2) emit **no** per-stage `cost_usd` on any
+stage — the one-directional coupling (sub-field present ⟹ top-level `cost_usd`
+present) forbids a band without the whole-record figure.
 
 ### Calibration against per-PR history (S6 — token ranges only)
 

--- a/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
@@ -125,6 +125,18 @@ model's blended rate, and
 `cost_usd = Σ over stages (stage tokens range × tier $/token)`, with
 split-tier stages widened as above.
 
+**Per-stage `cost_usd` bands (cost-present records only).** When a record is
+cost-present (state 3 below), the emitter also surfaces the per-stage
+decomposition that produced the whole-record figure: each exercised stage
+carries a `tokens_by_stage[].cost_usd` `{ low, high }` band (the stage's
+`tokens` range × its tier rate), with split-tier stages priced `low` at the
+cheaper representative model and `high` at the dearer one so the spread is
+strictly positive (`low < high`). This follows the format reference's
+**per-stage band pricing convention** — an emitter obligation (a SHOULD), not a
+validation-rejection rule, and not a new derivation. On a cost-omitted record no
+stage carries the sub-field (the coupling is one-directional: a per-stage band
+never appears without the top-level `cost_usd`).
+
 **The three grounding states.** The snapshot's Model Breakdown is marked
 "(if available)" in the cost-tracking format, so the methodology branches
 on **three** states, not two:

--- a/docs/superpowers/specs/2026-06-14-per-stage-cost-bands-emitter-design.md
+++ b/docs/superpowers/specs/2026-06-14-per-stage-cost-bands-emitter-design.md
@@ -1,0 +1,146 @@
+---
+name: per-stage-cost-bands-emitter
+description: Spec for the cost-estimator emitter honouring the #377 §4.3.1 SHOULD obligation — populating per-stage tokens_by_stage[].cost_usd bands on cost-present records now that a usable cost snapshot exists
+date: 2026-06-14
+status: draft
+---
+
+# Cost-estimator — Per-stage `cost_usd` Bands on Cost-present Records
+
+## Problem
+
+The #377 format revision
+(`docs/superpowers/specs/2026-06-11-format-revision-per-stage-cost-design.md`)
+**admits** an optional `tokens_by_stage[].cost_usd` `{ low, high }` band on
+cost-present records, one-directionally coupled to the top-level `cost_usd`
+(sub-field present ⟹ top-level present is *enforced*; top-level present ⟹ bands
+**SHOULD** be populated is an *emitter obligation*, not a validation-rejection
+rule — §4.3.1). When #377 landed, **no producer populated the bands**: the only
+cost-present record carrying them was the hand-authored Example 2, and the
+`cost-estimator` agent's charter explicitly deferred them —
+
+> "You emit **no** machine-checkable per-stage cost band (that is a separate
+> slice's deliverable); the widening lives in the whole-record band and the
+> prose."
+
+That deferral was correct at the time: the agent could only emit **cost-omitted**
+records, because `observability/costs/` was empty, so there was no rate to price a
+per-stage band against. **That precondition is now met.** The repo's first cost
+snapshot landed (`observability/costs/2026-06-13-costs.md`, PR #391) and carries a
+usable `## Model Breakdown`, so the agent can now emit **cost-present** records
+(S1 grounding state 3). This slice is the **falsifiable home** for the §4.3.1
+SHOULD obligation (issue #380).
+
+This is **implementation of an already-designed obligation**, not new design. The
+per-stage band *pricing convention* is fully specified in the format reference's
+**"Per-stage band pricing convention (emitter methodology, NOT a checked
+invariant)"** and **"Deriving a per-model rate from a snapshot"** sections
+(`skills/cost-estimation/references/estimate-record-format.md` §216, §229). This
+spec only makes the emitter honour it.
+
+## Approach
+
+Flip the `cost-estimator` agent's per-stage-band deferral into an **emit
+obligation on cost-present records**, and add the same obligation to the S1
+`cost-estimation` skill methodology (so the agent inherits it rather than
+re-deriving). The derivation is the one the format reference already defines:
+
+- On a **cost-present** record (grounding state 3 — a usable snapshot Model
+  Breakdown exists), for **every exercised stage**, emit a
+  `tokens_by_stage[].cost_usd` `{ low, high }` band = that stage's `tokens`
+  range × its tier's `$/token` rate from the snapshot.
+- A **split-tier** stage (e.g. the implementer's `Standard/Capable`) prices its
+  **low** bound at the **cheaper** representative model (`claude-sonnet-4`) and
+  its **high** bound at the **dearer** one (`claude-opus-4`), per the binding
+  table — producing a genuine, strictly-positive spread (`low < high`).
+- On a **cost-omitted** record (states 1 and 2 — no usable snapshot rate), **no**
+  stage carries a per-stage `cost_usd`; the sub-field is absent everywhere,
+  exactly as today. The one-directional coupling is preserved: a per-stage band
+  never appears without the top-level `cost_usd`.
+
+No format change is required — the format already admits the band. No new
+validation-rejection rule is introduced — absence of bands on a cost-present
+record remains valid (the obligation is a SHOULD, and the only checked predicate
+on a *present* split-tier band is `low < high`, already in the #377 checklist).
+
+## Acceptance Scenarios
+
+### Scenario A — Cost-present record carries per-stage bands
+
+**Given** a fixture repository with a populated `observability/costs/` snapshot
+whose Model Breakdown carries the binding table's named model keys, a parseable
+`MODEL_ROUTING.md`, and a target the agent classifies,
+**When** the `cost-estimator` agent runs to completion and produces a
+**cost-present** record (`cost_usd` present, `cost_basis: snapshot-actuals`),
+**Then** **every exercised stage** in `tokens_by_stage[]` carries a
+`cost_usd` `{ low, high }` band, and the split-tier stage's band has a
+**strictly-positive ordered spread** (`low < high`); and the one-directional
+coupling holds (no per-stage band exists without the top-level `cost_usd`).
+
+### Scenario B — Cost-omitted record carries no per-stage bands (unchanged)
+
+**Given** a fixture with an empty `observability/costs/` (or a snapshot with no
+usable Model Breakdown),
+**When** the agent runs and produces a **cost-omitted** record,
+**Then** no stage carries a `cost_usd` sub-field, the top-level `cost_usd` is
+absent, and the omission is disclosed in `Excluded` — exactly as before this
+slice.
+
+### Scenario C — Emitter convention, not a new validator
+
+**Given** the agent definition and the cost-estimation skill,
+**When** their charters are read,
+**Then** they instruct the emitter to populate per-stage bands on cost-present
+records by reference to the format's per-stage band pricing convention (they do
+**not** redefine it), and they do **not** introduce a new validation-rejection
+rule (absence of bands on a cost-present record stays valid; the only checked
+predicate on a present split-tier band remains `low < high`).
+
+## Functional Requirements
+
+- **FR-001** On a **cost-present** record (grounding state 3), the
+  `cost-estimator` emitter SHALL populate a `tokens_by_stage[].cost_usd`
+  `{ low, high }` band on **every exercised stage**.
+- **FR-002** A **split-tier** stage's per-stage band SHALL price `low` at the
+  cheaper representative model and `high` at the dearer one (per the binding
+  table), yielding `low < high`.
+- **FR-003** The emitter SHALL preserve the one-directional coupling: a
+  per-stage `cost_usd` SHALL NOT appear on a **cost-omitted** record, and the
+  sub-field SHALL be absent on every stage when the top-level `cost_usd` is
+  absent.
+- **FR-004** The agent and the S1 `cost-estimation` skill SHALL express this
+  obligation **by reference** to the format reference's per-stage band pricing
+  convention and rate-derivation sections — they SHALL NOT redefine the pricing
+  convention or introduce a new validation-rejection rule.
+- **FR-005** No change SHALL be made to `estimate-record-format.md` (the format
+  already admits the band) nor to the #377 validation checklist (the
+  `low < high` split-tier predicate already covers a present band).
+
+## Expected Outcome
+
+The cost-estimator's cost-present records become a machine-readable per-stage
+cost decomposition: each stage's dollar contribution is visible, and the
+split-tier widening that dominates the whole-record figure is traceable to the
+implementer stage rather than buried in prose. The §4.3.1 SHOULD obligation —
+honestly "admitted but unpopulated" at #377 — now has a producer and a
+falsifiable Layer 3 scenario.
+
+## Artefacts
+
+1. `agents/cost-estimator.agent.md` — flip the per-stage-band deferral into an
+   emit obligation on cost-present records (FR-001 – FR-004).
+2. `skills/cost-estimation/SKILL.md` — add the per-stage band emission step to
+   the cost-derivation methodology, by reference to the format convention
+   (FR-001, FR-004).
+3. `tdad_tests/scenarios/agents/cost-estimator/per-stage-cost-bands.md` — a
+   Layer 3 behavioural scenario for Scenario A (the falsifiable home #380 asks
+   for), reusing the `cost-estimator-cost-present` fixture.
+4. `README.md`, `plugin.json`, `marketplace.json`, `CHANGELOG.md` — version
+   0.49.0 (behaviour change to a shipped agent — minor bump). No component-count
+   change.
+
+## Exemptions
+
+None. This is a behaviour change to a shipped agent and carries its own spec
+(this file) as the first commit. The design lineage is #377 §4.3.1 / §216;
+no new design decisions are introduced beyond honouring that obligation.

--- a/tdad_tests/scenarios/agents/cost-estimator/per-stage-cost-bands.md
+++ b/tdad_tests/scenarios/agents/cost-estimator/per-stage-cost-bands.md
@@ -1,0 +1,72 @@
+---
+component: cost-estimator
+component_type: agent
+tier: behavioural
+fixture: cost-estimator-cost-present
+---
+
+# Scenario: per-stage cost_usd bands are populated on cost-present records (#380)
+
+## Given
+
+A fixture repository with a **populated** `observability/costs/` snapshot whose
+Model Breakdown carries the binding table's named model keys, a parseable
+`MODEL_ROUTING.md`, and a target the agent classifies — so the agent computes a
+**cost-present** record (`cost_usd` present, `cost_basis: snapshot-actuals`).
+
+This scenario is the falsifiable home for the #377 §4.3.1 SHOULD obligation
+(issue #380, spec
+`docs/superpowers/specs/2026-06-14-per-stage-cost-bands-emitter-design.md`;
+FR-001 – FR-003): now that a usable snapshot exists, the emitter must populate
+per-stage `cost_usd` bands. On cost-omitted records the obligation does not
+apply (there is no rate to price a band).
+
+## When
+
+The cost-estimator agent runs to completion, producing a cost-present record.
+
+## Then
+
+**Per-stage bands present (FR-001):**
+
+- **Every exercised stage** in `tokens_by_stage[]` carries a `cost_usd`
+  `{ low, high }` band (every stage that has a `tokens` band also has a
+  `cost_usd` band).
+- Each per-stage band is a well-formed two-key range with `low ≤ high`.
+
+**Split-tier strict spread (FR-002):**
+
+- The split-tier stage (the implementer, `model_tier` matching
+  `Standard/Capable` whitespace-insensitively) has a **strictly-positive ordered
+  spread**: `low < high` (the cheaper-model low bound is strictly below the
+  dearer-model high bound).
+
+**One-directional coupling preserved (FR-003):**
+
+- No per-stage `cost_usd` band appears unless the top-level `cost_usd` is also
+  present (here it is). The runner's cost-omitted scenarios
+  (`emits-conforming-record`, `empty-snapshot-not-refused`) cover the converse —
+  that no band appears on a cost-omitted record.
+
+## Rubric
+
+Layer 3 behavioural, graded by **presence/absence + ordering oracles** (no exact
+dollar values asserted, since those live in the snapshot, not the record). The
+oracle asserts `cost_usd` is present; that every `tokens_by_stage[]` entry with a
+`tokens` band also carries a `cost_usd` band; that each present band satisfies
+`low ≤ high`; and that the split-tier stage's band satisfies `low < high`. It
+never asserts the absolute rate or which bound binds to which model (that is an
+emitter convention the record cannot expose). The fixture pins the snapshot mix
+so a cost-present record is produced deterministically.
+
+## Cleanup
+
+Remove the temporary fixture repository.
+
+## Implementation note
+
+Reuses the `cost-estimator-cost-present` fixture (populated snapshot with the
+binding table's named keys) shared with `blended-rate-skew-surfaced.md`. The
+runner copies the fixture, runs a single-agent session, parses the returned
+record's `tokens_by_stage[]`, and applies the presence and `low < high`
+assertions above.


### PR DESCRIPTION
Closes #380.

Implements `docs/superpowers/specs/2026-06-14-per-stage-cost-bands-emitter-design.md` (committed as the first commit on this branch).

## What this does

The #377 format revision admitted an optional `tokens_by_stage[].cost_usd` band but no producer populated it — the agent could only emit cost-omitted records (empty `observability/costs/`). That precondition is now met: the repo's first cost snapshot (`observability/costs/2026-06-13-costs.md`, #391) carries a usable Model Breakdown. This slice is the falsifiable home for the §4.3.1 SHOULD obligation.

- On a **cost-present** record, every exercised stage now carries a `cost_usd` `{ low, high }` band = stage `tokens` × tier `$/token`.
- **Split-tier** stages (implementer `Standard/Capable`) price `low` at the cheaper model, `high` at the dearer — strictly-positive spread (`low < high`).
- **Cost-omitted** records are unchanged: no per-stage band (the one-directional coupling forbids a band without the top-level `cost_usd`).

## Design notes

- **Implementation of an existing design**, not new design — the per-stage band *pricing convention* is already fully specified in the format reference (§216, §229). The agent and skill reference it; they do **not** redefine it.
- **No format change** and **no new validation-rejection rule** — absence of bands on a cost-present record stays valid; the only checked predicate on a present split-tier band is `low < high` (already in the #377 checklist).
- Adds a Layer 3 behavioural scenario reusing the `cost-estimator-cost-present` fixture; graded by presence/ordering oracles (no absolute dollar values asserted).

## Validation

- Version 0.49.0 consistent across all 5 CI-checked locations (counts unchanged — no new component).
- Offline TDAD suite green (Layer 0 + 1, 17 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)