### PR TITLE
cost-estimation: tier→model family matching + disclosed cross-tier proxy (#411)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.49.0",
+  "plugin_version": "0.50.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.49.0"
+      "version": "0.50.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.50.0 — 2026-06-15
+
+### cost-estimation: tier→model family matching + disclosed cross-tier proxy (#411)
+
+Fixes the silent cost-omission #411 surfaced: the cost-estimation binding
+matched representative model keys **literally** (`claude-opus-4`,
+`claude-sonnet-4`), but real snapshots key their Model Breakdown by the
+**actual** model ids (`claude-opus-4-8`, …), so every estimate omitted
+cost even when a snapshot existed to ground it.
+
+- **Family matching (the core fix).** A snapshot key now resolves to a
+  tier's representative **by family stem** — it matches iff it starts with
+  the stem (`claude-opus-4` / `claude-sonnet-4`) **and** the next character
+  is `-` or end-of-string (so `claude-opus-4-8` → Most capable;
+  `claude-opus-40` does **not** match). Multiple rows in one family
+  aggregate into one blended rate, disclosed when >1. Only
+  `claude-opus-4` / `claude-sonnet-4` are estimating-tier families; haiku
+  and others bind to no tier. The stems are a maintained table (bumped per
+  model generation); a renamed family is a *signalled* miss (omission),
+  never a silent wrong rate.
+- **Disclosed cross-tier proxy (Option B′).** When an exercised tier's
+  family is **absent** but ≥1 estimating-tier family resolves, the missing
+  tier is **priced by a proxy** at the dearest present family's rate rather
+  than omitted — but as a **distinctly-typed, disclosed** figure: a new
+  additive `cost_basis` value **`snapshot-actuals-proxied`** (machine-
+  distinguishable from direct `snapshot-actuals`), with
+  `failure_direction: likely-overrun` and `confidence.cost: low` forced and
+  every proxied tier named. The proxy uses only observed snapshot rates —
+  never a vendor list price (the no-list-price-fallback rule is intact).
+- **Validator changes.** The `cost_basis` enum gains
+  `snapshot-actuals-proxied`; the "Split-tier spread" check exempts a
+  proxied (`snapshot-actuals-proxied`) split-tier band from the strict
+  `low < high` requirement (a cross-tier proxy legitimately collapses it);
+  the cost-pairing check requires a proxied record to carry the forced
+  overrun/low-confidence/disclosure trio. The three grounding states /
+  closed omission set are restated under family resolution.
+
+Touches the format reference (`skills/cost-estimation/references/estimate-record-format.md`),
+the skill (`skills/cost-estimation/SKILL.md`), and the `cost-estimator`
+agent in lockstep.
+
+**Decision discipline** — spec at
+`docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md`;
+spec-mode diaboli at
+`docs/superpowers/objections/cost-estimation-family-matching-design.md`
+(12 objections — 2 critical, 4 high — all accepted; the two criticals
+broke the naïve proxy and drove the engineered Option B′). Closes #411.
+
 ## 0.49.0 — 2026-06-14
 
 ### cost-estimator: populate per-stage cost_usd bands on cost-present records

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.49.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.50.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.49.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.50.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/cost-estimator.agent.md
+++ b/ai-literacy-superpowers/agents/cost-estimator.agent.md
@@ -195,9 +195,8 @@ Glob `observability/costs/per-pr/` for per-PR actuals records (format:
 
 ### Mechanical cost-omission (no salience judgment)
 
-When you compute a cost figure (state 3 — a usable snapshot exists), re-verify
-the binding **mechanically** — there is **no judgment about whether an unmapped
-tier "matters"**:
+When you compute a cost figure, re-verify the binding **mechanically** — there is
+**no judgment about whether an unmapped tier "matters"**:
 
 1. **Tier-mapping check.** Confirm every tier exercised by the target's stage set
    (each exercised `tokens_by_stage[].model_tier`, including each side of a
@@ -206,48 +205,53 @@ tier "matters"**:
    **"Stage/tier normalisation (the join key)"** section)
    **before** deciding a tier is unmapped: **strip the `{{LANGUAGE}}-` prefix**
    from the stage name, and compare tier labels **whitespace-insensitively** (so
-   `Standard/Capable` ↔ `Standard / Capable`). A literal-string match is **not**
-   sufficient — without normalisation a correctly-mapped split tier (the
-   implementer stage, the dominant cost driver) would be falsely reported unmapped
-   on a spacing mismatch and cost over-omitted.
+   `Standard/Capable` ↔ `Standard / Capable`).
 
-   > **Omit `cost_usd` (emit a cost-omitted record with disclosure) on any of
-   > this closed set of mechanical conditions** — each maps to one of the S1
-   > three grounding states; there is **no residual "or otherwise ungrounded"
-   > clause** and **no judgment** about whether an unmapped tier is
-   > "load-bearing":
+2. **Family-resolution check (v0.50.0 — family, not exact key).** For each
+   exercised tier, resolve its representative against the snapshot's Model
+   Breakdown **by family stem**, per the binding table: a snapshot key matches the
+   stem (`claude-opus-4` / `claude-sonnet-4`) iff it starts with the stem **and**
+   the next character is `-` or end-of-string (so `claude-opus-4-8` resolves Most
+   capable; `claude-opus-40` does not). Aggregate multiple matching rows into one
+   blended family rate (disclose when >1). Only `claude-opus-4` / `claude-sonnet-4`
+   are **estimating-tier** families; `claude-haiku-4-5` and others resolve to no
+   tier and are never a binding or proxy source.
+
+   > **The closed omission/grounding set (v0.50.0).** No residual "or otherwise
+   > ungrounded" clause; no salience judgment:
    >
-   > 1. **No cost snapshot** (S1 state 1) — `observability/costs/` holds no
-   >    usable snapshot.
-   > 2. **Snapshot present but no usable Model Breakdown** (S1 state 2) — the
-   >    snapshot exists but yields no usable Model Breakdown to rate against.
-   > 3. **Unmapped tier** — ANY exercised stage's tier is unmapped by the
-   >    binding table after the join-key normalisation above.
-   > 4. **Missing model key** — a representative model key the binding names
-   >    (`claude-opus-4`, `claude-sonnet-4`) is absent from the snapshot's
-   >    Model Breakdown.
-   >
-   > A **usable snapshot with every exercised tier mapped and every named key
-   > present** is S1 state 3 — `cost_usd` is **present**. Every omission
-   > trigger is one of the four named, checkable conditions above; none asks
-   > you to judge whether something is "ungrounded."
+   > 1. **No cost snapshot** → omit.
+   > 2. **Snapshot present but no usable Model Breakdown** → omit.
+   > 3. **Model Breakdown present but NO estimating-tier family resolves**
+   >    (neither `claude-opus-4` nor `claude-sonnet-4` family present — e.g. a
+   >    haiku-only snapshot) → omit, naming the cause. (This merges the old
+   >    "unmapped tier" + "missing model key" triggers under family resolution.)
+   > 4. **≥1 estimating-tier family resolves** → `cost_usd` **present** (see the
+   >    proxy step for any exercised tier whose family is absent).
 
-   On omission, **disclose the unmapped tier(s) in `Confidence rationale`** and
-   **name them in `Excluded`** as the omission cause. Do **not** invent a binding
-   for an unmapped tier.
-
-2. **Model-key check.** Confirm the representative model keys the binding table
-   names (`claude-opus-4`, `claude-sonnet-4`) exist in the snapshot's Model
-   Breakdown. A missing key is the same mechanical trigger as an unmapped tier:
-   the binding is **ungrounded**, so **omit `cost_usd` with disclosure** (the S1
-   state 2), naming the missing key as the cause. Do **not** invent a substitute
-   rate.
+3. **Cross-tier proxy (v0.50.0).** When some exercised tier's family is absent but
+   **≥1 estimating-tier family resolves**, do **not** omit — **proxy** the absent
+   tier at the **dearest present estimating family's** rate, and emit a
+   **distinctly-typed** record:
+   - set `cost_basis: snapshot-actuals-proxied` (not `snapshot-actuals`);
+   - **force `failure_direction: likely-overrun`** (dearest-present over-states)
+     and state in the prose that the figure is a deliberate over-estimate,
+     unsuitable for trend aggregation;
+   - force `confidence.cost: low`;
+   - **name every proxied tier and its source** in `Included`/`Confidence
+     rationale` ("Standard priced via a cross-tier proxy at the Most-capable
+     rate — the snapshot carries no `claude-sonnet-4` family").
+   - A proxied split-tier stage's per-stage band **may collapse**
+     (`low == high`) — that is exempt from the split-tier strict-spread check
+     under `snapshot-actuals-proxied` (format reference).
+   The proxy uses **only** observed snapshot rates — **never** a vendor list
+   price (the no-list-price-fallback rule is untouched). It is a distinct third
+   basis, not a relaxed `snapshot-actuals`.
 
 You **never edit** the binding table (you have no write tool, and the binding is
-the named revisable artefact, not your judgement). You only **detect** an
-ungrounded binding by the mechanical yes/no test and degrade to cost-omission,
-disclosing the cause. The only branch is "is every exercised tier mapped and every
-named key present?" — never a judgment about salience.
+the named revisable artefact, not your judgement). You only **detect** the
+grounding state by the mechanical family-resolution test and either ground
+directly, proxy with disclosure, or omit — never a judgment about salience.
 
 ## Provenance — `generated_by`
 

--- a/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
@@ -148,24 +148,33 @@ validation-rejection rule, and not a new derivation. On a cost-omitted record no
 stage carries the sub-field (the coupling is one-directional: a per-stage band
 never appears without the top-level `cost_usd`).
 
-**The three grounding states.** The snapshot's Model Breakdown is marked
-"(if available)" in the cost-tracking format, so the methodology branches
-on **three** states, not two:
+**The grounding states (four, under family resolution — v0.50.0).** The
+snapshot's Model Breakdown is marked "(if available)" in the cost-tracking
+format, and binding resolves tiers by **family stem** (above), so the
+methodology branches on **four** states. The canonical statement is the
+format reference's "grounding states for cost"; in brief:
 
-1. **No snapshot exists** — today's state; `observability/costs/` is
-   empty (the 2026-05-29 health snapshot records "Last cost capture:
-   never"). → `cost_usd` **omitted**, omission disclosed in `Excluded`.
+1. **No snapshot exists** — `observability/costs/` is empty. → `cost_usd`
+   **omitted**, disclosed in `Excluded`.
 2. **Snapshot exists but the Model Breakdown is absent or too coarse**
-   to yield a per-tier rate (only the always-present Provider Spend table
-   is populated, or the breakdown lacks the tiers the stage set needs). →
-   `cost_usd` **omitted**, omission disclosed in `Excluded` **naming this
-   specific cause** ("a cost snapshot exists but carries no usable
-   per-model breakdown"). The methodology does **not** silently fall
-   through to list price.
-3. **Snapshot exists with a usable Model Breakdown** → `cost_usd`
-   **present**, `cost_basis: snapshot-actuals`, `confidence.cost` set from
-   the snapshot's age and granularity, and the snapshot date/quality
-   disclosed in `Included`.
+   to yield a per-tier rate. → `cost_usd` **omitted**, disclosed **naming
+   this specific cause** ("a cost snapshot exists but carries no usable
+   per-model breakdown"). The methodology does **not** fall through to
+   list price.
+3. **Snapshot present but NO estimating-tier family resolves** — after
+   family resolution, neither the `claude-opus-4` nor the
+   `claude-sonnet-4` family is present (e.g. a haiku-only snapshot). →
+   `cost_usd` **omitted**, naming the cause. (This is the family-resolution
+   successor of the old "missing model key" omission.)
+4. **Snapshot present with ≥1 estimating-tier family resolving** →
+   `cost_usd` **present**, `confidence.cost` from the snapshot's
+   age/granularity, snapshot date/quality disclosed in `Included`. The
+   **basis** distinguishes two cases: every exercised tier's family
+   resolves directly → `cost_basis: snapshot-actuals`; at least one
+   exercised tier's family is absent and is priced by the **cross-tier
+   proxy** (binding table) → `cost_basis: snapshot-actuals-proxied`, with
+   `failure_direction: likely-overrun` and `confidence.cost: low` forced
+   and every proxied tier disclosed.
 
 **There is no list-price fallback.** A list-price guess is not an
 observed cost; emitting it as a first-class figure was the false
@@ -174,7 +183,7 @@ actuals, it is **omitted with disclosure**, and the day-one deliverable
 remains the token + time estimate.
 
 **The no-cost case is honest, not a failure.** When `cost_usd` is omitted
-(states 1 and 2), the record is **valid and complete** — it is the
+(states 1–3), the record is **valid and complete** — it is the
 expected day-one shape. The `Excluded` section carries an explicit
 omission disclosure, e.g.:
 

--- a/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/SKILL.md
@@ -104,7 +104,7 @@ no model or price, while the snapshot's Model Breakdown is keyed by model
 name. The binding is fixed in the format reference's
 **tier→model→$/token binding table**:
 
-| Model tier (MODEL_ROUTING) | Representative model (snapshot key) |
+| Model tier (MODEL_ROUTING) | Representative model **family stem** |
 | --- | --- |
 | Most capable | `claude-opus-4` |
 | Standard | `claude-sonnet-4` |
@@ -114,6 +114,17 @@ name. The binding is fixed in the format reference's
 capable` — and one complexity-dependent split, the implementer's
 `Standard / Capable`. There is **no standalone `Capable` tier with its
 own model**; the dearer end of the split resolves to `Most capable`.
+
+**Family resolution, not exact keys (v0.50.0).** A snapshot Model
+Breakdown key resolves to a tier's representative **by family stem** — it
+matches iff it starts with the stem and the next character is `-` or
+end-of-string (so `claude-opus-4` resolves the real id `claude-opus-4-8`,
+but not `claude-opus-40`). Multiple rows in one family aggregate into one
+blended rate (disclosed when >1). This is the #411 fix: a snapshot keyed
+by the actual model id now grounds cost where the old exact-string match
+silently omitted it. The full rule (delimiter, aggregation, and the
+**cross-tier proxy** for a tier whose family is absent) lives in the
+format reference's binding table — this skill does not restate it.
 
 **Deriving a per-model rate from a snapshot.** The snapshot's
 `## Model Breakdown` table gives, per model, quarter-aggregate

--- a/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
@@ -286,7 +286,7 @@ when those mixes diverge the figure skews. This is by design, so a
 downstream S2 author should not "fix" it by reintroducing a per-direction
 rate.
 
-## The three grounding states for cost
+## The grounding states for cost (four, under family resolution — v0.50.0)
 
 1. **No snapshot exists** → `cost_usd` and `cost_basis` **omitted**;
    omission disclosed in `Excluded`. `tokens`/`agent_compute_time` still
@@ -328,9 +328,11 @@ is the **defined cost-omitted sentinel**: the entry remains *present*
 path records what the emitter actually read — the directory it inspected and
 found empty (or without a usable snapshot). The `Excluded` prose names that the
 directory held no usable snapshot. The entry is **never dropped** and **never
-given a fabricated snapshot file path**. When a usable snapshot file exists
-(state 3), the `path` is that **file** (e.g.
-`observability/costs/2026-08-15-costs.md`).
+given a fabricated snapshot file path**. When a snapshot **file** exists
+(states 3 and 4 — a Model Breakdown is present, whether or not an
+estimating-tier family resolves), the `path` is that **file** (e.g.
+`observability/costs/2026-08-15-costs.md`); the directory sentinel is only
+for states 1 and 2, where no usable snapshot file exists.
 
 **Consumer special-case (do not double-count).** Because the trailing-slash
 directory path means *looked-and-found-nothing* rather than

--- a/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
+++ b/ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md
@@ -30,7 +30,7 @@ the body carries the human-readable disclosure prose.
 | `tokens_by_stage` | list of objects | yes | Per-stage breakdown. Each entry: `stage` (string — spec-writer, tdd-agent, implementer, code-reviewer, integration), `tokens` (range object), `model_tier` (string from the agent→model-tier mapping — may be a split tier such as `Standard/Capable`). May omit stages a target does not exercise; the omission must be reflected in the `Excluded` prose. |
 | `tokens_by_stage[].cost_usd` | range object `{ low, high }` | **optional, one-directionally coupled** — **present ⟹ top-level `cost_usd` present** (enforced); top-level `cost_usd` present ⟹ bands **SHOULD** be populated by emitters, but their **absence does NOT invalidate** the record (**not** an `iff` — the asymmetry is deliberate) | The per-stage dollar contribution. Makes the split-tier widening a machine-readable disclosure surface and a **record-internal** spread check: a validator can assert a split-tier stage's band is **non-collapsed (strictly spread)** — `low < high` — consistent with the binding table's tier ordering. It **cannot** assert the bounds equal the absolute `claude-sonnet-4`/`claude-opus-4` rates — those live in the snapshot, not the record (see the per-stage cost validation notes below). |
 | `cost_usd` | range object | **conditional (present-when-grounded)** | Estimated dollar cost as `{ low: float, high: float }`. **Present ONLY when an `observability/costs/` snapshot supplies a usable per-tier $/token rate.** When no usable rate exists, the field is **omitted entirely** and the omission is disclosed in `Excluded`. The format must not carry a placeholder, a null, or a forced list-price value. |
-| `cost_basis` | enum | **conditional (present-when-grounded)** | Present **iff** `cost_usd` is present. One of `snapshot-actuals` (rate derived from a snapshot Model Breakdown) — currently the only grounded basis. Records the provenance of the $/token rate so a reader knows the cost is observed, not guessed. |
+| `cost_basis` | enum | **conditional (present-when-grounded)** | Present **iff** `cost_usd` is present. One of `snapshot-actuals` (every priced tier's rate is derived from a snapshot Model Breakdown row of *that tier's own* model family) **or** `snapshot-actuals-proxied` (v0.50.0 — at least one exercised tier's family was **absent** from the snapshot and was priced by a disclosed **cross-tier proxy** at another present family's rate; see the binding table's *Cross-tier proxy* rule). Records the provenance of the $/token rate so a reader — human **or** machine — knows whether the cost is directly grounded or partly proxied **without reading prose**. The `snapshot-actuals-proxied` value is additive and backward-compatible: a record predating it carries `snapshot-actuals`, and a consumer that does not recognise the new value treats it as grounded-with-caveat. |
 | `agent_compute_time` | range object | yes | Estimated wall-clock spent in agent execution as `{ low: <duration>, high: <duration> }`. Durations are ISO 8601 durations or plain `"Nm"`/`"Nh"` strings. Derived from token volume. |
 | `human_gate_time` | string (qualitative caveat) | yes | A **disclosed qualitative caveat string**, NOT a numeric range. Total wall-clock is dominated by human availability at the orchestrator's disposition gates, and **is not estimated numerically at S1**. Carries a short prose statement to that effect, never a `{ low, high }` range. |
 | `confidence` | object | yes | **Per-axis** confidence object with keys `tokens`, `time`, and (iff `cost_usd` present) `cost`, each one of `low`, `medium`, `high`. A whole-record summary tier MAY be reported as `min()` of the present axes, but the per-axis values are authoritative. |
@@ -184,16 +184,60 @@ The single source of the `tier → model` map for cost derivation. The cost
 derivation reads this table so the binding is **not left to agent
 discretion**.
 
-| Model tier (MODEL_ROUTING) | Representative model (snapshot key) | $/token source |
+| Model tier (MODEL_ROUTING) | Representative model **family stem** | $/token source |
 | --- | --- | --- |
-| Most capable | `claude-opus-4` | blended rate from the snapshot Model Breakdown row for `claude-opus-4` |
-| Standard | `claude-sonnet-4` | blended rate from the snapshot Model Breakdown row for `claude-sonnet-4` |
-| Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-opus-4` (high) | **widened**: low bound uses the `claude-sonnet-4` rate, high bound uses the `claude-opus-4` rate |
+| Most capable | `claude-opus-4` | blended rate from the snapshot Model Breakdown row(s) of the `claude-opus-4` family |
+| Standard | `claude-sonnet-4` | blended rate from the snapshot Model Breakdown row(s) of the `claude-sonnet-4` family |
+| Standard / Capable (split) | spans `claude-sonnet-4` (low) … `claude-opus-4` (high) | **widened**: low bound uses the `claude-sonnet-4`-family rate, high bound uses the `claude-opus-4`-family rate |
 
 `MODEL_ROUTING.md` names exactly two tiers — `Standard` and `Most
 capable` — and one complexity-dependent split, the implementer's
 `Standard / Capable`. There is **no standalone `Capable` tier with its own
 model**; the dearer end of the split resolves to `Most capable`.
+
+**Family resolution — match by family stem, not exact key (v0.50.0).** A
+snapshot Model Breakdown key `K` resolves to a tier's representative
+**iff `K`, lowercased, starts with the family stem AND the next character
+is `-` or end-of-string** (the delimiter rule). So `claude-opus-4` resolves
+`claude-opus-4` and `claude-opus-4-8`, but **not** `claude-opus-40`,
+`claude-opus-4o`, or `claude-opus-5`. This is why a snapshot keyed by the
+*actual* model id (`claude-opus-4-8`) now grounds Most capable, where the
+old exact-string match silently omitted cost (#411). The stems
+(`claude-opus-4` / `claude-sonnet-4`) are a **maintained** table, bumped
+per model generation; a renamed family that no longer matches is a
+*signalled* miss (it falls through to omission — loud — never a silent
+wrong rate).
+
+**Family aggregation.** When **>1** Model Breakdown row matches one
+family, aggregate them into a single blended family rate:
+`$/token = Σ estimated_cost ÷ Σ (input + output) tokens` over the matching
+rows. Aggregating across model generations can blend divergent rates, so
+**when >1 row is aggregated the emitter discloses it** in
+`Confidence rationale` (the same disclosure discipline as the
+blended-rate skew below).
+
+**Cross-tier proxy — pricing a tier whose family is absent (v0.50.0).**
+When an exercised tier's family does **not** resolve in the snapshot but
+**≥1 estimating-tier family does** (Most capable / Standard — *not* haiku
+or any non-estimating family), the missing tier is priced by a **proxy**
+at the **dearest present estimating family's** rate, rather than omitted.
+A proxy is **distinctly typed and disclosed**, never a figure masquerading
+as direct grounding:
+
+- the record's `cost_basis` is **`snapshot-actuals-proxied`** (the
+  machine-readable marker — a consumer keys on this, not on prose);
+- the record **forces `failure_direction: likely-overrun`** — dearest-
+  present deliberately **over**-states the proxied tier, so the figure is
+  unsuitable for trend aggregation, and the prose says so;
+- `confidence.cost` is forced to **`low`** (secondary to the basis marker);
+- `Included`/`Confidence rationale` **names every proxied tier** and its
+  proxy source ("Standard priced via a cross-tier proxy at the
+  Most-capable rate — the snapshot carries no `claude-sonnet-4` family").
+
+The proxy is anchored **only** in this repo's observed snapshot rates — a
+vendor price card is still **never** used (the no-list-price-fallback rule
+is untouched). It is a distinct *third basis*, not a relaxation of
+`snapshot-actuals`.
 
 **Stage/tier normalisation (the join key).** A `tokens_by_stage[].stage`
 maps to a MODEL_ROUTING Agent Routing row by **stripping the
@@ -251,10 +295,22 @@ rate.
    `cost_usd` **omitted**; `Excluded` names this specific cause ("a cost
    snapshot exists but carries no usable per-model breakdown"). **No**
    silent fall-through to list price.
-3. **Snapshot present with a usable Model Breakdown** → `cost_usd`
-   **present**, `cost_basis: snapshot-actuals`, `confidence.cost` from the
-   snapshot's age/granularity, snapshot date/quality disclosed in
-   `Included`.
+3. **Snapshot present but NO estimating-tier family resolves** — the Model
+   Breakdown exists but, after family resolution (binding table), neither
+   the `claude-opus-4` nor the `claude-sonnet-4` family is present (e.g. a
+   haiku-only snapshot) → `cost_usd` **omitted**, `Excluded` naming the
+   cause. (This is the family-matching successor of the old "missing model
+   key" / "unmapped tier" omission triggers — v0.50.0.)
+4. **Snapshot present with ≥1 estimating-tier family resolving** →
+   `cost_usd` **present**, `confidence.cost` from the snapshot's
+   age/granularity, snapshot date/quality disclosed in `Included`. The
+   **basis** distinguishes two cases:
+   - every exercised tier's family resolves directly → `cost_basis:
+     snapshot-actuals`;
+   - at least one exercised tier's family is absent and is priced by the
+     **cross-tier proxy** (binding table) → `cost_basis:
+     snapshot-actuals-proxied`, with `failure_direction: likely-overrun`
+     and `confidence.cost: low` forced and every proxied tier disclosed.
 
 **There is no list-price fallback.** When cost cannot be grounded in
 actuals, it is omitted with disclosure — the no-cost record is **valid and
@@ -338,7 +394,14 @@ The checks a consuming command's Output Validation Checkpoint runs:
   label contains a `/`** (after the join-key whitespace normalisation);
   otherwise it is a single tier. A collapsed band (`low == high`) on a
   split-tier stage fails this check. **Single-tier** stages are exempt (they
-  may carry `low == high`, governed only by "Ranges well-formed"). A record
+  may carry `low == high`, governed only by "Ranges well-formed"). **Proxied
+  records are exempt (v0.50.0):** when the record's `cost_basis` is
+  `snapshot-actuals-proxied`, a split-tier band **may** collapse
+  (`low == high`) — the cross-tier proxy legitimately prices one or both ends
+  at the *same* present-family rate, so the both-ends-bind-different-models
+  assumption this check rests on no longer holds. The strict-spread predicate
+  therefore applies **only** when `cost_basis` is `snapshot-actuals` (every end
+  directly bound). A record
   with no per-stage `cost_usd` satisfies this check vacuously. (`model_tier` is a
   **required** sub-field of every `tokens_by_stage[]` entry, so a cost-bearing
   stage with an absent `model_tier` is a structural failure caught by the
@@ -363,8 +426,12 @@ The checks a consuming command's Output Validation Checkpoint runs:
   the `cost` axis by `target_kind` — it is independent (see the Cost axis
   rule above), so a `cost: low` beside `tokens: high` is valid.
 - [ ] **Cost pairing** — `cost_usd` and `cost_basis` are **both present or
-  both absent**; when absent, the `Excluded` section contains the
-  cost-omission disclosure.
+  both absent**; when present, `cost_basis` is one of `snapshot-actuals` or
+  `snapshot-actuals-proxied`; when absent, the `Excluded` section contains the
+  cost-omission disclosure. **Proxy coherence (v0.50.0):** a record with
+  `cost_basis: snapshot-actuals-proxied` must carry
+  `failure_direction: likely-overrun`, `confidence.cost: low`, and a proxied-
+  tier disclosure in `Included`/`Confidence rationale`.
 - [ ] **Time split** — both time fields present and **separate**:
   `agent_compute_time` a `{ low, high }` range, `human_gate_time` a
   qualitative caveat string (NOT a range).

--- a/docs/superpowers/objections/cost-estimation-family-matching-design.md
+++ b/docs/superpowers/objections/cost-estimation-family-matching-design.md
@@ -1,0 +1,123 @@
+---
+spec: docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md
+date: 2026-06-15
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+adjudication: all 12 accepted; human disposed the §3 fork to Option B′ (engineer the proxy properly) — absorbed into the spec
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "Option B's proxy collapses the implementer split-tier band to low == high (Sonnet end proxied to the Opus rate), which fails the existing 'Split-tier spread' (low < high, strict) validation check — the recommended option produces records the current validator rejects, on the exact snapshot it targets."
+    disposition: accepted
+    disposition_rationale: "The split-tier strict-spread check assumes both ends bind DIFFERENT representative models; a cross-tier proxy breaks that assumption legitimately. Resolution: the 'Split-tier spread' check is amended to apply only when both ends bind directly (non-proxied); a split-tier stage with a proxied end is EXEMPT and may collapse, with the collapse disclosed. Format-reference validation-checklist change (B′ embraces format change)."
+  - id: O2
+    category: implementation
+    severity: critical
+    claim: "A proxied figure carries cost_basis: snapshot-actuals, which the format defines as the rate derived from THAT tier's Model Breakdown row — so the field asserts a grounding the figure lacks, and a machine consumer cannot distinguish a proxied dollar from a directly-grounded one."
+    disposition: accepted
+    disposition_rationale: "Adopt O11: add an additive cost_basis enum value `snapshot-actuals-proxied`. Any record with ≥1 proxied tier carries it; fully-direct records keep `snapshot-actuals`. Machine-distinguishable; backward-compatible (old records unaffected; an unaware consumer treats the new value as grounded-with-caveat). Resolves the contract lie."
+  - id: O3
+    category: premise
+    severity: high
+    claim: "The 'observed snapshot rate, never list price → no-list-price-fallback intact' defence equivocates: an Opus rate applied to Standard traffic is not the observed cost of the thing being priced, regardless of provenance."
+    disposition: accepted
+    disposition_rationale: "Reframed: the proxy is NOT defended as 'still snapshot-actuals'. It is a distinct, named third basis (`snapshot-actuals-proxied`) — an explicitly-typed, confidence-floored, direction-forced approximation the human opted into. It differs from list-price in being anchored in THIS repo's observed spend AND in being typed so it can never masquerade as direct grounding. The no-list-price rule is untouched (vendor cards are still never used); the proxy is a new basis, not a smuggled list price."
+  - id: O4
+    category: implementation
+    severity: high
+    claim: "'Dearest-present = conservative' is asserted as absolute, but an over-estimate misleads a 'too cheap to bother / track' read and contaminates the cost trend the snapshot itself asks for."
+    disposition: accepted
+    disposition_rationale: "A proxied record FORCES `failure_direction: likely-overrun` and the disclosure states the figure is a deliberate over-estimate unsuitable for trend aggregation. The directional bias is named, not implied; 'conservative' is replaced with 'deliberately over-stating, disclosed as such'."
+  - id: O5
+    category: risk
+    severity: high
+    claim: "confidence.cost: low + prose is the sole proxy honesty control, but `cost: low` is already routine for stale snapshots, so a proxy is indistinguishable from a normal low-confidence grounded estimate to a non-prose consumer."
+    disposition: accepted
+    disposition_rationale: "Resolved by O2/O11: the `snapshot-actuals-proxied` basis is the structured, machine-readable proxy marker; `confidence.cost: low` is retained as a secondary signal, not the sole one. A consumer keys on the basis, not the confidence tier."
+  - id: O6
+    category: specification quality
+    severity: high
+    claim: "§5 promises a 'Layer-1 assertion that family matching resolves claude-opus-4-8 → Most capable', but resolution happens in the read-only agent's prose reasoning and leaves no machine-readable trace — the named test may be structurally unwritable."
+    disposition: accepted
+    disposition_rationale: "Test surfaces clarified: Layer-1 asserts the STATIC contract data (the family-stem rule + delimiter, the new `snapshot-actuals-proxied` enum value, the amended split-tier-spread exemption — all documented in the format reference and agent body, grep-able). The behavioural claim (agent resolves opus-4-8 → Most capable on a fixture snapshot) is Layer-2/3 acceptance documentation, gated on an API key — NOT a Layer-1 assertion. The spec no longer promises a structural test of agent-internal resolution."
+  - id: O7
+    category: implementation
+    severity: medium
+    claim: "Multi-row family aggregation (Σcost ÷ Σtokens) silently blends different model generations at different rates into one figure with no disclosure obligation, unlike the input/output blended-rate skew which must be surfaced."
+    disposition: accepted
+    disposition_rationale: "A disclosure obligation is added: when >1 Model Breakdown row is aggregated into a family rate, the agent names it in Confidence rationale (mirroring the blended-rate-skew disclosure)."
+  - id: O8
+    category: implementation
+    severity: medium
+    claim: "Prefix-on-family-stem is an unbounded forward match: `claude-opus-4` would bind a hypothetical claude-opus-40/claude-opus-4o, and a renamed family (claude-opus-5) silently fails to match — recreating #411 a generation later."
+    disposition: accepted
+    disposition_rationale: "Delimiter rule added: the stem matches iff the next character is `-` or end-of-string (so `claude-opus-4` matches `claude-opus-4` and `claude-opus-4-8`, NOT `claude-opus-40`/`claude-opus-4o`). The false-negative side (a future `claude-opus-5` family) is named as a deliberate, signalled maintenance point: the stem table is versioned per model generation (added to §6 / a maintenance note), not a silent miss — a no-family-resolves snapshot is state 2 (omit), which is loud, not silent."
+  - id: O9
+    category: specification quality
+    severity: medium
+    claim: "The proxy firing condition '≥1 family present (a usable rate exists)' is ambiguous for a haiku-only snapshot: haiku has a usable rate but resolves to no estimating tier — undefined whether the proxy fires from haiku or falls to state 2."
+    disposition: accepted
+    disposition_rationale: "Clarified: only ESTIMATING-TIER families (opus-4 / sonnet-4) count as 'present'. Haiku is never a proxy source. A haiku-only snapshot has no estimating-tier family → state 2 (omit). The firing condition reads '≥1 estimating-tier family resolves'."
+  - id: O10
+    category: scope
+    severity: medium
+    claim: "The spec bundles the contentious proxy (B) with the uncontroversial family-matching fix (§2) and writes §4/§5 as if B ships, raising the cost of choosing Option A."
+    disposition: accepted
+    disposition_rationale: "The human disposed to B′, so both ship — but the revised spec/surfaces explicitly tag each change as FAMILY-MATCHING (firm core) or PROXY (B′), so the two remain separable in the implementation and the audit trail (and so a future revert of the proxy would not disturb family-matching)."
+  - id: O11
+    category: alternatives
+    severity: medium
+    claim: "A more honest middle path is unacknowledged: add an additive cost_basis enum value (snapshot-actuals-proxied) so a proxy is machine-distinguishable — preserving B's relief while removing the O2 contract lie at the cost of one backward-compatible enum value."
+    disposition: accepted
+    disposition_rationale: "Adopted as the core of B′ (see O2). This is what makes the engineered proxy honest and contract-clean."
+  - id: O12
+    category: specification quality
+    severity: low
+    claim: "§4 rewords the state-2 'missing model key' trigger to 'no tier family resolves' without restating the agent's closed four-condition omission set, risking a divergent re-implementation."
+    disposition: accepted
+    disposition_rationale: "The spec restates the FULL post-change closed omission set: (1) no snapshot; (2) snapshot but no usable Model Breakdown; (3) Model Breakdown present but NO estimating-tier family resolves → omit (the merged successor of the old 'unmapped tier' + 'missing model key'). ≥1 estimating-tier family resolves → cost present (with proxy for absent families, B′)."
+---
+
+## Summary
+
+Spec-mode diaboli on the cost-estimation family-matching spec (#411) raised
+**12 objections — 2 critical, 4 high, 5 medium, 1 low** — across premise (1),
+implementation (5), risk (1), specification quality (3), scope (1), and
+alternatives (1). **All 12 accepted.** The family-matching premise (§2) was
+explicitly *not* challenged; the two criticals (O1, O2) and O3/O5/O11 all struck
+the **recommended cross-tier proxy** as originally specced.
+
+The human disposed the §3 load-bearing fork to **Option B′ — engineer the proxy
+properly** (rather than retreat to precise-omission Option A). The engineered
+proxy absorbs the objections via:
+
+- **O2/O11/O5** — a new additive `cost_basis` enum value
+  **`snapshot-actuals-proxied`** makes a proxied figure machine-distinguishable
+  (backward-compatible; direct figures keep `snapshot-actuals`).
+- **O1** — the "Split-tier spread" validator is amended: a split-tier stage with a
+  **proxied** end is exempt from the strict `low < high` requirement (the check
+  assumed both ends bind different models).
+- **O3** — the proxy is reframed as a distinct, named, opted-into third basis, not
+  "still snapshot-actuals"; the no-list-price rule is untouched.
+- **O4** — a proxied record forces `failure_direction: likely-overrun` and
+  discloses it is a deliberate over-estimate unsuitable for trend aggregation.
+- **O7/O8/O9/O12** — multi-row aggregation disclosure; a stem **delimiter rule**
+  (next char `-` or end-of-string); haiku-only → state 2 (only estimating-tier
+  families count); and the agent's full closed omission set restated.
+- **O6** — test surfaces clarified: Layer-1 asserts the static contract data; the
+  agent's runtime resolution is Layer-2/3 acceptance, not a Layer-1 test.
+- **O10** — family-matching (firm) and the proxy (B′) are tagged separately in the
+  surfaces list so they stay separable.
+
+## What was NOT challenged (diaboli disclosure)
+
+- The §1 diagnosis (exact-key binding silently omits cost on the real snapshot) —
+  correct and well-evidenced.
+- §2 family matching as the right *shape* of fix (the objections are about its
+  bounds, not its premise).
+- Keeping haiku out of the estimating tiers (a defensible scope line).
+- The version-bump/CHANGELOG mechanics (routine minor bump).
+- The blended-rate-skew simplification staying unchanged (separately sanctioned).
+- Deferring capture-time `/cost-capture` validation (reasonable complementary
+  slice).

--- a/docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md
@@ -1,0 +1,190 @@
+# Cost-Estimation Tier→Model Family Matching — Capability Design Spec
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-15 |
+| Status | Drafted — ready for spec-mode diaboli, then plan/implementation |
+| Author | claude-opus-4-8[1m] (interactive session with russmiles) |
+| Capability | Make the cost-estimation tier→model binding resolve by **model family** (not an exact key string), so a real captured snapshot grounds a dollar figure instead of silently omitting cost |
+| Fixes | #411 |
+| Plugin version target | `ai-literacy-superpowers` v0.49.0 → v0.50.0 (behaviour change to the cost-estimation methodology) |
+
+---
+
+## 1. Problem
+
+The cost-estimation methodology grounds a dollar figure by binding each
+MODEL_ROUTING tier to a **representative model key** and reading that
+model's blended rate from the latest `observability/costs/<date>-costs.md`
+snapshot's Model Breakdown. The binding table
+(`skills/cost-estimation/references/estimate-record-format.md`) names those
+keys **literally**: Most capable → `claude-opus-4`, Standard →
+`claude-sonnet-4`. The `cost-estimator` agent's mechanical check
+(`agents/cost-estimator.agent.md`, "Missing model key") omits cost when a
+named key is **absent** from the snapshot.
+
+The repo's only snapshot, `observability/costs/2026-06-13-costs.md`, keys
+its Model Breakdown as **`claude-opus-4-8`** and **`claude-haiku-4-5`** —
+the *actual* model ids. Neither literal binding key (`claude-opus-4`,
+`claude-sonnet-4`) is present, so **every** estimate omits cost — even
+though that snapshot was captured precisely so the estimator could ground
+cost (its prose flags the ~$0.83/1M Opus blended rate for exactly this).
+Observed across six consecutive estimates (#363–#368). The omission is
+**silent** (a cost-omitted record is valid-and-complete), so nothing
+surfaces the mismatch. (#411.)
+
+## 2. The fix — family matching (firm)
+
+The binding resolves a tier's representative by **model-family stem**, not
+an exact string. A snapshot Model Breakdown key `K` resolves to a tier `T`
+**iff `K`, lowercased, starts with `T`'s family stem**:
+
+| Tier | Family stem | Matches (examples) |
+| --- | --- | --- |
+| Most capable | `claude-opus-4` | `claude-opus-4`, `claude-opus-4-8`, `claude-opus-4-1`, … |
+| Standard | `claude-sonnet-4` | `claude-sonnet-4`, `claude-sonnet-4-5`, … |
+| Standard / Capable (split) | low `claude-sonnet-4` … high `claude-opus-4` | as above, per end |
+
+Rules:
+
+- **Prefix-on-family-stem**, case-insensitive. The stems are the
+  family roots `claude-opus-4` / `claude-sonnet-4` (a major family the
+  routing tiers actually map to), not full ids.
+- **Multiple matches in one family are aggregated** into a single blended
+  family rate: sum the matching rows' `estimated_cost` and their
+  `(input + output)` tokens, then `$/token = Σcost ÷ Σtokens`. This uses
+  all of a family's observed data and stays deterministic.
+- `claude-haiku-4-5` and other non-opus-4/non-sonnet-4 keys resolve to
+  **no** estimating tier (the binding table has only Most capable /
+  Standard / the split). They are simply not used for binding — their
+  presence neither grounds nor blocks a tier.
+- The match is documented and deterministic — **not** agent discretion.
+  The agent still holds no write tool and applies the table mechanically.
+
+This is necessary and unambiguous, and it directly answers #411. With it,
+the 2026-06-13 snapshot grounds the **Most capable** tier
+(`claude-opus-4-8` → Most-capable rate). It does **not**, on its own,
+ground the **Standard** tier from that snapshot, because the snapshot
+contains no `claude-sonnet-4*` row — which §3 addresses.
+
+## 3. The partial-snapshot decision (the genuine fork)
+
+Family matching alone leaves a real gap: the only snapshot we have is
+**opus-only** (the single-machine session it captured ran ~100% on Opus).
+A typical multi-stage task exercises Standard-tier stages (tdd-agent,
+integration-agent) whose family (`claude-sonnet-4*`) is **absent**. So
+after §2, those tasks would *still* omit cost. Two honest options:
+
+### Option A — precise omission (conservative)
+
+`cost_usd` is present **iff every exercised tier's family resolves** in
+the snapshot; otherwise omit, but with a **precise** `Excluded`
+disclosure naming the **specific missing tier family** (e.g. "Standard
+tier — no `claude-sonnet-4*` row in the snapshot"), rather than today's
+generic "keys absent". No approximation is introduced.
+
+- *Pro:* maximally honest; no new approximation class; smallest change.
+- *Con:* does **not** relieve #411's symptom for the current opus-only
+  snapshot — multi-tier tasks still omit (truthfully) until a snapshot
+  containing Sonnet data is captured. Family matching only fixes
+  Most-capable-only tasks and the disclosure quality.
+
+### Option B — disclosed cross-tier proxy (recommended)
+
+When an exercised tier's family is **absent** but the snapshot has a
+usable rate for **another** family, bind the missing tier to the
+**dearest present family's** rate, **disclosed** as a cross-tier proxy and
+with `confidence.cost` forced to **`low`**:
+
+- The proxy uses an **observed snapshot rate** (this repo's actual spend),
+  never a vendor list price — the no-list-price-fallback rule is intact.
+- **Dearest-present** is deliberately conservative: proxying Standard to
+  the Opus rate **over**-states (never under-states) the Standard cost, so
+  a "can I afford this?" read is not lulled by an optimistic figure.
+- The `Included`/`Confidence rationale` prose **names** every proxied
+  tier ("Standard priced via a cross-tier proxy at the Most-capable rate —
+  the snapshot carries no Sonnet data"), and `confidence.cost: low` is
+  forced whenever any proxy is used.
+- Only applies when **≥1** family is present (a usable rate exists). With
+  **no** usable Model Breakdown at all, the existing state-2 omission is
+  unchanged.
+
+- *Pro:* the 2026-06-13 snapshot now **grounds cost** (Most capable
+  directly; Standard/split-low via the disclosed Opus proxy), matching the
+  snapshot author's stated intent and relieving #411 with the data we
+  have.
+- *Con:* introduces a new, disclosed approximation class; the proxied
+  figure is a deliberate over-estimate.
+
+**Recommendation: Option B**, because #411's intent is "real snapshots
+should ground cost", the proxy is grounded in observed actuals (not list
+price), it is conservative, loudly disclosed, and confidence-capped — and
+it is the behaviour the captured snapshot's own prose anticipates. Option
+A is the fallback if the diaboli/human judges the proxy too strong; family
+matching (§2) ships either way and is itself a real improvement.
+
+**This is the load-bearing decision for the spec-mode diaboli and the
+human to dispose.**
+
+## 4. Grounding-state changes
+
+The three grounding states (`estimate-record-format.md`) are refined:
+
+- **State 1 (no snapshot):** unchanged — omit.
+- **State 2 (snapshot, no usable Model Breakdown / no family resolves at
+  all):** unchanged — omit, with the "no usable per-model breakdown"
+  cause. The "missing model key" trigger is **reworded** to "no tier
+  family resolves" (a tier family resolves by §2, not an exact key).
+- **State 3 (≥1 tier family resolves):** `cost_usd` **present**. Under
+  Option B, tiers whose family is absent are **proxied** (dearest present
+  family) with the disclosure + `confidence.cost: low`; under Option A,
+  cost is present **only** if *all* exercised families resolve, else state
+  2.
+
+No estimate-record **format** field changes — `cost_usd`, `cost_basis:
+snapshot-actuals`, `confidence.cost` are as today. (A proxy is disclosed
+in prose, not a new field — consistent with how the methodology discloses
+other caveats.) The blended-rate-skew simplification is unchanged.
+
+## 5. Surfaces changed
+
+1. `skills/cost-estimation/references/estimate-record-format.md` — the
+   binding table (family stems + aggregation), the "deriving a per-model
+   rate" step (resolve by family), the three grounding states (§4), and
+   (Option B) the proxy rule + its disclosure obligation.
+2. `skills/cost-estimation/SKILL.md` — the grounding-methodology section
+   mirrors the binding table; updated in lockstep.
+3. `agents/cost-estimator.agent.md` — the mechanical binding check
+   (currently "Missing model key" → omit) becomes family resolution +
+   (Option B) the proxy step; the worked-example caveat about
+   `claude-opus-4-8` is updated to reflect that it now **resolves** to
+   Most capable.
+4. Tests — a TDAD scenario / Layer-1 assertion that family matching
+   resolves `claude-opus-4-8` → Most capable and (Option B) that an
+   opus-only snapshot grounds cost with the proxy disclosure.
+5. Version triplet + CHANGELOG (the five `ai-literacy-superpowers`
+   CI-checked locations; minor bump).
+
+## 6. Out of scope
+
+- **Capture-time validation** (warning in `/cost-capture` when a
+  snapshot's keys won't bind) — a complementary idea from #411, deferrable
+  to its own slice; family matching makes most snapshots bind anyway.
+- **Per-direction (input/output) rates** — the blended-rate skew stays.
+- **Calibration / per-PR actuals** — untouched.
+- **Adding new tiers** (e.g. an `Inexpensive`/Haiku estimating tier) — the
+  binding table keeps Most capable / Standard / split.
+
+## 7. Spec-mode diaboli
+
+This spec goes through the spec-mode `/diaboli` gate before
+implementation — the §3 proxy decision especially. Objections recorded at
+`docs/superpowers/objections/2026-06-15-cost-estimation-family-matching-design.md`
+and absorbed here.
+
+## 8. References
+
+- Issue #411; the 2026-06-15 reflection (`REFLECTION_LOG.md`).
+- `skills/cost-estimation/references/estimate-record-format.md` (binding table, grounding states).
+- `skills/cost-estimation/SKILL.md`; `agents/cost-estimator.agent.md`.
+- `observability/costs/2026-06-13-costs.md` (the opus-only snapshot).

--- a/docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md
@@ -3,11 +3,12 @@
 | Field | Value |
 | --- | --- |
 | Date | 2026-06-15 |
-| Status | Drafted — ready for spec-mode diaboli, then plan/implementation |
+| Status | Diaboli-complete — 12 objections raised, all accepted; §3 fork disposed to **Option B′** (engineered proxy); ready for plan/implementation |
 | Author | claude-opus-4-8[1m] (interactive session with russmiles) |
-| Capability | Make the cost-estimation tier→model binding resolve by **model family** (not an exact key string), so a real captured snapshot grounds a dollar figure instead of silently omitting cost |
+| Capability | Make the cost-estimation tier→model binding resolve by **model family** (not an exact key string), and price a tier whose family is absent from the snapshot via a **distinctly-typed, disclosed proxy** — so a real captured snapshot grounds a dollar figure instead of silently omitting cost |
 | Fixes | #411 |
 | Plugin version target | `ai-literacy-superpowers` v0.49.0 → v0.50.0 (behaviour change to the cost-estimation methodology) |
+| Diaboli record | `docs/superpowers/objections/cost-estimation-family-matching-design.md` (12 objections, all accepted) |
 
 ---
 
@@ -16,175 +17,197 @@
 The cost-estimation methodology grounds a dollar figure by binding each
 MODEL_ROUTING tier to a **representative model key** and reading that
 model's blended rate from the latest `observability/costs/<date>-costs.md`
-snapshot's Model Breakdown. The binding table
-(`skills/cost-estimation/references/estimate-record-format.md`) names those
-keys **literally**: Most capable → `claude-opus-4`, Standard →
-`claude-sonnet-4`. The `cost-estimator` agent's mechanical check
-(`agents/cost-estimator.agent.md`, "Missing model key") omits cost when a
-named key is **absent** from the snapshot.
+snapshot's Model Breakdown. The binding table names those keys
+**literally**: Most capable → `claude-opus-4`, Standard →
+`claude-sonnet-4`. The `cost-estimator` agent omits cost when a named key
+is **absent**.
 
 The repo's only snapshot, `observability/costs/2026-06-13-costs.md`, keys
 its Model Breakdown as **`claude-opus-4-8`** and **`claude-haiku-4-5`** —
-the *actual* model ids. Neither literal binding key (`claude-opus-4`,
-`claude-sonnet-4`) is present, so **every** estimate omits cost — even
-though that snapshot was captured precisely so the estimator could ground
-cost (its prose flags the ~$0.83/1M Opus blended rate for exactly this).
-Observed across six consecutive estimates (#363–#368). The omission is
-**silent** (a cost-omitted record is valid-and-complete), so nothing
-surfaces the mismatch. (#411.)
+the *actual* model ids. Neither literal binding key is present, so **every**
+estimate omits cost — even though that snapshot was captured precisely so
+the estimator could ground cost. Observed across six consecutive estimates
+(#363–#368); the omission is **silent** (a cost-omitted record is
+valid-and-complete). (#411.)
 
-## 2. The fix — family matching (firm)
+This spec has **two parts**, kept separable (diaboli O10):
+
+- **§2 — family matching** (the firm core; the literal #411 fix).
+- **§3 — the engineered proxy** (Option B′; pricing a tier whose family is
+  absent, disposed by the human after the diaboli broke the naïve proxy).
+
+## 2. Family matching (firm core)
 
 The binding resolves a tier's representative by **model-family stem**, not
 an exact string. A snapshot Model Breakdown key `K` resolves to a tier `T`
-**iff `K`, lowercased, starts with `T`'s family stem**:
+**iff `K`, lowercased, starts with `T`'s family stem _and_ the character
+after the stem is `-` or end-of-string** (the delimiter rule, diaboli O8):
 
-| Tier | Family stem | Matches (examples) |
-| --- | --- | --- |
-| Most capable | `claude-opus-4` | `claude-opus-4`, `claude-opus-4-8`, `claude-opus-4-1`, … |
-| Standard | `claude-sonnet-4` | `claude-sonnet-4`, `claude-sonnet-4-5`, … |
-| Standard / Capable (split) | low `claude-sonnet-4` … high `claude-opus-4` | as above, per end |
+| Tier | Family stem | Matches | Does **not** match |
+| --- | --- | --- | --- |
+| Most capable | `claude-opus-4` | `claude-opus-4`, `claude-opus-4-8`, `claude-opus-4-1` | `claude-opus-40`, `claude-opus-4o`, `claude-opus-5` |
+| Standard | `claude-sonnet-4` | `claude-sonnet-4`, `claude-sonnet-4-5` | `claude-sonnet-45`, `claude-sonnet-5` |
+| Standard / Capable (split) | low `claude-sonnet-4` … high `claude-opus-4` | as above, per end | — |
 
-Rules:
+- **Delimiter-bounded prefix**, case-insensitive — closes the
+  false-positive match (`claude-opus-40`) the bare prefix would admit (O8).
+- **Multiple matches in one family are aggregated** into one blended family
+  rate: `$/token = Σ estimated_cost ÷ Σ (input + output) tokens` over the
+  matching rows. **When >1 row is aggregated, the agent discloses it** in
+  `Confidence rationale` (mirroring the blended-rate-skew disclosure) —
+  cross-generation blends are named, not silent (O7).
+- `claude-haiku-4-5` and any non-opus-4 / non-sonnet-4 key resolve to **no**
+  estimating tier (the table has only Most capable / Standard / the split).
+  They are never a binding *or* a proxy source — neither grounds nor blocks
+  a tier (O9).
+- **Stem-table maintenance (O8 false-negative side):** a future renamed
+  family (e.g. `claude-opus-5`) deliberately does **not** match — it is a
+  *signalled* miss (it drives state-3-with-no-family → state 2 omission,
+  which is loud), and the stem table is a per-model-generation maintenance
+  point, noted in §6. This is the opposite of #411's *silent* miss.
 
-- **Prefix-on-family-stem**, case-insensitive. The stems are the
-  family roots `claude-opus-4` / `claude-sonnet-4` (a major family the
-  routing tiers actually map to), not full ids.
-- **Multiple matches in one family are aggregated** into a single blended
-  family rate: sum the matching rows' `estimated_cost` and their
-  `(input + output)` tokens, then `$/token = Σcost ÷ Σtokens`. This uses
-  all of a family's observed data and stays deterministic.
-- `claude-haiku-4-5` and other non-opus-4/non-sonnet-4 keys resolve to
-  **no** estimating tier (the binding table has only Most capable /
-  Standard / the split). They are simply not used for binding — their
-  presence neither grounds nor blocks a tier.
-- The match is documented and deterministic — **not** agent discretion.
-  The agent still holds no write tool and applies the table mechanically.
+With §2 alone the 2026-06-13 snapshot grounds the **Most capable** tier
+(`claude-opus-4-8` → Most-capable rate). It does not, alone, ground the
+**Standard** tier from that snapshot (no `claude-sonnet-4*` row) — which §3
+handles.
 
-This is necessary and unambiguous, and it directly answers #411. With it,
-the 2026-06-13 snapshot grounds the **Most capable** tier
-(`claude-opus-4-8` → Most-capable rate). It does **not**, on its own,
-ground the **Standard** tier from that snapshot, because the snapshot
-contains no `claude-sonnet-4*` row — which §3 addresses.
+## 3. The engineered proxy (Option B′)
 
-## 3. The partial-snapshot decision (the genuine fork)
+When an exercised tier's estimating family is **absent** from the snapshot
+but **≥1 estimating-tier family resolves** (a usable rate exists), the
+missing tier is priced by a **proxy** rather than omitted — but as a
+**distinctly-typed, disclosed, direction-forced** figure, not a figure
+masquerading as direct grounding. (The naïve "reuse `snapshot-actuals`,
+disclose in prose" proxy was broken by diaboli O1/O2/O3/O5 and is **not**
+what ships.)
 
-Family matching alone leaves a real gap: the only snapshot we have is
-**opus-only** (the single-machine session it captured ran ~100% on Opus).
-A typical multi-stage task exercises Standard-tier stages (tdd-agent,
-integration-agent) whose family (`claude-sonnet-4*`) is **absent**. So
-after §2, those tasks would *still* omit cost. Two honest options:
+The engineered proxy:
 
-### Option A — precise omission (conservative)
+1. **Distinct basis (O2/O11/O5).** A record with **any** proxied tier
+   carries the new, additive `cost_basis` value
+   **`snapshot-actuals-proxied`** (not `snapshot-actuals`). This is
+   machine-distinguishable: a consumer keys on `cost_basis`, not on prose
+   or the (routinely-`low`) cost confidence. Fully-direct records keep
+   `snapshot-actuals`. Backward-compatible — old records and unaware
+   consumers are unaffected.
+2. **Dearest-present source, over-stating and saying so (O3/O4).** The
+   missing tier binds to the **dearest present estimating family's** rate.
+   A proxied record **forces `failure_direction: likely-overrun`** and the
+   prose states the figure is a **deliberate over-estimate, unsuitable for
+   trend aggregation** — the directional bias is named, not implied. The
+   proxy is **not** defended as "still observed actuals"; it is a distinct,
+   opted-into third basis. The no-list-price-fallback rule is untouched:
+   vendor price cards are still never used; the proxy is anchored only in
+   this repo's observed snapshot rates.
+3. **Forced low cost confidence.** `confidence.cost: low` whenever any
+   proxy is used (secondary to the `cost_basis` marker, not the sole
+   signal).
+4. **Per-tier disclosure.** `Included`/`Confidence rationale` names every
+   proxied tier and its source ("Standard priced via a cross-tier proxy at
+   the Most-capable rate — the snapshot carries no Sonnet family").
+5. **Split-tier collapse is allowed when proxied (O1).** A split-tier stage
+   whose one end is proxied legitimately collapses to a single rate
+   (`low == high`); such a band is **exempt** from the "Split-tier spread"
+   strict-`low < high` check (§4 amends the checklist line). The exemption
+   keys on the proxied basis, so a *directly-bound* split tier is still
+   required to spread.
 
-`cost_usd` is present **iff every exercised tier's family resolves** in
-the snapshot; otherwise omit, but with a **precise** `Excluded`
-disclosure naming the **specific missing tier family** (e.g. "Standard
-tier — no `claude-sonnet-4*` row in the snapshot"), rather than today's
-generic "keys absent". No approximation is introduced.
+Consequence: the 2026-06-13 opus-only snapshot now **grounds cost** —
+Most-capable directly, Standard and the split's low end via the
+`snapshot-actuals-proxied` Opus rate — relieving #411 with the data we
+have, honestly and machine-distinguishably.
 
-- *Pro:* maximally honest; no new approximation class; smallest change.
-- *Con:* does **not** relieve #411's symptom for the current opus-only
-  snapshot — multi-tier tasks still omit (truthfully) until a snapshot
-  containing Sonnet data is captured. Family matching only fixes
-  Most-capable-only tasks and the disclosure quality.
+## 4. Grounding states, the closed omission set, and the validator
 
-### Option B — disclosed cross-tier proxy (recommended)
+### 4.1 The closed omission set (restated in full — O12)
 
-When an exercised tier's family is **absent** but the snapshot has a
-usable rate for **another** family, bind the missing tier to the
-**dearest present family's** rate, **disclosed** as a cross-tier proxy and
-with `confidence.cost` forced to **`low`**:
+The agent's omission decision is a closed set; family matching merges the
+old "unmapped tier" + "missing model key" triggers into one
+family-resolution trigger:
 
-- The proxy uses an **observed snapshot rate** (this repo's actual spend),
-  never a vendor list price — the no-list-price-fallback rule is intact.
-- **Dearest-present** is deliberately conservative: proxying Standard to
-  the Opus rate **over**-states (never under-states) the Standard cost, so
-  a "can I afford this?" read is not lulled by an optimistic figure.
-- The `Included`/`Confidence rationale` prose **names** every proxied
-  tier ("Standard priced via a cross-tier proxy at the Most-capable rate —
-  the snapshot carries no Sonnet data"), and `confidence.cost: low` is
-  forced whenever any proxy is used.
-- Only applies when **≥1** family is present (a usable rate exists). With
-  **no** usable Model Breakdown at all, the existing state-2 omission is
-  unchanged.
+1. **No snapshot** → omit.
+2. **Snapshot present, no usable Model Breakdown** → omit ("no usable
+   per-model breakdown").
+3. **Model Breakdown present but NO estimating-tier family resolves**
+   (neither `claude-opus-4*` nor `claude-sonnet-4*`, after §2) → omit,
+   naming the cause. (A haiku-only snapshot lands here — O9.)
+4. **≥1 estimating-tier family resolves** → `cost_usd` **present**. Tiers
+   whose family resolves bind directly (`cost_basis: snapshot-actuals`);
+   tiers whose family is absent are **proxied** per §3 (`cost_basis:
+   snapshot-actuals-proxied` for the whole record).
 
-- *Pro:* the 2026-06-13 snapshot now **grounds cost** (Most capable
-  directly; Standard/split-low via the disclosed Opus proxy), matching the
-  snapshot author's stated intent and relieving #411 with the data we
-  have.
-- *Con:* introduces a new, disclosed approximation class; the proxied
-  figure is a deliberate over-estimate.
+### 4.2 Format-reference changes
 
-**Recommendation: Option B**, because #411's intent is "real snapshots
-should ground cost", the proxy is grounded in observed actuals (not list
-price), it is conservative, loudly disclosed, and confidence-capped — and
-it is the behaviour the captured snapshot's own prose anticipates. Option
-A is the fallback if the diaboli/human judges the proxy too strong; family
-matching (§2) ships either way and is itself a real improvement.
+- **`cost_basis` enum** gains `snapshot-actuals-proxied` alongside
+  `snapshot-actuals` (additive; backward-compatible).
+- **Binding table** documents the family stems + delimiter rule + family
+  aggregation (§2).
+- **Three grounding states** reworded to family resolution (§4.1); state 2
+  "missing model key" language replaced.
+- **"Split-tier spread" checklist line** amended: applies to a present
+  split-tier `cost_usd` band **only when that record's `cost_basis` is
+  `snapshot-actuals`** (both ends directly bound); a
+  `snapshot-actuals-proxied` split-tier band is **exempt** and may collapse
+  (O1).
+- **Cost-pairing checklist line**: `cost_usd` is present with `cost_basis`
+  ∈ {`snapshot-actuals`, `snapshot-actuals-proxied`}.
 
-**This is the load-bearing decision for the spec-mode diaboli and the
-human to dispose.**
+## 5. Surfaces changed (tagged firm-core vs proxy — O10)
 
-## 4. Grounding-state changes
-
-The three grounding states (`estimate-record-format.md`) are refined:
-
-- **State 1 (no snapshot):** unchanged — omit.
-- **State 2 (snapshot, no usable Model Breakdown / no family resolves at
-  all):** unchanged — omit, with the "no usable per-model breakdown"
-  cause. The "missing model key" trigger is **reworded** to "no tier
-  family resolves" (a tier family resolves by §2, not an exact key).
-- **State 3 (≥1 tier family resolves):** `cost_usd` **present**. Under
-  Option B, tiers whose family is absent are **proxied** (dearest present
-  family) with the disclosure + `confidence.cost: low`; under Option A,
-  cost is present **only** if *all* exercised families resolve, else state
-  2.
-
-No estimate-record **format** field changes — `cost_usd`, `cost_basis:
-snapshot-actuals`, `confidence.cost` are as today. (A proxy is disclosed
-in prose, not a new field — consistent with how the methodology discloses
-other caveats.) The blended-rate-skew simplification is unchanged.
-
-## 5. Surfaces changed
-
-1. `skills/cost-estimation/references/estimate-record-format.md` — the
-   binding table (family stems + aggregation), the "deriving a per-model
-   rate" step (resolve by family), the three grounding states (§4), and
-   (Option B) the proxy rule + its disclosure obligation.
-2. `skills/cost-estimation/SKILL.md` — the grounding-methodology section
-   mirrors the binding table; updated in lockstep.
-3. `agents/cost-estimator.agent.md` — the mechanical binding check
-   (currently "Missing model key" → omit) becomes family resolution +
-   (Option B) the proxy step; the worked-example caveat about
-   `claude-opus-4-8` is updated to reflect that it now **resolves** to
-   Most capable.
-4. Tests — a TDAD scenario / Layer-1 assertion that family matching
-   resolves `claude-opus-4-8` → Most capable and (Option B) that an
-   opus-only snapshot grounds cost with the proxy disclosure.
-5. Version triplet + CHANGELOG (the five `ai-literacy-superpowers`
-   CI-checked locations; minor bump).
+1. `skills/cost-estimation/references/estimate-record-format.md` —
+   **[core]** binding table (family stems, delimiter, aggregation
+   disclosure), grounding states / closed omission set; **[proxy]** the new
+   `cost_basis` enum value, the proxy rule + disclosure, the split-tier
+   exemption + cost-pairing checklist edits.
+2. `skills/cost-estimation/SKILL.md` — **[core]** mirror the binding-table
+   family resolution; **[proxy]** the proxy methodology + its disclosure
+   and `likely-overrun` forcing.
+3. `agents/cost-estimator.agent.md` — **[core]** the mechanical check
+   restated as the §4.1 closed set with family resolution (the
+   `claude-opus-4-8`-worked-example caveat updated to "resolves to Most
+   capable"); **[proxy]** the proxy step, the forced overrun + low cost
+   confidence, the per-tier disclosure.
+4. Tests (**O6 — surfaces clarified**) — **Layer-1 / structural** asserts
+   the *static contract data*: the family-stem + delimiter rule and the new
+   `snapshot-actuals-proxied` enum value documented in the format reference,
+   and the amended split-tier-spread exemption text. The *behavioural*
+   claim (the agent resolving `claude-opus-4-8` → Most capable and
+   proxying Standard on a fixture snapshot) is **Layer-2/3 acceptance
+   documentation**, gated on an API key — **not** a Layer-1 assertion of
+   agent-internal reasoning.
+5. Version triplet + CHANGELOG — the five `ai-literacy-superpowers`
+   CI-checked locations; minor bump 0.49.0 → 0.50.0.
 
 ## 6. Out of scope
 
-- **Capture-time validation** (warning in `/cost-capture` when a
-  snapshot's keys won't bind) — a complementary idea from #411, deferrable
-  to its own slice; family matching makes most snapshots bind anyway.
+- **Capture-time validation** (a `/cost-capture` warning when a snapshot's
+  keys won't bind) — a complementary #411 idea, deferred to its own slice;
+  family matching makes most snapshots bind anyway.
+- **Stem-table auto-discovery** — the family stems (`claude-opus-4`,
+  `claude-sonnet-4`) are a **maintained** table, bumped per model
+  generation (O8); auto-deriving them from MODEL_ROUTING is not in scope.
 - **Per-direction (input/output) rates** — the blended-rate skew stays.
 - **Calibration / per-PR actuals** — untouched.
-- **Adding new tiers** (e.g. an `Inexpensive`/Haiku estimating tier) — the
-  binding table keeps Most capable / Standard / split.
+- **Adding an Inexpensive/Haiku estimating tier** — the table keeps Most
+  capable / Standard / split.
 
-## 7. Spec-mode diaboli
+## 7. Spec-mode diaboli — outcomes
 
-This spec goes through the spec-mode `/diaboli` gate before
-implementation — the §3 proxy decision especially. Objections recorded at
-`docs/superpowers/objections/2026-06-15-cost-estimation-family-matching-design.md`
-and absorbed here.
+The spec-mode `/diaboli` gate raised **12 objections** — **2 critical, 4
+high, 5 medium, 1 low** — **all accepted**
+(`docs/superpowers/objections/cost-estimation-family-matching-design.md`).
+The criticals (O1 split-tier-spread collapse; O2 `cost_basis` lie) and
+O3/O5/O11 all struck the naïve proxy; the human disposed the §3 fork to
+**Option B′ — engineer the proxy properly**, whose load-bearing
+resolutions are the additive `snapshot-actuals-proxied` basis (O2/O11), the
+split-tier-spread exemption (O1), the forced `likely-overrun` +
+over-estimate disclosure (O3/O4), the delimiter rule + aggregation
+disclosure (O7/O8), the haiku→state-2 clarification (O9), the restated
+closed omission set (O12), and the clarified test surfaces (O6).
 
 ## 8. References
 
 - Issue #411; the 2026-06-15 reflection (`REFLECTION_LOG.md`).
-- `skills/cost-estimation/references/estimate-record-format.md` (binding table, grounding states).
-- `skills/cost-estimation/SKILL.md`; `agents/cost-estimator.agent.md`.
+- `skills/cost-estimation/references/estimate-record-format.md`;
+  `skills/cost-estimation/SKILL.md`; `agents/cost-estimator.agent.md`.
 - `observability/costs/2026-06-13-costs.md` (the opus-only snapshot).

--- a/tdad_tests/scenarios/skills/cost-estimation/family-matching-and-proxy.md
+++ b/tdad_tests/scenarios/skills/cost-estimation/family-matching-and-proxy.md
@@ -1,0 +1,120 @@
+---
+component: cost-estimation
+component_type: skill
+tier: structural
+---
+
+# Scenario: tier→model binding resolves by family stem, and an absent family is priced by a disclosed, distinctly-typed cross-tier proxy
+
+## Given
+
+The family-matching slice (#411, spec
+`docs/superpowers/specs/2026-06-15-cost-estimation-family-matching-design.md`)
+fixes the silent cost-omission #411 surfaced: the cost-estimation binding
+matched representative model keys **literally** (`claude-opus-4`,
+`claude-sonnet-4`), but real snapshots key their Model Breakdown by the
+**actual** model ids (`claude-opus-4-8`), so cost was omitted on every run.
+
+This is a **structural** scenario. Per the diaboli's O6, family resolution is
+agent-internal reasoning that leaves no machine-readable trace in the record;
+this scenario therefore asserts the **static contract text** of the format
+reference
+(`ai-literacy-superpowers/skills/cost-estimation/references/estimate-record-format.md`)
+and the `cost-estimator` agent body — **not** the output of the agent run
+(that behavioural falsification is Layer-2/3 acceptance, API-gated, out of
+scope here).
+
+## When
+
+The edited format reference's binding table, `cost_basis` field, three
+grounding states, and validation checklist — and the agent's mechanical
+cost-omission section — are read as the closed contract.
+
+## Then
+
+**Family matching (the core fix):**
+
+- The binding table resolves a tier's representative **by family stem** with a
+  **delimiter rule**: a snapshot key matches the stem (`claude-opus-4` /
+  `claude-sonnet-4`) iff it starts with the stem **and** the next character is
+  `-` or end-of-string. So `claude-opus-4-8` resolves Most capable, and
+  `claude-opus-40` / `claude-opus-4o` do **not** — the delimiter closes the
+  false-positive match.
+- Multiple matching rows in one family **aggregate** into one blended rate
+  (`Σ cost ÷ Σ tokens`), and aggregating **>1** row carries a **disclosure
+  obligation** in `Confidence rationale`.
+- Only `claude-opus-4` / `claude-sonnet-4` are **estimating-tier** families;
+  `claude-haiku-4-5` and other keys resolve to **no** tier and are never a
+  binding or proxy source.
+
+**The closed omission/grounding set (restated under family resolution):**
+
+- States 1–2 (no snapshot; snapshot but no usable Model Breakdown) → omit,
+  unchanged.
+- **State 3 — Model Breakdown present but NO estimating-tier family resolves**
+  (e.g. a **haiku-only** snapshot) → **omit**, naming the cause. This merges
+  the old "unmapped tier" + "missing model key" triggers.
+- **State 4 — ≥1 estimating-tier family resolves** → `cost_usd` **present**.
+
+**The disclosed cross-tier proxy (Option B′):**
+
+- When an exercised tier's family is **absent** but ≥1 estimating-tier family
+  resolves, the missing tier is **priced by a proxy** at the **dearest present
+  estimating family's** rate — **not** omitted.
+- A proxied record is **distinctly typed**: `cost_basis:
+  snapshot-actuals-proxied` (the additive enum value, machine-distinguishable
+  from direct `snapshot-actuals`). The `cost_basis` field documents both
+  values, and the enum is additive/backward-compatible.
+- A proxied record **forces** `failure_direction: likely-overrun` and
+  `confidence.cost: low`, and **names every proxied tier and its source** in
+  `Included`/`Confidence rationale` — the "Cost pairing" checklist line
+  requires this trio under `snapshot-actuals-proxied`.
+- The proxy uses **only** observed snapshot rates — the
+  **no-list-price-fallback** rule is **untouched** (no vendor price card).
+
+**The split-tier-spread exemption (diaboli O1):**
+
+- The "Split-tier spread" checklist line requires a strict `low < high` on a
+  present split-tier band **only when `cost_basis` is `snapshot-actuals`**. A
+  `snapshot-actuals-proxied` split-tier band **may collapse** (`low == high`) —
+  the cross-tier proxy legitimately prices one end at the same present-family
+  rate, so the both-ends-bind-different-models assumption no longer holds.
+
+**The agent applies it mechanically:**
+
+- The agent's cost-omission section resolves tiers by **family stem** (the
+  family-resolution check), restates the **closed** omission/grounding set, and
+  carries the **cross-tier proxy** step (dearest present family, the
+  `snapshot-actuals-proxied` basis, the forced overrun + low cost confidence +
+  per-tier disclosure). It **never** invents a binding or uses a list price.
+
+## Rubric
+
+Layer 1 structural. Every assertion is verifiable by reading the binding table,
+the `cost_basis` field definition, the three-grounding-states text, the
+validation checklist ("Split-tier spread", "Cost pairing"), and the agent's
+mechanical cost-omission section — not by running the agent.
+
+The scenario **passes** only when: the binding resolves by family stem with the
+delimiter rule; family aggregation carries a >1-row disclosure obligation;
+`cost_basis` documents both `snapshot-actuals` and `snapshot-actuals-proxied` as
+an additive, backward-compatible enum; a haiku-only / no-estimating-family
+snapshot omits (state 3); a proxied record is distinctly typed and forces
+`likely-overrun` + `cost: low` + per-tier disclosure; the split-tier strict-
+spread predicate applies only under `snapshot-actuals`; and the no-list-price
+rule is reaffirmed.
+
+The scenario **fails** if a future edit reverts to exact-key matching, drops the
+delimiter rule (re-admitting `claude-opus-40`), lets a proxy reuse
+`snapshot-actuals` (the diaboli-O2 contract lie), drops the `likely-overrun` /
+`cost: low` / disclosure forcing on a proxy, applies the split-tier strict-
+spread check to a proxied band, or introduces a vendor-list-price fallback.
+
+## Notes
+
+Scope is the #411 family-matching slice only. Capture-time validation (a
+`/cost-capture` warning for unbindable snapshot keys) and stem-table
+auto-discovery are explicitly deferred (spec §6). The behavioural claim — the
+agent, run against the opus-only 2026-06-13 snapshot, actually grounds
+Most-capable directly and proxies Standard — is Layer-2/3 acceptance, gated on
+an API key, not asserted here.


### PR DESCRIPTION
Fixes **#411** — the silent cost-omission the pipeline-map reflection surfaced. The cost-estimation binding matched representative model keys **literally** (`claude-opus-4`/`claude-sonnet-4`), but real snapshots key their Model Breakdown by the *actual* model ids (`claude-opus-4-8`), so **every** estimate omitted cost even when a snapshot existed to ground it.

## What ships

- **Family matching (the core fix).** A snapshot key resolves a tier's representative **by family stem** — it matches iff it starts with the stem (`claude-opus-4`/`claude-sonnet-4`) **and** the next char is `-` or end-of-string (so `claude-opus-4-8` → Most capable; `claude-opus-40` does **not**). Multiple matching rows aggregate into one blended rate, disclosed when >1. Only opus-4/sonnet-4 are estimating-tier families; haiku binds to none. Stems are a maintained, per-generation table; a renamed family is a *signalled* miss (omission), never a silent wrong rate.
- **Disclosed cross-tier proxy (Option B′).** When an exercised tier's family is **absent** but ≥1 estimating-tier family resolves, the missing tier is priced at the **dearest present family's** rate — but as a **distinctly-typed** figure: the new additive `cost_basis: snapshot-actuals-proxied` (machine-distinguishable from direct `snapshot-actuals`; backward-compatible), with `failure_direction: likely-overrun` + `confidence.cost: low` forced and every proxied tier named. Observed snapshot rates only — **no** vendor list price (the no-list-price rule is intact).
- **Validator + lockstep.** `cost_basis` enum extended; the "Split-tier spread" check exempts proxied bands (O1); cost-pairing requires the proxy coherence trio; the closed grounding/omission set restated under family resolution across the **format reference, SKILL, and agent** in lockstep. New TDAD scenario `family-matching-and-proxy.md` guards the contract.
- **Version triplet → 0.50.0** across all five `ai-literacy-superpowers` CI-checked locations.

## Decision discipline

Spec-first commit. **Spec-mode diaboli** raised **12 objections (2 critical, 4 high), all accepted** — the two criticals (split-tier-spread collapse; `cost_basis` lie) broke the naïve proxy and drove the human-disposed **Option B′** (additive enum, split-tier exemption, forced overrun, delimiter rule, haiku→omit, restated closed set). Spec + objection record included.

## End-to-end validation

The `cost-estimator`, run against the updated methodology, now produces a **cost-present** record (`cost_usd {0.18, 0.48}`, `cost_basis: snapshot-actuals-proxied`, Standard tiers proxied at the Opus rate) for the **same 2026-06-13 snapshot that omitted cost six times** during the pipeline-map arc. The fix is demonstrated, not just asserted.

## Review

Project `code-reviewer`: initial **FINDINGS** (two blocking lockstep gaps — SKILL grounding-states section unchanged; renumbered state refs), both **fixed** in a follow-up commit; the criticals/highs verified genuinely closed. Closes #411.