### PR TITLE
verify_rhs: recognise CLAUDE.md + .claude/HARNESS.md promotions (#319, #320)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.53.0",
+  "plugin_version": "0.53.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.53.0"
+      "version": "0.53.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.53.1 — 2026-06-15
+
+### reflections: verify_rhs recognises CLAUDE.md + .claude/HARNESS.md promotions (#319, #320)
+
+`verify_rhs` (the Path 1 archival pre-check) rejected valid, documented
+promotion forms, so `archive-promoted-reflections.sh` kept those entries
+in the active set forever.
+
+- **#320 — HARNESS path resolution.** The check hard-coded `HARNESS.md`
+  at the repo root, but the plugin's own `/superpowers-init` scaffolds to
+  `.claude/HARNESS.md`. A canonical `Promoted: → HARNESS.md: <constraint>`
+  line therefore never verified in projects that follow the recommended
+  layout. A new `resolve_file` helper now resolves the constraint heading
+  against the repo root **or** the `.claude/` scaffold; `propose_for_entry`
+  uses the same resolution.
+- **#319 — CLAUDE.md and explicit .claude paths.** Promotions to
+  `CLAUDE.md` (root or per-component `<subdir>/CLAUDE.md`) and the explicit
+  `.claude/HARNESS.md: <constraint>` form fell through to a rejection.
+  `verify_rhs` now models a `CLAUDE_FORM` (verifies the quoted excerpt in
+  the named CLAUDE.md) and accepts the `.claude/HARNESS.md:` alias. The
+  formal grammar in the archival spec and the RHS-form lists in `/reflect`
+  and the integration-agent are updated to match.
+- Layer 0 coverage added: eight `verify_rhs` unit cases plus an end-to-end
+  archival case proving a `.claude/HARNESS.md`-only project archives.
+
 ## 0.53.0 — 2026-06-15
 
 ### reflections: one-file-per-entry storage + union-merge default (#398)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.53.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.53.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/integration-agent.agent.md
+++ b/ai-literacy-superpowers/agents/integration-agent.agent.md
@@ -188,7 +188,8 @@ follows the grammar:
 Where `<RHS>` is one of:
 
 - `AGENTS.md <SECTION>: "<quoted excerpt>"`
-- `HARNESS.md: <constraint name>`
+- `[<subdir>/]CLAUDE.md "<quoted excerpt>"`
+- `[.claude/]HARNESS.md: <constraint name>`
 - `aged-out, no promotion warranted`
 - `superseded by <YYYY-MM-DD>`
 

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -190,7 +190,10 @@ AGENTS.md/HARNESS.md edit, then regenerate the aggregate with
 
 ```text
 - **Promoted**: 2026-05-15 → AGENTS.md STYLE: "Multi-repo scheduled agents"
+- **Promoted**: 2026-05-15 → CLAUDE.md "Treat ports as the domain boundary"
+- **Promoted**: 2026-05-15 → src/renderer/CLAUDE.md "Wrap at column 80"
 - **Promoted**: 2026-05-15 → HARNESS.md: Reflections via PR workflow
+- **Promoted**: 2026-05-15 → .claude/HARNESS.md: Reflections via PR workflow
 - **Promoted**: 2026-05-15 → aged-out, no promotion warranted
 ```
 

--- a/ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
+++ b/ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
@@ -136,9 +136,30 @@ bounded_entries() {
   rm -f "$tmpfile"
 }
 
+# resolve_file: echo the first existing path among the candidates, or
+# return 1 if none exist. Lets verifiers honour the plugin's own scaffold
+# layout — /superpowers-init writes HARNESS.md to .claude/HARNESS.md, not
+# the repo root — without hard-coding a single location.
+resolve_file() {
+  local p
+  for p in "$@"; do
+    if [ -f "$p" ]; then
+      printf '%s' "$p"
+      return 0
+    fi
+  done
+  return 1
+}
+
 # verify_rhs: return 0 if the Promoted line's right-hand side resolves to
-# actual content in the current tree (AGENTS.md / HARNESS.md) or is a
-# closure form. Return 1 otherwise.
+# actual content in the current tree, or is a closure form. Return 1
+# otherwise. Recognised promotion targets:
+#   - AGENTS.md <SECTION>: "<quote>"          → quote present in AGENTS.md
+#   - [<subdir>/]CLAUDE.md "<quote>"          → quote present in that CLAUDE.md
+#   - [.claude/]HARNESS.md: <constraint>      → `### <constraint>` heading,
+#                                               resolved against root or the
+#                                               .claude/ scaffold location
+#   - closure / supersede forms               → accepted as-is
 verify_rhs() {
   local rhs="$1"
   case "$rhs" in
@@ -146,9 +167,21 @@ verify_rhs() {
       local quoted; quoted=$(echo "$rhs" | sed -E 's/^.*"(.*)".*$/\1/')
       [ -f AGENTS.md ] && grep -qF "$quoted" AGENTS.md
       ;;
-    HARNESS.md:*)
-      local cname; cname=$(echo "$rhs" | sed -E 's/^HARNESS.md:[[:space:]]*//')
-      [ -f HARNESS.md ] && grep -qF "### $cname" HARNESS.md
+    *CLAUDE.md\ \"*\")
+      # CLAUDE_FORM: the path is everything before the quoted excerpt, so a
+      # bare `CLAUDE.md` and a per-component `<subdir>/CLAUDE.md` both work.
+      local cpath cquoted
+      cpath="${rhs%% \"*}"
+      cquoted=$(echo "$rhs" | sed -E 's/^.*"(.*)".*$/\1/')
+      [ -f "$cpath" ] && grep -qF "$cquoted" "$cpath"
+      ;;
+    HARNESS.md:*|.claude/HARNESS.md:*)
+      # HARNESS_FORM: .claude/HARNESS.md is an alias for HARNESS.md; verify
+      # the `### <constraint>` heading in whichever location the project uses.
+      local cname hpath
+      cname=$(echo "$rhs" | sed -E 's#^(\.claude/)?HARNESS\.md:[[:space:]]*##')
+      hpath=$(resolve_file HARNESS.md .claude/HARNESS.md) \
+        && grep -qF "### $cname" "$hpath"
       ;;
     aged-out*|"no promotion"*|superseded\ by\ *)
       return 0
