### PR TITLE
Affordances: ## Affordances section + /harness-affordance add (step 3, #200)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.53.3",
+  "plugin_version": "0.54.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.53.3"
+      "version": "0.54.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.54.0 — 2026-06-16
+
+### affordances: HARNESS.md section + guided `/harness-affordance add` (#200)
+
+Sequencing step 3 of the harness-affordances epic makes the discovery
+scanner's inventory a first-class part of the harness.
+
+- **`templates/HARNESS.md` `## Affordances` section** — a top-level section
+  (after Garbage Collection, before Status) carrying the field schema in
+  comments, a reference to `observability/affordance-invocations.json`, and
+  four worked example entries (cli, central-mcp, current-user cli, hook).
+- **`/harness-affordance add <name>`** — replaces the stub with a guided
+  flow: seed from the newest discovery draft (matched by permission pattern),
+  prompt for the governance fields (Identity with five-value framing, Audit
+  trail with "none is fine" guidance), auto-date `Last reviewed`, validate
+  (required fields, Mode/Trigger pairing, permission existence across project
+  **and** user settings — warn, not block), and write idempotently. Re-runs
+  edit in place keyed on the **permission pattern**, not the heading name, so
+  a rename never duplicates an entry.
+- **`/harness-init`** gains Affordances as a sixth, opt-in (default off)
+  feature; **`/harness-status`** counts declared affordances.
+- **Docs** — new explanation (the contractor scenario, identity as the
+  load-bearing field, the source-of-truth split) and reference (field-by-
+  field schema) pages; the discover how-to updated for `add`.
+- **Tests** — a Layer 0 test validates the template's example entries against
+  the schema (required fields, Mode/Trigger pairing, date format).
+- Spec-mode `/diaboli` raised 12 objections (3 high); all adjudicated before
+  implementation (idempotency keys on permission pattern; `add` reads user
+  settings; concrete init integration; direct-write confirmed).
+
 ## 0.53.3 — 2026-06-16
 
 ### docs: exploration findings for microsoft/AI-Engineering-Coach (#340)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.53.3-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.54.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.53.3 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.54.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.53.3",
+  "version": "0.54.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-affordance.md
+++ b/ai-literacy-superpowers/commands/harness-affordance.md
@@ -110,10 +110,15 @@ every governance field; the command only transcribes their answers, so
    - `Trigger` present **iff** `Mode: hook`;
    - **permission existence** — check whether the `Permission` pattern
      appears in any of `.claude/settings.json`,
-     `.claude/settings.local.json`, or `~/.claude/settings.json`. If it does
-     not, **warn** (do not block): "Permission `<pattern>` is not in any
-     settings allowlist — the affordance may precede its grant, or the
-     pattern may be mistyped."
+     `.claude/settings.local.json`, or `~/.claude/settings.json`. If a
+     settings layer is absent or unreadable in this environment (sandboxed
+     sessions, CI), skip it but **say so**, so a clean "absent" is not
+     confused with "could not check". If the pattern is found, pass
+     silently. If it is not found in any *readable* layer, **warn** (do not
+     block), naming which layers were checked: "Permission `<pattern>` not
+     found in <layers checked> — the affordance may precede its grant, the
+     pattern may be mistyped, or the user layer (`~/.claude/settings.json`)
+     was not readable here."
 
 7. **Write into `HARNESS.md` `## Affordances`** (idempotent):
    - If an entry already exists whose `Permission` field string-equals the
@@ -121,9 +126,12 @@ every governance field; the command only transcribes their answers, so
      its heading unless the user renamed it. Never append a second entry for
      the same permission pattern.
    - Otherwise append a new `### <name>` entry.
