### PR TITLE
chore: mark cost-estimation #413/#414 spec statuses complete

### DIFF
--- a/docs/superpowers/specs/2026-06-15-cost-capture-binding-gap-warning-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-capture-binding-gap-warning-design.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Date | 2026-06-15 |
-| Status | Diaboli-complete — 10 objections raised, all accepted and absorbed; ready for plan/implementation |
+| Status | **Complete** — shipped as `ai-literacy-superpowers` v0.51.0 (#413 / PR #415); 10 objections raised, all accepted and absorbed |
 | Author | claude-opus-4-8[1m] (interactive session with russmiles) |
 | Capability | At capture time, `/cost-capture` tells the human whether the snapshot it just wrote will let the prospective `cost-estimator` ground a dollar figure — recorded as a structured, checkable line — closing the binding-gap feedback loop where a human can act |
 | Fixes | #413 |

--- a/docs/superpowers/specs/2026-06-15-cost-estimation-stem-table-maintenance-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-estimation-stem-table-maintenance-design.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Date | 2026-06-15 |
-| Status | Diaboli-complete — 12 objections raised, all accepted; design pivoted (drop the GC staleness rule → deterministic mention-consistency check); ready for plan/implementation |
+| Status | **Complete** — shipped as `ai-literacy-superpowers` v0.52.0 (#414 / PR #416); 12 objections raised, all accepted; design pivoted (dropped the GC staleness rule → deterministic mention-consistency check) |
 | Author | claude-opus-4-8[1m] (interactive session with russmiles) |
 | Capability | Keep the cost-estimation tier→model **family stem table** singly-sourced and internally consistent — a declared canonical list, an add-and-retire maintenance discipline, and a deterministic check that the cost files do not drift from it |
 | Fixes | #414 |


### PR DESCRIPTION
Docs-only. Both spec `Status` lines lagged at "ready for plan/implementation"; #413 shipped v0.51.0 (#415) and #414 shipped v0.52.0 (#416). Flips both to **Complete** with the version/PR map. `chore`-exempt; no version bump.