@@ -201,10 +234,12 @@ propose_for_entry() {
     return 0
   fi
 
-  # Cross-reference Constraint field against HARNESS.md
-  local constraint; constraint=$(extract_field "$entry" "Constraint")
-  if [ -f HARNESS.md ] && [ -n "$constraint" ] && [ "$constraint" != "none" ]; then
-    if grep -qF "$constraint" HARNESS.md; then
+  # Cross-reference Constraint field against HARNESS.md (root or .claude/ scaffold)
+  local constraint hpath
+  constraint=$(extract_field "$entry" "Constraint")
+  hpath=$(resolve_file HARNESS.md .claude/HARNESS.md || true)
+  if [ -n "$hpath" ] && [ -n "$constraint" ] && [ "$constraint" != "none" ]; then
+    if grep -qF "$constraint" "$hpath"; then
       echo "**Likely-promoted to HARNESS.md** (constraint \"$constraint\" matches)."
       echo ""
       echo "Proposed line:"

--- a/docs/superpowers/specs/2026-04-30-reflection-log-archival-design.md
+++ b/docs/superpowers/specs/2026-04-30-reflection-log-archival-design.md
@@ -152,14 +152,25 @@ ineligible for Path 1 auto-archive until tagged.
 ```text
 PROMOTED_LINE := "- **Promoted**: " DATE " " "→" " " RHS
 DATE          := YYYY "-" MM "-" DD
-RHS           := AGENTS_FORM | HARNESS_FORM | CLOSURE_FORM | SUPERSEDE_FORM
+RHS           := AGENTS_FORM | CLAUDE_FORM | HARNESS_FORM
+               | CLOSURE_FORM | SUPERSEDE_FORM
 AGENTS_FORM   := "AGENTS.md " SECTION ": " QUOTED_STRING
-HARNESS_FORM  := "HARNESS.md: " CONSTRAINT_NAME
+CLAUDE_FORM   := [ PATH "/" ] "CLAUDE.md " QUOTED_STRING
+HARNESS_FORM  := [ ".claude/" ] "HARNESS.md: " CONSTRAINT_NAME
 CLOSURE_FORM  := "no promotion (" RATIONALE ")"
                 | "aged-out, no promotion warranted"
 SUPERSEDE_FORM := "superseded by " DATE
 SECTION       := "STYLE" | "GOTCHA" | "ARCH_DECISION"
+PATH          := relative directory of a per-component CLAUDE.md
 ```
+
+`CLAUDE_FORM` covers promotions to the root `CLAUDE.md` or a
+per-component sub-`CLAUDE.md` (verified by grepping the quoted excerpt
+in that file). `HARNESS_FORM` resolves the constraint heading against
+whichever `HARNESS.md` the project uses — the repo root or the
+`.claude/HARNESS.md` location `/superpowers-init` scaffolds to — and
+the `.claude/` prefix may be stated explicitly. (Added per issues
+#319 and #320.)
 
 Implementation contract: **all parseable Promoted lines trigger
 archival regardless of right-hand side**. The right-hand side is

--- a/tdad_tests/layer0_deterministic/test-archive-promoted-reflections.sh
+++ b/tdad_tests/layer0_deterministic/test-archive-promoted-reflections.sh
@@ -65,6 +65,19 @@ test_archives_harness_form_when_constraint_present() {
   assert_contains "$WORK_DIR/reflections/archive/2026.md" "Reflections via PR workflow"
 }
 
+test_archives_harness_form_when_constraint_in_dot_claude() {
+  # #320: HARNESS.md lives only at .claude/HARNESS.md (the /superpowers-init
+  # scaffold). A bare `HARNESS.md: <constraint>` promotion must still archive.
+  setup_workspace
+  rm -f "$WORK_DIR/HARNESS.md"
+  mkdir -p "$WORK_DIR/.claude"
+  echo "### Reflections via PR workflow" > "$WORK_DIR/.claude/HARNESS.md"
+  load_fixture "reflection-log-promoted-harness.md"
+  ( cd "$WORK_DIR" && bash "$SCRIPT" --dry-run=false )
+  assert_file_exists "$WORK_DIR/reflections/archive/2026.md"
+  assert_contains "$WORK_DIR/reflections/archive/2026.md" "Reflections via PR workflow"
+}
+
 test_skips_harness_form_when_constraint_missing() {
   setup_workspace
   echo "# HARNESS.md (empty)" > "$WORK_DIR/HARNESS.md"
@@ -87,6 +100,7 @@ test_happy_path_archives_agents_promoted_entry
 test_skips_when_agents_content_missing
 test_archives_aged_out_form
 test_archives_harness_form_when_constraint_present
+test_archives_harness_form_when_constraint_in_dot_claude
 test_skips_harness_form_when_constraint_missing
 test_2025_entry_archives_to_2025_md
 echo "All tests passed."

--- a/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
+++ b/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
@@ -15,6 +15,18 @@ source "$LIB_PATH"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_eq() { [ "$1" = "$2" ] || fail "expected '$2' got '$1'"; }
 
+# mk_workspace: create a throwaway tree wired for verify_rhs, which greps
+# promotion targets relative to the current directory.
+mk_workspace() {
+  local ws; ws=$(mktemp -d)
+  printf '## STYLE\n- Multi-repo scheduled agents\n' > "$ws/AGENTS.md"
+  printf '# Project Conventions\n- Treat ports as the domain boundary\n' > "$ws/CLAUDE.md"
+  mkdir -p "$ws/src" "$ws/.claude"
+  printf '# Module Notes\n- Renderer wraps at column 80\n' > "$ws/src/CLAUDE.md"
+  printf '## Constraints\n### Reflections via PR workflow\n' > "$ws/.claude/HARNESS.md"
+  printf '%s' "$ws"
+}
+
 test_split_entries_on_empty_log() {
   local count
   count=$(split_entries "$FIXTURES_DIR/reflection-log-empty.md" | grep -c "^---ENTRY---$" || true)
@@ -97,6 +109,61 @@ test_bounded_entries_day_window_clips() {
   assert_eq "$count" "50"
 }
 
+# --- verify_rhs promotion-target coverage (#319, #320) ---
+# verify_rhs greps targets relative to cwd; a ( cd … ) subshell inherits the
+# sourced functions, so each case runs against a purpose-built workspace.
+
+test_verify_rhs_agents_form() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && verify_rhs 'AGENTS.md STYLE: "Multi-repo scheduled agents"' ) \
+    || fail "AGENTS form should verify"
+  rm -rf "$ws"
+}
+test_verify_rhs_claude_root_form() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && verify_rhs 'CLAUDE.md "Treat ports as the domain boundary"' ) \
+    || fail "root CLAUDE.md form should verify"
+  rm -rf "$ws"
+}
+test_verify_rhs_claude_subcomponent_form() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && verify_rhs 'src/CLAUDE.md "Renderer wraps at column 80"' ) \
+    || fail "sub-component CLAUDE.md form should verify"
+  rm -rf "$ws"
+}
+test_verify_rhs_claude_form_negative() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && ! verify_rhs 'CLAUDE.md "text that is not present"' ) \
+    || fail "CLAUDE.md form with absent quote should not verify"
+  rm -rf "$ws"
+}
+test_verify_rhs_harness_form_resolves_dot_claude() {
+  # Only .claude/HARNESS.md exists; the bare HARNESS.md: form must still verify.
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && verify_rhs 'HARNESS.md: Reflections via PR workflow' ) \
+    || fail "HARNESS.md: form should resolve .claude/HARNESS.md"
+  rm -rf "$ws"
+}
+test_verify_rhs_dot_claude_harness_explicit_form() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && verify_rhs '.claude/HARNESS.md: Reflections via PR workflow' ) \
+    || fail "explicit .claude/HARNESS.md: form should verify"
+  rm -rf "$ws"
+}
+test_verify_rhs_harness_form_resolves_root() {
+  local ws; ws=$(mk_workspace)
+  printf '## Constraints\n### Root-only constraint\n' > "$ws/HARNESS.md"
+  ( cd "$ws" && verify_rhs 'HARNESS.md: Root-only constraint' ) \
+    || fail "HARNESS.md: form should still resolve a root HARNESS.md"
+  rm -rf "$ws"
+}
+test_verify_rhs_unknown_form_fails() {
+  local ws; ws=$(mk_workspace)
+  ( cd "$ws" && ! verify_rhs 'README.md: something' ) \
+    || fail "unknown target should not verify"
+  rm -rf "$ws"
+}
+
 test_split_entries_on_empty_log
 test_split_entries_on_single_entry
 test_parse_promoted_agents_form