-   - If the `## Affordances` section does not exist, create it **after
-     `## Garbage Collection` and before `## Status`** (matching the
-     template's section order).
+   - If the `## Affordances` section does not exist, create it
+     **immediately before `## Observability`** (i.e. directly after the
+     `## Garbage Collection` section), matching the template's section
+     order. Do not place it just above `## Status` — `## Observability` and
+     `## Read-side filtering` sit between Affordances and Status in the
+     template.
 
 8. **Validation checkpoint.** Re-read the entry just written and verify it
    against the field schema (required fields present, `Trigger`/`Mode`

--- a/ai-literacy-superpowers/commands/harness-affordance.md
+++ b/ai-literacy-superpowers/commands/harness-affordance.md
@@ -1,6 +1,6 @@
 ---
 name: harness-affordance
-description: Manage the project's affordance inventory — declared tools the agent can invoke, the identity each tool runs under, and the audit trail each tool produces. Subcommands - discover (scan config to produce a draft inventory), add (planned), review (planned). See docs/superpowers/specs/2026-04-26-harness-affordances-design.md for the design.
+description: Manage the project's affordance inventory — declared tools the agent can invoke, the identity each tool runs under, and the audit trail each tool produces. Subcommands - discover (scan config to produce a draft inventory), add (promote a draft into HARNESS.md with governance metadata), review (planned). See docs/superpowers/specs/2026-04-26-harness-affordances-design.md for the design.
 ---
 
 # /harness-affordance \<subcommand\> [args...]
@@ -52,18 +52,87 @@ server.
      **Identity** and **Audit trail** filled in (the scanner only
      supplies the machine-derivable fields)."
 
-### `add` *(not yet implemented)*
+### `add <name>`
 
-Planned for sequencing step 3. Will guide annotation of a draft
-entry — prompts for Identity, Audit trail, optional Notes, then
-appends the completed entry to `HARNESS.md`.
+Guided annotation that promotes one affordance into the `## Affordances`
+section of `HARNESS.md`, mirroring `/harness-constrain`. The human dictates
+every governance field; the command only transcribes their answers, so
+`HARNESS.md` stays human-authored in spirit. Requires a `<name>` argument
+(the heading the entry will carry); if omitted, ask for one.
 
-If invoked today, tell the user: "`/harness-affordance add` is not
-yet implemented (sequencing step 3 of the affordances design). For
-now, copy entries from the discovery output to HARNESS.md by hand
-and fill in Identity and Audit trail. See
-`docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
-for the design."
+### Process
+
+1. **Seed from a draft, if any.** Look for the newest discovery scratch
+   file — the lexically last `.claude/affordance-discovery-*.md` (filenames
+   are date-stamped). If it contains an entry whose `Permission` matches
+   what the user is annotating, use that entry's `Mode`, `Trigger` (if
+   present), and `Permission` as the starting point. Otherwise prompt for:
+   - `Mode` — `cli` / `local-mcp` / `central-mcp` / `hook`
+   - `Trigger` — **only if** `Mode: hook`; one of the Claude Code hook
+     events (`PreToolUse` / `PostToolUse` / `Stop` / `SubagentStop` /
+     `SessionStart` / `SessionEnd` / `UserPromptSubmit` / `PreCompact` /
+     `Notification`)
+   - `Permission` — the allowlist pattern that authorises this affordance
+
+   A wrapper-hook draft (the scanner's known #205 gap) may seed a
+   wrapper-derived name like `bash-stop`; the user is free to pass a clearer
+   `<name>` — idempotency keys on `Permission`, not the heading, so renaming
+   never creates a duplicate.
+
+2. **Identity** *(load-bearing governance question — whose credentials
+   authorise the action)*. Prompt with the five values and their
+   definitions:
+   - `user-sso` — the human's external SSO credentials (GitHub PAT, Slack
+     token, cloud SSO). Highest-attribution failure mode.
+   - `service-account` — shared bot credentials; per-user attribution lost.
+   - `current-user` — the human running the session, no boundary crossed
+     (filesystem, local network); still attributable, may have no remote
+     audit trail.
+   - `runtime-resolved` — identity depends on session config. **Require a
+     resolution-chain narrative in Notes** (e.g. `gh`: `$GITHUB_TOKEN` →
+     keychain → fail).
+   - `none` — no authentication boundary crossed at all.
+
+3. **Audit trail.** Prompt with the pattern `<source>: <retention>,
+   <access scope>`. State explicitly that **`none` is fine and is itself
+   governance signal** — it tells reviewers where the gaps are without
+   forcing fabrication.
+
+4. **Last reviewed.** Set to today's date automatically — an `add` is a
+   genuine first review.
+
+5. **Optional fields.** `Constraint references` (constraints that depend on
+   this affordance) and `Notes` (freeform context).
+
+6. **Validate** before writing:
+   - required fields present: `Mode`, `Identity`, `Audit trail`,
+     `Permission`, `Last reviewed`;
+   - `Trigger` present **iff** `Mode: hook`;
+   - **permission existence** — check whether the `Permission` pattern
+     appears in any of `.claude/settings.json`,
+     `.claude/settings.local.json`, or `~/.claude/settings.json`. If it does
+     not, **warn** (do not block): "Permission `<pattern>` is not in any
+     settings allowlist — the affordance may precede its grant, or the
+     pattern may be mistyped."
+
+7. **Write into `HARNESS.md` `## Affordances`** (idempotent):
+   - If an entry already exists whose `Permission` field string-equals the
+     new pattern, **edit that entry in place** (replace its fields), keeping
+     its heading unless the user renamed it. Never append a second entry for
+     the same permission pattern.
+   - Otherwise append a new `### <name>` entry.
+   - If the `## Affordances` section does not exist, create it **after
+     `## Garbage Collection` and before `## Status`** (matching the
+     template's section order).
+
+8. **Validation checkpoint.** Re-read the entry just written and verify it
+   against the field schema (required fields present, `Trigger`/`Mode`
+   pairing, `Last reviewed` is a `YYYY-MM-DD` date with no residual `TODO`
+   placeholder). Fix any deviation in place — do not re-prompt the user.
+
+Report the entry written and its location. (Constraint-chaining — suggesting
+a `/harness-constrain` that references this affordance — arrives in
+sequencing step 4, once the chained constraints that consume it exist.)
 
 ### `review` *(not yet implemented)*
 

--- a/ai-literacy-superpowers/commands/harness-init.md
+++ b/ai-literacy-superpowers/commands/harness-init.md
@@ -167,14 +167,17 @@ corresponding section (`## Context`, `## Constraints`,
 generated content from user responses. For unselected features, preserve
 the existing section content verbatim — do not modify it. If the
 **Affordances** feature is newly selected on a project that lacks the
-section, insert `## Affordances` from the template **after
-`## Garbage Collection` and before `## Status`** (matching the template's
-section order) without touching the other sections.
+section, insert `## Affordances` from the template **immediately before
+`## Observability`** (i.e. directly after the `## Garbage Collection`
+section), matching the template's section order, without touching the other
+sections.
 
-Section boundaries are defined by the `##` headings in the template:
-`## Context`, `## Constraints`, `## Garbage Collection`, `## Affordances`,
-`## Status`. Each section runs from its `##` heading to the next `##`
-heading or end of file.
+Section boundaries are defined by **every** `##` heading in the template, in
+order: `## Context`, `## Constraints`, `## Garbage Collection`,
+`## Affordances`, `## Observability`, `## Read-side filtering`, `## Status`.
+Each section runs from its `##` heading to the **next** `##` heading or end
+of file — so the section after `## Affordances` is `## Observability`, not
+`## Status`.
 
 **Template version marker (both first run and re-run):**
 
@@ -193,8 +196,10 @@ verify its structure against `templates/HARNESS.md`.
 
 **Structural checks:**
 
-1. All 4 top-level sections present: `## Context`,
+1. The 4 mandatory top-level sections present: `## Context`,
    `## Constraints`, `## Garbage Collection`, `## Observability`
+   (`## Affordances` is optional — see check 6 — and `## Read-side
+   filtering` and `## Status` are validated by checks 3-4)
 2. Context section has `### Stack` and `### Conventions`
    subsections (either with content or the placeholder marker)
 3. Observability section has `### Operating cadence`,
@@ -207,9 +212,9 @@ verify its structure against `templates/HARNESS.md`.
    current plugin version
 6. **Affordances (optional):** `## Affordances` is only required when the
    Affordances feature was selected. If selected, the section is present
-   (with example entries or the placeholder marker) and sits after
-   `## Garbage Collection`. If not selected, its absence is **not** a
-   failure.
+   (with example entries or the placeholder marker) and sits **between
+   `## Garbage Collection` and `## Observability`** (its template position).
+   If not selected, its absence is **not** a failure.
 
 If any check fails, fix HARNESS.md in place:
 

--- a/ai-literacy-superpowers/commands/harness-init.md
+++ b/ai-literacy-superpowers/commands/harness-init.md
@@ -42,7 +42,7 @@ it."
 
 ### 3. Select Features
 
-Present a feature selection menu. The five selectable areas are:
+Present a feature selection menu. The six selectable areas are:
 
 | Feature | What it configures | Default (first run) |
 | --- | --- | --- |
@@ -51,8 +51,12 @@ Present a feature selection menu. The five selectable areas are:
 | Garbage collection | Periodic entropy checks | on |
 | CI configuration | GitHub Actions workflow + auto-enforcer | on |
 | Observability | README badge + status section | on |
+| Affordances | Declared-tool inventory (`## Affordances` section) | off |
 
-**First run** (no HARNESS.md exists): all features default to on.
+**First run** (no HARNESS.md exists): all features default to on **except
+Affordances, which is opt-in (default off)** — most projects adopt it later
+via `/harness-affordance discover` once they have a populated permissions
+allowlist to scan. The user can turn it on here.
 
 **Re-run** (HARNESS.md exists): detect which sections are already
 configured by checking for the placeholder marker
@@ -147,20 +151,30 @@ the section body with the placeholder marker:
 <!-- Not yet configured. Run /harness-init and select this feature to set up. -->
 ```
 
+**Affordances** is opt-in: if **unselected** (the default), replace the
+`## Affordances` section body with the placeholder marker like any other
+unselected feature. If **selected**, keep the section's example entries and
+schema comments in place and tell the user to run
+`/harness-affordance discover` to populate it from their real config.
+
 Write the result to `HARNESS.md` at the project root.
 
 **Re-run** (HARNESS.md exists):
 
 Read the existing `HARNESS.md`. For each selected feature, replace the
 corresponding section (`## Context`, `## Constraints`,
-`## Garbage Collection`, or `## Status`) with freshly generated content
-from user responses. For unselected features, preserve the existing
-section content verbatim — do not modify it.
+`## Garbage Collection`, `## Affordances`, or `## Status`) with freshly
+generated content from user responses. For unselected features, preserve
+the existing section content verbatim — do not modify it. If the
+**Affordances** feature is newly selected on a project that lacks the
+section, insert `## Affordances` from the template **after
+`## Garbage Collection` and before `## Status`** (matching the template's
+section order) without touching the other sections.
 
 Section boundaries are defined by the `##` headings in the template:
-`## Context`, `## Constraints`, `## Garbage Collection`, `## Status`.
-Each section runs from its `##` heading to the next `##` heading or
-end of file.
+`## Context`, `## Constraints`, `## Garbage Collection`, `## Affordances`,
+`## Status`. Each section runs from its `##` heading to the next `##`
+heading or end of file.
 
 **Template version marker (both first run and re-run):**
 
@@ -191,6 +205,11 @@ verify its structure against `templates/HARNESS.md`.
 5. Template version marker comment present:
    `<!-- template-version: X.Y.Z -->` where X.Y.Z matches the
    current plugin version
+6. **Affordances (optional):** `## Affordances` is only required when the
+   Affordances feature was selected. If selected, the section is present
+   (with example entries or the placeholder marker) and sits after
+   `## Garbage Collection`. If not selected, its absence is **not** a
+   failure.
 
 If any check fails, fix HARNESS.md in place:
 

--- a/ai-literacy-superpowers/commands/harness-status.md
+++ b/ai-literacy-superpowers/commands/harness-status.md
@@ -39,6 +39,14 @@ Count GC rules by status:
 - Active (deterministic or agent enforcement)
 - Inactive (no enforcement configured)
 
+### 4a. Count Affordances
+
+If a `## Affordances` section exists, count its declared affordances by
+counting `### ` headings within the section (each heading is one
+affordance, per the one-affordance-per-permission-pattern rule). Ignore the
+section's HTML comments. If the section is absent, skip this — affordances
+are an opt-in feature.
+
 ### 5. Present Summary
 
 ```text
@@ -54,6 +62,9 @@ Last audit: YYYY-MM-DD (N days ago)
 ### Garbage Collection: N/M active
 - Auto-fix enabled: X rules
 - Report-only: Y rules
+
+### Affordances: N declared
+[Omit this whole line when there is no ## Affordances section]
 
 ### Drift: [none detected / warning]
 [Details if drift was detected in last audit]

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -363,6 +363,79 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 -->
 ---
 
+## Affordances
+
+<!-- Each entry declares one tool the agent can invoke. Identity is
+     the load-bearing governance question — whose credentials authorise
+     the action. Audit Trail's honest answer "none" is itself useful
+     governance signal.
+
+     Runtime invocation data (which agent invoked which tool, when, how
+     often) lives in observability/affordance-invocations.json and is
+     referenced — not inlined — here. HARNESS.md remains entirely
+     human-authored: the /harness-affordance add command only transcribes
+     governance fields the human dictates.
+
+     The discovery scanner (run via /harness-affordance discover) produces
+     a draft inventory from existing config. Promote entries with
+     /harness-affordance add <name> (or by hand), filling in the
+     governance-only fields (Identity, Audit trail, Last reviewed).
+
+     One affordance per permission pattern. Bash(gh *) is one affordance;
+     Bash(gh pr *) is a separate, narrower one. Field schema and value
+     definitions: docs/reference/affordance-schema.md.
+
+     Delete the example entries below once real entries are added. -->
+
+<!-- Runtime invocation data: observability/affordance-invocations.json -->
+
+### gh-cli
+
+- **Mode**: cli
+- **Identity**: runtime-resolved
+- **Audit trail**: github-audit (org audit log, 90-day retention,
+  admin-only access) — assumes credentials resolve to a real GitHub
+  identity; if `$GITHUB_TOKEN` resolves to a service account the audit
+  trail will record that account, not the user
+- **Permission**: `Bash(gh *)` (allowlist in `.claude/settings.local.json`)
+- **Last reviewed**: 2026-04-26
+- **Notes**: `gh` resolves credentials in this order: `$GITHUB_TOKEN` →
+  keychain (`gh auth login`) → fail. Confirm which path is active before
+  relying on this entry.
+
+### honeycomb-mcp
+
+- **Mode**: central-mcp (api.honeycomb.io)
+- **Identity**: service-account (HONEYCOMB_API_KEY shared across team)
+- **Audit trail**: honeycomb-query-log (per-team, 30-day retention,
+  team-admin access)
+- **Permission**: `mcp__honeycomb__*` (allowlist in user
+  `~/.claude/settings.json`)
+- **Last reviewed**: 2026-04-26
+
+### shell-write-to-tmp
+
+- **Mode**: cli
+- **Identity**: current-user (the human running the Claude Code session)
+- **Audit trail**: none
+- **Permission**: `Bash(echo *)` (allowlist)
+- **Last reviewed**: 2026-04-26
+- **Notes**: ephemeral session-local writes; if persistence is required,
+  promote to a tracked artefact
+
+### sync-to-global-cache-hook
+
+- **Mode**: hook
+- **Trigger**: Stop
+- **Identity**: current-user
+- **Audit trail**: none (hook stderr, lost at session end)
+- **Permission**: `hooks.Stop` entry in `.claude/settings.local.json`
+  invoking `ai-literacy-superpowers/scripts/sync-to-global-cache.sh`
+- **Last reviewed**: 2026-04-26
+- **Notes**: invokes `rsync` under the current user after every session
+
+---
+
 ## Observability
 
 <!-- Snapshot cadence controls how often /harness-health should run.

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.29.0 -->
+<!-- template-version: 0.54.0 -->
 
 ## Context
 
@@ -367,8 +367,8 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 
 <!-- Each entry declares one tool the agent can invoke. Identity is
      the load-bearing governance question — whose credentials authorise
-     the action. Audit Trail's honest answer "none" is itself useful
-     governance signal.
+     the action. The Audit trail field's honest answer "none" is itself
+     useful governance signal.
 
      Runtime invocation data (which agent invoked which tool, when, how
      often) lives in observability/affordance-invocations.json and is

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
@@ -1,0 +1,94 @@
+---
+title: Harness Affordances
+---
+# Harness Affordances
+
+An **affordance** is one tool the agent can invoke — a CLI command, an MCP
+server, or a hook — declared in `HARNESS.md` together with the two questions
+that matter for governance: *whose credentials does it run under?* and
+*where would you find a record of what it did?* The `## Affordances` section
+makes the agent's tool inventory a first-class, review-facing artefact,
+sibling to Context, Constraints, and Garbage Collection.
+
+## Why the section exists: the contractor scenario
+
+Imagine a contractor brought in for a two-week engagement to review a
+project's AI governance posture. Their first task is to answer, for every
+tool the agent can use: what is it, under whose authority does it run, and
+what audit trail does it leave?
+
+Without an affordances section they must reconstruct that inventory by hand:
+read `~/.claude/settings.json` and `.claude/settings.local.json` for
+permission patterns (which say *what is allowed* but not *under whose
+authority*), open and read every hook script referenced by path, consult
+each MCP server's documentation to learn whether it runs locally or hits a
+remote API under what credential, and read every `agents/*.agent.md`
+frontmatter to map agents to tools. A diligent reviewer can do this in two
+to four hours; a less-diligent one produces a wrong inventory or skips it.
+Either way the project's governance pace is gated on how thorough someone
+was on day one, because **the inventory does not exist as a review-facing
+artefact**.
+
+The deeper failure this enables: *agents executing under shared or escalated
+identity without that fact being visible at review time*. A constraint like
+"all production-affecting actions require human review" is unenforceable if
+no one knows which actions are production-affecting — which depends on which
+identity executes them.
+
+## Identity is the load-bearing question
+
+The section deliberately surfaces **Identity**, not transport, as the
+primary field. Whether a tool is a CLI or an MCP server matters less than
+whose credentials it borrows:
+
+- `user-sso` actions appear in remote audit logs *as if the human did
+  them* — the highest-attribution failure mode.
+- `service-account` actions are attributable only to a shared bot, so
+  per-user attribution is lost.
+- `current-user` actions cross no authentication boundary but are still
+  attributable to a real principal.
+- `runtime-resolved` identity depends on session configuration (env vars,
+  profile selection, IAM role) — a known unknown the reviewer must trace.
+- `none` crosses no boundary at all.
+
+**Audit Trail** is the second first-class field, and its honest answer
+`none` is itself governance signal: it tells reviewers where the gaps are
+without forcing anyone to fabricate a log that does not exist.
+
+## The source-of-truth split
+
+The section preserves the harness invariant that **`HARNESS.md` is 100%
+human-authored**. Three layers stay distinct:
+
+- **Config files** (`settings.json`, `.mcp.json`, hook registrations) are
+  the machine-derivable substrate — what is *granted*.
+- **`observability/affordance-invocations.json`** holds runtime data — which
+  agent invoked which tool, when, how often. It is *referenced* from the
+  section header, never inlined.
+- **`HARNESS.md ## Affordances`** is the review-facing prose layer humans
+  own — what is *declared*, with the governance judgments (Identity, Audit
+  Trail) that no scanner can infer.
+
+The discovery scanner reads the first layer to produce a draft; the human
+promotes entries (via `/harness-affordance add`, which only transcribes the
+governance fields they dictate) into the third. Nothing automated authors
+the prose layer.
+
+## Capability-based security, made legible
+
+Permissions enforce *what tools the agent actually has*; affordances declare
+*what tools it should have, and under what authority*. Pairing the two makes
+the governance loop explicit and sets up **chained constraints** (later
+sequencing steps) that reason across the inventory — e.g. "every affordance
+has a matching permission allowlist entry" (blocking) and "every permission
+has a declared affordance" (advisory). The affordance section is the
+declarative half of a capability model that was previously implicit in
+scattered config.
+
+## Related
+
+- [Discover affordances](../how-to/discover-affordances.md) — produce a
+  draft inventory and promote entries with `add`.
+- [Affordance schema](../reference/affordance-schema.md) — field-by-field
+  reference.
+- [Harness Affordances — Design Spec](../../../superpowers/specs/2026-04-26-harness-affordances-design.md)

--- a/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
@@ -96,21 +96,36 @@ the entries.
 
 ## Promote entries to HARNESS.md
 
-For each draft entry you want to keep:
+Use the guided `add` subcommand — it seeds from the newest discovery
+draft, prompts only for the governance fields, dates the entry, validates
+it, and writes it into `HARNESS.md`:
 
-1. **Fill in `Identity`** — whose credentials does this tool run
-   under? Use one of: `user-sso`, `service-account`, `current-user`,
-   `runtime-resolved`, `none`. See the
-   [affordances design spec](../../../superpowers/specs/2026-04-26-harness-affordances-design.md)
-   for the full definitions.
-2. **Fill in `Audit trail`** — where would you find a record of what
-   the agent did? `none` is encouraged when there genuinely is no
-   audit trail; the visibility is the point.
-3. **Set `Last reviewed`** to today's date.
-4. **Copy the entry** into `HARNESS.md` under `## Affordances`.
+```text
+/harness-affordance add gh-cli
+```
 
-In a future release `/harness-affordance add <name>` will guide
-this annotation interactively. For now it is hand-edited.
+`add` walks you through:
+
+1. **`Identity`** — whose credentials does this tool run under? One of
+   `user-sso`, `service-account`, `current-user`, `runtime-resolved`,
+   `none` (the command explains each; for `runtime-resolved` it asks for
+   the resolution chain).
+2. **`Audit trail`** — where would you find a record of what the agent
+   did? `none` is encouraged when there genuinely is no audit trail; the
+   visibility is the point.
+3. **`Last reviewed`** is set to today automatically.
+
+It then validates required fields and the `Mode`/`Trigger` pairing, warns
+(without blocking) if the permission pattern is not in any settings
+allowlist, and writes the entry — creating the `## Affordances` section if
+absent. Idempotency keys on the **permission pattern**, so re-running `add`
+for the same permission edits the existing entry in place rather than
+duplicating it, even if you give it a different heading name.
+
+You can still hand-edit `HARNESS.md` directly if you prefer; `add` is the
+guided path. See the
+[affordance schema reference](../reference/affordance-schema.md) for the
+field-by-field definitions.
 
 ## Disambiguation
 
@@ -135,14 +150,18 @@ changed.
 
 ## What the scanner does NOT do
 
-- It never writes to `HARNESS.md`. Promotion is always a human
-  action.
-- It does not read `~/.claude/settings.json` (user-level settings
-  are out of scope for project-level governance).
-- It does not infer `Identity`, `Audit trail`, or `Last reviewed` —
-  these are governance judgments that humans must make.
-- It does not ship `add` or `review` subcommands — those land in
-  later sequencing steps of the affordances design.
+- The **scanner** never writes to `HARNESS.md`. Promotion is a human
+  action — done through the guided `/harness-affordance add` (which only
+  transcribes the governance fields you dictate) or by hand.
+- The **scanner** does not read `~/.claude/settings.json` (user-level
+  settings are out of scope for project-level discovery). Note that
+  `/harness-affordance add`'s permission-existence check *does* consult
+  user-level settings, so a user-level MCP grant does not trigger a
+  spurious warning when you promote it.
+- The scanner does not infer `Identity`, `Audit trail`, or `Last
+  reviewed` — these are governance judgments that humans must make.
+- The `review` subcommand (re-validation + the staleness GC rule) lands
+  in a later sequencing step of the affordances design.
 
 ## Related
 

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
@@ -18,7 +18,12 @@ ambiguity flagged in `Notes` (or declared `Identity: runtime-resolved`).
 
 This makes affordance identity a stable string — the `Permission` pattern —
 which is what `/harness-affordance add` keys idempotency on (not the heading
-name, which you may rename freely).
+name, which you may rename freely). It follows that each entry carries
+**exactly one permission pattern** in its `Permission` field: a tool that
+needs two patterns (e.g. `Bash(echo *)` *and* `Bash(touch *)`) is two
+affordances, not one entry with a comma-joined value — otherwise the
+string-equality idempotency match would never fire and `add` would append
+duplicates.
 
 ## Fields
 

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
@@ -1,0 +1,112 @@
+---
+title: Affordance Schema
+---
+# Affordance Schema
+
+Field-by-field reference for entries in the `## Affordances` section of
+`HARNESS.md`. Each entry is one affordance — one tool the agent can invoke —
+under a `### <name>` heading, where `<name>` is a human-chosen label.
+
+## Granularity: one affordance per permission pattern
+
+The unit of an affordance is one entry in the permissions allowlist.
+`Bash(gh *)` is one affordance; `Bash(gh pr *)` is a separate, narrower
+affordance. An MCP server with twenty methods exposed under
+`mcp__server__*` is one affordance, not twenty. The same CLI used under two
+different identities in different sessions is one entry with the runtime
+ambiguity flagged in `Notes` (or declared `Identity: runtime-resolved`).
+
+This makes affordance identity a stable string — the `Permission` pattern —
+which is what `/harness-affordance add` keys idempotency on (not the heading
+name, which you may rename freely).
+
+## Fields
+
+| Field | Required | Source | Values |
+| --- | --- | --- | --- |
+| `Mode` | yes | machine-derivable | `local-mcp` / `central-mcp` / `cli` / `hook` |
+| `Trigger` | yes for `Mode: hook`; absent otherwise | machine-derivable | a Claude Code hook event (see below) |
+| `Identity` | yes | human-owned | `user-sso` / `service-account` / `current-user` / `runtime-resolved` / `none` |
+| `Audit trail` | yes | human-owned | named log with retention + access scope, or `none` |
+| `Permission` | yes | machine-derivable | the allowlist pattern that authorises this affordance |
+| `Last reviewed` | yes | procedure-controlled | `YYYY-MM-DD` |
+| `Constraint references` | optional | human-owned | constraints that depend on this affordance |
+| `Notes` | optional | human-owned | freeform context the schema does not capture |
+
+### `Mode`
+
+- `local-mcp` — MCP server running on the user's machine (may call out to
+  remote APIs).
+- `central-mcp` — MCP server hosted remotely (e.g. by the tool provider).
+- `cli` — a shell command the agent invokes (`gh`, `git`, `npx`, custom
+  scripts).
+- `hook` — a Claude Code hook script registered in settings. Each hook is
+  its own affordance; if a hook invokes a CLI internally, that CLI is *also*
+  an affordance — the hook is the surface the agent triggers, the CLI is the
+  underlying capability.
+
+### `Trigger`
+
+Present **if and only if** `Mode: hook`. One of the Claude Code hook events:
+`PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`,
+`SessionEnd`, `UserPromptSubmit`, `PreCompact`, `Notification`. Disambiguates
+a script wired to multiple events.
+
+### `Identity` — the load-bearing field
+
+*Whose credentials authorise the action?*
+
+- `user-sso` — the human's external SSO credentials (GitHub PAT, Slack
+  token, cloud SSO). Actions appear in remote audit logs as if the user did
+  them. **Highest-attribution failure mode.**
+- `service-account` — dedicated bot credentials shared across the team or
+  pinned to the project. Per-user attribution is lost.
+- `current-user` — the human running the session, no special credentials,
+  no boundary crossed (filesystem, local network, `git status`). Still
+  attributable to a real principal even with no remote audit trail —
+  distinct from `none`.
+- `runtime-resolved` — identity depends on session configuration (env vars,
+  profile, IAM role). **`Notes` must document the resolution chain.** Chained
+  constraints treat this as a known unknown and may flag it for human review.
+- `none` — no authentication boundary crossed at all (pure local
+  computation, no filesystem effects, no network).
+
+### `Audit trail`
+
+Free-text, ideally `<source>: <retention>, <access scope>` (e.g.
+`github-audit (org audit log, 90-day retention, admin-only access)`). The
+honest answer `none` is encouraged and is itself governance signal.
+
+### `Permission`
+
+Links the affordance to the entry in Claude Code's `permissions` allowlist
+that authorises it. This pairing makes the governance loop explicit:
+affordances declare what tools the agent *should* have; permissions enforce
+what it *actually* has. `/harness-affordance add` warns (without blocking) if
+the pattern is absent from `.claude/settings.json`,
+`.claude/settings.local.json`, and `~/.claude/settings.json` — an affordance
+may legitimately precede its grant.
+
+### `Last reviewed`
+
+`YYYY-MM-DD`. Set to today automatically on `add` (a genuine first review)
+and bumped thereafter only by `/harness-affordance review` (a later
+sequencing step) after three re-validation checks — Identity, Audit Trail,
+and Permission — pass. Editing other fields does **not** bump it, so the
+staleness GC rule (also a later step) stays meaningful.
+
+## Matching algorithm
+
+When a chained constraint compares affordances against permissions,
+"matching" is **string equality** on the `Permission` pattern. A permission
+`Bash(gh pr *)` matches the affordance whose `Permission` is exactly
+`Bash(gh pr *)` and no other. Broader patterns subsume narrower invocations
+rather than producing separate entries — `gh pr merge` authorised by
+`Bash(gh *)` is recorded against the single broader-pattern affordance.
+
+## Related
+
+- [Harness Affordances](../explanation/harness-affordances.md) — why the
+  section exists.
+- [Discover affordances](../how-to/discover-affordances.md) — produce and
+  promote entries.

