### PR TITLE
Promote three dispositioned findings to AGENTS.md + CLAUDE.md (#339, #347, #348)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,66 @@
   `docs/superpowers/specs/2026-06-14-reservoir-warden-design.md`
   (Approach, FR-011); builds on the line-201 advisory-hook decision.
 
+- Decision: **schema evolution routes by fact granularity** — where a new
+  fact lives on a schema surface is decided by whether the fact varies per
+  element or applies to the whole record, not by idiom symmetry. Three
+  sub-rules: (1) **Per-element facts** (vary across elements in a collection)
+  reuse the existing per-element field with a string-prefix convention (e.g.
+  `Q<N> (question-name):` and `CC<N> (question-name):` on
+  `challenge_notes[]`) — no schema touch. (2) **Model-level / wrapper facts**
+  (apply to the whole record, do not vary per element) are added as an
+  additive optional field on the wrapper (e.g. `cross_check_status` on
+  `LegibilityModel`) — a schema touch is justified. (3) **Single-writer
+  invariant** — every audit-trail entry has exactly one author and one
+  source; a side-effect on a sibling record is recorded as a reference from
+  the writer, never duplicated as a second entry on the sibling. Reason:
+  recording a model-level fact at per-element granularity is N records for a
+  1-record fact and collapses under prefix-matching; recording a per-element
+  fact on the wrapper makes it ambiguous which element owns it; the
+  single-writer rule keeps audit trails attributable. The symmetry of a
+  sibling-sentinel idiom *feels* right because the symmetry is visible — the
+  granularity rule is invisible until a consumer surfaces it, so route by
+  granularity, not by idiom. Two instances: dl-s2a (PR #336, v0.2.0) split
+  the schema into `LegibilityElement` (per-element) + `LegibilityModel`
+  (wrapper) — implicit application; dl-s3 (v0.4.0) added `cross_check_status`
+  to `LegibilityModel` as an additive wrapper field, dropped the per-element
+  CC-skipped sentinel (a model-level fact pulled up to the wrapper), and kept
+  a subject-only audit trail — explicit application. Source: spec
+  `docs/superpowers/specs/2026-05-29-dl-s3-cross-check-mechanism-design.md`
+  (§3.3 worked example); `docs/superpowers/stories/dl-s3-cross-check-mechanism-design.md`
+  stories #1, #3, #4; schema template
+  `diagnostic-legibility/templates/legibility-element.md`. Promoted per #347.
+
+- Decision: **agents producing structured output for programmatic consumers
+  use dispatcher-first error contracts** — no silent fallback on unrecognised
+  input. An agent whose output is consumed by an orchestrator, a downstream
+  command, or `/diagnose` must spec **both** a success shape and a structured
+  refusal shape. The refusal shape is a **single line**, pattern-matchable,
+  prefixed with the agent name and the literal `refusal:` (e.g.
+  `diagnostic-legibility refusal: <reason>.`), and is emitted **instead of**
+  the success-shape YAML/JSON block — never alongside it. Programmatic
+  dispatchers route by "no success block + presence of the refusal prefix";
+  humans read the refusal line in the markdown response and act. Reason: a
+  forgiving fallback (e.g. silently defaulting an unrecognised `mode:` marker
+  to `mode: full` with a prose warning) silently corrupts dispatcher intent
+  and is invisible to pattern-matching; a structured refusal fails loud and
+  machine-legibly. Three occurrences drove the promotion: choice-cartographer
+  O7 (PR #341 lineage) chose a structured `cartograph_pending_count: N` field
+  over prose narration of pending stories; dl-s3 spec-mode O6 refused on an
+  unrecognised `mode:` value rather than falling back; dl-s3 spec-mode O7's
+  unified precondition-violation table emits valid YAML only in the
+  asymmetric case (via the model-level `cross_check_status` field) and
+  refuses structurally everywhere else. **Code-mode diaboli check:** any new
+  agent emitting structured output must have BOTH a success-shape and a
+  refusal-shape spec'd — a read-only check at the code gate. This sharpens
+  the human-gate refusal mention in the agent-emit/dispatcher-persist/
+  human-disposes entry above (the trust boundary) into an explicit *output
+  contract* for machine consumers. Source:
+  `docs/superpowers/stories/dl-s3-cross-check-mechanism-design.md` story #6;
+  dl-s3 spec §3.6/§3.7; precedents
+  `docs/superpowers/objections/dl-s2b-challenge-protocol-design.md` and
+  `docs/superpowers/objections/choice-cartographer.md` (O7). Promoted per #348.
+
 ## TEST_STRATEGY
 
 <!-- How tests are structured in this project. Helps agents write consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.53.3 — 2026-06-16
 
+### compound learning: promote three dispositioned findings (#339, #347, #348)
+
+Curation pass landing three choice-cartographer findings that the human had
+already dispositioned `promoted`, turning recurring lessons into standing
+guardrails (no plugin version bump — convention files only).
+
+- **#339** → `CLAUDE.md` Marketplace Versioning: a cross-PR coordination rule
+  for `marketplace.json`'s `plugin_version` (owned by `ai-literacy-superpowers`
+  PRs; non-owning PRs take main's value verbatim). Specs can now reference the
+  convention instead of restating the merge-time rule per spec.
+- **#347** → `AGENTS.md` ARCH_DECISIONS: "schema evolution routes by fact
+  granularity" — per-element facts use a per-element field with a string
+  prefix; model-level facts earn an additive wrapper field; audit entries keep
+  a single writer.
+- **#348** → `AGENTS.md` ARCH_DECISIONS: "dispatcher-first error contracts for
+  agent output" — structured output for programmatic consumers must spec a
+  single-line, pattern-matchable refusal shape emitted instead of the success
+  block, with no silent fallback (third-occurrence promotion).
+
 ### auto-enforcer: record deterministic results without source interpolation (#424)
 
 The `Run deterministic constraints` step in `templates/ci-auto-enforcer.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,23 @@ After every plugin version bump, update `plugin_version` in
 version. This is the common case — plugin code changes, listing
 contract stays the same.
 
+**Cross-PR coordination on `plugin_version`:**
+
+`plugin_version` is shared mutable state across every PR that touches
+`marketplace.json` — including PRs that do **not** bump
+`ai-literacy-superpowers` (e.g. a sister-plugin bump). Ownership is
+split so concurrent PRs don't clobber each other:
+
+- The top-level `plugin_version` is **owned by `ai-literacy-superpowers`
+  PRs**. A PR that does not bump that plugin must not change it.
+- Each `plugins[].version` entry is **owned by its own plugin's PRs**.
+
+If a rebase or merge surfaces a conflict on `plugin_version` from a
+non-`ai-literacy-superpowers` PR, take **main's value verbatim** — that
+PR only owns its own `plugins[]` entry bump, not the top-level pointer.
+Specs may reference this convention instead of restating the merge-time
+rule per spec.
+
 **When to bump `version` (listing version):**
 
 Bump when the listing contract itself changes:


### PR DESCRIPTION
Closes #339, #347, #348.

A compound-learning curation pass landing three choice-cartographer findings the human had **already dispositioned `promoted`** — turning recurring lessons into standing guardrails. Convention files only (`AGENTS.md`, `CLAUDE.md`); no plugin version bump.

## What lands

- **#339 → `CLAUDE.md` Marketplace Versioning.** A cross-PR coordination rule for `marketplace.json`'s `plugin_version`: the top-level pointer is owned by `ai-literacy-superpowers` PRs; each `plugins[].version` is owned by its own plugin's PRs; a non-owning PR takes main's `plugin_version` verbatim on conflict. Removes the need to restate the merge-time rule per spec (the dl-s2b §9 workaround).
- **#347 → `AGENTS.md` ARCH_DECISIONS — "schema evolution routes by fact granularity".** Per-element facts reuse a per-element field with a string prefix (no schema touch); model-level facts earn an additive wrapper field; audit entries keep a single writer. Instances: dl-s2a (PR #336) and dl-s3.
- **#348 → `AGENTS.md` ARCH_DECISIONS — "dispatcher-first error contracts for agent output".** Structured output for programmatic consumers must spec a single-line, pattern-matchable refusal shape (`<agent> refusal: <reason>.`) emitted *instead of* the success block, with no silent fallback. Third-occurrence promotion (choice-cartographer O7, dl-s3 O6, dl-s3 O7); flagged as a code-mode diaboli check.

## Notes

- Each entry cites its source story/spec/objection records (all verified to exist), and the `disposition: promoted` field in those stories already records the decision.
- Verified the cartographer field name is current (`cartograph_pending_count`, renamed from `henney_*`).
- `#348` cross-references and sharpens the existing agent-emit/dispatcher-persist/human-disposes ARCH_DECISIONS entry rather than duplicating it.
- Spec-first exempt via `chore/` branch prefix + `chore` label (curation, no behaviour change).