@@ -111,4 +178,12 @@ test_extract_field_signal
 test_resolve_year
 test_bounded_entries_count_is_inclusive_of_max
 test_bounded_entries_day_window_clips
+test_verify_rhs_agents_form
+test_verify_rhs_claude_root_form
+test_verify_rhs_claude_subcomponent_form
+test_verify_rhs_claude_form_negative
+test_verify_rhs_harness_form_resolves_dot_claude
+test_verify_rhs_dot_claude_harness_explicit_form
+test_verify_rhs_harness_form_resolves_root
+test_verify_rhs_unknown_form_fails
 echo "All tests passed."


### PR DESCRIPTION
Fixes #319, #320.

## Problem

`verify_rhs` (the Path 1 archival pre-check in `reflection-log-helpers.sh`) rejected valid, documented `Promoted` forms, so `archive-promoted-reflections.sh` kept those reflections in the active set indefinitely.

- **#320** — the check hard-coded `[ -f HARNESS.md ]` at the repo root, but the plugin's own `/superpowers-init` scaffolds to `.claude/HARNESS.md`. So the canonical `Promoted: → HARNESS.md: <constraint>` form **never verified** in projects following the recommended layout.
- **#319** — promotions to `CLAUDE.md` (root or per-component `<subdir>/CLAUDE.md`) and the explicit `.claude/HARNESS.md: <constraint>` form fell through to `return 1`. The issue author had to reword real promotions into lossy `superseded by …` closures.

