### PR TITLE
Affordances: review subcommand + staleness GC rule (step 6, #202)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.55.0",
+  "plugin_version": "0.56.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.55.0"
+      "version": "0.56.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -230,15 +230,17 @@ jobs:
           # as a warning so a stale/undated entry reaches a reader on the cron.
           out=$(bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh 2>&1 || true)
           echo "$out"
-          {
-            echo "### Affordance review staleness"
-            echo ""
-            echo '```'
-            echo "$out"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          if echo "$out" | grep -qE '^(STALE|UNDATED):'; then
-            echo "::warning::Affordance review staleness: some affordances are overdue for review — run /harness-affordance review <name>"
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+              echo "### Affordance review staleness"
+              echo ""
+              echo '```'
+              echo "$out"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if echo "$out" | grep -qE '^(STALE|UNDATED|FUTURE):'; then
+            echo "::warning::Affordance review staleness: some affordances are overdue for review or have a bad date — run /harness-affordance review <name>"
           fi
 
       - name: Summary

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -219,6 +219,28 @@ jobs:
             echo "No promoted entries to archive this week"
           fi
 
+      - name: "GC: Affordance review staleness"
+        run: |
+          if [ ! -x ai-literacy-superpowers/scripts/harness-affordance-staleness.sh ]; then
+            echo "harness-affordance-staleness.sh missing or not executable — skipping"
+            exit 0
+          fi
+          # Report-only: the scanner self-skips when there is no ## Affordances
+          # section and always exits 0. Surface findings in the step summary and
+          # as a warning so a stale/undated entry reaches a reader on the cron.
+          out=$(bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh 2>&1 || true)
+          echo "$out"
+          {
+            echo "### Affordance review staleness"
+            echo ""
+            echo '```'
+            echo "$out"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if echo "$out" | grep -qE '^(STALE|UNDATED):'; then
+            echo "::warning::Affordance review staleness: some affordances are overdue for review — run /harness-affordance review <name>"
+          fi
+
       - name: Summary
         if: always()
         run: echo "GC run complete. See HARNESS.md for rule details."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.56.0 — 2026-06-16
+
+### affordances: review subcommand + staleness GC rule (#202)
+
+Sequencing step 6 of the harness-affordances epic — the per-affordance
+staleness loop.
+
+- **`/harness-affordance review <name>`** — interactive re-validation that
+  bumps `Last reviewed` to today **only if all three checks pass** (Identity,
+  Audit trail, Permission), each with an explicit `yes / no / needs-edit`
+  prompt. A bump after any edit requires re-answering all three; a failing
+  check leaves the date and records a single idempotent `[review-gap: <check>]`
+  Notes line. Inline edits follow the same human-dictates/command-transcribes
+  discipline as `add`.
+- **`scripts/harness-affordance-staleness.sh`** — a deterministic, report-only
+  scanner that flags non-example affordances (hooks **included**) whose
+  `Last reviewed` is older than the threshold, or undated. UTC-normalised age
+  (`--today` makes it hermetic). Threshold precedence: `--max-age-days` flag >
+  a human-owned `<!-- affordance-review-threshold-days: N -->` marker the
+  scanner reads from HARNESS.md > default 180.
+- **Weekly GC**: a `gc.yml` step runs the scanner, prints findings to the step
+  summary, and emits a `::warning::` when any exist (self-skips with no
+  `## Affordances` section) — so the rule genuinely runs on the cron, not only
+  via `/harness-gc`. A matching template GC rule (commented opt-in) covers the
+  on-demand agent path.
+- **Layer 0 tests** over the scanner (stale/fresh/undated, hook inclusion,
+  example skip, threshold override, marker read, UTC determinism).
+- Spec-mode `/diaboli` raised 10 objections (3 high), all adjudicated before
+  implementation — the load-bearing fix wired the rule into `gc.yml` (a
+  template GC rule alone is never run by the hardcoded cron) and made the
+  scanner read the threshold from HARNESS.md rather than only a CLI flag.
+
 ## 0.55.0 — 2026-06-16
 
 ### affordances: chained constraints — declaration-vs-enforcement loop (#201)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.55.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.56.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.55.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.56.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/commands/harness-affordance.md
+++ b/ai-literacy-superpowers/commands/harness-affordance.md
@@ -1,6 +1,6 @@
 ---
 name: harness-affordance
-description: Manage the project's affordance inventory — declared tools the agent can invoke, the identity each tool runs under, and the audit trail each tool produces. Subcommands - discover (scan config to produce a draft inventory), add (promote a draft into HARNESS.md with governance metadata), review (planned). See docs/superpowers/specs/2026-04-26-harness-affordances-design.md for the design.
+description: Manage the project's affordance inventory — declared tools the agent can invoke, the identity each tool runs under, and the audit trail each tool produces. Subcommands - discover (scan config to produce a draft inventory), add (promote a draft into HARNESS.md with governance metadata), review (re-validate one affordance and bump its Last reviewed date if all three checks pass). See docs/superpowers/specs/2026-04-26-harness-affordances-design.md for the design.
 ---
 
 # /harness-affordance \<subcommand\> [args...]
@@ -142,16 +142,53 @@ Report the entry written and its location. (Constraint-chaining — suggesting
 a `/harness-constrain` that references this affordance — arrives in
 sequencing step 4, once the chained constraints that consume it exist.)
 
-### `review` *(not yet implemented)*
+### `review <name>`
 
-Planned for sequencing step 6. Will walk through the three
-re-validation checks (Identity, Audit trail, Permission) and bump
-`Last reviewed` if all pass.
+Interactive re-validation of one affordance. Bumps its `Last reviewed` date
+to today **only if all three checks pass**, so the date attests to a genuine
+human re-validation rather than a `git log` mtime. Like `add`, any field the
+human chooses to edit is **dictated by the human and transcribed by the
+command** — the command never authors governance content.
 
-If invoked today, tell the user: "`/harness-affordance review` is
-not yet implemented (sequencing step 6 of the affordances design).
-For now, hand-edit `Last reviewed` after manually re-validating
-the three checks listed in the design spec."
+Match `<name>` to a `### <name>` heading under `## Affordances` (if no match,
+say so and list the headings). Then walk the three checks, each with an
+explicit `still correct? yes / no / needs-edit` prompt — **no implicit
+"everything looks fine" passing**:
+
+1. **Identity check.** Show the entry's `Identity`. For `runtime-resolved`,
+   ask specifically whether the resolution chain in `Notes` still holds; for
+   fixed identities, whether the named credential still exists and belongs to
+   the named principal.
+2. **Audit trail check.** Show the `Audit trail`. The endpoint still exists,
+   retention matches what is stated, access scope holds. For `none`, confirm
+   no audit log has been added since the last review.
+3. **Permission check.** Show the `Permission`. Confirm the pattern is still
+   present in a settings allowlist (`.claude/settings.json`,
+   `.claude/settings.local.json`, or `~/.claude/settings.json`).
+
+**Disposition:**
+
+- **All three `yes`** → bump `Last reviewed` to today, and **remove any
+  `[review-gap: <check>]` Notes lines** for checks that now pass.
+- **Any `needs-edit`** → open that field for inline edit (the human dictates
+  the new value; you transcribe it). An edit alone does **not** bump the
+  date: a bump after any edit requires the human to re-answer **all three**
+  checks `yes` — do not shortcut to a single-field confirmation.
+- **Any `no`** the human cannot resolve in-session → leave `Last reviewed`
+  **unchanged** and record the gap as a single Notes line per failing check,
+  prefixed `[review-gap: <check>]` (Identity / Audit trail / Permission).
+  **Update that line in place** if one already exists for the check rather
+  than appending a duplicate, so the staleness rule keeps firing without the
+  Notes section growing unbounded. Editing `Notes` or `Constraint references`
+  never bumps the date on its own.
+
+Validation checkpoint: re-read the entry; confirm `Last reviewed` is a
+`YYYY-MM-DD` date and was bumped **iff** all three checks passed this session.
+
+(Staleness is surfaced separately by the `Affordance review staleness` GC
+rule — `scripts/harness-affordance-staleness.sh` — which flags entries whose
+`Last reviewed` is older than the configured threshold. `review` is the fix
+for what that rule reports.)
 
 ## Routing
 

--- a/ai-literacy-superpowers/scripts/harness-affordance-check.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-check.sh
@@ -84,7 +84,7 @@ PARSED=$(printf '%s\n' "$SECTION" | awk '
     printf "DECL\t%s\n", pats[1]
   }
   /^### / { flush(); name = $0; sub(/^### +/, "", name); sub(/[[:space:]]+$/, "", name); is_example = 0; mode = ""; perm_raw = "" ; next }
-  /<!--[^>]*affordance-example[^>]*-->/ { is_example = 1 }
+  /^[[:space:]]*<!--[[:space:]]*affordance-example[[:space:]]*-->[[:space:]]*$/ { is_example = 1 }
   /^- \*\*Mode\*\*:/ { m = $0; sub(/^- \*\*Mode\*\*:[[:space:]]*/, "", m); split(m, a, " "); mode = a[1] }
   /^- \*\*Permission\*\*:/ { perm_raw = $0; sub(/^- \*\*Permission\*\*:[[:space:]]*/, "", perm_raw) }
   END { flush() }

--- a/ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
@@ -37,21 +37,6 @@ for cand in "$PROJECT_DIR/HARNESS.md" "$PROJECT_DIR/.claude/HARNESS.md"; do
 done
 [ -n "$HARNESS" ] || { echo "No HARNESS.md under $PROJECT_DIR — nothing to check."; exit 0; }
 
-# Threshold: flag > HARNESS.md marker > default 180.
-MAX_AGE=180
-marker=$(grep -oE 'affordance-review-threshold-days:[[:space:]]*[0-9]+' "$HARNESS" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
-[ -n "$marker" ] && MAX_AGE="$marker"
-[ -n "$MAX_AGE_FLAG" ] && MAX_AGE="$MAX_AGE_FLAG"
-
-# UTC epoch (midnight) for a YYYY-MM-DD string; empty on parse failure.
-date_to_epoch() {
-  date -u -j -f '%Y-%m-%d' "$1" '+%s' 2>/dev/null || date -u -d "$1" '+%s' 2>/dev/null || true
-}
-
-TODAY="${TODAY_OVERRIDE:-$(date -u '+%Y-%m-%d')}"
-TODAY_EPOCH=$(date_to_epoch "$TODAY")
-[ -n "$TODAY_EPOCH" ] || { echo "Could not parse today's date ($TODAY)." >&2; exit 0; }
-
 # Extract the ## Affordances section body (heading to next ## heading).
 SECTION=$(awk '
   /^## Affordances[[:space:]]*$/ { inside=1; next }
@@ -60,6 +45,37 @@ SECTION=$(awk '
 ' "$HARNESS")
 [ -n "$SECTION" ] || { echo "No ## Affordances section in $HARNESS — nothing to check."; exit 0; }
 
+# Threshold: flag > HARNESS.md marker > default 180. The marker is read from
+# the ## Affordances section only (its designated home), never the whole file.
+MAX_AGE=180
+marker=$(printf '%s\n' "$SECTION" | grep -oE 'affordance-review-threshold-days:[[:space:]]*[0-9]+' 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+[ -n "$marker" ] && MAX_AGE="$marker"
+[ -n "$MAX_AGE_FLAG" ] && MAX_AGE="$MAX_AGE_FLAG"
+
+# UTC-midnight epoch for a YYYY-MM-DD string; empty on parse failure OR when the
+# parsed epoch does not round-trip back to the exact input (rejects
+# calendar-impossible dates like 2026-02-30 identically on BSD and GNU). The
+# explicit 00:00:00 pins midnight UTC on both date implementations — BSD
+# `date -u -j -f '%Y-%m-%d'` alone fills the time-of-day from localtime-now.
+date_to_epoch() {
+  local epoch
+  epoch=$(date -u -j -f '%Y-%m-%d %H:%M:%S' "$1 00:00:00" '+%s' 2>/dev/null \
+        || date -u -d "$1 00:00:00 UTC" '+%s' 2>/dev/null || true)
+  [ -n "$epoch" ] || return 0
+  # Round-trip: the epoch must reformat to the same calendar date.
+  local back
+  back=$(date -u -j -f '%s' "$epoch" '+%Y-%m-%d' 2>/dev/null \
+       || date -u -d "@$epoch" '+%Y-%m-%d' 2>/dev/null || true)
+  [ "$back" = "$1" ] && printf '%s' "$epoch"
+  # Always succeed: failure is signalled by empty output, never a non-zero
+  # exit (which would abort the caller's `x=$(date_to_epoch ...)` under set -e).
+  return 0
+}
+
+TODAY="${TODAY_OVERRIDE:-$(date -u '+%Y-%m-%d')}"
+TODAY_EPOCH=$(date_to_epoch "$TODAY")
+[ -n "$TODAY_EPOCH" ] || { echo "Could not parse today's date ($TODAY)." >&2; exit 0; }
+
 # Emit one row per non-example entry: name<TAB>last_reviewed (date may be empty).
 # Classification is by the example marker only — hooks are included.
 ENTRIES=$(printf '%s\n' "$SECTION" | awk '
@@ -67,7 +83,7 @@ ENTRIES=$(printf '%s\n' "$SECTION" | awk '
     if (name != "" && !is_example) printf "%s\t%s\n", name, last
   }
   /^### / { flush(); name=$0; sub(/^### +/,"",name); sub(/[[:space:]]+$/,"",name); is_example=0; last=""; next }
-  /<!--[^>]*affordance-example[^>]*-->/ { is_example=1 }
+  /^[[:space:]]*<!--[[:space:]]*affordance-example[[:space:]]*-->[[:space:]]*$/ { is_example=1 }
   /^- \*\*Last reviewed\*\*:/ { last=$0; sub(/^- \*\*Last reviewed\*\*:[[:space:]]*/,"",last); sub(/[[:space:]].*$/,"",last) }
   END { flush() }
 ')
@@ -86,7 +102,9 @@ while IFS=$'\t' read -r name last; do
     continue
   fi
   age_days=$(( (TODAY_EPOCH - reviewed_epoch) / 86400 ))
-  if [ "$age_days" -gt "$MAX_AGE" ]; then
+  if [ "$age_days" -lt 0 ]; then
+    findings+="FUTURE: affordance '$name' Last reviewed $last is in the future — not a credible review date"$'\n'
+  elif [ "$age_days" -gt "$MAX_AGE" ]; then
     findings+="STALE: affordance '$name' last reviewed $last ($age_days days ago; threshold $MAX_AGE)"$'\n'
   fi
 done <<< "$ENTRIES"

--- a/ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# harness-affordance-staleness.sh — the affordance review-staleness GC rule
+# (spec 2026-06-16-affordance-review-and-staleness-design.md, step 6).
+#
+# Flags every non-example affordance (INCLUDING hooks — a hook's Identity /
+# Audit trail can go stale too) whose `Last reviewed: YYYY-MM-DD` date is older
+# than the threshold, or which has no valid date. Report-only: it prints
+# findings and ALWAYS exits 0 (the fix is a human running
+# /harness-affordance review <name>, a governance judgment, not a mechanical
+# edit).
+#
+# Threshold precedence: --max-age-days flag > a HARNESS.md marker
+# `<!-- affordance-review-threshold-days: N -->` > default 180 days.
+# Age is computed in UTC so the day-count is machine-independent.
+#
+# Usage:
+#   harness-affordance-staleness.sh [--max-age-days=N] [--today=YYYY-MM-DD] [project-dir]
+# (--today overrides "now" so tests are hermetic.)
+
+MAX_AGE_FLAG=""
+TODAY_OVERRIDE=""
+PROJECT_DIR="."
+for arg in "$@"; do
+  case "$arg" in
+    --max-age-days=*) MAX_AGE_FLAG="${arg#--max-age-days=}" ;;
+    --today=*) TODAY_OVERRIDE="${arg#--today=}" ;;
+    --*) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    *) PROJECT_DIR="$arg" ;;
+  esac
+done
+
+# Resolve HARNESS.md (repo root or .claude/ scaffold).
+HARNESS=""
+for cand in "$PROJECT_DIR/HARNESS.md" "$PROJECT_DIR/.claude/HARNESS.md"; do
+  [ -f "$cand" ] && { HARNESS="$cand"; break; }
+done
+[ -n "$HARNESS" ] || { echo "No HARNESS.md under $PROJECT_DIR — nothing to check."; exit 0; }
+
+# Threshold: flag > HARNESS.md marker > default 180.
+MAX_AGE=180
+marker=$(grep -oE 'affordance-review-threshold-days:[[:space:]]*[0-9]+' "$HARNESS" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+[ -n "$marker" ] && MAX_AGE="$marker"
+[ -n "$MAX_AGE_FLAG" ] && MAX_AGE="$MAX_AGE_FLAG"
+
+# UTC epoch (midnight) for a YYYY-MM-DD string; empty on parse failure.
+date_to_epoch() {
+  date -u -j -f '%Y-%m-%d' "$1" '+%s' 2>/dev/null || date -u -d "$1" '+%s' 2>/dev/null || true
+}
+
+TODAY="${TODAY_OVERRIDE:-$(date -u '+%Y-%m-%d')}"
+TODAY_EPOCH=$(date_to_epoch "$TODAY")
+[ -n "$TODAY_EPOCH" ] || { echo "Could not parse today's date ($TODAY)." >&2; exit 0; }
+
+# Extract the ## Affordances section body (heading to next ## heading).
+SECTION=$(awk '
+  /^## Affordances[[:space:]]*$/ { inside=1; next }
+  /^## / { if (inside) exit }
+  inside { print }
+' "$HARNESS")
+[ -n "$SECTION" ] || { echo "No ## Affordances section in $HARNESS — nothing to check."; exit 0; }
+
+# Emit one row per non-example entry: name<TAB>last_reviewed (date may be empty).
+# Classification is by the example marker only — hooks are included.
+ENTRIES=$(printf '%s\n' "$SECTION" | awk '
+  function flush() {
+    if (name != "" && !is_example) printf "%s\t%s\n", name, last
+  }
+  /^### / { flush(); name=$0; sub(/^### +/,"",name); sub(/[[:space:]]+$/,"",name); is_example=0; last=""; next }
+  /<!--[^>]*affordance-example[^>]*-->/ { is_example=1 }
+  /^- \*\*Last reviewed\*\*:/ { last=$0; sub(/^- \*\*Last reviewed\*\*:[[:space:]]*/,"",last); sub(/[[:space:]].*$/,"",last) }
+  END { flush() }
+')
+[ -n "$ENTRIES" ] || { echo "No reviewable affordances (only examples, or section empty)."; exit 0; }
+
+findings=""
+while IFS=$'\t' read -r name last; do
+  [ -z "$name" ] && continue
+  if ! printf '%s' "$last" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    findings+="UNDATED: affordance '$name' has no valid Last reviewed date — review overdue"$'\n'
+    continue
+  fi
+  reviewed_epoch=$(date_to_epoch "$last")
+  if [ -z "$reviewed_epoch" ]; then
+    findings+="UNDATED: affordance '$name' Last reviewed '$last' is not a parseable date"$'\n'
+    continue
+  fi
+  age_days=$(( (TODAY_EPOCH - reviewed_epoch) / 86400 ))
+  if [ "$age_days" -gt "$MAX_AGE" ]; then
+    findings+="STALE: affordance '$name' last reviewed $last ($age_days days ago; threshold $MAX_AGE)"$'\n'
+  fi
+done <<< "$ENTRIES"
+
+if [ -n "$findings" ]; then
+  printf '%s' "$findings" | LC_ALL=C sort
+else
+  echo "OK: all affordances reviewed within $MAX_AGE days."
+fi
+exit 0

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.55.0 -->
+<!-- template-version: 0.56.0 -->
 
 ## Context
 
@@ -393,6 +393,24 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 - **Tool**: npx libyear (or ecosystem equivalent)
 - **Auto-fix**: false
 -->
+
+<!-- Uncomment if using the Affordances feature (sequencing step 6). The
+     scanner is report-only and self-skips when there is no populated
+     ## Affordances section, so it is safe to leave active. Tune the
+     threshold via the `affordance-review-threshold-days` marker in the
+     ## Affordances section header (the scanner reads it; the --max-age-days
+     flag below overrides it).
+
+### Affordance review staleness
+
+- **What it checks**: Whether any affordance in the ## Affordances section has
+  a `Last reviewed` date older than the configured threshold (default 180
+  days / ~6 months), or no valid date at all
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
+- **Auto-fix**: false (the fix is a human running /harness-affordance review <name>)
+-->
 ---
 
 ## Affordances
@@ -420,6 +438,11 @@ Run /governance-audit quarterly to keep governance constraints fresh.
      Delete the example entries below once real entries are added. -->
 
 <!-- Runtime invocation data: observability/affordance-invocations.json -->
+
+<!-- affordance-review-threshold-days: 180 -->
+<!-- ^ Tune the review-staleness threshold here (the staleness GC rule reads
+     this value). This line is human-owned and survives /harness-upgrade. -->
+
 
 ### gh-cli
 <!-- affordance-example -->

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
@@ -95,10 +95,17 @@ may legitimately precede its grant.
 ### `Last reviewed`
 
 `YYYY-MM-DD`. Set to today automatically on `add` (a genuine first review)
-and bumped thereafter only by `/harness-affordance review` (a later
-sequencing step) after three re-validation checks — Identity, Audit Trail,
-and Permission — pass. Editing other fields does **not** bump it, so the
-staleness GC rule (also a later step) stays meaningful.
+and bumped thereafter only by `/harness-affordance review <name>` after its
+three re-validation checks — Identity, Audit trail, and Permission — all
+pass. A failing check leaves the date and records a single
+`[review-gap: <check>]` Notes line instead. Editing other fields does **not**
+bump the date, so the **`Affordance review staleness`** GC rule
+(`scripts/harness-affordance-staleness.sh`) stays meaningful: it flags any
+affordance whose `Last reviewed` is older than the configured threshold
+(default 180 days; tune it via the `affordance-review-threshold-days` marker
+in the `## Affordances` section header) or has no valid date. Hook entries
+are included (their Identity/Audit trail can go stale too); example entries
+are skipped. The rule is report-only — the fix is running `review`.
 
 ## Matching algorithm
 

--- a/docs/superpowers/objections/affordance-review-and-staleness-design-code.md
+++ b/docs/superpowers/objections/affordance-review-and-staleness-design-code.md
@@ -1,0 +1,90 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
+date: 2026-06-16
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: risk
+    severity: high
+    claim: "The threshold-marker grep scans the whole HARNESS.md and takes head -1, not the ## Affordances section the adjudication (A2) designates — any earlier line carrying 'affordance-review-threshold-days: N' wins; safe in the shipped template only by the accident that the prose reference lacks a colon+number."
+    evidence: "Marker grep runs against the full file, unscoped to the section."
+    disposition: amend
+    disposition_rationale: "Scope the marker resolution to the ## Affordances section (reuse the section extractor that already bounds entry parsing), so the marker is read from its designated home, not the whole file."
+  - id: O2
+    category: risk
+    severity: medium
+    claim: "BSD `date -u -j -f '%Y-%m-%d'` fills the missing time-of-day from localtime-now, not UTC midnight, so the A6 machine-independence guarantee does not hold on the maintainers' macOS path."
+    evidence: "date -u -j -f '%Y-%m-%d' with no time fields; -u governs output, not parse-time field-fill on BSD."
+    disposition: amend
+    disposition_rationale: "Pin midnight UTC explicitly: parse 'YYYY-MM-DD 00:00:00' (BSD '%Y-%m-%d %H:%M:%S'; GNU '... 00:00:00 UTC'), so both today and Last reviewed are exact UTC-midnight epochs and the day-count is machine-independent."
+  - id: O3
+    category: implementation
+    severity: medium
+    claim: "A future Last reviewed date yields a negative age and passes the -gt staleness test, so a non-credible future date is reported as the freshest possible state."
+    evidence: "age_days = today - reviewed; only age > MAX flagged; a 2099 date is negative and never flagged."
+    disposition: amend
+    disposition_rationale: "Flag a future date as a distinct finding (FUTURE: ...): a Last reviewed in the future cannot reflect a real past review and is at least as suspect as a stale one."
+  - id: O4
+    category: implementation
+    severity: medium
+    claim: "The shape regex passes calendar-impossible dates (2026-02-30) which BSD rejects (UNDATED) but GNU rolls over (valid wrong epoch) — platform-divergent classification."
+    evidence: "Regex checks digit/dash shape only; GNU date rolls 2026-02-30 to 2026-03-02."
+    disposition: amend
+    disposition_rationale: "Round-trip validate: parse to epoch, reformat the epoch back to %Y-%m-%d UTC, and require it equals the input; a rolled-over (impossible) date fails the round-trip and is reported UNDATED on every platform."
+  - id: O5
+    category: risk
+    severity: medium
+    claim: "The gc.yml step writes unconditionally to $GITHUB_STEP_SUMMARY; when unset (local act / non-Actions), the redirect is unguarded and not covered by the scanner's || true."
+    evidence: "Brace-group redirect to $GITHUB_STEP_SUMMARY with no guard."
+    disposition: amend
+    disposition_rationale: "Guard the step-summary write with [ -n \"${GITHUB_STEP_SUMMARY:-}\" ]; always echo the output to the step log so findings reach a reader regardless of environment."
+  - id: O6
+    category: implementation
+    severity: medium
+    claim: "The example-marker match is unanchored, so a Notes line quoting the literal <!-- affordance-example --> comment trips is_example and silently drops a real entry from staleness scanning (the same unanchored pattern as harness-affordance-check.sh)."
+    evidence: "/<!--[^>]*affordance-example[^>]*-->/ fires on any line in the block; check.sh shares the pattern."
+    disposition: amend
+    disposition_rationale: "Anchor the example marker to a line that is ONLY the marker comment (^[[:space:]]*<!--[[:space:]]*affordance-example[[:space:]]*-->[[:space:]]*$) in BOTH the staleness scanner and harness-affordance-check.sh, so prose mentioning the marker cannot disable an entry."
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "The Layer 0 suite covers happy-path classifications but not the three adjudicated robustness behaviours: competing-marker precedence (O1), UTC cross-timezone independence (A6/O2), and the malformed/future-date classes."
+    evidence: "UTC test asserts only self-consistency for a fixed --today; no competing-marker or TZ-varied or future-date case."
+    disposition: amend
+    disposition_rationale: "Add Layer 0 cases: a competing earlier marker outside the section must not win; the same fixture under different TZ env yields the same verdict; a future date is FUTURE; an impossible date (2026-02-30) is UNDATED on any platform."
+  - id: O8
+    category: implementation
+    severity: low
+    claim: "The dual-form date parser accepts different input sets on BSD vs GNU, a portability win bought with a determinism loss for edge inputs."
+    evidence: "BSD strict -f vs GNU permissive -d accept different residual inputs."
+    disposition: amend
+    disposition_rationale: "Resolved by O4: the round-trip validation makes both platforms reject any input that does not reformat back to the exact YYYY-MM-DD, collapsing the accepted-input sets to the same strict set."
+  - id: O9
+    category: risk
+    severity: low
+    claim: "review's idempotent gap-Notes (A3) and re-affirm-all-three (A4) are model-facing prose with no deterministic guard; a model could append a duplicate line or bump on a single-field confirm undetected."
+    evidence: "review is model-mediated; the validation checkpoint only re-reads that Last reviewed is a date."
+    disposition: acknowledge
+    disposition_rationale: "Inherent to a model-mediated command (the spec accepts review is not unit-testable). The deterministic staleness scanner is the safety net — it keeps firing until a genuine review bumps the date, so a mis-gated bump self-corrects on the next cycle. Named as a residual-trust point, not hardened with a guard in this step."
+---
+
+# Objection record — affordance review + staleness (code mode)
+
+Nine objections (1 high, 6 medium, 2 low); no critical. Adjudicated
+2026-06-16: eight **amend** (hardening applied in this PR), one **acknowledge**
+(O9, inherent model-mediation residual). The load-bearing fixes: scope the
+threshold marker to the section (O1); pin UTC midnight so the date math is
+genuinely machine-independent (O2); round-trip-validate dates so impossible
+ones classify the same on every platform (O4/O8); flag future dates (O3);
+anchor the example marker to its own line in both affordance scripts (O6);
+guard the gc.yml summary write (O5); and add the missing edge-case tests (O7).
+
+## Explicitly not challenged
+
+- Hooks included in staleness scanning (A5/A9) — correctly marker-only.
+- set -euo pipefail + LC_ALL=C sort output determinism.
+- Exit-0-always report-only semantics.
+- The --today hermeticity mechanism itself.
+- The flag > marker > default precedence ordering (only the marker's scope, O1).
+- review's transcription-only discipline as written (A7).

--- a/docs/superpowers/objections/affordance-review-and-staleness-design.md
+++ b/docs/superpowers/objections/affordance-review-and-staleness-design.md
@@ -1,0 +1,97 @@
+---
+spec: docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
+date: 2026-06-16
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: high
+    claim: "A weekly+deterministic GC rule has no scheduled consumer — gc.yml runs a hardcoded step list and never reads HARNESS.md Tool lines, so staleness surfaces only on a manual /harness-gc run."
+    evidence: "Spec declares weekly/deterministic; gc.yml enumerates fixed named steps; the harness-gc agent is the only consumer that reads the section and runs arbitrary Tool commands."
+    disposition: amend
+    disposition_rationale: "Add a report-only step to gc.yml that runs the staleness scanner, so the rule genuinely runs on the weekly cron (for projects that vendor the plugin and have an ## Affordances section; self-skips otherwise). The template GC rule stays for the on-demand harness-gc agent path. Both consumers named in the spec."
+  - id: O2
+    category: specification quality
+    severity: high
+    claim: "'Configurable via a HARNESS.md setting' is met only by a flag in a template-managed Tool line, not a value the scanner reads from HARNESS.md; /harness-upgrade may overwrite it and a direct scanner run ignores it."
+    evidence: "Scanner reads the threshold only from the CLI flag; it never parses HARNESS.md."
+    disposition: amend
+    disposition_rationale: "The scanner READS the threshold from a human-owned HARNESS.md marker comment (<!-- affordance-review-threshold-days: N -->), with precedence: --max-age-days flag > HARNESS.md marker > default 180. The marker lives in the human-authored ## Affordances section header (not the template-managed GC rule line), so /harness-upgrade does not clobber a tuned value (resolves O10)."
+  - id: O3
+    category: specification quality
+    severity: high
+    claim: "Repeated failing reviews pile up duplicate Notes gap lines with no de-duplication or update-in-place rule; a resolved gap leaves stale Notes behind."
+    evidence: "Spec adds 'a Notes line describing the gap' on every failing review with no idempotency rule."
+    disposition: amend
+    disposition_rationale: "review writes a SINGLE gap line per failing check, keyed by a stable prefix `[review-gap: <check>]`, updating it in place rather than appending; a passing review removes that check's gap line. Notes growth is bounded and resolved gaps are cleaned up."
+  - id: O4
+    category: specification quality
+    severity: medium
+    claim: "The 'needs-edit then re-affirm' path is ambiguous about whether the date bumps after re-walking all three checks or just confirming the edited field."
+    evidence: "Spec: 'the edit does not bump the date unless the human then re-affirms all three pass' — re-affirmation gesture unspecified."
+    disposition: amend
+    disposition_rationale: "State explicitly: a bump after ANY edit requires re-answering ALL THREE checks (no single-field shortcut). The date attests to a full re-validation or it is not bumped."
+  - id: O5
+    category: implementation
+    severity: medium
+    claim: "'Mirrors harness-affordance-check.sh's parsing idiom' over-claims reuse — that script drops hooks and extracts Permission patterns; the staleness scanner must include hooks and read Last reviewed."
+    evidence: "check.sh flush() returns for hook entries and extracts patterns, not dates."
+    disposition: amend
+    disposition_rationale: "Clarify the scanner reuses ONLY the section-extraction awk, not the entry classifier. It classifies entries solely by the example marker (skip example-marked, keep everything else including hooks) and reads Last reviewed; it never inspects Permission for hook shape (resolves O9)."
+  - id: O6
+    category: risk
+    severity: medium
+    claim: "Age computation crosses an unpinned timezone/DST boundary; a bare YYYY-MM-DD interpreted at local midnight can yield off-by-one verdicts across machines near the threshold."
+    evidence: "Dual-form date helper does no TZ pinning; determinism claimed only via --today."
+    disposition: amend
+    disposition_rationale: "Normalise the age computation to UTC: derive 'today' via date -u and interpret Last reviewed as a UTC date, so the day-count is machine-independent. State UTC explicitly."
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "review writes HARNESS.md (model-mediated) but restates the human-dictates/command-transcribes discipline only for the bump, not for the inline field edits, leaving room for the model to author governance content."
+    evidence: "review 'opens that field for inline edit'; add explicitly transcribes only."
+    disposition: amend
+    disposition_rationale: "Restate the transcription-only discipline for review's inline edits: the human dictates the new value for any edited field; the command only transcribes. The date attests to a human re-validation, never a model edit."
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "Undated/stale findings exit 0 with no scheduled consumer (per O1), so the 'review overdue by definition' condition can be silently lost."
+    evidence: "Exit 0 always; gc.yml reports only its own hardcoded steps."
+    disposition: amend
+    disposition_rationale: "Resolved by O1: the new gc.yml step prints the scanner output into the workflow step summary and emits a ::warning:: when findings exist, so stale/undated entries reach a reader on the cron. An acceptance scenario asserts the workflow surfaces findings."
+  - id: O9
+    category: implementation
+    severity: low
+    claim: "If the scanner reuses check.sh's hooks.-pattern detection it could mis-skip a hook entry it was told to include."
+    evidence: "check.sh drops hooks.-pattern entries; staleness must include them."
+    disposition: amend
+    disposition_rationale: "Resolved by O5: classify entries only by the example marker; never inspect Permission for hook shape."
+  - id: O10
+    category: scope
+    severity: low
+    claim: "A locally-tuned --max-age-days in the template-managed Tool line may be clobbered by /harness-upgrade."
+    evidence: "Knob sited in the template GC rule line; projects adopt template rules via upgrade."
+    disposition: amend
+    disposition_rationale: "Resolved by O2: the tunable threshold lives in a human-owned HARNESS.md marker, not the template-managed GC rule line, so upgrade does not regress it."
+---
+
+# Objection record — affordance review + staleness (spec mode)
+
+Ten objections (3 high, 5 medium, 2 low); no critical, no premise. All
+adjudicated 2026-06-16 — every objection **amend**. The two load-bearing
+resolutions: (O1/O8) a real gc.yml step so the "weekly" rule actually runs on
+the cron and its findings reach a reader; and (O2/O10) the scanner reads the
+threshold from a human-owned HARNESS.md marker (flag > marker > default), so
+"configurable via a HARNESS.md setting" is literally true and survives
+/harness-upgrade. The amended design is in the spec's Adjudication section.
+
+## Explicitly not challenged
+
+- The bump-iff-all-three-pass core rule (faithful to the parent O11 procedure).
+- The example-marker skip anchoring (consistent with the steps-4+5 adjudication).
+- `--today` for hermetic fixtures.
+- `set -euo pipefail` + LC_ALL=C sort determinism.
+- The premise of step 6 (Last reviewed is meaningless without a bump-and-flag loop).
+- review's Permission check reading the user settings layer (interactive path,
+  consistent with add; not the deterministic CI check's project-only scope).

--- a/docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
@@ -1,0 +1,164 @@
+# Spec: `/harness-affordance review` + staleness GC rule (sequencing step 6)
+
+**Date**: 2026-06-16
+**Author**: Russ Miles + assistant
+**Parent design**: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+(O11 disposition — the re-validation procedure)
+**Builds on**: step 3 (`add`, the `Last reviewed` field) and steps 4+5 (the
+deterministic check pattern)
+**Driving issue**: #202
+**Status**: design — awaiting spec-mode `/diaboli` and user review
+
+## Problem
+
+Every affordance carries a `Last reviewed: YYYY-MM-DD` date. Step 3 sets it
+on `add` (a genuine first review). But nothing yet **bumps** it, and nothing
+**flags** it when it goes stale. Per the parent spec's O11, the date is only
+meaningful if a defined re-validation procedure controls it — otherwise it
+degrades into a `git log` mtime check that says nothing about whether the
+governance facts (Identity, Audit trail, Permission) still hold.
+
+Step 6 closes the per-affordance staleness loop with two halves:
+
+1. a **`review` command** that bumps the date only after three explicit
+   re-validation checks pass; and
+2. a deterministic **staleness GC rule** that flags affordances whose date
+   has aged past a configurable threshold.
+
+## Scope
+
+1. **`commands/harness-affordance.md` — implement `review <name>`.** Replace
+   the "not yet implemented" stub with the interactive three-check flow.
+2. **`scripts/harness-affordance-staleness.sh`** — a deterministic scanner
+   that flags affordances with a stale `Last reviewed` date.
+3. **One GC rule** in `templates/HARNESS.md` `## Garbage Collection`
+   (weekly, deterministic, report-only), with a configurable threshold.
+4. **Docs** — update the how-to and the explanation/reference pages.
+5. **Layer 0 tests** over the staleness scanner.
+6. Minor version bump.
+
+**Out of scope** (later steps): the runtime tuple recorder (step 7) and CI
+discovery automation (step 8).
+
+## `review <name>` behaviour
+
+Interactive re-validation that bumps `Last reviewed` **only if all three
+checks pass**. Given a name (matched by `### <name>` heading under
+`## Affordances`):
+
+1. **Identity check.** Show the entry's `Identity`; ask "still correct?
+   yes / no / needs-edit". For `runtime-resolved`, prompt specifically that
+   the resolution chain in Notes has not changed; for fixed identities, that
+   the named credential still exists and belongs to the named principal.
+2. **Audit trail check.** Show the `Audit trail`; ask the same. The endpoint
+   exists, retention matches, access scope holds. For `none`, confirm no
+   audit log has been added since last review.
+3. **Permission check.** Show the `Permission`; confirm the pattern is still
+   present in a settings allowlist (`.claude/settings.json`,
+   `.claude/settings.local.json`, or `~/.claude/settings.json`).
+
+Each check is **explicit** — no implicit "everything looks fine" passing; the
+human answers each of the three.
+
+- **All three `yes`** → bump `Last reviewed` to today.
+- **Any `needs-edit`** → open that field for inline edit; the edit itself
+  does **not** bump the date unless the human then re-affirms all three pass.
+- **Any `no`** the human cannot fix in-session → leave `Last reviewed`
+  **unchanged** and add a `Notes` line describing the gap (so the staleness
+  rule keeps firing until it is resolved). Editing other fields (Notes,
+  Constraint references) never bumps the date on its own.
+
+Validation checkpoint: re-read the entry; confirm `Last reviewed` is a
+`YYYY-MM-DD` date and was bumped iff all three checks passed.
+
+## The staleness scanner
+
+`scripts/harness-affordance-staleness.sh [--max-age-days=N] [--today=YYYY-MM-DD] [project-dir]`
+
+1. Resolve `HARNESS.md` (root or `.claude/`). Absent → exit 0, nothing to
+   check.
+2. Extract the `## Affordances` section. Absent → exit 0.
+3. For each **non-example** entry (skip `<!-- affordance-example -->`-marked
+   entries; **include** hook entries — a hook's Identity/Audit trail can go
+   stale too), read its `Last reviewed` date. An entry missing a parseable
+   `YYYY-MM-DD` date is reported as `UNDATED: affordance '<name>' has no
+   valid Last reviewed date` (a review is overdue by definition).
+4. Compute age in days from `Last reviewed` to **today** (`--today` overrides
+   the system date so tests are hermetic). Age `>` `--max-age-days`
+   (default **180**) → `STALE: affordance '<name>' last reviewed <date>
+   (<age> days ago; threshold <N>)`.
+5. Print findings `LC_ALL=C`-sorted; print `OK: all affordances reviewed
+   within <N> days` when none. **Exit 0 always** — this is a report-only GC
+   rule, not a blocking gate.
+
+Deterministic given `--today`. `set -euo pipefail`.
+
+## Threshold is configurable, not hardcoded
+
+The default is 180 days, but the threshold is set in `HARNESS.md` itself: the
+GC rule's `Tool` line carries `--max-age-days=180`. A project edits that
+number in its own `HARNESS.md` to tune the cadence — the knob lives in the
+project's harness, not baked into the script (the script default applies only
+when the flag is omitted). This satisfies "configurable via a HARNESS.md
+setting, not hardcoded".
+
+## GC rule (templates/HARNESS.md `## Garbage Collection`)
+
+```text
+### Affordance review staleness
+
+- **What it checks**: Whether any affordance in the ## Affordances section has
+  a `Last reviewed` date older than the configured threshold (default 180
+  days / ~6 months), or no valid date at all
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh --max-age-days=180
+- **Auto-fix**: false
+```
+
+Report-only (`Auto-fix: false`): the fix is a human running
+`/harness-affordance review <name>`, which is a governance judgment, not a
+mechanical edit.
+
+## Acceptance scenarios
+
+1. **All checks pass** → `review` bumps `Last reviewed` to today.
+2. **A check fails** → date unchanged; a Notes line records the gap.
+3. **Stale entry** → the scanner flags it by name with its age and the
+   threshold; exit 0.
+4. **Fresh entry** (within threshold) → not flagged.
+5. **Undated entry** → reported as undated (review overdue).
+6. **Example entries** → never flagged (skipped).
+7. **Hook entry** → IS subject to staleness (included).
+8. **Threshold override** → `--max-age-days=30` flags an entry the default
+   180 would not.
+9. **Hermetic** → `--today` fixes "now" so the same fixture yields the same
+   verdict on any day.
+
+## Functional requirements
+
+- **FR1** `review <name>` runs the three explicit checks and bumps
+  `Last reviewed` to today **iff** all pass; a failing check leaves the date
+  and adds a Notes gap line.
+- **FR2** `harness-affordance-staleness.sh` flags non-example affordances
+  (including hooks) whose `Last reviewed` is older than `--max-age-days`
+  (default 180) or undated; report-only (exit 0); `--today` makes it
+  deterministic.
+- **FR3** One weekly deterministic report-only GC rule in the template, with
+  the threshold set via the `--max-age-days` flag in the `Tool` line.
+- **FR4** Docs (how-to + reference/explanation) cover `review` and the
+  staleness rule.
+- **FR5** Layer 0 tests cover the staleness scenarios against hermetic
+  fixtures (via `--today` and `project-dir`).
+
+## Risks and mitigations
+
+- **Date math portability** (`date -d` vs BSD `date -j`). Mitigated by
+  computing the age from `YYYY-MM-DD` epoch seconds with the same
+  dual-form pattern the existing reflection-log helpers use
+  (`date -j -f %Y-%m-%d` || `date -d`).
+- **"Now"-dependence breaks hermetic tests.** Mitigated by `--today`.
+- **`review` is model-mediated, not unit-testable.** Mitigated by the
+  deterministic staleness scanner (which is the only mechanically-verifiable
+  half) carrying the Layer 0 coverage; `review`'s bump-iff-all-pass logic is
+  covered by the manual acceptance scenarios and its validation checkpoint.

--- a/docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
+++ b/docs/superpowers/specs/2026-06-16-affordance-review-and-staleness-design.md
@@ -7,7 +7,8 @@
 **Builds on**: step 3 (`add`, the `Last reviewed` field) and steps 4+5 (the
 deterministic check pattern)
 **Driving issue**: #202
-**Status**: design — awaiting spec-mode `/diaboli` and user review
+**Status**: design — spec-mode `/diaboli` reviewed, all 10 dispositions
+adjudicated 2026-06-16 (see Adjudication); ready for implementation
 
 ## Problem
 
@@ -150,6 +151,57 @@ mechanical edit.
   staleness rule.
 - **FR5** Layer 0 tests cover the staleness scenarios against hermetic
   fixtures (via `--today` and `project-dir`).
+
+## Adjudication (post-diaboli, 2026-06-16)
+
+Spec-mode `/diaboli` raised ten objections (3 high; record:
+`docs/superpowers/objections/affordance-review-and-staleness-design.md`). All
+adjudicated — every objection **amend**. The binding refinements below
+supersede the original wording where they conflict and drive implementation.
+
+- **A1/A8 (O1/O8) — wire the rule into the weekly cron.** `gc.yml` runs a
+  hardcoded step list and never reads HARNESS.md `Tool` lines, so a template
+  GC rule alone runs only via the on-demand `harness-gc` agent. This step
+  **adds a report-only step to `.github/workflows/gc.yml`** that runs the
+  staleness scanner, prints its output to the workflow step summary, and
+  emits a `::warning::` when findings exist (it self-skips when there is no
+  `## Affordances` section). The template GC rule stays for the agent path.
+  Both consumers are named.
+- **A2/A10 (O2/O10) — the scanner READS the threshold from HARNESS.md.**
+  Precedence: `--max-age-days` flag > a human-owned HARNESS.md marker
+  `<!-- affordance-review-threshold-days: N -->` > default **180**. The
+  marker ships in the human-authored `## Affordances` section header (not the
+  template-managed GC rule `Tool` line), so a tuned value is a genuine
+  HARNESS.md setting the scanner resolves, and `/harness-upgrade` does not
+  clobber it.
+- **A3 (O3) — bounded, idempotent gap Notes.** A failing `review` check
+  writes a **single** gap line per check, keyed by a stable prefix
+  `[review-gap: <check>]`, updating it in place rather than appending; a
+  passing review **removes** that check's gap line. Notes growth is bounded
+  and resolved gaps are cleaned up.
+- **A4 (O4) — a bump requires re-answering all three checks.** After any
+  inline edit, the date bumps only if the human re-answers **all three**
+  checks `yes` — no single-field shortcut. The date attests to a full
+  re-validation or it is not bumped.
+- **A5/A9 (O5/O9) — reuse only the section extractor.** The scanner reuses
+  only the `## Affordances` section-extraction `awk` from
+  `harness-affordance-check.sh`, **not** its entry classifier. It classifies
+  entries solely by the `<!-- affordance-example -->` marker (skip
+  example-marked; keep everything else, **including hooks**) and reads
+  `Last reviewed`. It never inspects `Permission` for hook shape.
+- **A6 (O6) — UTC-normalised age.** "Today" is derived via `date -u` and
+  `Last reviewed` is interpreted as a UTC date, so the day-count is
+  machine-independent regardless of the runner's timezone.
+- **A7 (O7) — transcription-only edits.** `review`'s inline edits follow the
+  same discipline as `add`: the human dictates the new value for any edited
+  field; the command only transcribes. `Last reviewed` attests to a human
+  re-validation, never a model edit.
+
+### Added acceptance scenario
+
+10. **Workflow surfaces findings** — the `gc.yml` staleness step prints stale
+    / undated entries to the step summary and warns when any exist; it
+    self-skips (no warning) when there is no `## Affordances` section.
 
 ## Risks and mitigations
 

--- a/tdad_tests/layer0_deterministic/test-affordance-staleness.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-staleness.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for harness-affordance-staleness.sh (step 6). --today fixes
+# "now" so every scenario is hermetic; fixtures live in temp project dirs.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+S="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/harness-affordance-staleness.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# mkproj <harness-body> -> temp dir
+mkproj() { local d; d=$(mktemp -d); printf '%s\n' "$1" > "$d/HARNESS.md"; printf '%s' "$d"; }
+
+run() { OUT=$("$S" "$@" 2>&1); }
+
+BODY='# H
+## Affordances
+### stale-tool
+- **Mode**: cli
+- **Last reviewed**: 2025-01-01
+### fresh-tool
+- **Mode**: cli
+- **Last reviewed**: 2026-06-01
+### a-hook
+- **Mode**: hook
+- **Last reviewed**: 2024-01-01
+### example-tool
+<!-- affordance-example -->
+- **Mode**: cli
+- **Last reviewed**: 2020-01-01
+### undated-tool
+- **Mode**: cli
+- **Last reviewed**: TODO
+## Status'
+
+d=$(mkproj "$BODY")
+
+# Scenario 3/4/5/6/7: default threshold 180, today 2026-06-16.
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "STALE: affordance 'stale-tool'" || fail "stale-tool should be STALE: $OUT"
+echo "$OUT" | grep -q "STALE: affordance 'a-hook'" || fail "hook entry must be INCLUDED in staleness: $OUT"
+echo "$OUT" | grep -q "UNDATED: affordance 'undated-tool'" || fail "undated entry should be UNDATED: $OUT"
+echo "$OUT" | grep -q "fresh-tool" && fail "fresh-tool (within 180d) must not be flagged: $OUT"
+echo "$OUT" | grep -q "example-tool" && fail "example entry must be skipped: $OUT"
+rm -rf "$d"
+
+# Scenario 8: threshold override flags an otherwise-fresh entry.
+d=$(mkproj "$BODY")
+run --today=2026-06-16 --max-age-days=10 "$d"
+echo "$OUT" | grep -q "STALE: affordance 'fresh-tool'" || fail "fresh-tool (15d) should flag at threshold 10: $OUT"
+rm -rf "$d"
+
+# All-fresh -> OK line, exit 0.
+d=$(mkproj '# H
+## Affordances
+### t
+- **Mode**: cli
+- **Last reviewed**: 2026-06-10
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "OK: all affordances reviewed within 180 days" || fail "all-fresh should report OK: $OUT"
+rm -rf "$d"
+
+# HARNESS.md marker threshold is read; the flag overrides it.
+d=$(mkproj '# H
+<!-- affordance-review-threshold-days: 30 -->
+## Affordances
+### t
+- **Mode**: cli
+- **Last reviewed**: 2026-05-01
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "threshold 30" || fail "scanner should read the HARNESS.md marker threshold (30): $OUT"
+echo "$OUT" | grep -q "STALE: affordance 't'" || fail "46d entry should be stale at marker threshold 30: $OUT"
+run --today=2026-06-16 --max-age-days=180 "$d"
+echo "$OUT" | grep -q "OK:" || fail "flag (180) should override the marker (30): $OUT"
+rm -rf "$d"
+
+# No ## Affordances section -> graceful, exit 0.
+d=$(mkproj '# H
+## Constraints')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -qi "nothing to check" || fail "no section should report nothing to check: $OUT"
+rm -rf "$d"
+
+# UTC determinism: the same fixture + --today yields the same verdict.
+d=$(mkproj '# H
+## Affordances
+### t
+- **Mode**: cli
+- **Last reviewed**: 2026-01-01
+## Status')
+a=$("$S" --today=2026-06-16 "$d")
+b=$("$S" --today=2026-06-16 "$d")
+[ "$a" = "$b" ] || fail "scanner must be deterministic for a fixed --today"
+rm -rf "$d"
+
+echo "All affordance-staleness tests passed."

--- a/tdad_tests/layer0_deterministic/test-affordance-staleness.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-staleness.sh
@@ -61,19 +61,80 @@ run --today=2026-06-16 "$d"
 echo "$OUT" | grep -q "OK: all affordances reviewed within 180 days" || fail "all-fresh should report OK: $OUT"
 rm -rf "$d"
 
-# HARNESS.md marker threshold is read; the flag overrides it.
+# HARNESS.md marker threshold (read from INSIDE the ## Affordances section) is
+# applied; the flag overrides it.
 d=$(mkproj '# H
-<!-- affordance-review-threshold-days: 30 -->
 ## Affordances
+<!-- affordance-review-threshold-days: 30 -->
 ### t
 - **Mode**: cli
 - **Last reviewed**: 2026-05-01
 ## Status')
 run --today=2026-06-16 "$d"
-echo "$OUT" | grep -q "threshold 30" || fail "scanner should read the HARNESS.md marker threshold (30): $OUT"
+echo "$OUT" | grep -q "threshold 30" || fail "scanner should read the in-section marker threshold (30): $OUT"
 echo "$OUT" | grep -q "STALE: affordance 't'" || fail "46d entry should be stale at marker threshold 30: $OUT"
 run --today=2026-06-16 --max-age-days=180 "$d"
 echo "$OUT" | grep -q "OK:" || fail "flag (180) should override the marker (30): $OUT"
+rm -rf "$d"
+
+# O1: a competing marker OUTSIDE the ## Affordances section must NOT win.
+d=$(mkproj '# H
+<!-- affordance-review-threshold-days: 999 -->
+## Affordances
+<!-- affordance-review-threshold-days: 30 -->
+### t
+- **Mode**: cli
+- **Last reviewed**: 2026-05-01
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "threshold 30" || fail "O1: the in-section marker (30) must win over an earlier out-of-section one (999): $OUT"
+rm -rf "$d"
+
+# O2: UTC machine-independence — the same fixture yields the same verdict
+# under wildly different timezones.
+d=$(mkproj '# H
+## Affordances
+### t
+- **Mode**: cli
+- **Last reviewed**: 2026-01-01
+## Status')
+a=$(TZ=Pacific/Kiritimati "$S" --today=2026-06-16 "$d")
+b=$(TZ=Pacific/Pago_Pago "$S" --today=2026-06-16 "$d")
+[ "$a" = "$b" ] || fail "O2: verdict must be timezone-independent (got '$a' vs '$b')"
+rm -rf "$d"
+
+# O3: a future Last reviewed date is FUTURE, not silently fresh.
+d=$(mkproj '# H
+## Affordances
+### futuristic
+- **Mode**: cli
+- **Last reviewed**: 2099-01-01
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "FUTURE: affordance 'futuristic'" || fail "O3: future date should be flagged FUTURE: $OUT"
+rm -rf "$d"
+
+# O4: a calendar-impossible date is UNDATED on any platform (not rolled over).
+d=$(mkproj '# H
+## Affordances
+### bad-date
+- **Mode**: cli
+- **Last reviewed**: 2026-02-30
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "UNDATED: affordance 'bad-date'" || fail "O4: impossible date should be UNDATED: $OUT"
+rm -rf "$d"
+
+# O6: a Notes line quoting the example marker must NOT skip a real entry.
+d=$(mkproj '# H
+## Affordances
+### real
+- **Mode**: cli
+- **Last reviewed**: 2020-01-01
+- **Notes**: this is not an <!-- affordance-example --> entry
+## Status')
+run --today=2026-06-16 "$d"
+echo "$OUT" | grep -q "STALE: affordance 'real'" || fail "O6: a real entry mentioning the marker in Notes must still be scanned: $OUT"
 rm -rf "$d"
 
 # No ## Affordances section -> graceful, exit 0.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -50,6 +50,7 @@ BASH_TEST_SCRIPTS = [
     "test-auto-enforcer",
     "test-affordances-template",
     "test-affordance-check",
+    "test-affordance-staleness",
 ]
 
 


### PR DESCRIPTION
Closes #202. Sequencing **step 6** of the harness-affordances epic — the per-affordance staleness loop.

## What ships

- **`/harness-affordance review <name>`** — interactive re-validation that bumps `Last reviewed` to today **only if all three checks pass** (Identity, Audit trail, Permission), each with an explicit `yes / no / needs-edit` prompt. A bump after any edit requires re-answering all three; a failing check leaves the date and records a single idempotent `[review-gap: <check>]` Notes line. Inline edits follow `add`'s human-dictates/command-transcribes discipline.
- **`scripts/harness-affordance-staleness.sh`** — a deterministic, report-only scanner flagging non-example affordances (hooks **included**) whose `Last reviewed` is stale, undated, in the **future**, or calendar-impossible. UTC-normalised, hermetic via `--today`. Threshold precedence: `--max-age-days` flag > a `<!-- affordance-review-threshold-days: N -->` marker the scanner reads **from the `## Affordances` section** > default 180.
- **Weekly GC**: a `gc.yml` step runs the scanner, prints findings to the step summary, and warns when any exist (self-skips with no section) — so the rule actually runs on the cron, since `gc.yml` runs a hardcoded step list and never reads HARNESS.md Tool lines. A commented-opt-in template GC rule covers the on-demand `/harness-gc` agent path.
- Docs + Layer 0 tests. Minor bump 0.55.0 → 0.56.0.

## Spec-first + adversarial review

- **Spec** committed first; resolved the issue's threshold-config question.
- **Spec-mode `/diaboli`**: 10 objections (3 high), all adjudicated — the load-bearing fix wired the rule into `gc.yml` (a template GC rule alone is never run by the cron) and made the scanner read the threshold from HARNESS.md, not just a CLI flag.
- **Code-mode `/diaboli`**: 9 objections (1 high), 8 amended + 1 acknowledged. Highlights: scoped the marker read to the section (O1, was whole-file); **pinned UTC midnight** because `date -u -j -f '%Y-%m-%d'` on BSD fills the time-of-day from *localtime now* — verified TZ-invariant across +14/−11 (O2); round-trip-validate dates so `2026-02-30` is rejected identically on BSD/GNU (O4); flag future dates (O3); anchored the example marker to its own line in both affordance scripts (O6); fixed a `set -e` abort where a round-trip-rejected date silently killed the script.

## Out of scope

The runtime tuple recorder (step 7) and CI discovery automation (step 8) — each its own spec.