### PR TITLE
Auto-enforcer: fix parser dedup, multi-line rules, comment-mode, retry (#322–#325)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.53.1",
+  "plugin_version": "0.53.2",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.53.1"
+      "version": "0.53.2"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.53.2 — 2026-06-15
+
+### auto-enforcer: four PR-enforcement bug fixes (#322, #323, #324, #325)
+
+Four defects in `templates/ci-auto-enforcer.yml` quietly degraded PR-time
+constraint enforcement for every adopter of the GitHub Action.
+
+- **#325 — duplicate constraint rows.** The constraint parser appended
+  the final block at section exit **and** again at the EOF flush, so any
+  `HARNESS.md` with a `## ` section after `## Constraints` ran (and listed)
+  its last constraint twice. The section-exit path now resets state and the
+  trailing flush is gated on still being inside the section.
+- **#324 — truncated multi-line rules.** `parse_field` returned only the
+  first physical line of a `Rule:`, so multi-paragraph agent constraints
+  reached the model half-stated (the agent even reported the rule as
+  "incomplete"). It now folds continuation lines until the next list item.
+- **#323 — COMMENT_MODE never applied.** `comment_mode = "${COMMENT_MODE}"`
+  inside a single-quoted heredoc was a literal string, so `findings-only`
+  never suppressed all-PASS comments. The value is now passed as a
+  positional argv. `SKIP` also counts as a finding so a silently-disabled
+  gate still surfaces a comment.
+- **#322 — no retry on transient overload.** A single `urlopen` with a
+  broad `except` turned an Anthropic `429`/`529` into a `SKIP`pped
+  enforcement gate. Agent calls now retry transient overloads with backoff
+  (2s, 4s), retry one network error, and fail fast on non-transient HTTP
+  errors; a half-second pace between agent calls flattens the burst.
+- **Tests.** New Layer 0 suite (`test-auto-enforcer.sh`) extracts the real
+  embedded Python from the template and exercises all four fixes — nine
+  cases, verified to fail against the pre-fix template (RED→GREEN).
+
 ## 0.53.1 — 2026-06-15
 
 ### reflections: verify_rhs recognises CLAUDE.md + .claude/HARNESS.md promotions (#319, #320)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ constraint enforcement for every adopter of the GitHub Action.
 
 - **#325 — duplicate constraint rows.** The constraint parser appended
   the final block at section exit **and** again at the EOF flush, so any
-  `HARNESS.md` with a `## ` section after `## Constraints` ran (and listed)
+  `HARNESS.md` with a `##` section after `## Constraints` ran (and listed)
   its last constraint twice. The section-exit path now resets state and the
   trailing flush is gated on still being inside the section.
 - **#324 — truncated multi-line rules.** `parse_field` returned only the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.53.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.53.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/auto-enforcer-action/SKILL.md
+++ b/ai-literacy-superpowers/skills/auto-enforcer-action/SKILL.md
@@ -127,7 +127,9 @@ env:
 
 Controls when a PR comment is posted:
 
-- `findings-only` (default) — post only when agent findings exist
+- `findings-only` (default) — post only when there is something to act
+  on: any `FAIL`, `ADVISORY`, or `SKIP` result. An all-`PASS` run posts
+  no comment.
 - `always` — post a comment even when all constraints pass
 
 ```yaml
@@ -174,8 +176,11 @@ auto-enforcer posts a comment on the PR with a summary table:
   non-zero and blocks merge until fixed
 - **ADVISORY** — an agent constraint found potential issues; review
   the findings but the job does not fail
-- **SKIP** — the constraint was excluded by configuration or could
-  not be parsed
+- **SKIP** — the constraint was excluded by configuration, could not
+  be parsed, or its agent API call did not complete after retries
+  (transient `429`/`529` overloads are retried with backoff before a
+  SKIP is recorded). A SKIP surfaces a PR comment even in
+  `findings-only` mode so a silently-disabled gate stays visible.
 
 ### Distinguishing failures from advisories
 

--- a/ai-literacy-superpowers/templates/ci-auto-enforcer.yml
+++ b/ai-literacy-superpowers/templates/ci-auto-enforcer.yml
@@ -67,9 +67,13 @@ jobs:
                   in_constraints = True
                   continue
               if in_constraints and line.strip().startswith("## ") and not line.strip().startswith("### "):
+                  # Section exit: flush the in-flight block and reset, so the
+                  # trailing EOF flush below cannot re-append it (#325).
                   in_constraints = False
                   if current_name:
                       blocks.append({"name": current_name, "lines": current_block})
+                      current_name = ""
+                      current_block = []
                   continue
               if in_constraints and line.strip().startswith("### "):
                   if current_name:
@@ -80,16 +84,33 @@ jobs:
               if in_constraints and current_name:
                   current_block.append(line)
 
-          if current_name:
+          # Trailing flush — only fires when EOF is reached *inside* the
+          # constraints section (gated on in_constraints so it cannot
+          # double-append a block already flushed at section exit, #325).
+          if in_constraints and current_name:
               blocks.append({"name": current_name, "lines": current_block})
 
-          # Parse each block for metadata
+          # Parse each block for metadata. A field's value runs from its
+          # `- Field:` list item until the next list item — continuation
+          # lines (wrapped multi-paragraph rules) are folded in, so a
+          # multi-line Rule reaches the agent whole rather than truncated
+          # to its first physical line (#324).
           def parse_field(lines, field):
+              pattern = rf"[-*]\s+\**{field}\**\s*:\s*(.*)"
+              value_parts = []
+              in_field = False
               for line in lines:
-                  match = re.match(rf"[-*]\s+\**{field}\**\s*:\s*(.*)", line, re.IGNORECASE)
-                  if match:
-                      return match.group(1).strip()
-              return ""
+                  if not in_field:
+                      m = re.match(pattern, line, re.IGNORECASE)
+                      if m:
+                          value_parts.append(m.group(1).strip())
+                          in_field = True
+                      continue
+                  if re.match(r"[-*]\s+", line):
+                      break
+                  if line.strip():
+                      value_parts.append(line.strip())
+              return " ".join(value_parts).strip()
 
           include = os.environ.get("INCLUDE_CONSTRAINTS", "").strip()
           exclude = os.environ.get("EXCLUDE_CONSTRAINTS", "").strip()
@@ -238,7 +259,7 @@ jobs:
 
             # Build the prompt and call Claude API via python to handle escaping
             python3 - "$name" "$rule" "$RESULTS_FILE" <<'AGENTEOF'
-          import json, sys, urllib.request, os
+          import json, sys, urllib.request, urllib.error, os, time
 
           name = sys.argv[1]
           rule = sys.argv[2]
@@ -281,20 +302,48 @@ jobs:
               }
           )
 
-          try:
-              with urllib.request.urlopen(req, timeout=60) as resp:
-                  data = json.loads(resp.read())
-                  text = data.get("content", [{}])[0].get("text", "Unable to parse response")
-                  if "NO_FINDINGS" in text:
-                      status = "PASS"
-                      finding_text = "--"
-                  else:
-                      status = "ADVISORY"
-                      finding_text = text[:500]
-          except Exception as e:
-              status = "SKIP"
-              finding_text = f"API call failed: {str(e)[:200]}"
-              print(f"::warning::Agent constraint '{name}' skipped — {e}")
+          # Call the API with bounded retry. Transient backpressure
+          # (429/529) and one-off network errors retry with backoff;
+          # non-transient HTTP errors (auth, malformed) fail fast so we
+          # don't burn the retry window. Without this a transient
+          # Anthropic overload silently turned an enforcement gate into a
+          # SKIP (#322).
+          status = "SKIP"
+          finding_text = "API call did not complete"
+          for attempt in range(3):
+              try:
+                  with urllib.request.urlopen(req, timeout=60) as resp:
+                      data = json.loads(resp.read())
+                      text = data.get("content", [{}])[0].get("text", "Unable to parse response")
+                      if "NO_FINDINGS" in text:
+                          status = "PASS"
+                          finding_text = "--"
+                      else:
+                          status = "ADVISORY"
+                          finding_text = text[:500]
+                  break
+              except urllib.error.HTTPError as e:
+                  if e.code in (429, 529) and attempt < 2:
+                      time.sleep(2 ** (attempt + 1))  # 2s, then 4s
+                      continue
+                  status = "SKIP"
+                  finding_text = f"API call failed: HTTP Error {e.code}: {str(e)[:200]}"
+                  print(f"::warning::Agent constraint '{name}' skipped — {e}")
+                  break
+              except urllib.error.URLError as e:
+                  # Network-level error (DNS, timeout): retry once, then skip.
+                  if attempt < 1:
+                      time.sleep(2)
+                      continue
+                  status = "SKIP"
+                  finding_text = f"API call failed: {str(e)[:200]}"
+                  print(f"::warning::Agent constraint '{name}' skipped — {e}")
+                  break
+              except Exception as e:
+                  status = "SKIP"
+                  finding_text = f"API call failed: {str(e)[:200]}"
+                  print(f"::warning::Agent constraint '{name}' skipped — {e}")
+                  break
 
           print(f"Result: {status}")
 
@@ -309,6 +358,9 @@ jobs:
           AGENTEOF
 
             echo "::endgroup::"
+            # Flatten the call rate so a burst of agent constraints is less
+            # likely to trip Anthropic's overload signal (#322, Option B).
+            sleep 0.5
           done
 
           echo "ALL_RESULTS_FILE=$RESULTS_FILE" >> "$GITHUB_ENV"
@@ -326,14 +378,19 @@ jobs:
           fi
 
           # Build the comment body
-          COMMENT=$(python3 - "$RESULTS_FILE" <<'COMMENTEOF'
+          COMMENT=$(python3 - "$RESULTS_FILE" "$COMMENT_MODE" <<'COMMENTEOF'
           import json, sys
 
           results_file = sys.argv[1]
+          # COMMENT_MODE is passed as argv, not interpolated into the
+          # single-quoted heredoc (which would leave it the literal
+          # "${COMMENT_MODE}" and never match) (#323).
+          comment_mode = sys.argv[2]
           results = json.load(open(results_file))
-          comment_mode = "${COMMENT_MODE}"
 
-          has_findings = any(r["status"] in ("FAIL", "ADVISORY") for r in results)
+          # SKIP counts as a finding so a skipped enforcement gate stays
+          # visible even in findings-only mode (#322/#323).
+          has_findings = any(r["status"] in ("FAIL", "ADVISORY", "SKIP") for r in results)
 
           if not has_findings and comment_mode == "findings-only":
               print("SKIP_COMMENT")

--- a/tdad_tests/layer0_deterministic/test-auto-enforcer.sh
+++ b/tdad_tests/layer0_deterministic/test-auto-enforcer.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for templates/ci-auto-enforcer.yml.
+#
+# The auto-enforcer ships as a single self-contained workflow template, so
+# its logic lives in Python heredocs embedded in the YAML. Rather than test
+# a copy (which would drift), this harness EXTRACTS each block from the YAML
+# at test time and exercises the real shipped code against crafted inputs.
+#
+# Covers the four bugs fixed for the auto-enforcer cluster:
+#   #325 parser double-appends the last constraint
+#   #324 parse_field truncates multi-line rules
+#   #323 COMMENT_MODE never applies (single-quoted heredoc)
+#   #322 no retry on transient 429/529
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML="$SCRIPT_DIR/../../ai-literacy-superpowers/templates/ci-auto-enforcer.yml"
+
+python3 - "$YAML" <<'HARNESS_EOF'
+import json, os, subprocess, sys, tempfile, textwrap
+
+yaml_path = sys.argv[1]
+yaml_lines = open(yaml_path).read().split("\n")
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def extract_block(marker):
+    """Return the dedented Python body of the `<<'MARKER'` heredoc."""
+    start = next((i for i, l in enumerate(yaml_lines) if f"<<'{marker}'" in l), None)
+    if start is None:
+        fail(f"heredoc opener for {marker} not found in template")
+    body = []
+    for l in yaml_lines[start + 1:]:
+        if l.strip() == marker:
+            return textwrap.dedent("\n".join(body))
+        body.append(l)
+    fail(f"heredoc {marker} never closed")
+
+
+PARSER_SRC = extract_block("PYEOF")
+COMMENT_SRC = extract_block("COMMENTEOF")
+AGENT_SRC = extract_block("AGENTEOF")
+
+
+# --- #325 + #324: the constraint parser ---------------------------------
+def test_parser_dedup_and_multiline():
+    harness = textwrap.dedent("""\
+        # HARNESS.md
+
+        ## Constraints
+
+        ### First constraint
+        - **Rule**: A single-line rule.
+        - **Enforcement**: agent
+        - **Scope**: pr
+
+        ### Second constraint
+        - **Rule**: This rule wraps across
+          multiple physical lines and the
+          continuation must be folded in.
+        - **Enforcement**: agent
+        - **Scope**: pr
+
+        ## Garbage Collection
+
+        ### Some GC rule
+        - **Frequency**: weekly
+        """)
+    with tempfile.TemporaryDirectory() as d:
+        open(os.path.join(d, "HARNESS.md"), "w").write(harness)
+        env_file = os.path.join(d, "gh_env")
+        open(env_file, "w").close()
+        env = dict(os.environ, GITHUB_ENV=env_file,
+                   INCLUDE_CONSTRAINTS="", EXCLUDE_CONSTRAINTS="")
+        r = subprocess.run([sys.executable, "-c", PARSER_SRC], cwd=d, env=env,
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            fail(f"parser exited {r.returncode}: {r.stderr}")
+        written = open(env_file).read()
+        agents = None
+        for line in written.split("\n"):
+            if line.startswith("AGENT_CONSTRAINTS="):
+                agents = json.loads(line[len("AGENT_CONSTRAINTS="):])
+        if agents is None:
+            fail("parser wrote no AGENT_CONSTRAINTS")
+        names = [c["name"] for c in agents]
+        # #325: each constraint exactly once despite the trailing ## section
+        if len(names) != len(set(names)):
+            fail(f"parser emitted duplicate constraints: {names}")
+        if len(names) != 2:
+            fail(f"expected 2 agent constraints, got {len(names)}: {names}")
+        # #324: the multi-line rule is folded whole, not truncated
+        second = next(c for c in agents if c["name"] == "Second constraint")
+        if "continuation must be folded in" not in second["rule"]:
+            fail(f"multi-line rule truncated: {second['rule']!r}")
+        if "multiple physical lines" not in second["rule"]:
+            fail(f"multi-line rule missing middle line: {second['rule']!r}")
+
+
+def test_parser_constraints_as_final_section():
+    # #325 acceptance: when ## Constraints is the LAST section, behaviour is
+    # unchanged — the trailing flush still emits the final constraint once.
+    harness = textwrap.dedent("""\
+        # HARNESS.md
+
+        ## Constraints
+
+        ### Only constraint
+        - **Rule**: Just one.
+        - **Enforcement**: agent
+        - **Scope**: pr
+        """)
+    with tempfile.TemporaryDirectory() as d:
+        open(os.path.join(d, "HARNESS.md"), "w").write(harness)
+        env_file = os.path.join(d, "gh_env")
+        open(env_file, "w").close()
+        env = dict(os.environ, GITHUB_ENV=env_file,
+                   INCLUDE_CONSTRAINTS="", EXCLUDE_CONSTRAINTS="")
+        subprocess.run([sys.executable, "-c", PARSER_SRC], cwd=d, env=env,
+                       capture_output=True, text=True, check=True)
+        agents = next(json.loads(l[len("AGENT_CONSTRAINTS="):])
+                      for l in open(env_file).read().split("\n")
+                      if l.startswith("AGENT_CONSTRAINTS="))
+        if [c["name"] for c in agents] != ["Only constraint"]:
+            fail(f"final-section constraint mis-parsed: {agents}")
+
+
+# --- #323: comment-mode honoured via argv -------------------------------
+def run_comment(results, mode):
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(results, f)
+        rf = f.name
+    try:
+        r = subprocess.run([sys.executable, "-c", COMMENT_SRC, rf, mode],
+                           capture_output=True, text=True, check=True)
+        return r.stdout.strip()
+    finally:
+        os.unlink(rf)
+
+
+def test_comment_mode_findings_only_suppresses_all_pass():
+    out = run_comment([{"name": "a", "type": "agent", "status": "PASS", "findings": "--"}],
+                      "findings-only")
+    if out != "SKIP_COMMENT":
+        fail(f"all-PASS findings-only should SKIP_COMMENT, got: {out!r}")
+
+
+def test_comment_mode_always_posts_all_pass():
+    out = run_comment([{"name": "a", "type": "agent", "status": "PASS", "findings": "--"}],
+                      "always")
+    if "Auto-Enforcer Results" not in out:
+        fail(f"mode=always should post a comment, got: {out!r}")
+
+
+def test_comment_skip_is_a_finding():
+    out = run_comment([{"name": "a", "type": "agent", "status": "SKIP", "findings": "x"}],
+                      "findings-only")
+    if "Auto-Enforcer Results" not in out:
+        fail(f"SKIP should surface a comment in findings-only, got: {out!r}")
+
+
+def test_comment_fail_posts():
+    out = run_comment([{"name": "a", "type": "deterministic", "status": "FAIL", "findings": "boom"}],
+                      "findings-only")
+    if "Auto-Enforcer Results" not in out:
+        fail(f"FAIL should post a comment, got: {out!r}")
+
+
+# --- #322: bounded retry on transient errors ----------------------------
+RETRY_PREAMBLE = textwrap.dedent("""\
+    import os, urllib.request, urllib.error, time
+    _count_file = os.environ["CALL_COUNT_FILE"]
+    _scenario = os.environ["FAKE_SCENARIO"]
+    _n = {"i": 0}
+    class _Resp:
+        def __init__(self, b): self._b = b
+        def read(self): return self._b
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    def _fake(req, timeout=60):
+        _n["i"] += 1
+        open(_count_file, "w").write(str(_n["i"]))
+        if _scenario == "529_then_ok":
+            if _n["i"] == 1:
+                raise urllib.error.HTTPError("u", 529, "Overloaded", {}, None)
+            return _Resp(b'{"content":[{"text":"NO_FINDINGS"}]}')
+        if _scenario == "persistent_529":
+            raise urllib.error.HTTPError("u", 529, "Overloaded", {}, None)
+        if _scenario == "fail_fast_401":
+            raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+        raise AssertionError("unknown scenario")
+    urllib.request.urlopen = _fake
+    time.sleep = lambda *a, **k: None
+    """)
+
+
+def run_agent(scenario):
+    patched = RETRY_PREAMBLE + AGENT_SRC
+    with tempfile.TemporaryDirectory() as d:
+        rf = os.path.join(d, "results.json")
+        open(rf, "w").write("[]")
+        ccf = os.path.join(d, "calls")
+        env = dict(os.environ, FAKE_SCENARIO=scenario, CALL_COUNT_FILE=ccf,
+                   ANTHROPIC_API_KEY="test-key", AGENT_MODEL="claude-test")
+        env.pop("DIFF_FILE", None)
+        r = subprocess.run([sys.executable, "-c", patched, "Test", "A rule", rf],
+                           cwd=d, env=env, capture_output=True, text=True)
+        if r.returncode != 0:
+            fail(f"agent block exited {r.returncode} ({scenario}): {r.stderr}")
+        status = json.load(open(rf))[-1]["status"]
+        calls = int(open(ccf).read()) if os.path.exists(ccf) else 0
+        return status, calls
+
+
+def test_retry_transient_then_succeeds():
+    status, calls = run_agent("529_then_ok")
+    if status != "PASS":
+        fail(f"529-then-OK should retry to PASS, got {status}")
+    if calls != 2:
+        fail(f"529-then-OK should make 2 calls, made {calls}")
+
+
+def test_retry_persistent_skips_after_window():
+    status, calls = run_agent("persistent_529")
+    if status != "SKIP":
+        fail(f"persistent 529 should end SKIP, got {status}")
+    if calls != 3:
+        fail(f"persistent 529 should exhaust 3 attempts, made {calls}")
+
+
+def test_non_transient_fails_fast():
+    status, calls = run_agent("fail_fast_401")
+    if status != "SKIP":
+        fail(f"401 should SKIP, got {status}")
+    if calls != 1:
+        fail(f"401 should fail fast (1 call), made {calls}")
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+for t in TESTS:
+    t()
+print(f"All {len(TESTS)} auto-enforcer tests passed.")
+HARNESS_EOF

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -47,6 +47,7 @@ BASH_TEST_SCRIPTS = [
     "test-reflection-log-helpers",
     "test-archive-promoted-reflections",
     "test-migrate-reflection-log",
+    "test-auto-enforcer",
 ]
 
 


### PR DESCRIPTION
Fixes #322, #323, #324, #325.

Four defects in `templates/ci-auto-enforcer.yml` quietly degraded PR-time constraint enforcement for every adopter of the GitHub Action. All four live in the same single-file workflow template; fixed together with a Layer 0 test harness.

## Fixes

| # | Bug | Fix |
|---|-----|-----|
| **#325** | Parser appended the last constraint at section exit **and** at the EOF flush, so a `HARNESS.md` with any `## ` section after `## Constraints` listed (and ran) its last constraint twice. | Reset parse state on section exit; gate the trailing flush on still being inside the section. |
| **#324** | `parse_field` returned only the first physical line of a `Rule:`, so multi-paragraph agent constraints reached the model half-stated (the agent reported the rule "incomplete"). | Fold continuation lines into the value until the next list item. |
| **#323** | `comment_mode = "${COMMENT_MODE}"` inside a single-quoted heredoc was a literal string — `findings-only` never suppressed all-PASS comments. | Pass `COMMENT_MODE` as a positional argv. `SKIP` now counts as a finding so a silently-disabled gate still surfaces a comment. |
| **#322** | A single `urlopen` with a broad `except` turned a transient Anthropic `429`/`529` into a `SKIP`pped enforcement gate. | Retry transient overloads with backoff (2s, 4s), retry one network error, fail fast on other HTTP errors; half-second pacing between agent calls flattens the burst. |

## Tests (RED→GREEN verified)

New Layer 0 suite `test-auto-enforcer.sh` **extracts the real embedded Python blocks from the template** at test time (no drift) and exercises all four fixes across nine cases:

- parser: dedup with a trailing `## Garbage Collection` section; full multi-line rule folded; `## Constraints`-as-final-section unchanged.
- comment: all-PASS findings-only → SKIP_COMMENT; mode=always posts; SKIP and FAIL both post.
- retry: 529-then-OK → PASS in 2 calls; persistent 529 → SKIP after 3; 401 → fail-fast in 1 call (urllib monkeypatched, `time.sleep` stubbed).

Proven to **fail against the pre-fix template** for all four bugs (duplicate constraint, truncated rule, comment-on-all-pass, no-retry).

## Notes

Spec-first exempt via `fix` label (correctness fixes to a workflow template). Docs: `auto-enforcer-action` SKILL updated for the corrected `findings-only`/SKIP behaviour and the retry semantics. Patch bump 0.53.1 → 0.53.2 across all five CI-checked locations + README.