## Fix

- New `resolve_file` helper picks the first existing path among candidates; `verify_rhs` and `propose_for_entry` use it to resolve `HARNESS.md` against the repo root **or** `.claude/HARNESS.md`.
- `verify_rhs` now models a `CLAUDE_FORM` — the path is everything before the quoted excerpt, so bare `CLAUDE.md` and `<subdir>/CLAUDE.md` both verify the excerpt against that file — and accepts the explicit `.claude/HARNESS.md:` alias.
- Formal grammar in `2026-04-30-reflection-log-archival-design.md` and the RHS-form lists in `/reflect` and the integration-agent updated to match.

## Tests (RED→GREEN verified)

- Proved the regression directly: the lib from `main` **rejects** both the CLAUDE root form and `HARNESS.md:`→`.claude` resolution; the new lib verifies both.
- Eight `verify_rhs` Layer 0 unit cases (AGENTS, CLAUDE root, CLAUDE sub-component, CLAUDE negative, HARNESS→.claude resolution, explicit `.claude/HARNESS.md:`, HARNESS root still works, unknown target rejected).
- End-to-end archival case: a `.claude/HARNESS.md`-only project now archives a `HARNESS.md:` promotion (the headline #320 scenario).

## Notes

Spec-first exempt via `fix` label (correctness fixes to a verifier that was rejecting valid promotions). Patch bump 0.53.0 → 0.53.1 across all five CI-checked locations + README table. Related #321 was already fixed by #398 and is closed.