### PR TITLE
Auto-enforcer: record deterministic results via heredoc argv, not source interpolation (#424)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.53.2",
+  "plugin_version": "0.53.3",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.53.2"
+      "version": "0.53.3"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.53.3 — 2026-06-16
+
+### auto-enforcer: record deterministic results without source interpolation (#424)
+
+The `Run deterministic constraints` step in `templates/ci-auto-enforcer.yml`
+built a `python3 -c "…"` body by shell-interpolating each tool's stdout into
+a triple-quoted Python literal. Any tool that printed `'''` (or other quote
+characters) terminated the literal early and raised a `SyntaxError`, failing
+the whole step — so a tool that **passed** could still break the run, and the
+interpolation was a latent injection vector.
+
+- The step now uses the same safe heredoc-argv pattern as the agent and
+  comment steps: a single-quoted heredoc (no shell expansion) with the
+  results file, name, status, and tool output passed via `sys.argv` *after*
+  the source is parsed, so no character in tool output can corrupt the script.
+- Layer 0 coverage added: tool stdout containing `'''`, `"`, `"""`, and
+  shell-like `$(…)` text is recorded verbatim; a PASS result records `--`.
+  Verified to SyntaxError against the pre-fix interpolation form (RED→GREEN).
+
 ## 0.53.2 — 2026-06-15
 
 ### auto-enforcer: four PR-enforcement bug fixes (#322, #323, #324, #325)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.3-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.53.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.53.3 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/templates/ci-auto-enforcer.yml
+++ b/ai-literacy-superpowers/templates/ci-auto-enforcer.yml
@@ -188,18 +188,23 @@ jobs:
               echo "$OUTPUT"
             fi
 
-            # Append result to JSON file
-            python3 -c "
+            # Append result to JSON file. Values arrive via argv *after* the
+            # source is parsed (single-quoted heredoc → no shell expansion),
+            # so a tool whose stdout contains Python quote characters can
+            # never corrupt the script body the way `python3 -c "...$OUTPUT"`
+            # interpolation did (#424).
+            python3 - "$RESULTS_FILE" "$name" "$STATUS" "$OUTPUT" <<'DETEOF'
           import json, sys
-          results = json.load(open('$RESULTS_FILE'))
+          results_file, name, status, output = sys.argv[1:5]
+          results = json.load(open(results_file))
           results.append({
-              'name': '''$name''',
-              'type': 'deterministic',
-              'status': '$STATUS',
-              'findings': '''$OUTPUT'''.strip()[:500] if '$STATUS' == 'FAIL' else '--'
+              "name": name,
+              "type": "deterministic",
+              "status": status,
+              "findings": output.strip()[:500] if status == "FAIL" else "--",
           })
-          json.dump(results, open('$RESULTS_FILE', 'w'))
-          "
+          json.dump(results, open(results_file, "w"))
+          DETEOF
             echo "::endgroup::"
           done
 

--- a/tdad_tests/layer0_deterministic/test-auto-enforcer.sh
+++ b/tdad_tests/layer0_deterministic/test-auto-enforcer.sh
@@ -44,6 +44,7 @@ def extract_block(marker):
 PARSER_SRC = extract_block("PYEOF")
 COMMENT_SRC = extract_block("COMMENTEOF")
 AGENT_SRC = extract_block("AGENTEOF")
+DET_SRC = extract_block("DETEOF")
 
 
 # --- #325 + #324: the constraint parser ---------------------------------
@@ -127,6 +128,41 @@ def test_parser_constraints_as_final_section():
                       if l.startswith("AGENT_CONSTRAINTS="))
         if [c["name"] for c in agents] != ["Only constraint"]:
             fail(f"final-section constraint mis-parsed: {agents}")
+
+
+# --- #424: deterministic record passes tool stdout via argv -------------
+def test_deterministic_record_handles_quote_chars():
+    # Tool stdout with Python quote characters and shell-like text must be
+    # recorded verbatim, not interpolated into the script body where it
+    # would corrupt the source and SyntaxError the whole step.
+    nasty = "err: stray ''' and \" and \"\"\" and $(whoami) and ' here"
+    with tempfile.TemporaryDirectory() as d:
+        rf = os.path.join(d, "r.json")
+        open(rf, "w").write("[]")
+        r = subprocess.run([sys.executable, "-c", DET_SRC, rf, "My Tool", "FAIL", nasty],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            fail(f"deterministic record block errored on quote-heavy output: {r.stderr}")
+        recs = json.load(open(rf))
+        if len(recs) != 1:
+            fail(f"expected 1 record, got {len(recs)}")
+        if recs[0]["name"] != "My Tool":
+            fail(f"name mangled: {recs[0]['name']!r}")
+        if "stray" not in recs[0]["findings"]:
+            fail(f"findings lost: {recs[0]['findings']!r}")
+        if "$(whoami)" not in recs[0]["findings"]:
+            fail("shell-like text not preserved verbatim (would mean expansion)")
+
+
+def test_deterministic_record_pass_has_no_findings():
+    with tempfile.TemporaryDirectory() as d:
+        rf = os.path.join(d, "r.json")
+        open(rf, "w").write("[]")
+        subprocess.run([sys.executable, "-c", DET_SRC, rf, "T", "PASS", "noisy '''output"],
+                       check=True, capture_output=True)
+        recs = json.load(open(rf))
+        if recs[0]["findings"] != "--":
+            fail(f"PASS should record '--' findings, got {recs[0]['findings']!r}")
 
 
 # --- #323: comment-mode honoured via argv -------------------------------


### PR DESCRIPTION
Fixes #424.

## Problem

The `Run deterministic constraints` step in `templates/ci-auto-enforcer.yml` built a `python3 -c "…"` body by shell-interpolating each tool's stdout (`$OUTPUT`) into a triple-quoted Python literal:

```python
'findings': '''$OUTPUT'''.strip()[:500] if '$STATUS' == 'FAIL' else '--'
```

Any tool that printed `'''` (or other Python quote characters) terminated the literal early and raised a `SyntaxError`, failing the whole step. So a tool that **passed** could still break the run, and the interpolation was a latent injection vector (arbitrary stdout became executed Python source).

## Fix

Switch to the same safe heredoc-argv pattern the agent and comment steps already use — a single-quoted heredoc (no shell expansion) with values passed via `sys.argv` *after* the source is parsed:

```bash
python3 - "$RESULTS_FILE" "$name" "$STATUS" "$OUTPUT" <<'DETEOF'
import json, sys
results_file, name, status, output = sys.argv[1:5]
...
DETEOF
```

No character in tool output can corrupt the script body. This also makes the template internally consistent — all four embedded-Python steps now use the heredoc-argv shape.

## Tests (RED→GREEN verified)

Extended the Layer 0 harness (`test-auto-enforcer.sh`, which extracts the real embedded Python from the template):

- tool stdout containing `'''`, `"`, `"""`, and shell-like `$(…)` text is recorded **verbatim** and the block exits 0;
- a PASS result records `--` findings.

Proven RED against the old interpolation form: it `SyntaxError`s on `'''` output, while the new block records it cleanly.

## Notes

Spec-first exempt via `fix` label. Internal robustness fix — no user-facing docs reference the recording mechanism. Patch bump 0.53.2 → 0.53.3 across all five CI-checked locations + README.