### PR TITLE
Affordances: chained constraints — declaration-vs-enforcement loop (steps 4+5, #201)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.54.0",
+  "plugin_version": "0.55.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.54.0"
+      "version": "0.55.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.55.0 — 2026-06-16
+
+### affordances: chained constraints — declaration-vs-enforcement loop (#201)
+
+Sequencing steps 4+5 of the harness-affordances epic: the asymmetric
+constraint pair that checks the `## Affordances` section against the
+permissions allowlist.
+
+- **`scripts/harness-affordance-check.sh`** — one deterministic `shell + jq`
+  script, two directions: `--direction=blocking` (affordance-without-
+  permission, exits 1 on a gap) and `--direction=advisory` (permission-
+  without-affordance, warns, always exits 0). Matching is **string equality**
+  on the permission pattern.
+- **Two-condition gate.** The check is `unverified` (exit 0, no-op) unless
+  the section has a real (non-example) affordance **and** a project
+  permissions allowlist is readable — so it never fires on un-migrated
+  adopters or in CI without a committed allowlist. Example entries (marked
+  `<!-- affordance-example -->`) and hook-mode affordances are skipped.
+- **Two constraint entries** in the HARNESS.md template's `## Constraints`
+  (commented opt-in, `Scope: pr`); adopters pick them up via
+  `/harness-upgrade`. The step-3 example entries gain the per-entry marker.
+- **Layer 0 tests** exercise all acceptance scenarios against hermetic
+  fixture directories (the check takes a project-dir argument).
+- Spec-mode `/diaboli` raised 12 objections (1 critical, 4 high); all
+  adjudicated before implementation — the critical caught that hook
+  affordances would false-fire the blocking check (now skipped), and the
+  enforcement model (pr scope, honest self-gating) was user-confirmed.
+
 ## 0.54.0 — 2026-06-16
 
 ### affordances: HARNESS.md section + guided `/harness-affordance add` (#200)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.54.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.55.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.54.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.55.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/harness-affordance-check.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-check.sh
@@ -12,14 +12,13 @@ set -euo pipefail
 #                         always exits 0.
 #
 # Matching is STRING EQUALITY on the permission pattern (one affordance per
-# pattern). hook-mode affordances are skipped (their Permission is a
+# pattern). Hook-mode affordances are skipped (their Permission is a
 # hooks.<Trigger> registration, not an allowlist pattern). Example entries
-# carrying <!-- affordance-example --> are skipped.
+# carrying the <!-- affordance-example --> marker are skipped.
 #
 # Reads PROJECT settings only (.claude/settings.json, .claude/settings.local.json)
-# for determinism; the user layer is not read here. The check is UNVERIFIED
-# (exit 0, no finding) unless both: a non-example affordance exists, and a
-# readable allowlist exists.
+# for determinism. The check is UNVERIFIED (exit 0, no finding) unless both: a
+# real (non-example) affordance exists, and a readable, valid allowlist exists.
 #
 # Usage: harness-affordance-check.sh [--direction=blocking|advisory] [project-dir]
 
@@ -53,89 +52,97 @@ SECTION=$(awk '
 ' "$HARNESS")
 [ -n "$SECTION" ] || unverified "no ## Affordances section in $HARNESS"
 
-# Emit one TSV row per real (non-example, non-hook) affordance:
-#   OK<TAB>name<TAB>pattern        — a well-formed single pattern
-#   DIAG<TAB>name<TAB>reason       — Permission could not be parsed cleanly
-# Example-marked and hook-mode entries are dropped entirely.
+# Parse entries into TSV rows:
+#   OK<TAB>name<TAB>pattern   — one well-formed permission pattern
+#   DIAG<TAB>name<TAB>reason  — Permission could not be parsed to one pattern
+#   DECL<TAB>pattern          — every permission-shaped token declared (incl.
+#                               multi-pattern entries), used by the advisory set
+# Example-marked and hook entries are dropped entirely. A token is
+# "permission-shaped" if it looks like Word(...), mcp__..., or hooks.... —
+# annotation paths like `.claude/settings.local.json` are ignored.
 PARSED=$(printf '%s\n' "$SECTION" | awk '
-  function flush() {
-    if (name == "" || is_example || mode == "hook") { return }
-    if (perm_raw == "") { printf "DIAG\t%s\tno Permission field\n", name; return }
-    # The pattern is the first backticked token; anything before the first
-    # " (" parenthetical that carries a comma signals multiple patterns.
-    head = perm_raw
-    p = index(head, " (")
-    if (p > 0) head = substr(head, 1, p - 1)
-    if (index(head, ",") > 0) {
+  function is_pattern(t) { return (t ~ /^[A-Za-z_]+\(/ || t ~ /^mcp__/ || t ~ /^hooks\./) }
+  function flush(   i, n, tmp, tok, is_hook) {
+    if (name == "" || is_example) return
+    n = 0; delete pats
+    tmp = perm_raw
+    while (match(tmp, /`[^`]+`/)) {
+      tok = substr(tmp, RSTART + 1, RLENGTH - 2)
+      tmp = substr(tmp, RSTART + RLENGTH)
+      if (is_pattern(tok)) { n++; pats[n] = tok }
+    }
+    is_hook = (mode == "hook")
+    for (i = 1; i <= n; i++) if (pats[i] ~ /^hooks\./) is_hook = 1
+    if (is_hook) return
+    if (n == 0) { printf "DIAG\t%s\tPermission has no recognisable pattern\n", name; return }
+    if (n > 1) {
       printf "DIAG\t%s\tmultiple permission patterns in one field (split into separate affordances)\n", name
+      for (i = 1; i <= n; i++) printf "DECL\t%s\n", pats[i]
       return
     }
-    if (match(perm_raw, /`[^`]+`/)) {
-      pat = substr(perm_raw, RSTART + 1, RLENGTH - 2)
-      printf "OK\t%s\t%s\n", name, pat
-    } else {
-      printf "DIAG\t%s\tPermission has no `pattern` token\n", name
-    }
+    printf "OK\t%s\t%s\n", name, pats[1]
+    printf "DECL\t%s\n", pats[1]
   }
-  /^### / { flush(); name = $0; sub(/^### +/, "", name); sub(/[[:space:]]+$/, "", name); is_example=0; mode=""; perm_raw="" ; next }
-  /affordance-example/ { is_example=1 }
-  /^- \*\*Mode\*\*:/ { m=$0; sub(/^- \*\*Mode\*\*:[[:space:]]*/, "", m); split(m, a, " "); mode=a[1] }
-  /^- \*\*Permission\*\*:/ { perm_raw=$0; sub(/^- \*\*Permission\*\*:[[:space:]]*/, "", perm_raw) }
+  /^### / { flush(); name = $0; sub(/^### +/, "", name); sub(/[[:space:]]+$/, "", name); is_example = 0; mode = ""; perm_raw = "" ; next }
+  /<!--[^>]*affordance-example[^>]*-->/ { is_example = 1 }
+  /^- \*\*Mode\*\*:/ { m = $0; sub(/^- \*\*Mode\*\*:[[:space:]]*/, "", m); split(m, a, " "); mode = a[1] }
+  /^- \*\*Permission\*\*:/ { perm_raw = $0; sub(/^- \*\*Permission\*\*:[[:space:]]*/, "", perm_raw) }
   END { flush() }
 ')
 
-# A real affordance exists?
-if ! printf '%s\n' "$PARSED" | grep -q '^OK\|^DIAG'; then
+# A real affordance exists? (any OK or DIAG row — POSIX grep, no GNU \|)
+if ! printf '%s\n' "$PARSED" | grep -qE '^(OK|DIAG)	'; then
   unverified "no real affordances declared (only examples, or section empty)"
 fi
 
-# Build the allowlist: union of .permissions.allow[] across readable project
-# settings files, de-duplicated, C-sorted.
+# Build the allowlist: union of .permissions.allow[] across readable, VALID
+# project settings files, de-duplicated, C-sorted. An invalid settings file
+# goes unverified rather than silently dropping its grants.
 ALLOW_FILES=()
 for f in "$PROJECT_DIR/.claude/settings.json" "$PROJECT_DIR/.claude/settings.local.json"; do
-  [ -f "$f" ] && ALLOW_FILES+=("$f")
+  if [ -f "$f" ]; then
+    jq empty "$f" >/dev/null 2>&1 || unverified "settings file $f is not valid JSON"
+    ALLOW_FILES+=("$f")
+  fi
 done
 [ "${#ALLOW_FILES[@]}" -gt 0 ] || unverified "no readable project settings allowlist (.claude/settings*.json)"
 
 ALLOWLIST=$(jq -r '.permissions.allow[]?' "${ALLOW_FILES[@]}" 2>/dev/null | LC_ALL=C sort -u)
 
-contains_pattern() {
-  printf '%s\n' "$ALLOWLIST" | grep -qxF "$1"
-}
-
-failed=0
+in_allowlist() { printf '%s\n' "$ALLOWLIST" | grep -qxF "$1"; }
 
 if [ "$DIRECTION" = "blocking" ]; then
-  # Surface parse diagnostics first (non-blocking), then real gaps (blocking).
+  diags=""
+  fails=""
   while IFS=$'\t' read -r kind name extra; do
-    [ -z "$kind" ] && continue
-    if [ "$kind" = "DIAG" ]; then
-      echo "DIAGNOSTIC: affordance '$name' — $extra"
-    fi
+    case "$kind" in
+      DIAG) diags+="DIAGNOSTIC: affordance '$name' — $extra"$'\n' ;;
+      OK)
+        if ! in_allowlist "$extra"; then
+          fails+="FAIL: affordance '$name' declares Permission $extra with no matching allowlist entry"$'\n'
+        fi
+        ;;
+    esac
   done <<< "$PARSED"
-  while IFS=$'\t' read -r kind name pat; do
-    [ "$kind" = "OK" ] || continue
-    if ! contains_pattern "$pat"; then
-      echo "FAIL: affordance '$name' declares Permission $pat with no matching allowlist entry"
-      failed=1
-    fi
-  done <<< "$PARSED"
-  if [ "$failed" -eq 0 ]; then
-    echo "OK: every declared affordance has a matching permission."
+  # Deterministic order regardless of HARNESS.md entry order.
+  [ -n "$diags" ] && printf '%s' "$diags" | LC_ALL=C sort
+  if [ -n "$fails" ]; then
+    printf '%s' "$fails" | LC_ALL=C sort
+    exit 1
   fi
-  exit "$failed"
+  echo "OK: every declared affordance has a matching permission."
+  exit 0
 else
   # advisory: allowlist patterns with no declared affordance. Never fails.
-  declared=$(printf '%s\n' "$PARSED" | awk -F '\t' '$1=="OK"{print $3}' | LC_ALL=C sort -u)
-  count=0
+  declared=$(printf '%s\n' "$PARSED" | awk -F '\t' '$1=="DECL"{print $2}' | LC_ALL=C sort -u)
+  findings=""
   while IFS= read -r pat; do
     [ -z "$pat" ] && continue
-    if ! printf '%s\n' "$declared" | grep -qxF "$pat"; then
-      echo "ADVISORY: permission $pat has no declared affordance"
-      count=$((count + 1))
-    fi
+    printf '%s\n' "$declared" | grep -qxF "$pat" || findings+="ADVISORY: permission $pat has no declared affordance"$'\n'
   done <<< "$ALLOWLIST"
-  if [ "$count" -eq 0 ]; then
+  if [ -n "$findings" ]; then
+    printf '%s' "$findings" | LC_ALL=C sort
+  else
     echo "OK: every permission has a declared affordance."
   fi
   exit 0

--- a/ai-literacy-superpowers/scripts/harness-affordance-check.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-check.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# harness-affordance-check.sh — the affordance/permission chained constraints
+# (spec 2026-06-16-affordance-chained-constraints-design.md, steps 4+5).
+#
+# Two directions, one script:
+#   --direction=blocking  affordance-without-permission. Every non-example,
+#                         non-hook affordance's Permission pattern must appear
+#                         in the permissions allowlist. Exits 1 on a gap.
+#   --direction=advisory  permission-without-affordance. Every allowlist
+#                         pattern should have a declared affordance. Warns;
+#                         always exits 0.
+#
+# Matching is STRING EQUALITY on the permission pattern (one affordance per
+# pattern). hook-mode affordances are skipped (their Permission is a
+# hooks.<Trigger> registration, not an allowlist pattern). Example entries
+# carrying <!-- affordance-example --> are skipped.
+#
+# Reads PROJECT settings only (.claude/settings.json, .claude/settings.local.json)
+# for determinism; the user layer is not read here. The check is UNVERIFIED
+# (exit 0, no finding) unless both: a non-example affordance exists, and a
+# readable allowlist exists.
+#
+# Usage: harness-affordance-check.sh [--direction=blocking|advisory] [project-dir]
+
+DIRECTION="blocking"
+PROJECT_DIR="."
+for arg in "$@"; do
+  case "$arg" in
+    --direction=blocking) DIRECTION="blocking" ;;
+    --direction=advisory) DIRECTION="advisory" ;;
+    --direction=*) echo "Unknown --direction (use blocking|advisory)" >&2; exit 2 ;;
+    *) PROJECT_DIR="$arg" ;;
+  esac
+done
+
+unverified() { echo "skipped (unverified): $1"; exit 0; }
+
+command -v jq >/dev/null 2>&1 || unverified "jq is not installed (brew install jq)"
+
+# Resolve HARNESS.md (repo root or .claude/ scaffold).
+HARNESS=""
+for cand in "$PROJECT_DIR/HARNESS.md" "$PROJECT_DIR/.claude/HARNESS.md"; do
+  [ -f "$cand" ] && { HARNESS="$cand"; break; }
+done
+[ -n "$HARNESS" ] || unverified "no HARNESS.md under $PROJECT_DIR"
+
+# Extract the ## Affordances section body (heading to next ## heading).
+SECTION=$(awk '
+  /^## Affordances[[:space:]]*$/ { inside=1; next }
+  /^## / { if (inside) exit }
+  inside { print }
+' "$HARNESS")
+[ -n "$SECTION" ] || unverified "no ## Affordances section in $HARNESS"
+
+# Emit one TSV row per real (non-example, non-hook) affordance:
+#   OK<TAB>name<TAB>pattern        — a well-formed single pattern
+#   DIAG<TAB>name<TAB>reason       — Permission could not be parsed cleanly
+# Example-marked and hook-mode entries are dropped entirely.
+PARSED=$(printf '%s\n' "$SECTION" | awk '
+  function flush() {
+    if (name == "" || is_example || mode == "hook") { return }
+    if (perm_raw == "") { printf "DIAG\t%s\tno Permission field\n", name; return }
+    # The pattern is the first backticked token; anything before the first
+    # " (" parenthetical that carries a comma signals multiple patterns.
+    head = perm_raw
+    p = index(head, " (")
+    if (p > 0) head = substr(head, 1, p - 1)
+    if (index(head, ",") > 0) {
+      printf "DIAG\t%s\tmultiple permission patterns in one field (split into separate affordances)\n", name
+      return
+    }
+    if (match(perm_raw, /`[^`]+`/)) {
+      pat = substr(perm_raw, RSTART + 1, RLENGTH - 2)
+      printf "OK\t%s\t%s\n", name, pat
+    } else {
+      printf "DIAG\t%s\tPermission has no `pattern` token\n", name
+    }
+  }
+  /^### / { flush(); name = $0; sub(/^### +/, "", name); sub(/[[:space:]]+$/, "", name); is_example=0; mode=""; perm_raw="" ; next }
+  /affordance-example/ { is_example=1 }
+  /^- \*\*Mode\*\*:/ { m=$0; sub(/^- \*\*Mode\*\*:[[:space:]]*/, "", m); split(m, a, " "); mode=a[1] }
+  /^- \*\*Permission\*\*:/ { perm_raw=$0; sub(/^- \*\*Permission\*\*:[[:space:]]*/, "", perm_raw) }
+  END { flush() }
+')
+
+# A real affordance exists?
+if ! printf '%s\n' "$PARSED" | grep -q '^OK\|^DIAG'; then
+  unverified "no real affordances declared (only examples, or section empty)"
+fi
+
+# Build the allowlist: union of .permissions.allow[] across readable project
+# settings files, de-duplicated, C-sorted.
+ALLOW_FILES=()
+for f in "$PROJECT_DIR/.claude/settings.json" "$PROJECT_DIR/.claude/settings.local.json"; do
+  [ -f "$f" ] && ALLOW_FILES+=("$f")
+done
+[ "${#ALLOW_FILES[@]}" -gt 0 ] || unverified "no readable project settings allowlist (.claude/settings*.json)"
+
+ALLOWLIST=$(jq -r '.permissions.allow[]?' "${ALLOW_FILES[@]}" 2>/dev/null | LC_ALL=C sort -u)
+
+contains_pattern() {
+  printf '%s\n' "$ALLOWLIST" | grep -qxF "$1"
+}
+
+failed=0
+
+if [ "$DIRECTION" = "blocking" ]; then
+  # Surface parse diagnostics first (non-blocking), then real gaps (blocking).
+  while IFS=$'\t' read -r kind name extra; do
+    [ -z "$kind" ] && continue
+    if [ "$kind" = "DIAG" ]; then
+      echo "DIAGNOSTIC: affordance '$name' — $extra"
+    fi
+  done <<< "$PARSED"
+  while IFS=$'\t' read -r kind name pat; do
+    [ "$kind" = "OK" ] || continue
+    if ! contains_pattern "$pat"; then
+      echo "FAIL: affordance '$name' declares Permission $pat with no matching allowlist entry"
+      failed=1
+    fi
+  done <<< "$PARSED"
+  if [ "$failed" -eq 0 ]; then
+    echo "OK: every declared affordance has a matching permission."
+  fi
+  exit "$failed"
+else
+  # advisory: allowlist patterns with no declared affordance. Never fails.
+  declared=$(printf '%s\n' "$PARSED" | awk -F '\t' '$1=="OK"{print $3}' | LC_ALL=C sort -u)
+  count=0
+  while IFS= read -r pat; do
+    [ -z "$pat" ] && continue
+    if ! printf '%s\n' "$declared" | grep -qxF "$pat"; then
+      echo "ADVISORY: permission $pat has no declared affordance"
+      count=$((count + 1))
+    fi
+  done <<< "$ALLOWLIST"
+  if [ "$count" -eq 0 ]; then
+    echo "OK: every permission has a declared affordance."
+  fi
+  exit 0
+fi

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.54.0 -->
+<!-- template-version: 0.55.0 -->
 
 ## Context
 
@@ -105,6 +105,38 @@
 - **Enforcement**: unverified
 - **Tool**: none yet
 - **Scope**: pr
+
+<!-- Uncomment if using the Affordances feature (the chained-constraint
+     pair from the harness-affordances design, steps 4-5). The check
+     self-gates to "unverified" (passes, no-op) until the project has at
+     least one real (non-example) affordance AND a readable project
+     permissions allowlist, so it is safe to leave active. Matching is
+     string equality on the permission pattern; hook-mode affordances are
+     skipped. The Tool path assumes the plugin is vendored at
+     `ai-literacy-superpowers/` (as in this repo) — adjust it to your
+     plugin install location otherwise.
+
+### Affordances have matching permissions
+
+- **Rule**: Every non-example, non-hook affordance declared in the
+  `## Affordances` section must have a `Permission` pattern that appears
+  verbatim (string equality) in the permissions allowlist
+  (`.claude/settings.json` or `.claude/settings.local.json`). An affordance
+  without a matching permission is a tool the agent has declared but cannot
+  invoke — a safety gap.
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking
+- **Scope**: pr
+
+### Permissions have declared affordances
+
+- **Rule**: Every entry in the permissions allowlist should have a matching
+  affordance in the `## Affordances` section. An ungoverned permission is
+  paperwork debt, not a safety violation — flag it, do not block.
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory
+- **Scope**: pr
+-->
 
 <!-- Uncomment if using spec-first development:
 
@@ -390,6 +422,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 <!-- Runtime invocation data: observability/affordance-invocations.json -->
 
 ### gh-cli
+<!-- affordance-example -->
 
 - **Mode**: cli
 - **Identity**: runtime-resolved
@@ -404,6 +437,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   relying on this entry.
 
 ### honeycomb-mcp
+<!-- affordance-example -->
 
 - **Mode**: central-mcp (api.honeycomb.io)
 - **Identity**: service-account (HONEYCOMB_API_KEY shared across team)
@@ -414,6 +448,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 - **Last reviewed**: 2026-04-26
 
 ### shell-write-to-tmp
+<!-- affordance-example -->
 
 - **Mode**: cli
 - **Identity**: current-user (the human running the Claude Code session)
@@ -424,6 +459,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   promote to a tracked artefact
 
 ### sync-to-global-cache-hook
+<!-- affordance-example -->
 
 - **Mode**: hook
 - **Trigger**: Stop

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
@@ -78,10 +78,26 @@ the prose layer.
 
 Permissions enforce *what tools the agent actually has*; affordances declare
 *what tools it should have, and under what authority*. Pairing the two makes
-the governance loop explicit and sets up **chained constraints** (later
-sequencing steps) that reason across the inventory — e.g. "every affordance
-has a matching permission allowlist entry" (blocking) and "every permission
-has a declared affordance" (advisory). The affordance section is the
+the governance loop explicit through an **asymmetric pair of chained
+constraints** (`scripts/harness-affordance-check.sh`) that reason across the
+inventory:
+
+- **Affordances have matching permissions** — *blocking*. Every non-example,
+  non-hook affordance's `Permission` pattern must appear verbatim in the
+  permissions allowlist. A declared tool the agent cannot actually invoke is
+  a real safety gap.
+- **Permissions have declared affordances** — *advisory*. Every allowlist
+  entry should have a governing affordance. An ungoverned grant is paperwork
+  debt, flagged not blocked.
+
+Matching is string equality on the permission pattern (one affordance per
+pattern). Both directions **self-gate to `unverified`** until the project has
+a real affordance *and* a readable allowlist, so they never fire on a project
+that has not adopted affordances yet, and they skip the example entries
+(marked with `<!-- affordance-example -->`) and hook-mode affordances (whose
+`Permission` is a hook registration, not an allowlist pattern). The
+constraints ship commented in the HARNESS.md template's `## Constraints`
+section; uncomment them to activate. The affordance section is the
 declarative half of a capability model that was previously implicit in
 scattered config.
 

--- a/docs/superpowers/objections/affordance-chained-constraints-design-code.md
+++ b/docs/superpowers/objections/affordance-chained-constraints-design-code.md
@@ -1,0 +1,95 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
+date: 2026-06-16
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: risk
+    severity: high
+    claim: "Example-skip keys on the bare substring 'affordance-example' anywhere in an entry, so a real affordance whose Notes mention it is silently skipped — a false-negative disabling the safety check for that entry."
+    evidence: "harness-affordance-check.sh: '/affordance-example/ { is_example=1 }' is unanchored."
+    disposition: amend
+    disposition_rationale: "Anchor the skip to the HTML comment marker form (<!-- ... affordance-example ... -->), not a bare substring, so prose mentioning the string cannot disable a real entry."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "DIAGNOSTIC entries are dropped from the advisory 'declared' set, so a governed permission in a multi-pattern/flagged affordance is falsely reported as an ungoverned ADVISORY."
+    evidence: "declared=$(... $1==\"OK\"{print $3} ...) excludes DIAG rows."
+    disposition: amend
+    disposition_rationale: "Emit a DECL row for every permission-shaped token in any non-example, non-hook entry (including multi-pattern ones); the advisory 'declared' set is built from DECL rows, so a flagged-but-governed permission is not reported ungoverned."
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "The comma heuristic for multi-pattern detection false-positives on a single pattern containing a comma and false-negates on space-joined patterns (only the first is extracted)."
+    evidence: "comma-before-first-' (' heuristic; match(/`[^`]+`/) extracts only the first token."
+    disposition: amend
+    disposition_rationale: "Replace the comma heuristic with counting permission-SHAPED backticked tokens (Word(...), mcp__..., hooks....): exactly 1 => OK with that pattern; >1 => DIAGNOSTIC (multiple patterns); 0 => DIAGNOSTIC (no pattern). Annotation paths like `.claude/settings.local.json` are not permission-shaped and are ignored."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "The real-affordance gate uses GNU grep alternation '\\|', literal under BSD/macOS grep (the dev platform), so a populated project self-skips to unverified — silently disabling the safety check on the enforcement machine while CI stays green."
+    evidence: "grep -q '^OK\\|^DIAG'; confirmed masked locally only by the harness ugrep wrapper."
+    disposition: amend
+    disposition_rationale: "Replace all '\\|' alternation with POSIX 'grep -qE' / separate greps. Verified the bare BSD grep treats '\\|' as literal."
+  - id: O5
+    category: risk
+    severity: medium
+    claim: "A malformed settings JSON file is silently swallowed (jq 2>/dev/null), so a corrupt file that grants a pattern yields a false blocking FAIL with no hint of the real cause."
+    evidence: "jq -r '.permissions.allow[]?' over multiple files, stderr discarded."
+    disposition: amend
+    disposition_rationale: "Validate each settings file with 'jq empty' before union; if any is invalid JSON, go unverified with a message naming the file (a parse failure must not masquerade as a governance gap)."
+  - id: O6
+    category: implementation
+    severity: medium
+    claim: "Blocking FAIL/DIAGNOSTIC lines are emitted in document order, not C-sorted, contradicting the spec's 'sorted LC_ALL=C before reporting' determinism claim (advisory IS sorted)."
+    evidence: "blocking loop iterates PARSED in document order; only advisory is sorted."
+    disposition: amend
+    disposition_rationale: "Sort the blocking DIAGNOSTIC and FAIL lines LC_ALL=C before printing, so both directions share the same determinism guarantee."
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "A hook entry with a missing/malformed Mode line is treated as non-hook and FAILs against its hooks.<Trigger> Permission — re-opening the O1 false-fire-on-hooks failure mode."
+    evidence: "mode captured only from a '- **Mode**:' line; flush skips only mode=='hook'."
+    disposition: amend
+    disposition_rationale: "Belt-and-suspenders: also skip any entry whose extracted pattern is a 'hooks.*' registration, regardless of the Mode field, so a hook with an absent/garbled Mode is still not matched against the allowlist."
+  - id: O8
+    category: implementation
+    severity: medium
+    claim: "The section extractor stops at the first line beginning '## ', so an entry whose Notes contain a column-0 '## ' line truncates the section, silently dropping later entries."
+    evidence: "awk '/^## / { if (inside) exit }' with no fenced-code awareness."
+    disposition: acknowledge
+    disposition_rationale: "Low blast radius: affordance fields are single bullet lines per the schema, and a column-0 '## ' inside an entry is malformed markdown. Documented as a constraint on entry authoring rather than hardened now; a fenced-code-aware parser is disproportionate for this step."
+  - id: O9
+    category: risk
+    severity: low
+    claim: "The Layer 0 test covers happy paths only; the adjudicated robustness behaviours (example-in-Notes, DIAGNOSTIC-in-advisory, malformed JSON, hook-without-Mode, multi-pattern) are asserted, not verified."
+    evidence: "test covers scenarios 1-7 + one hook-skip + one union; no edge fixtures."
+    disposition: amend
+    disposition_rationale: "Add Layer 0 cases for: example-marker mentioned in a real entry's Notes (must NOT skip), DIAGNOSTIC entry's permission not flagged ungoverned in advisory, malformed settings JSON => unverified, hook entry with no Mode line => skipped, space-joined multi-pattern => DIAGNOSTIC."
+  - id: O10
+    category: scope
+    severity: low
+    claim: "Both constraints ship commented-out, so the live harness never exercises them and the commented text can drift from the script's --direction contract."
+    evidence: "templates/HARNESS.md wraps both entries in one opt-in comment."
+    disposition: acknowledge
+    disposition_rationale: "Deliberate, consistent with the template's opt-in idiom for non-default features (Affordances is opt-in). The check self-gates, so the script-level Layer 0 tests are the enforcement-behaviour guarantee. Drift risk noted; a future step may activate them once affordances are in wide use."
+---
+
+# Objection record — affordance chained constraints (code mode)
+
+Ten objections: 0 critical, 4 high, 4 medium, 2 low. The implementation
+realised the adjudicated design structurally; these objections concern
+parser/gate robustness against imperfect input. Adjudicated 2026-06-16:
+eight **amend** (hardening applied in the same PR), two **acknowledge**
+(O8 low-blast-radius markdown edge; O10 deliberate commented opt-in). The
+highest-leverage fix is O4 (POSIX grep) — the gate was silently masked
+locally by the harness `ugrep` wrapper and would self-skip the safety check
+on a clean BSD-grep machine.
+
+## Explicitly not challenged
+
+- String-equality matching (parent O5), faithfully implemented via grep -qxF.
+- jq-missing => exit-0-unverified for tooling absence.
+- project-dir hermeticism (A11) and project-settings-only reads (A5).
+- The advisory always-exit-0 contract (only the DIAGNOSTIC leakage, O2).

--- a/docs/superpowers/objections/affordance-chained-constraints-design.md
+++ b/docs/superpowers/objections/affordance-chained-constraints-design.md
@@ -1,0 +1,111 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
+date: 2026-06-16
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "The 'backticked token' Permission parse extracts `hooks.Stop` for hook-mode affordances, which is never an allowlist pattern, so the blocking direction false-fires on every hook affordance."
+    evidence: "Template hook entry: '- **Permission**: `hooks.Stop` entry in `.claude/settings.local.json` invoking ...'; allowlist holds Bash(...)/mcp__ patterns, never hooks.Stop."
+    disposition: amend
+    disposition_rationale: "The blocking direction SKIPS Mode: hook affordances entirely — hook registrations are not permission-allowlist-gated, so they have no allowlist counterpart to match. Document that hooks are out of the affordance-without-permission relation."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "A 'deterministic, blocking' constraint at Scope: commit contradicts the harness model where commit scope is the advisory inner loop and strict/blocking enforcement lives at pr (CI)."
+    evidence: "constraint-design/SKILL.md: commit = PreToolUse hook (advisory), pr = CI (strict)."
+    disposition: amend
+    disposition_rationale: "Change the blocking constraint to Scope: pr (the idiomatic strict/blocking loop). See the enforcement-model decision recorded with O6/O9 (user-confirmed)."
+  - id: O3
+    category: risk
+    severity: high
+    claim: "Keying a SAFETY constraint's enforcement on deleting one sentinel line makes a silently-disabled blocking check trivial — the dangerous false-negative direction, with no meta-check that the gate never opened."
+    evidence: "Spec: 'Deleting the sentinel is the human's explicit signal'."
+    disposition: amend
+    disposition_rationale: "Replace the section-level sentinel with a PER-ENTRY example marker. The check enforces on every non-example entry automatically; there is no ceremony to forget, so the gate cannot be silently left closed. An entry being real (unmarked) is the signal, not a separate deletion."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "Deleting the sentinel while leaving example entries enforces the blocking check against fabricated example permissions."
+    evidence: "Gate condition 1 keys only on sentinel-absence, not example removal; template ships four example entries."
+    disposition: amend
+    disposition_rationale: "Resolved by the per-entry marker (O3): example-marked entries are skipped by both directions, so leftover examples never enforce. The human deletes examples and adds real entries; the check ignores whatever examples remain."
+  - id: O5
+    category: specification quality
+    severity: high
+    claim: "Reading per-machine ~/.claude/settings.json breaks the 'byte-identical output' determinism claim and diverges from the discovery scanner's project-only source set."
+    evidence: "Spec reads user layer while claiming determinism; scanner reads project config only."
+    disposition: amend
+    disposition_rationale: "The CHECK reads PROJECT settings only (.claude/settings.json, .claude/settings.local.json) — matching the discovery scanner's source set and restoring per-repo determinism. (Step 3's interactive `add` keeps reading the user layer; the deterministic CI check does not.)"
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "Advisory always-exit-0 plus blocking self-gating on every common CI/adopter config means the pair can ship enforcing nothing strict."
+    evidence: "Advisory never fails; blocking unverified when no readable allowlist; Scope commit (no CI run)."
+    disposition: amend
+    disposition_rationale: "Enforcement model (user-confirmed): blocking ships Scope: pr and enforces strictly in CI for projects that commit their permissions allowlist (.claude/settings.json). For projects that only use gitignored .claude/settings.local.json, the check honestly self-gates to unverified in CI and still runs locally. Document the enforcement points explicitly rather than implying universal CI blocking."
+  - id: O7
+    category: premise
+    severity: medium
+    claim: "The gate keys on an examples sentinel the merged step-3 template does not contain; the spec must retro-add it, and the gate is undefined for projects that adopted step 3 already."
+    evidence: "Merged template has prose 'Delete the example entries' but no machine-readable sentinel."
+    disposition: amend
+    disposition_rationale: "This PR adds the per-entry example markers to the step-3 template examples (shipped via /harness-upgrade). Projects on the pre-marker template have unmarked examples; the check will flag their fake example permissions — which is correct feedback to delete the examples — and re-running /harness-upgrade installs the markers. Note this transition window in the spec."
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "The 'Not yet configured placeholder' unverified branch references a marker string the template does not define."
+    evidence: "No such placeholder string in the template Affordances block."
+    disposition: amend
+    disposition_rationale: "Drop the placeholder branch. The gate is: section absent OR no non-example entries => nothing to enforce (vacuous pass); otherwise enforce on the non-example entries. No placeholder-string matching needed."
+  - id: O9
+    category: alternatives
+    severity: medium
+    claim: "pr scope is the idiomatic home for a deterministic blocking check and dissolves O2 and most of O6."
+    evidence: "constraint-design/SKILL.md: 'Start with pr scope for most constraints'; existing safety constraints use pr."
+    disposition: amend
+    disposition_rationale: "Adopted — blocking constraint ships Scope: pr (see O2/O6)."
+  - id: O10
+    category: implementation
+    severity: medium
+    claim: "Treating a malformed multi-pattern Permission as a 'non-match' makes a parse limitation indistinguishable from a real safety gap, both producing a blocking exit-1."
+    evidence: "Spec Risks treats malformed field as a blocking finding."
+    disposition: amend
+    disposition_rationale: "A Permission field that does not parse to a single allowlist-shaped pattern (multi-pattern, or non-pattern text) is reported as a distinct DIAGNOSTIC line, not a blocking FAIL. The blocking exit-1 is reserved for a well-formed pattern with no matching allowlist entry — a genuine gap."
+  - id: O11
+    category: scope
+    severity: medium
+    claim: "FR6 requires Layer 0 to cover scenarios depending on per-machine settings files with no fixture-injection mechanism specified."
+    evidence: "Scenarios depend on allowlist readability; FR3 read the user layer; no path override given."
+    disposition: amend
+    disposition_rationale: "The check takes a project-dir argument and (per O5) reads only project settings under it, so Layer 0 tests point it at hermetic fixture directories with synthetic .claude/settings.json + HARNESS.md. No user-layer read => fully reproducible tests."
+  - id: O12
+    category: specification quality
+    severity: low
+    claim: "Allowlist set construction across settings layers lacks a stated precedence/union rule."
+    evidence: "Spec names de-duplication but not the merge rule."
+    disposition: amend
+    disposition_rationale: "State the rule: the allowlist is the UNION of .permissions.allow[] across the readable PROJECT settings files (.claude/settings.json and .claude/settings.local.json), de-duplicated. A pattern present in either satisfies an affordance."
+---
+
+# Objection record — affordance chained constraints (spec mode)
+
+Twelve objections: 1 critical, 4 high, 6 medium, 1 low. The critical (O1)
+and two highs (O3, O4) re-opened the O8 universal-fire / silent-disable
+failure modes the gate was meant to close; O2/O5/O6/O9 concern where and
+whether the pair actually enforces. All adjudicated 2026-06-16 — every
+objection **amend**. Two resolutions are load-bearing and user-confirmed:
+(a) the blocking direction skips hook-mode affordances and reads project
+settings only; (b) gating moves from a section sentinel to per-entry example
+markers, and the blocking constraint ships `Scope: pr`. The amended design
+is captured in the spec's Adjudication section.
+
+## Explicitly not challenged
+
+- String-equality matching (settled in the parent spec's O5).
+- The asymmetric blocking/advisory split (parent O9).
+- One check script with a `--direction` flag.
+- jq-missing => exit-0-unverified for tooling absence.
+- The minor version bump and the steps 6-8 deferrals.

--- a/docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
@@ -1,0 +1,199 @@
+# Spec: Affordance chained constraints (sequencing steps 4 + 5)
+
+**Date**: 2026-06-16
+**Author**: Russ Miles + assistant
+**Parent design**: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+(Chained Constraints; O5, O8, O9 dispositions)
+**Builds on**: step 3 (`2026-06-16-affordances-section-and-add-design.md`, PR #433)
+**Driving issue**: #201
+**Status**: design — awaiting spec-mode `/diaboli` and user review
+
+## Problem
+
+Step 3 made the affordance inventory a first-class `## Affordances` section,
+but nothing yet *checks* it against reality. The whole point of pairing
+affordances with permissions is the governance loop:
+
+- **Affordances declare** what tools the agent should have access to.
+- **Permissions enforce** what the agent actually has access to.
+
+Without a constraint reasoning across both, the two drift: a permission gets
+removed without reviewing the affordance (the agent declares a tool it can no
+longer invoke), or a permission gets granted without a governing affordance
+(an ungoverned capability). Steps 4 and 5 close that loop with the
+**asymmetric pair** designed in the parent spec's O9.
+
+## Scope
+
+Sequencing steps 4 and 5, shipped together (they share one check script):
+
+1. **Affordance-without-permission (blocking).** Every affordance's
+   `Permission` pattern must appear in the permissions allowlist. A missing
+   permission is a real safety concern. Deterministic, **blocking**.
+2. **Permission-without-affordance (advisory).** Every allowlist entry
+   should have a matching affordance. A missing affordance is paperwork debt.
+   Deterministic, **advisory** (warns, never fails).
+3. One deterministic check script (`shell + jq`) backing both directions.
+4. Both constraints in `templates/HARNESS.md` under `## Constraints`;
+   adopters pick them up via `/harness-upgrade`.
+5. Layer 0 tests over the check script.
+6. Minor version bump.
+
+**Out of scope**: `/harness-affordance review` + the staleness GC rule
+(step 6), the runtime tuple recorder (step 7), CI discovery automation
+(step 8), and the further exemplar constraints (identity-confusion,
+auditless-pre-tool-hook) the parent spec lists as motivating but unbuilt.
+
+## Matching algorithm (per O5)
+
+**String equality on the permission pattern.** An affordance whose
+`Permission` field is `` `Bash(gh pr *)` `` matches the allowlist entry
+`Bash(gh pr *)` and no other. No subset reasoning, no wildcard expansion —
+broader patterns subsume narrower invocations rather than producing separate
+entries, which is exactly the "one affordance per permission pattern"
+granularity rule step 3 already enforces. This keeps the check trivially
+deterministic.
+
+The affordance's pattern is the backticked token in
+`- **Permission**: \`<pattern>\` (...)`. The allowlist patterns are the
+strings in `.permissions.allow[]` of the settings files.
+
+## Gating: stay `unverified` until comparable (resolves the #201 open question)
+
+The parent spec's O8 warns: if the constraint fires before a project has
+affordances, it fires *universally* on day one (everyone has permissions, no
+one has affordances). Two independent conditions must both hold before the
+check enforces; if either fails, the check is **`unverified`** — it exits 0
+with a one-line "skipped (unverified): <reason>" and never fails or warns.
+
+1. **Affordances are populated.** The `## Affordances` section exists and no
+   longer carries the **examples sentinel**. Step 3 ships the section with
+   four example entries; this spec adds a machine-readable sentinel comment
+   to that block:
+
+   ```text
+   <!-- affordance-examples-present: the affordance chained constraints stay
+        unverified until you replace these examples with real entries and
+        delete this line -->
+   ```
+
+   While the sentinel is present (or the section is absent, or holds only the
+   "Not yet configured" placeholder), the check is unverified. Deleting the
+   sentinel is the human's explicit "these are real affordances now" signal —
+   no separate marker file, no fragile example-name heuristic.
+
+2. **The allowlist is readable.** At least one of `.claude/settings.json`,
+   `.claude/settings.local.json`, or `~/.claude/settings.json` exists and
+   parses. This matters because `.claude/settings.local.json` and the user
+   layer are commonly gitignored/per-machine, so a CI runner may have no
+   readable allowlist. Rather than report every affordance as
+   permission-less (the O8 universal-fire failure mode, transplanted to CI),
+   the check stays unverified when it cannot see an allowlist to compare
+   against. The settings files actually read are named in the output so the
+   verdict is honest about what it could see.
+
+This makes the **blocking** direction safe everywhere: it enforces only on a
+machine that has both real affordances *and* a readable allowlist (the
+human's working tree at commit time), and self-skips in CI or on an
+un-migrated adopter. It satisfies the acceptance criterion "ships
+`unverified` for projects without an `## Affordances` section; graduates to
+`deterministic` once the section is populated" — graduation is automatic and
+data-driven, not a manual edit.
+
+## The check script
+
+`scripts/harness-affordance-check.sh [--direction=blocking|advisory] [project-dir]`
+
+1. Resolve `HARNESS.md` (project root or `.claude/HARNESS.md`). Absent → exit
+   0, unverified.
+2. Extract the `## Affordances` section. Absent, placeholder-only, or
+   examples-sentinel present → exit 0, unverified.
+3. Collect affordance `Permission` patterns (backticked token per entry).
+4. Collect allowlist patterns via `jq -r '.permissions.allow[]?'` over each
+   readable settings file (project `.claude/settings.json`,
+   `.claude/settings.local.json`, user `~/.claude/settings.json`),
+   de-duplicated. No readable file → exit 0, unverified.
+5. **`--direction=blocking`**: for each affordance pattern not in the
+   allowlist set, print `FAIL: affordance '<name>' declares Permission
+   <pattern> with no matching allowlist entry`. Any failure → exit 1.
+   Otherwise exit 0.
+6. **`--direction=advisory`**: for each allowlist pattern not in any
+   affordance's `Permission`, print `ADVISORY: permission <pattern> has no
+   declared affordance`. Always exit 0 (advisory never fails); the warnings
+   are the signal.
+
+`set -euo pipefail`; `jq` required (clear install hint if absent, exit 0
+unverified — missing tooling must not block). Deterministic: same inputs →
+byte-identical output; patterns sorted `LC_ALL=C` before reporting.
+
+## Constraint entries (templates/HARNESS.md `## Constraints`)
+
+```text
+### Affordances have matching permissions
+- **Rule**: Every affordance declared in the ## Affordances section must
+  have a Permission pattern that appears verbatim in the permissions
+  allowlist (.claude/settings.json, .claude/settings.local.json, or
+  ~/.claude/settings.json). An affordance without a permission is a tool the
+  agent has declared but cannot invoke.
+- **Enforcement**: deterministic
+- **Tool**: ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking
+- **Scope**: commit
+
+### Permissions have declared affordances
+- **Rule**: Every entry in the permissions allowlist should have a matching
+  affordance in the ## Affordances section. An ungoverned permission is
+  paperwork debt, not a safety violation — flag, do not block.
+- **Enforcement**: deterministic
+- **Tool**: ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory
+- **Scope**: commit
+```
+
+Scope is `commit` (the human's machine has the settings files the check
+needs). The check self-gates to `unverified` wherever the data is not
+present, so it is also safe if a project wires it into `pr`/CI.
+
+## Acceptance scenarios
+
+1. **Un-migrated adopter** (no `## Affordances`): both directions exit 0,
+   unverified.
+2. **Examples not yet replaced** (sentinel present): both directions exit 0,
+   unverified — no universal fire.
+3. **No readable allowlist** (CI without settings files): exit 0, unverified.
+4. **Real affordance missing its permission**: blocking exits 1 naming the
+   affordance; advisory still exits 0.
+5. **Allowlist entry with no affordance**: advisory prints the warning and
+   exits 0; blocking exits 0 (that direction does not care).
+6. **Fully paired** (every affordance has a permission and vice versa): both
+   exit 0, no findings.
+7. **Matching is string equality**: `Bash(gh *)` in the allowlist does **not**
+   satisfy an affordance declaring `Bash(gh pr *)`; they are distinct.
+
+## Functional requirements
+
+- **FR1** A deterministic `harness-affordance-check.sh` backs both
+  directions via `--direction`, using string-equality matching.
+- **FR2** Blocking direction exits non-zero on an affordance whose
+  `Permission` is absent from the allowlist; advisory direction warns and
+  always exits 0.
+- **FR3** The check is `unverified` (exit 0, no finding) unless **both** the
+  affordances are populated (examples sentinel removed) and an allowlist is
+  readable.
+- **FR4** Both constraints ship in `templates/HARNESS.md` under
+  `## Constraints`, scope `commit`, with the matching algorithm documented in
+  the Rule text.
+- **FR5** Step 3's example block gains the machine-readable examples
+  sentinel that the gate keys on.
+- **FR6** Layer 0 tests cover the seven acceptance scenarios.
+
+## Risks and mitigations
+
+- **Universal fire on day one (O8).** Mitigated by the two-condition gate
+  (FR3): no real affordances or no readable allowlist → unverified.
+- **CI has no `.claude/settings.local.json` (gitignored).** Mitigated by the
+  allowlist-readable condition — the check skips rather than failing every
+  affordance.
+- **Pattern-extraction brittleness** (multi-pattern Permission fields). Step
+  3's reference already mandates one pattern per `Permission` field; the
+  check extracts the single backticked token and treats a malformed
+  multi-pattern field as a non-match (surfaced by the blocking direction as a
+  finding the human resolves by splitting the entry).

--- a/docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordance-chained-constraints-design.md
@@ -6,7 +6,9 @@
 (Chained Constraints; O5, O8, O9 dispositions)
 **Builds on**: step 3 (`2026-06-16-affordances-section-and-add-design.md`, PR #433)
 **Driving issue**: #201
-**Status**: design — awaiting spec-mode `/diaboli` and user review
+**Status**: design — spec-mode `/diaboli` reviewed, all 12 dispositions
+adjudicated 2026-06-16 (see Adjudication; enforcement model user-confirmed);
+ready for implementation
 
 ## Problem
 
@@ -184,6 +186,68 @@ present, so it is also safe if a project wires it into `pr`/CI.
 - **FR5** Step 3's example block gains the machine-readable examples
   sentinel that the gate keys on.
 - **FR6** Layer 0 tests cover the seven acceptance scenarios.
+
+## Adjudication (post-diaboli, 2026-06-16)
+
+Spec-mode `/diaboli` raised twelve objections (1 critical, 4 high; record:
+`docs/superpowers/objections/affordance-chained-constraints-design.md`). All
+adjudicated — every objection **amend**. The binding refinements below
+supersede the original wording where they conflict, and drive
+implementation. The enforcement model (A2/A6) was confirmed by the user.
+
+- **A1 (O1, critical) — the blocking direction skips `Mode: hook`
+  affordances.** A hook's `Permission` field is a `hooks.<Trigger>`
+  registration, not a `.permissions.allow[]` pattern, so it has no allowlist
+  counterpart. Hooks are out of the affordance-without-permission relation
+  entirely (both directions ignore them). This removes the
+  false-fire-on-every-hook bug.
+- **A2/A6/A9 (O2/O6/O9) — blocking ships `Scope: pr`; honest self-gating.**
+  The blocking constraint runs in CI (the strict loop). It enforces strictly
+  for projects that **commit** their allowlist (`.claude/settings.json`); for
+  projects that only use the gitignored `.claude/settings.local.json`, the
+  check self-gates to `unverified` in CI (it cannot see an allowlist) and
+  still runs locally. The spec documents these enforcement points explicitly
+  rather than implying universal CI blocking. The advisory direction is also
+  `Scope: pr` and always exits 0 (a CI warning).
+- **A3/A4/A7/A8 (O3/O4/O7/O8) — per-entry example markers replace the section
+  sentinel.** Each template example entry carries a machine-readable
+  `<!-- affordance-example -->` marker on the line after its `### ` heading.
+  Both directions **skip** marked entries. The gate is then simply: enforce
+  on the **non-example** entries. There is no sentinel to forget to delete
+  (removing O3's silent-never-opened gate), leftover examples never enforce
+  against fabricated permissions (O4), and the "present but empty" placeholder
+  branch is dropped (O8). This PR adds the markers to the step-3 examples
+  (delivered via `/harness-upgrade`); a project still on the pre-marker
+  template gets correct "delete these examples" feedback and re-runs upgrade.
+- **A5 (O5) — the check reads PROJECT settings only**
+  (`.claude/settings.json`, `.claude/settings.local.json`), matching the
+  discovery scanner's source set and restoring per-repo determinism. The
+  user layer (`~/.claude/settings.json`) is read by step-3's interactive
+  `add`, not by this deterministic CI check.
+- **A10 (O10) — parse failures are a distinct diagnostic, not a FAIL.** A
+  `Permission` field that does not parse to a single allowlist-shaped pattern
+  (multi-pattern or free text) is reported as a `DIAGNOSTIC:` line advising
+  the human to split the entry. The blocking exit-1 is reserved for a
+  well-formed pattern with no matching allowlist entry — a genuine gap.
+- **A11 (O11) — hermetic tests via `project-dir`.** The check takes a
+  project-directory argument and reads only the project settings under it, so
+  Layer 0 tests point it at fixture directories with synthetic
+  `.claude/settings.json` + `HARNESS.md`. No user-layer read; fully
+  reproducible.
+- **A12 (O12) — allowlist is the de-duplicated union** of `.permissions.allow[]`
+  across the readable project settings files; a pattern in either satisfies
+  an affordance.
+
+### The two-condition gate (final form)
+
+The check is **`unverified`** (exit 0, no finding) unless **both**:
+
+1. the `## Affordances` section exists and has at least one **non-example**
+   entry (an entry without the `<!-- affordance-example -->` marker); and
+2. at least one project settings file with a `.permissions.allow` array is
+   readable.
+
+Otherwise it exits 0 with `skipped (unverified): <reason>`.
 
 ## Risks and mitigations
 

--- a/tdad_tests/layer0_deterministic/test-affordance-check.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for harness-affordance-check.sh (affordance chained constraints,
+# steps 4+5). The check takes a project-dir argument and reads only project
+# settings under it, so every scenario runs against a hermetic fixture dir.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/harness-affordance-check.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# mkproj <harness-body> <allowlist-json|-> -> echoes a temp project dir.
+# allowlist "-" means write no settings file.
+mkproj() {
+  local dir; dir=$(mktemp -d)
+  mkdir -p "$dir/.claude"
+  printf '%s\n' "$1" > "$dir/HARNESS.md"
+  if [ "$2" != "-" ]; then
+    printf '%s\n' "$2" > "$dir/.claude/settings.json"
+  fi
+  printf '%s' "$dir"
+}
+
+# run <dir> <direction> -> sets RC and OUT
+run() {
+  set +e
+  OUT=$("$CHECK" --direction="$2" "$1" 2>&1)
+  RC=$?
+  set -e
+}
+
+REAL='# H
+## Affordances
+### my-tool
+- **Mode**: cli
+- **Permission**: `Bash(foo *)` (allowlist)
+## Status'
+
+# Scenario 1: no ## Affordances section -> unverified, exit 0.
+d=$(mkproj '# H
+## Constraints' '{"permissions":{"allow":["Bash(foo *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "no-section should exit 0 (got $RC)"
+echo "$OUT" | grep -q "unverified" || fail "no-section should report unverified: $OUT"
+rm -rf "$d"
+
+# Scenario 2: only an example-marked entry -> unverified.
+d=$(mkproj '# H
+## Affordances
+### gh-cli
+<!-- affordance-example -->
+- **Mode**: cli
+- **Permission**: `Bash(gh *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(gh *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "examples-only should exit 0 (got $RC)"
+echo "$OUT" | grep -q "unverified" || fail "examples-only should be unverified: $OUT"
+rm -rf "$d"
+
+# Scenario 3: real affordance but no readable allowlist -> unverified.
+d=$(mkproj "$REAL" '-')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "no-allowlist should exit 0 (got $RC)"
+echo "$OUT" | grep -q "unverified" || fail "no-allowlist should be unverified: $OUT"
+rm -rf "$d"
+
+# Scenario 4: real affordance missing its permission -> blocking exit 1; advisory exit 0.
+d=$(mkproj "$REAL" '{"permissions":{"allow":["Bash(other *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 1 ] || fail "missing-permission blocking should exit 1 (got $RC)"
+echo "$OUT" | grep -q "FAIL: affordance 'my-tool'" || fail "blocking should name the gap: $OUT"
+run "$d" advisory
+[ "$RC" -eq 0 ] || fail "advisory should always exit 0 (got $RC)"
+echo "$OUT" | grep -q "ADVISORY: permission Bash(other \*)" || fail "advisory should flag the ungoverned permission: $OUT"
+rm -rf "$d"
+
+# Scenario: hook-mode affordance is skipped (its Permission is a hooks.* registration).
+d=$(mkproj '# H
+## Affordances
+### a-hook
+- **Mode**: hook
+- **Trigger**: Stop
+- **Permission**: `hooks.Stop` entry in `.claude/settings.local.json`
+### my-tool
+- **Mode**: cli
+- **Permission**: `Bash(foo *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(foo *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "hook should be skipped, my-tool matches -> exit 0 (got $RC: $OUT)"
+echo "$OUT" | grep -q "a-hook" && fail "hook affordance must not appear as a finding: $OUT"
+rm -rf "$d"
+
+# Scenario 6: fully paired -> both clean, exit 0.
+d=$(mkproj "$REAL" '{"permissions":{"allow":["Bash(foo *)"]}}')
+run "$d" blocking; [ "$RC" -eq 0 ] || fail "paired blocking should exit 0 (got $RC: $OUT)"
+run "$d" advisory; [ "$RC" -eq 0 ] || fail "paired advisory should exit 0 (got $RC: $OUT)"
+echo "$OUT" | grep -q "every permission has a declared affordance" || fail "paired advisory should report clean: $OUT"
+rm -rf "$d"
+
+# Scenario 7: string equality — Bash(gh *) does not satisfy Bash(gh pr *).
+d=$(mkproj '# H
+## Affordances
+### gh-pr
+- **Mode**: cli
+- **Permission**: `Bash(gh pr *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(gh *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 1 ] || fail "string-equality: broad pattern must not satisfy narrow (got $RC: $OUT)"
+rm -rf "$d"
+
+# Scenario: malformed multi-pattern Permission -> DIAGNOSTIC, not a blocking FAIL.
+d=$(mkproj '# H
+## Affordances
+### multi
+- **Mode**: cli
+- **Permission**: `Bash(echo *)`, `Bash(touch *)` (allowlist)
+### good
+- **Mode**: cli
+- **Permission**: `Bash(ok *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(ok *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "diagnostic should not block when no real gap (got $RC: $OUT)"
+echo "$OUT" | grep -q "DIAGNOSTIC: affordance 'multi'" || fail "multi-pattern should emit a diagnostic: $OUT"
+echo "$OUT" | grep -q "FAIL:" && fail "multi-pattern must not be a FAIL: $OUT"
+rm -rf "$d"
+
+# Allowlist union across both settings files.
+d=$(mktemp -d); mkdir -p "$d/.claude"
+printf '%s\n' "$REAL" > "$d/HARNESS.md"
+echo '{"permissions":{"allow":["Bash(base *)"]}}' > "$d/.claude/settings.json"
+echo '{"permissions":{"allow":["Bash(foo *)"]}}' > "$d/.claude/settings.local.json"
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "union: .local grant should satisfy the affordance (got $RC: $OUT)"
+rm -rf "$d"
+
+echo "All affordance-check tests passed."

--- a/tdad_tests/layer0_deterministic/test-affordance-check.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-check.sh
@@ -133,4 +133,69 @@ run "$d" blocking
 [ "$RC" -eq 0 ] || fail "union: .local grant should satisfy the affordance (got $RC: $OUT)"
 rm -rf "$d"
 
+# O1: a real entry whose Notes mention "affordance-example" (without the
+# comment marker) must NOT be skipped — it still enforces.
+d=$(mkproj '# H
+## Affordances
+### real-tool
+- **Mode**: cli
+- **Permission**: `Bash(foo *)` (allowlist)
+- **Notes**: see the affordance-example section of the docs
+## Status' '{"permissions":{"allow":["Bash(other *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 1 ] || fail "O1: entry mentioning affordance-example in Notes must still enforce (got $RC: $OUT)"
+rm -rf "$d"
+
+# O2: a DIAGNOSTIC (multi-pattern) entry's permissions must NOT be reported as
+# ungoverned by the advisory direction.
+d=$(mkproj '# H
+## Affordances
+### multi
+- **Mode**: cli
+- **Permission**: `Bash(a *)`, `Bash(b *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(a *)","Bash(b *)"]}}')
+run "$d" advisory
+echo "$OUT" | grep -q "ADVISORY" && fail "O2: governed multi-pattern permissions must not be flagged ungoverned: $OUT"
+rm -rf "$d"
+
+# O3: space-joined two patterns -> DIAGNOSTIC (not silently one OK).
+d=$(mkproj '# H
+## Affordances
+### space-joined
+- **Mode**: cli
+- **Permission**: `Bash(a *)` `Bash(b *)` (allowlist)
+### good
+- **Mode**: cli
+- **Permission**: `Bash(ok *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(ok *)"]}}')
+run "$d" blocking
+echo "$OUT" | grep -q "DIAGNOSTIC: affordance 'space-joined'" || fail "O3: space-joined patterns should diagnose: $OUT"
+[ "$RC" -eq 0 ] || fail "O3: diagnostic must not block when no real gap (got $RC: $OUT)"
+rm -rf "$d"
+
+# O5: malformed settings JSON -> unverified (not a false FAIL).
+d=$(mktemp -d); mkdir -p "$d/.claude"
+printf '%s\n' "$REAL" > "$d/HARNESS.md"
+printf '{ this is not json' > "$d/.claude/settings.json"
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "O5: malformed JSON should go unverified, not FAIL (got $RC: $OUT)"
+echo "$OUT" | grep -q "not valid JSON" || fail "O5: should name the invalid settings file: $OUT"
+rm -rf "$d"
+
+# O7: a hook entry with NO Mode line is still skipped (its Permission is a
+# hooks.* registration).
+d=$(mkproj '# H
+## Affordances
+### modeless-hook
+- **Trigger**: Stop
+- **Permission**: `hooks.Stop` entry in `.claude/settings.local.json`
+### my-tool
+- **Mode**: cli
+- **Permission**: `Bash(foo *)` (allowlist)
+## Status' '{"permissions":{"allow":["Bash(foo *)"]}}')
+run "$d" blocking
+[ "$RC" -eq 0 ] || fail "O7: hook with no Mode line must be skipped (got $RC: $OUT)"
+echo "$OUT" | grep -q "modeless-hook" && fail "O7: modeless hook must not be a finding: $OUT"
+rm -rf "$d"
+
 echo "All affordance-check tests passed."

--- a/tdad_tests/layer0_deterministic/test-affordance-check.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-check.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# shellcheck disable=SC2016
+# The single-quoted HARNESS.md fixtures below contain literal markdown
+# backticks (e.g. `Bash(foo *)`) and must NOT be expanded — that is the whole
+# point of the affordance Permission field. SC2016 is suppressed file-wide.
+#
 # Layer 0 test for harness-affordance-check.sh (affordance chained constraints,
 # steps 4+5). The check takes a project-dir argument and reads only project
 # settings under it, so every scenario runs against a hermetic fixture dir.

--- a/tdad_tests/layer0_deterministic/test-affordance-check.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-check.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
 # shellcheck disable=SC2016
-# The single-quoted HARNESS.md fixtures below contain literal markdown
-# backticks (e.g. `Bash(foo *)`) and must NOT be expanded — that is the whole
-# point of the affordance Permission field. SC2016 is suppressed file-wide.
-#
+# (SC2016 suppressed file-wide: the single-quoted HARNESS.md fixtures below
+# contain literal markdown backticks — e.g. `Bash(foo *)` — that must NOT be
+# expanded; that is the whole point of the affordance Permission field. A
+# file-level directive must precede the first command, hence its position
+# above `set`.)
+set -euo pipefail
 # Layer 0 test for harness-affordance-check.sh (affordance chained constraints,
 # steps 4+5). The check takes a project-dir argument and reads only project
 # settings under it, so every scenario runs against a hermetic fixture dir.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -49,6 +49,7 @@ BASH_TEST_SCRIPTS = [
     "test-migrate-reflection-log",
     "test-auto-enforcer",
     "test-affordances-template",
+    "test-affordance-check",
 ]
 
 


### PR DESCRIPTION
Closes #201. Sequencing **steps 4+5** of the harness-affordances epic — the asymmetric constraint pair that closes the declaration-vs-enforcement loop (design `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`).

## What ships

- **`scripts/harness-affordance-check.sh`** — one deterministic `shell + jq` check, two directions:
  - `--direction=blocking` — affordance-without-permission. Every non-example, non-hook affordance's `Permission` pattern must appear in the allowlist; exits 1 on a gap.
  - `--direction=advisory` — permission-without-affordance. Every allowlist entry should have an affordance; warns, always exits 0.
  - Matching is **string equality** on the permission pattern. Hook-mode affordances and example-marked entries are skipped; parse failures are a distinct **DIAGNOSTIC** class, not a blocking FAIL.
- **Two-condition gate** → `unverified` (no-op) unless a real (non-example) affordance exists **and** a valid project allowlist is readable, so it never fires on un-migrated adopters or in CI without a committed allowlist.
- **Two constraint entries** in the HARNESS.md template (`## Constraints`, commented opt-in, `Scope: pr`); per-entry `<!-- affordance-example -->` markers on the step-3 examples.
- **Layer 0 tests** across all acceptance scenarios + the hardening edge cases, hermetic via the check's `project-dir` argument.
- Minor bump 0.54.0 → 0.55.0.

## Spec-first + adversarial review

- **Spec** committed first; resolved the issue's open **gating question** (two-condition gate) and the enforcement model.
- **Spec-mode `/diaboli`**: 12 objections (**1 critical**, 4 high), all adjudicated before implementation (`objections/affordance-chained-constraints-design.md`). The critical caught that hook affordances (`Permission: \`hooks.Stop\`…`) would false-fire the blocking check — now skipped. Enforcement model (`pr` scope, honest self-gating) **user-confirmed**.
- **Code-mode `/diaboli`**: 10 objections (4 high), 8 amended + 2 acknowledged (`…-code.md`). The standout was a **BSD-vs-GNU grep portability bug** (`\|` is literal in BSD grep) that was masked locally by the harness `ugrep` wrapper and would have silently self-skipped the safety check on a clean macOS/CI machine — fixed to POSIX `grep -qE` and **verified with `/usr/bin/grep`**. Also hardened the example-marker anchor, multi-pattern detection, advisory `declared` set, JSON validation, output sorting, and hook-skip robustness.

## Out of scope

`/harness-affordance review` + staleness GC (step 6), the runtime recorder (step 7), CI discovery automation (step 8) — each a later step.