--- a/docs/superpowers/objections/affordances-section-and-add-design-code.md
+++ b/docs/superpowers/objections/affordances-section-and-add-design-code.md
@@ -1,0 +1,82 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
+date: 2026-06-16
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: high
+    claim: "The A12 insertion anchor 'after Garbage Collection, before Status' is operationally ambiguous: the template actually places Affordances immediately before Observability, with Observability and Read-side filtering still between Affordances and Status. 'Before Status' does not uniquely identify the real insertion point."
+    evidence: "templates/HARNESS.md order: GC -> Affordances -> Observability -> Read-side filtering -> Status; add step 7 and init step 7 name only GC and Status as anchors."
+    disposition: amend
+    disposition_rationale: "Change the anchor in both add and init to the unambiguous 'immediately before ## Observability (after ## Garbage Collection)'."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "harness-init's re-run section-boundary list enumerates five headings and omits Observability and Read-side filtering, so insert/replace logic keyed on the list can mis-bound the Affordances section and swallow the two omitted sections."
+    evidence: "init step 7 boundary list: Context, Constraints, GC, Affordances, Status; template also has Observability and Read-side filtering between Affordances and Status."
+    disposition: amend
+    disposition_rationale: "Make the boundary list complete (all seven template headings) so the enumerated authority matches the general 'next ## heading' rule."
+  - id: O3
+    category: implementation
+    severity: medium
+    claim: "init step 8 validation is internally inconsistent with step 7 (different heading enumerations) and the optional-Affordances check only requires 'after GC', not the full ordered position, so a misplaced section passes validation."
+    evidence: "step 8 check 1 lists Context/Constraints/GC/Observability; step 7 list omits Observability; check 6 requires only 'after GC'."
+    disposition: amend
+    disposition_rationale: "Reconcile the two enumerations and tighten check 6 to the precise placement (immediately before Observability)."
+  - id: O4
+    category: risk
+    severity: medium
+    claim: "The template ships template-version 0.29.0 while plugin.json is 0.54.0, so the Template Currency GC rule fires a false 'template stale' signal; the artefact that documents the 0.54.0 template claims to be the 0.29.0 template."
+    evidence: "templates/HARNESS.md l.13 marker 0.29.0; plugin.json 0.54.0; this PR adds template content."
+    disposition: amend
+    disposition_rationale: "Bump the template-version marker to 0.54.0 — the template changed structurally in this release."
+  - id: O5
+    category: risk
+    severity: medium
+    claim: "The add permission check reads ~/.claude/settings.json (A2) but specifies no behaviour when that file is unreadable/absent, silently degrading to the project-only false-positive case A2 was meant to remove."
+    evidence: "add step 6 lists the three files with no read-failure handling; A2/A6 rationale."
+    disposition: amend
+    disposition_rationale: "Specify: if a settings layer cannot be read, the warning distinguishes 'not found in readable settings (could not check ~/.claude)' from a clean absence, so the warning's meaning stays honest."
+  - id: O6
+    category: implementation
+    severity: low
+    claim: "The template intro comment writes 'Audit Trail' (capital T) while the field name everywhere else is 'Audit trail' (lower-case t)."
+    evidence: "templates/HARNESS.md l.370 comment vs entry lines / reference / scanner / test."
+    disposition: amend
+    disposition_rationale: "Lower-case the comment to 'Audit trail' to match the field schema contract."
+  - id: O7
+    category: implementation
+    severity: low
+    claim: "The shell-write-to-tmp example narrowed Permission from the parent's two comma-joined patterns to one, sidestepping an A1 string-equality idempotency break, but the one-pattern-per-Permission rule is left undocumented."
+    evidence: "parent example 'Bash(echo *), Bash(touch *)'; template 'Bash(echo *)'; A1 string-equality."
+    disposition: amend
+    disposition_rationale: "Add an explicit 'one permission pattern per Permission field' note to the schema reference (follows from the granularity rule and keeps A1 idempotency sound)."
+  - id: O8
+    category: implementation
+    severity: low
+    claim: "No template example or test exercises Mode: local-mcp, the one Mode value with no worked example, despite being a governance-relevant (local-but-may-call-remote) distinction."
+    evidence: "template examples are cli/central-mcp/cli/hook; test asserts only hook + non-hook."
+    disposition: acknowledge
+    disposition_rationale: "Accepted as-is: the reference page defines local-mcp in prose and the table; adding a fifth example is not worth the template bloat. Noted for a future example refresh."
+---
+
+# Objection record — affordances section + harness-affordance add (code mode)
+
+Eight objections (2 high, 3 medium, 3 low); no critical, no premise. The two
+high objections (O1, O2) share one root: the template interleaves
+`## Observability` and `## Read-side filtering` between `## Affordances` and
+`## Status`, while every placement/boundary instruction named only Garbage
+Collection and Status as anchors — operationally ambiguous against the real
+artefact. Adjudicated 2026-06-16: seven **amend** (fixes applied in the same
+PR), one **acknowledge** (O8). All fixes are in the implementation commit
+that follows this record.
+
+## Explicitly not challenged
+
+- A1 idempotency keying on the Permission pattern (faithfully implemented
+  across command, how-to, and reference).
+- A4 status live-counting; A5 Layer 0 test scope honesty; A7 dropped forward
+  suggestion; A8 newest-draft seeding; A11 human-authored-in-spirit framing.
+- The how-to's `add` accuracy (no residual "add does not exist" claims).

