### PR TITLE
Scope gc-rotate shell GC rules to project-owned scripts (#361)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.52.0",
+  "plugin_version": "0.52.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.52.0"
+      "version": "0.52.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.52.1 — 2026-06-15
+
+### gc-rotate: scope shell-script GC rules to project-owned files (#361)
+
+The rotating GC check's shell-syntax (rule 2) and strict-mode (rule 3)
+rules scanned **every** `*.sh` under the project, excluding only
+`*/.git/*`. In non-trivial projects this pulled in vendored, generated,
+and untracked scripts and flooded the session-end banner with
+false positives — `bash -n` choking on `zsh` snapshots written under
+`CLAUDE_CONFIG_DIR`, `node_modules` scripts, and nested worktrees that
+were never meant to follow this plugin's conventions.
+
+- **Scope to tracked files.** Both rules now enumerate scripts via a new
+  `list_owned_shell_scripts` helper that uses `git ls-files -z -- '*.sh'`,
+  which skips `node_modules`, nested worktrees, `CLAUDE_CONFIG_DIR`
+  snapshots, and build output for free. Paths are re-anchored to
+  `PROJECT_DIR` and the loops read NUL-delimited entries so paths with
+  spaces survive.
+- **Graceful fallback.** Outside a git repo the helper falls back to the
+  previous `find` walk, so non-git projects are unaffected.
+
 ## 0.52.0 — 2026-06-15
 
 ### cost-estimation: single-source the family stem table + deterministic drift guard (#414)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.52.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.52.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.52.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.52.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
+++ b/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
@@ -30,6 +30,24 @@ case "$cadence" in
   monthly)     STALENESS_THRESHOLD=30 ;;
 esac
 
+# Emit the shell scripts the project actually owns, NUL-delimited.
+#
+# Prefer git's tracked-file set: it skips node_modules, nested worktrees,
+# CLAUDE_CONFIG_DIR zsh snapshots, and build output for free, so the shell
+# rules only ever see scripts this project is responsible for. Fall back to
+# a filesystem walk when the project is not a git repo. Paths from
+# `git ls-files` are relative to PROJECT_DIR, so re-anchor them.
+list_owned_shell_scripts() {
+  if git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$PROJECT_DIR" ls-files -z -- '*.sh' \
+      | while IFS= read -r -d '' rel; do
+          printf '%s\0' "${PROJECT_DIR%/}/$rel"
+        done
+  else
+    find "$PROJECT_DIR" -name "*.sh" -not -path "*/.git/*" -print0 2>/dev/null
+  fi
+}
+
 # Rotate through rules by day-of-year
 day_of_year=$(date +%j | sed 's/^0*//')
 rule_index=$((day_of_year % 4))
@@ -72,11 +90,11 @@ case $rule_index in
   2)
     # Shell scripts syntax
     failed_files=""
-    while IFS= read -r f; do
+    while IFS= read -r -d '' f; do
       if ! bash -n "$f" 2>/dev/null; then
         failed_files="${failed_files}\n- $f"
       fi
-    done < <(find "$PROJECT_DIR" -name "*.sh" -not -path "*/.git/*" 2>/dev/null)
+    done < <(list_owned_shell_scripts)
     if [ -n "$failed_files" ]; then
       printf '{"systemMessage": "GC check (shell syntax): syntax errors found in:%s"}' "$failed_files"
     fi
@@ -84,11 +102,11 @@ case $rule_index in
   3)
     # Shell scripts strict mode
     missing_files=""
-    while IFS= read -r f; do
+    while IFS= read -r -d '' f; do
       if ! head -15 "$f" | grep -q "set -euo pipefail"; then
         missing_files="${missing_files}\n- $f"
       fi
-    done < <(find "$PROJECT_DIR" -name "*.sh" -not -path "*/.git/*" 2>/dev/null)
+    done < <(list_owned_shell_scripts)
     if [ -n "$missing_files" ]; then
       printf '{"systemMessage": "GC check (strict mode): missing set -euo pipefail in:%s"}' "$missing_files"
     fi

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -127,6 +127,11 @@ plugin manifest currency) are not included — they require LLM
 judgement and are triggered via `/harness-gc` or
 `/harness-health --deep`.
 
+The two shell-script rules scope their scan to project-owned scripts
+via `git ls-files` (falling back to a filesystem walk outside a git
+repo), so vendored `node_modules` scripts, nested worktrees, and
+`CLAUDE_CONFIG_DIR` shell snapshots do not trigger false positives.
+
 ### Curation nudge
 
 - **Script**: `hooks/scripts/curation-nudge.sh`


### PR DESCRIPTION
Fixes #361.

## Problem

The rotating GC check (`hooks/scripts/gc-rotate.sh`, Stop hook) scanned **every** `*.sh` under the project, excluding only `*/.git/*`. Both whole-tree rules — rule 2 (shell syntax, `bash -n`) and rule 3 (strict mode, `set -euo pipefail`) — pulled in untracked / vendored / generated scripts and flooded the session-end banner with false positives:

- `node_modules/**` dependency scripts
- nested git worktrees checked out inside the tree
- `zsh` shell-snapshot files written under `CLAUDE_CONFIG_DIR` (these are `zsh`, so `bash -n` reports them as syntax errors)

The check is advisory-only, so the net effect was cost with no signal — and it trained users to ignore the GC banner.

## Fix

Both rules now enumerate scripts through a new `list_owned_shell_scripts` helper that uses `git ls-files -z -- '*.sh'` (tracked files only), which skips `node_modules`, nested worktrees, `CLAUDE_CONFIG_DIR` snapshots, and build output for free. Outside a git repo it falls back to the previous `find` walk, so non-git projects are unaffected. Paths are re-anchored to `PROJECT_DIR` and the loops read NUL-delimited entries so paths with spaces survive.

## Verification

Simulated the flood scenario (tracked `owned.sh` + untracked `node_modules/pkg/install.sh` + a `zsh` snapshot):

- **Old `find`** listed all three (the two junk files are pure false positives).
- **New helper** listed only `owned.sh`.

`bash -n` passes on the updated script; helper output re-verified to be readable, correctly anchored paths.

## Version / docs

- Patch bump 0.52.0 → 0.52.1 (bug fix to plugin files) across all five CI-checked locations + README table cell.
- CHANGELOG entry added under the new `0.52.1` heading.
- Reference docs (`reference/hooks.md`) note the new tracked-file scoping for the two shell rules.

Spec-first exempt via the `fix` label (targeted bug fix, no design work needed).