--- a/docs/superpowers/objections/affordances-section-and-add-design.md
+++ b/docs/superpowers/objections/affordances-section-and-add-design.md
@@ -1,0 +1,110 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
+date: 2026-06-16
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: high
+    claim: "Idempotency keyed on heading-name matching is undermined by the scanner's order-dependent disambiguation suffixes, so a re-run add can edit the wrong entry or create a duplicate under a shifted name."
+    evidence: "spec add behaviour step 6; scanner unique_name() assigns -2/-3 suffixes from lex-sorted scan order; how-to claims stability only against array re-ordering."
+    disposition: amend
+    disposition_rationale: "Key idempotency on the Permission pattern (the parent spec's 'one affordance per permission pattern' identity + string-equality matching), not the heading name. The heading is the human's label; add matches/edits the entry whose Permission field equals the new entry's pattern."
+  - id: O2
+    category: specification quality
+    severity: high
+    claim: "The permission-existence validation says 'some settings file' but the scanner reads only project-level settings, not user-level settings where the parent spec's own examples place MCP permissions."
+    evidence: "spec add step 6; parent honeycomb-mcp example uses user-level settings; scanner reads only project settings."
+    disposition: amend
+    disposition_rationale: "Name the exact files add checks: project .claude/settings.json, .claude/settings.local.json, AND user ~/.claude/settings.json. Reading user-level settings is what makes warn-not-block safe (see O6)."
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "FR3 does not specify how Affordances integrates with harness-init's fixed five-row feature menu, placeholder-marker re-run mechanism, and mandatory four-section validation step."
+    evidence: "spec FR3; harness-init.md steps 3, 7, 8."
+    disposition: amend
+    disposition_rationale: "Specify: add a sixth 'Affordances' feature row, default OFF (opt-in) on first run, additive on re-run; define its placeholder marker; step-8 validation treats Affordances as optional (present iff selected), so a project without it still validates."
+  - id: O4
+    category: specification quality
+    severity: medium
+    claim: "FR4 ('count affordances') is underspecified: harness-status presents a fixed template from parsed Status fields, not live section parsing."
+    evidence: "spec FR4; harness-status.md steps 2, 5."
+    disposition: amend
+    disposition_rationale: "Status live-counts '### ' headings under '## Affordances' at status time (no new persisted Status field) and adds an 'Affordances: N declared' line to the summary; omit the line when the section is absent."
+  - id: O5
+    category: implementation
+    severity: medium
+    claim: "The proposed Layer 0 test over the static template block exercises no behaviour add performs, giving false confidence about the riskiest paths."
+    evidence: "spec Risks; listed assertions cover only static template shape."
+    disposition: accept
+    disposition_rationale: "Reframe the Risks section honestly: the Layer 0 test validates the TEMPLATE schema only (the static artefact). add's write logic is model-mediated and is NOT covered by it — covered instead by the add validation checkpoint and the manual acceptance scenarios. Do not present the template test as testing add."
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "Warn-not-block plus the scanner not reading user-level settings means the common MCP case warns on every legitimate add, eroding a safety signal."
+    evidence: "spec add step 6; parent Chained Constraints; scanner read scope."
+    disposition: amend
+    disposition_rationale: "Resolved by O2 (add reads user-level settings too, cutting the false-positive rate). Keep warn-not-block: an affordance may legitimately precede its grant, and this step does not own the blocking affordance-without-permission constraint (that is step 4)."
+  - id: O7
+    category: scope
+    severity: medium
+    claim: "The add step-8 suggestion of a harness-constrain 'chained-constraint hook for steps 4-5' either dead-ends or leaks step 4-5 design into this step."
+    evidence: "spec add step 8; Out of scope lists steps 4-5."
+    disposition: amend
+    disposition_rationale: "Drop the forward-pointing /harness-constrain suggestion from step 3. add ends after the write + validation checkpoint. The chaining suggestion returns in step 4 when the constraints that consume it exist."
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "The seed step matches against a dated discovery scratch file but does not say which date's file is used when multiple coexist, nor what happens when none exist."
+    evidence: "spec add step 1; scanner writes a fresh dated file per run."
+    disposition: amend
+    disposition_rationale: "Seed from the NEWEST .claude/affordance-discovery-*.md (lexically last, since names are date-stamped). If none exists or no entry matches by Permission, prompt for everything."
+  - id: O9
+    category: risk
+    severity: medium
+    claim: "The schema-lock claim conflates the finished template (concrete values) with the TODO-laden draft; the schema acceptance scenario tests the template, not add applied to a real draft."
+    evidence: "spec Schema-is-locked; scanner emits TODO placeholders."
+    disposition: accept
+    disposition_rationale: "Reframe the claim: the scanner output matches only the machine-derivable SUBSET (Mode/Permission), with Identity/Audit trail/Last reviewed as TODO placeholders the human fills. The add validation checkpoint is the guard that the placeholder->filled transform produces a schema-valid entry (no leftover TODO)."
+  - id: O10
+    category: risk
+    severity: low
+    claim: "The #205 hook-wrapper gap means a wrapper-named draft seeds a misleading name; the name-correction burden interacts with O1's name-stability problem."
+    evidence: "spec Schema-is-locked; scanner header."
+    disposition: acknowledge
+    disposition_rationale: "Note in the spec that a wrapper-hook draft seeds a wrapper-derived name the human renames at add time. Structurally mitigated by O1 (idempotency keys on Permission, not name), so a later rename does not create a duplicate."
+  - id: O11
+    category: alternatives
+    severity: low
+    claim: "The idempotent direct-write into HARNESS.md reintroduces the pattern the parent spec rejected as a Non-Goal without re-stating why add is exempt; the emit-for-paste alternative is not acknowledged."
+    evidence: "spec add step 7; parent Non-Goals + Goal 7."
+    disposition: amend
+    disposition_rationale: "User-confirmed: keep direct write. State the resolution explicitly in the spec: a guided add is human-authored in spirit — the human invokes it and dictates every governance field; the command only transcribes their answers (no autonomous agent authorship). Acknowledge the emit-for-paste alternative and why it was not chosen (UX parity with /harness-constrain)."
+  - id: O12
+    category: specification quality
+    severity: low
+    claim: "'Creating the section if it is absent' does not specify the insertion point, producing noisy diffs and interacting badly with init's section-boundary logic."
+    evidence: "spec add step 7; harness-init.md step 7."
+    disposition: amend
+    disposition_rationale: "Insertion rule: when absent, add inserts '## Affordances' after '## Garbage Collection' and before '## Status' (matching the template's section order), so init's heading-to-heading boundary logic stays stable."
+---
+
+# Objection record — affordances section + harness-affordance add (spec mode)
+
+Twelve objections (3 high, 6 medium, 3 low); no critical or premise. All
+adjudicated 2026-06-16: ten **amend** (fold the fix into the spec), two
+**accept/acknowledge** (reframe a claim honestly). O11 (direct-write vs
+emit-for-paste) was the one genuine fork and was decided by the user in
+favour of direct write, with the human-authored-in-spirit rationale made
+explicit. The adjudication is captured in the spec's "Adjudication" section
+and drives implementation.
+
+## Explicitly not challenged
+
+- The premise that a scanned draft is a dead end without a promotion path.
+- Auto-dating Last-reviewed to today on add (a genuine first review).
+- Reusing the parent field schema verbatim rather than re-deriving it.
+- The minor version bump 0.53.3 to 0.54.0.
+- The Mode/Trigger pairing rule.
+- Including docs (explanation + reference + how-to update) in scope.

--- a/docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
@@ -4,7 +4,8 @@
 **Author**: Russ Miles + assistant
 **Parent design**: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
 **Driving issue**: #200 (sequencing step 3 of the harness-affordances epic)
-**Status**: design — awaiting spec-mode `/diaboli` and user review
+**Status**: design — spec-mode `/diaboli` reviewed, all 12 dispositions
+adjudicated 2026-06-16 (see Adjudication section); ready for implementation
 
 ## Problem
 
@@ -137,6 +138,65 @@ pairing, date format), fixing deviations in place.
 - **FR4** `harness-status` counts affordance entries.
 - **FR5** Docs: explanation + reference pages, and the existing how-to
   updated for `add`.
+
+## Adjudication (post-diaboli, 2026-06-16)
+
+Spec-mode `/diaboli` raised twelve objections (record:
+`docs/superpowers/objections/affordances-section-and-add-design.md`). All
+adjudicated; the binding refinements below supersede the looser wording
+above where they conflict, and drive implementation.
+
+- **A1 (O1) — idempotency keys on the Permission pattern, not the heading
+  name.** `add` matches/edits the existing `## Affordances` entry whose
+  `Permission` field string-equals the new entry's pattern (the parent
+  spec's "one affordance per permission pattern" identity). The `### <name>`
+  heading is the human's label and may be renamed freely without creating a
+  duplicate. This dissolves the scanner-suffix instability (`gh-cli-2` vs
+  `gh-cli-3`) and the wrapper-hook rename burden (A10).
+- **A2/A6 (O2/O6) — `add` checks three settings files for the permission:**
+  `.claude/settings.json`, `.claude/settings.local.json`, and user-level
+  `~/.claude/settings.json`. Reading the user layer (where MCP grants
+  commonly live) is what keeps warn-not-block honest — it removes the
+  false-positive warnings that would otherwise erode the safety signal the
+  step-4 blocking constraint depends on. Behaviour stays **warn, not block**
+  (an affordance may legitimately precede its grant; this step does not own
+  the blocking constraint).
+- **A3 (O3) — `harness-init` integration is concrete:** add a sixth
+  selectable feature row, **Affordances (default off / opt-in)**, additive on
+  re-run; it carries its own placeholder marker like every other section; and
+  step-8 validation treats `## Affordances` as **optional** (validated only
+  when selected), so existing four-section projects still pass.
+- **A4 (O4) — `harness-status` live-counts** `### ` headings under
+  `## Affordances` at status time (no new persisted Status field) and adds an
+  `Affordances: N declared` line, omitted when the section is absent.
+- **A5 (O5) — the Layer 0 test covers the template only.** It validates the
+  static example block's field schema and Mode/Trigger pairing. It does
+  **not** test `add`'s write logic (model-mediated) — that is covered by the
+  `add` validation checkpoint and the manual acceptance scenarios. The Risks
+  section's earlier wording is corrected accordingly.
+- **A7 (O7) — drop the forward `/harness-constrain` suggestion.** `add` ends
+  after the write + validation checkpoint. The constraint-chaining suggestion
+  returns in step 4, when the constraints that consume it exist.
+- **A8 (O8) — seed from the newest draft.** `add` seeds from the lexically
+  last `.claude/affordance-discovery-*.md` (names are date-stamped), matching
+  a draft entry by Permission; if none exists or none matches, prompt for
+  everything.
+- **A9 (O9) — schema-lock claim narrowed.** The scanner output matches only
+  the machine-derivable subset (`Mode`/`Permission`); `Identity`/`Audit
+  trail`/`Last reviewed` arrive as `TODO` placeholders the human fills. The
+  `add` validation checkpoint guards that the placeholder→filled transform
+  leaves no residual `TODO` in a required field.
+- **A11 (O11) — direct write, human-authored in spirit (user-confirmed).**
+  `add` writes the entry into `HARNESS.md` directly. This is consistent with
+  the parent's "100% human-authored" invariant *in spirit*: the human invokes
+  `add` and dictates every governance field; the command only transcribes
+  their answers — no autonomous agent authorship. The emit-for-paste
+  alternative (as `discover` uses) was considered and declined for UX parity
+  with `/harness-constrain`.
+- **A12 (O12) — insertion point fixed.** When `## Affordances` is absent,
+  `add` inserts it **after `## Garbage Collection`, before `## Status`**,
+  matching the template's section order so init's heading-to-heading boundary
+  logic stays stable.
 
 ## Risks and mitigations
 

--- a/docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordances-section-and-add-design.md
@@ -1,0 +1,153 @@
+# Spec: Affordances section + `/harness-affordance add` (sequencing step 3)
+
+**Date**: 2026-06-16
+**Author**: Russ Miles + assistant
+**Parent design**: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+**Driving issue**: #200 (sequencing step 3 of the harness-affordances epic)
+**Status**: design — awaiting spec-mode `/diaboli` and user review
+
+## Problem
+
+Step 2 (PR #199) shipped the discovery scanner: `/harness-affordance
+discover` reads project config and emits a draft affordance inventory to
+a gitignored scratch file. But the inventory has no first-class home — no
+`## Affordances` section in the harness, and no guided way to promote a
+draft entry into it. A scanned draft is a dead end: the human must
+hand-copy entries into a section that does not yet exist in the template,
+filling governance fields with no guidance.
+
+This step makes the inventory a first-class part of the harness.
+
+## Scope (this spec)
+
+Sequencing step 3 only. Ships:
+
+1. **`templates/HARNESS.md` — new `## Affordances` section.** A top-level
+   section, sibling to `## Constraints` and `## Garbage Collection`,
+   carrying the schema in HTML comments, a reference to
+   `observability/affordance-invocations.json`, and four example entries
+   (cli, central-mcp, cli-under-current-user, hook) — exactly the block
+   defined in the parent spec (§ "The Affordance Block in HARNESS.md").
+2. **`commands/harness-affordance.md` — implement `add <name>`.** Replace
+   the "not yet implemented" stub with the guided-annotation flow from the
+   parent spec (§ "The `/harness-affordance` command").
+3. **`commands/harness-init.md`** — surface the affordances section as a
+   selectable feature during init and re-run.
+4. **`commands/harness-status.md`** — count affordances in the summary.
+5. **Docs** — an explanation page (why the section exists) and a reference
+   page (field-by-field schema); update the existing
+   `how-to/discover-affordances.md` to cover `add`.
+6. Minor version bump (0.53.3 → 0.54.0).
+
+**Out of scope** (later steps, per the parent spec's sequencing): the two
+chained constraints (steps 4-5), `/harness-affordance review` + the
+staleness GC rule (step 6), the runtime tuple recorder (step 7), and CI
+discovery automation (step 8).
+
+## Schema is locked against real scanner output
+
+The parent spec's field schema is reused verbatim — this spec does not
+re-derive it. The issue's "waiting for" gate (validate the schema against
+what the scanner actually produces) was discharged here: running the step-2
+scanner against a synthetic `.claude/settings.local.json` + `.mcp.json`
+emits entries with exactly `Mode`, `Identity` (TODO), `Audit trail` (TODO),
+`Permission`, and `Last reviewed` (TODO) — the machine-derivable subset of
+the schema, with the human-owned governance fields left as placeholders.
+The template's example entries therefore match the shape a real `discover`
+draft is promoted from.
+
+One known gap, already tracked as **#205** (O8 deferral): the scanner does
+not yet emit `hook`-mode entries for shell-wrapper hook commands. The
+template still carries a hand-authored hook example so the schema is
+documented even where the scanner cannot yet derive it; the `add` flow
+supports `Mode: hook` + `Trigger` regardless.
+
+## `add` — resolved open question
+
+The issue asked what `add` should do with no draft from `discover`. The
+parent spec already answers it (§ command, `add` step 1): **prompt for
+everything from scratch** (Mode, Trigger if `Mode: hook`, Permission) — do
+not refuse. A draft, when present in the discovery scratch file, is used as
+the starting point. This spec adopts that behaviour; no refuse-and-require-
+discover path.
+
+## `add <name>` behaviour
+
+Guided annotation mirroring `/harness-constrain`. Given a name:
+
+1. **Seed.** If the discovery scratch file
+   (`.claude/affordance-discovery-<date>.md`) contains an entry whose
+   derived name matches `<name>`, use its `Mode` / `Trigger` / `Permission`
+   as the starting point. Otherwise prompt for `Mode` (cli / local-mcp /
+   central-mcp / hook), `Trigger` (only if `Mode: hook`), and `Permission`.
+2. **Identity.** Prompt with the five-value definitions and the
+   load-bearing-question framing (`user-sso` / `service-account` /
+   `current-user` / `runtime-resolved` / `none`). For `runtime-resolved`,
+   require a resolution-chain narrative in Notes.
+3. **Audit trail.** Prompt with explicit "`none` is fine and is itself
+   governance signal" guidance.
+4. **Last reviewed.** Set to today's date automatically (this is a genuine
+   first review).
+5. **Optional.** Constraint references, Notes.
+6. **Validate** before writing:
+   - required fields present (`Mode`, `Identity`, `Audit trail`,
+     `Permission`, `Last reviewed`);
+   - `Trigger` present iff `Mode: hook`;
+   - `Permission` pattern actually appears in some settings file (warn, do
+     not hard-block, if absent — the affordance may precede the grant);
+   - **idempotency:** if an entry with `### <name>` already exists under
+     `## Affordances`, edit it in place rather than appending a duplicate.
+7. **Write.** Append (or replace) the entry under `## Affordances`,
+   creating the section if it is absent.
+8. **Suggest** a follow-up `/harness-constrain` pre-filled with the
+   affordance name (chained-constraint hook for steps 4-5).
+
+## Validation checkpoint
+
+Per the project's output-validation convention, `add` re-reads the entry it
+wrote and checks it against the field schema (required fields, mode/trigger
+pairing, date format), fixing deviations in place.
+
+## Acceptance scenarios
+
+1. **Section validates schema.** The template's four example entries each
+   carry every required field; the hook example carries `Trigger`; no
+   non-hook example carries `Trigger`.
+2. **`add` from a draft.** With a matching discovery draft entry, `add
+   <name>` seeds Mode/Permission from it, prompts only for the governance
+   fields, and writes a complete entry.
+3. **`add` from scratch.** With no draft, `add <name>` prompts for
+   everything and writes a complete entry.
+4. **Idempotent.** Re-running `add <name>` edits the existing entry in
+   place; the section never holds two `### <name>` headings.
+5. **init re-run.** On an existing project, init offers to add the
+   `## Affordances` section without overwriting other sections.
+6. **status counts.** `/harness-status` reports the affordance count.
+
+## Functional requirements
+
+- **FR1** `templates/HARNESS.md` carries a `## Affordances` section with
+  the schema comments, the invocation-data reference, and the four example
+  entries from the parent spec.
+- **FR2** `/harness-affordance add <name>` implements the guided flow
+  above: seed-or-prompt, governance prompts, auto-dated `Last reviewed`,
+  field validation, idempotent write, constraint-chaining suggestion.
+- **FR3** `harness-init` treats the affordances section as a selectable
+  feature, additive on re-run.
+- **FR4** `harness-status` counts affordance entries.
+- **FR5** Docs: explanation + reference pages, and the existing how-to
+  updated for `add`.
+
+## Risks and mitigations
+
+- **Schema drift between scanner and template.** Mitigated by validating
+  the template schema against live scanner output (above) and by an
+  acceptance scenario asserting the example entries carry every field.
+- **`add` is model-mediated (a command spec, not a script), so it is not
+  directly unit-testable.** Mitigated by a Layer 0 test over the *template*
+  Affordances block (deterministic: parse the example entries, assert the
+  field schema and the mode/trigger pairing) — the static artefact the
+  command produces entries against.
+- **Permission-existence check too strict.** Mitigated by warning rather
+  than hard-blocking when the pattern is absent (an affordance may be
+  declared before its permission is granted).

--- a/tdad_tests/layer0_deterministic/test-affordances-template.sh
+++ b/tdad_tests/layer0_deterministic/test-affordances-template.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the ## Affordances section in templates/HARNESS.md.
+#
+# This validates the STATIC template block (the four example entries) against
+# the affordance field schema — required fields, Mode/Trigger pairing, Mode
+# value, and Last-reviewed date format. It does NOT test /harness-affordance
+# add's write logic, which is model-mediated (a command spec, not a script);
+# that is covered by the add validation checkpoint and the spec's manual
+# acceptance scenarios (see the step-3 spec's Adjudication A5).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS="$SCRIPT_DIR/../../ai-literacy-superpowers/templates/HARNESS.md"
+
+python3 - "$HARNESS" <<'PYEOF'
+import re, sys
+
+text = open(sys.argv[1]).read()
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# Isolate the ## Affordances section (heading to next ## heading).
+m = re.search(r"^## Affordances\s*$(.*?)^## ", text, re.MULTILINE | re.DOTALL)
+if not m:
+    fail("no ## Affordances section found in templates/HARNESS.md")
+section = m.group(1)
+
+# Strip HTML comments so example field lines inside comments are not parsed.
+section_nc = re.sub(r"<!--.*?-->", "", section, flags=re.DOTALL)
+
+# Split into entries on ### headings.
+parts = re.split(r"^### (.+?)\s*$", section_nc, flags=re.MULTILINE)
+# parts = [pre, name1, body1, name2, body2, ...]
+entries = list(zip(parts[1::2], parts[2::2]))
+if len(entries) < 4:
+    fail(f"expected the 4 example entries, found {len(entries)}: "
+         f"{[n for n, _ in entries]}")
+
+VALID_MODES = {"local-mcp", "central-mcp", "cli", "hook"}
+REQUIRED = ["Mode", "Identity", "Audit trail", "Permission", "Last reviewed"]
+
+
+def field(body, name):
+    # `- **Field**: value` — value may wrap onto continuation lines.
+    m = re.search(rf"^- \*\*{re.escape(name)}\*\*:\s*(.*)$", body, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+for name, body in entries:
+    for req in REQUIRED:
+        if field(body, req) is None:
+            fail(f"entry '{name}' missing required field '{req}'")
+
+    mode = field(body, "Mode")
+    # Mode value may carry a parenthetical (e.g. "central-mcp (api.honeycomb.io)").
+    mode_word = mode.split()[0] if mode else ""
+    if mode_word not in VALID_MODES:
+        fail(f"entry '{name}' has invalid Mode '{mode}'")
+
+    trigger = field(body, "Trigger")
+    if mode_word == "hook" and trigger is None:
+        fail(f"entry '{name}' is Mode: hook but has no Trigger")
+    if mode_word != "hook" and trigger is not None:
+        fail(f"entry '{name}' is Mode: {mode_word} but declares a Trigger")
+
+    last = field(body, "Last reviewed")
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", last or ""):
+        fail(f"entry '{name}' Last reviewed is not YYYY-MM-DD: '{last}'")
+
+# At least one hook example (exercises the Trigger pairing) and one non-hook.
+modes = {field(b, "Mode").split()[0] for _, b in entries}
+if "hook" not in modes:
+    fail("expected at least one hook example to exercise the Trigger pairing")
+if not (modes - {"hook"}):
+    fail("expected at least one non-hook example")
+
+print(f"All affordance-template checks passed ({len(entries)} entries).")
+PYEOF

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -48,6 +48,7 @@ BASH_TEST_SCRIPTS = [
     "test-archive-promoted-reflections",
     "test-migrate-reflection-log",
     "test-auto-enforcer",
+    "test-affordances-template",
 ]
 
 


### PR DESCRIPTION
Closes #200. Sequencing **step 3** of the harness-affordances epic (design spec `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`).

Makes the discovery scanner's inventory a first-class part of the harness.

## What ships

- **`templates/HARNESS.md` `## Affordances` section** — top-level, between Garbage Collection and Observability; schema in comments, a reference to `observability/affordance-invocations.json`, and four worked example entries (cli, central-mcp, current-user cli, hook).
- **`/harness-affordance add <name>`** — replaces the stub with the guided flow: seed from the newest discovery draft (matched by permission pattern), prompt for Identity (five-value framing) and Audit trail ("none is fine"), auto-date `Last reviewed`, validate (required fields, Mode/Trigger pairing, permission existence across project + user settings — warn, not block), write idempotently (keyed on the **permission pattern**, not the heading, so renames never duplicate), inserting the section immediately before `## Observability` if absent.
- **`/harness-init`** — Affordances as a sixth, opt-in (default off) feature; additive and optional in re-run + validation.
- **`/harness-status`** — live-counts declared affordances.
- **Docs** — new explanation (contractor scenario, identity as the load-bearing field, source-of-truth split) + reference (field-by-field schema) pages; discover how-to updated for `add`.
- **Layer 0 test** validating the template's example entries against the schema.
- Minor bump 0.53.3 → 0.54.0.

## Spec-first + adversarial review (acceptance criteria)

- **Spec** committed as the first commit; the issue's open question (no-draft `add`) was already answered by the parent spec (prompt-from-scratch). Schema validated against real scanner output (the "waiting for" gate).
- **Spec-mode `/diaboli`**: 12 objections (3 high) — all adjudicated before implementation (record: `objections/affordances-section-and-add-design.md`). Key: idempotency keys on permission pattern (O1); `add` reads user settings (O2); concrete init integration (O3); direct-write confirmed by the user, human-authored-in-spirit (O11).
- **Code-mode `/diaboli`**: 8 objections (2 high) — 7 amended in this PR, 1 acknowledged (record: `objections/affordances-section-and-add-design-code.md`). The high pair caught a real anchor ambiguity (the template has Observability + Read-side filtering between Affordances and Status); fixed to the unambiguous "immediately before `## Observability`". Also bumped a stale template-version marker (0.29.0 → 0.54.0).

## Out of scope

The chained constraints (steps 4-5), `/harness-affordance review` + staleness GC (step 6), the runtime recorder (step 7), and CI discovery automation (step 8) — each a later sequencing step.