### PR TITLE
Affordances: runtime invocation recorder + dead-inventory analyzer (step 7, #203)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.56.0",
+  "plugin_version": "0.57.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.56.0"
+      "version": "0.57.0"
     },
     {
       "name": "model-cards",

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 # Discovery scanner output — per-session drafts that are reviewed and
 # (if approved) copied into HARNESS.md by hand. Never committed.
 .claude/affordance-discovery-*.md
+
+# Affordance runtime invocation log — per-machine, append-only NDJSON written
+# by the PostToolUse recorder hook. Gitignored to dissolve the cross-machine
+# merge problem; it answers "did MY sessions invoke this?" locally.
+observability/affordance-invocations.json
+
 _site/
 site/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.57.0 — 2026-06-17
+
+### affordances: runtime invocation recorder + dead-inventory analyzer (#203)
+
+Sequencing step 7 — the affordance section's runtime backbone.
+
+- **`hooks/scripts/affordance-invocation-recorder.sh`** — a PostToolUse hook
+  (registered in `hooks.json`) appending one minimal NDJSON tuple per `Bash` /
+  `mcp__*` call to the gitignored `observability/affordance-invocations.json`.
+  Built-in file tools are not recorded. **Privacy is enforced, not just
+  declared**: the Bash `program` field strips env-var prefixes (`GH_TOKEN=…
+  gh` → `gh`), `basename`s paths (`/a/b/deploy.sh` → `deploy.sh`), and accepts
+  only a clean `^[A-Za-z0-9._-]+$` shape — no arguments, paths, secrets, or
+  user identity. Uses grep/sed (no jq), never blocks, self-trims to 5000 lines.
+- **`scripts/harness-affordance-invocations.sh`** — a report-only analyzer:
+  `--check=freshness` (is the recorder operating?) and `--check=dead-inventory`
+  (each declared, non-example, **non-hook** affordance observed within N days?).
+  Bash matching is program-coarse and **conservative** (an observed program
+  marks every Bash affordance sharing it as observed — a false-alive, never a
+  false-dead); MCP/named matching is exact. Hermetic via `--today`; tolerates
+  any malformed NDJSON line.
+- **Local, per-machine.** The data file is gitignored (the user-confirmed
+  answer to cross-machine merge), so the two GC rules and the checks are
+  **local observability via `/harness-gc`, not CI governance** — stated
+  honestly. A reference page documents the stable tuple format.
+- Spec-mode `/diaboli` raised 12 objections (6 high), all adjudicated before
+  implementation: keep the `.json` filename (the existing reference), sanitise
+  the Bash program token so the no-secrets guarantee is real, recorder uses
+  grep/sed (no jq silent-no-op trap), exclude hooks from dead-inventory, and
+  frame the gitignored consequence honestly.
+
 ## 0.56.0 — 2026-06-16
 
 ### affordances: review subcommand + staleness GC rule (#202)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.56.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.57.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.56.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.57.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, and reservoir check (Stop) close all feedback loops at session end; template currency check (SessionStart) nudges on plugin upgrade",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, and reservoir check (Stop) close all feedback loops at session end; template currency check (SessionStart) nudges on plugin upgrade",
   "hooks": {
     "PreToolUse": [
       {
@@ -14,6 +14,18 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/markdownlint-check.sh",
             "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/affordance-invocation-recorder.sh",
+            "timeout": 10
           }
         ]
       }

--- a/ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh
+++ b/ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh
@@ -68,11 +68,20 @@ record() {
   printf '{"tool":"%s","program":%s,"invoker":"%s","session":"%s","ts":"%s"}\n' \
     "$tool" "$prog" "$invoker" "$session" "$ts" >> "$file"
 
-  # Bound the file (gitignored, per-machine) — keep well over the 30-day window.
-  local n
-  n=$(wc -l < "$file" 2>/dev/null | tr -d ' ' || printf '0')
-  if [ "${n:-0}" -gt "$MAX_LINES" ]; then
-    tail -n "$MAX_LINES" "$file" > "$file.tmp" 2>/dev/null && mv "$file.tmp" "$file"
+  # Bound the file (gitignored, per-machine). Gate the trim on an O(1) byte-size
+  # check so the common path is a single append + one stat; only when the file
+  # exceeds the byte cap do we tail+rewrite. The tail goes into a UNIQUE tmp so
+  # concurrent trims cannot clobber each other's tmp or read a half-written one.
+  local bytes cap tmp
+  cap=2000000  # ~2 MB — well over the 30-day dead-inventory window
+  bytes=$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null || printf '0')
+  if [ "${bytes:-0}" -gt "$cap" ]; then
+    tmp="$file.$$.${RANDOM:-0}.tmp"
+    if tail -n "$MAX_LINES" "$file" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+      rm -f "$tmp" 2>/dev/null
+    fi
   fi
 }
 

--- a/ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh
+++ b/ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# affordance-invocation-recorder.sh — PostToolUse hook (step 7 of the
+# harness-affordances design, spec 2026-06-17-affordance-runtime-recorder-design.md).
+#
+# Appends one minimal NDJSON tuple per affordance-relevant tool call to the
+# gitignored observability/affordance-invocations.json (NDJSON content). Records
+# only Bash and mcp__* invocations (the tools that map to affordances) — never
+# the built-in file tools. Privacy: it records the tool name, the Bash program
+# NAME only (env-var prefixes stripped, path basename'd, allowlist-shaped — no
+# arguments, no paths, no secrets), a best-effort invoker, an opaque session id,
+# and a UTC timestamp. No tool arguments, no file contents, no user identity.
+#
+# Best-effort: uses grep/sed (no jq dependency), never blocks, never delays the
+# session, and always exits 0 — a recorder must never interfere with a session.
+
+FILE_REL="observability/affordance-invocations.json"
+MAX_LINES=5000
+
+record() {
+  local input tool prog invoker session ts file
+  input=$(cat)
+
+  tool=$(printf '%s' "$input" | grep -oE '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+         | sed -E 's/.*"tool_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  [ -n "$tool" ] || return 0
+
+  # Only record affordance-relevant tools (CLIs via Bash, and MCP servers).
+  case "$tool" in
+    Bash|mcp__*) ;;
+    *) return 0 ;;
+  esac
+
+  prog="null"
+  if [ "$tool" = "Bash" ]; then
+    local command c first base
+    command=$(printf '%s' "$input" | grep -oE '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+              | sed -E 's/.*"command"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+    c="$command"
+    # Strip leading KEY=VALUE env-var prefixes (which may carry secrets).
+    while printf '%s' "$c" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]'; do
+      c=$(printf '%s' "$c" | sed -E 's/^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+//')
+    done
+    first=$(printf '%s' "$c" | awk '{print $1}')
+    base=$(basename -- "$first" 2>/dev/null || printf '')
+    # Record only a clean program-name shape; a path, quote, or shell syntax
+    # collapses to null so no path or argument can leak.
+    if printf '%s' "$base" | grep -qE '^[A-Za-z0-9._-]+$'; then
+      prog="\"$base\""
+    fi
+  fi
+
+  session=$(printf '%s' "$input" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+            | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+  printf '%s' "$session" | grep -qE '^[A-Za-z0-9._-]+$' || session="unknown"
+
+  # invoker: best-effort. PostToolUse rarely exposes the invoking agent; record
+  # it only if a safe-shaped value is present, else "unknown". The feature's
+  # value (dead-inventory) does not depend on it.
+  invoker=$(printf '%s' "$input" | grep -oE '"(agent|invoker|subagent)"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+            | sed -E 's/.*:[[:space:]]*"([^"]*)".*/\1/' || printf '')
+  printf '%s' "$invoker" | grep -qE '^[A-Za-z0-9._-]+$' || invoker="unknown"
+
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  file="${CLAUDE_PROJECT_DIR:-.}/$FILE_REL"
+  mkdir -p "$(dirname "$file")"
+  printf '{"tool":"%s","program":%s,"invoker":"%s","session":"%s","ts":"%s"}\n' \
+    "$tool" "$prog" "$invoker" "$session" "$ts" >> "$file"
+
+  # Bound the file (gitignored, per-machine) — keep well over the 30-day window.
+  local n
+  n=$(wc -l < "$file" 2>/dev/null | tr -d ' ' || printf '0')
+  if [ "${n:-0}" -gt "$MAX_LINES" ]; then
+    tail -n "$MAX_LINES" "$file" > "$file.tmp" 2>/dev/null && mv "$file.tmp" "$file"
+  fi
+}
+
+# Never let a recorder failure surface to the session.
+record 2>/dev/null || true
+exit 0

--- a/ai-literacy-superpowers/scripts/harness-affordance-invocations.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-invocations.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# harness-affordance-invocations.sh — analyzer for the runtime invocation log
+# (spec 2026-06-17-affordance-runtime-recorder-design.md, step 7). Report-only.
+#
+#   --check=freshness       Is observability/affordance-invocations.json present
+#                           and its newest ts within --max-age-days (default 7)?
+#                           A stale/missing file => the recorder is probably not
+#                           operating (LOCAL signal — the file is gitignored).
+#   --check=dead-inventory  For each declared, non-example, NON-HOOK affordance,
+#                           was any matching invocation seen within
+#                           --max-age-days (default 30)? Unobserved => flagged.
+#
+# Matching: exact tool equality / mcp__server__* prefix for MCP and named tools;
+# program-coarse for Bash (Bash(<prog> *) matches a tuple with program <prog> —
+# conservative: an observed program marks every Bash affordance sharing it as
+# observed, a false-alive never a false-dead). Hook affordances are excluded
+# (a PostToolUse recorder cannot observe hook firings).
+#
+# Reads project files only; --today fixes "now" for hermetic tests. Exits 0
+# always. NDJSON lines that do not parse are skipped (any line, not just the last).
+
+CHECK="freshness"
+MAX_AGE_FLAG=""
+TODAY_OVERRIDE=""
+PROJECT_DIR="."
+for arg in "$@"; do
+  case "$arg" in
+    --check=freshness) CHECK="freshness" ;;
+    --check=dead-inventory) CHECK="dead-inventory" ;;
+    --check=*) echo "Unknown --check (freshness|dead-inventory)" >&2; exit 2 ;;
+    --max-age-days=*) MAX_AGE_FLAG="${arg#--max-age-days=}" ;;
+    --today=*) TODAY_OVERRIDE="${arg#--today=}" ;;
+    --*) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    *) PROJECT_DIR="$arg" ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "jq not installed — cannot analyze invocations (brew install jq)."; exit 0; }
+
+FILE="$PROJECT_DIR/observability/affordance-invocations.json"
+
+# UTC epoch (midnight) for YYYY-MM-DD; round-trip validated; always returns 0.
+date_to_epoch() {
+  local epoch back
+  epoch=$(date -u -j -f '%Y-%m-%d %H:%M:%S' "$1 00:00:00" '+%s' 2>/dev/null \
+        || date -u -d "$1 00:00:00 UTC" '+%s' 2>/dev/null || true)
+  [ -n "$epoch" ] || return 0
+  back=$(date -u -j -f '%s' "$epoch" '+%Y-%m-%d' 2>/dev/null || date -u -d "@$epoch" '+%Y-%m-%d' 2>/dev/null || true)
+  [ "$back" = "$1" ] && printf '%s' "$epoch"
+  return 0
+}
+
+TODAY="${TODAY_OVERRIDE:-$(date -u '+%Y-%m-%d')}"
+TODAY_EPOCH=$(date_to_epoch "$TODAY")
+[ -n "$TODAY_EPOCH" ] || { echo "Could not parse today's date ($TODAY)." >&2; exit 0; }
+
+if [ "$CHECK" = "freshness" ]; then
+  MAX_AGE="${MAX_AGE_FLAG:-7}"
+  if [ ! -f "$FILE" ]; then
+    echo "STALE: no invocation file at $FILE — the recorder may not be operating."
+    exit 0
+  fi
+  # -R 'fromjson?' reads NDJSON line-by-line and skips ANY unparseable line
+  # (not just the trailing one), keeping jq's exit status 0.
+  newest=$(jq -rR 'fromjson? | select(.ts != null) | .ts' "$FILE" 2>/dev/null | LC_ALL=C sort | tail -1)
+  if [ -z "$newest" ]; then
+    echo "STALE: invocation file has no parseable timestamps."
+    exit 0
+  fi
+  newest_epoch=$(jq -rn --arg t "$newest" '($t | fromdateiso8601)' 2>/dev/null || true)
+  if [ -z "$newest_epoch" ]; then
+    echo "STALE: newest timestamp ($newest) is not parseable."
+    exit 0
+  fi
+  age_days=$(( (TODAY_EPOCH - newest_epoch) / 86400 ))
+  if [ "$age_days" -gt "$MAX_AGE" ]; then
+    echo "STALE: newest invocation is $age_days days old (threshold $MAX_AGE) — recorder may be off."
+  else
+    echo "OK: recorder active (newest invocation $age_days days old, threshold $MAX_AGE)."
+  fi
+  exit 0
+fi
+
+# --- dead-inventory ---
+MAX_AGE="${MAX_AGE_FLAG:-30}"
+
+HARNESS=""
+for cand in "$PROJECT_DIR/HARNESS.md" "$PROJECT_DIR/.claude/HARNESS.md"; do
+  [ -f "$cand" ] && { HARNESS="$cand"; break; }
+done
+[ -n "$HARNESS" ] || { echo "No HARNESS.md under $PROJECT_DIR — nothing to check."; exit 0; }
+
+SECTION=$(awk '
+  /^## Affordances[[:space:]]*$/ { inside=1; next }
+  /^## / { if (inside) exit }
+  inside { print }
+' "$HARNESS")
+[ -n "$SECTION" ] || { echo "No ## Affordances section — nothing to check."; exit 0; }
+
+# Declared, non-example, NON-HOOK affordances: emit name<TAB>permission-pattern.
+DECLARED=$(printf '%s\n' "$SECTION" | awk '
+  function is_pattern(t){ return (t ~ /^[A-Za-z_]+\(/ || t ~ /^mcp__/) }
+  function flush(   i,n,tmp,tok,is_hook){
+    if (name=="" || is_example) return
+    n=0; delete pats; tmp=perm
+    while (match(tmp, /`[^`]+`/)) { tok=substr(tmp,RSTART+1,RLENGTH-2); tmp=substr(tmp,RSTART+RLENGTH); if (is_pattern(tok)){n++; pats[n]=tok} }
+    is_hook=(mode=="hook")
+    for(i=1;i<=n;i++) if (pats[i] ~ /^hooks\./) is_hook=1
+    if (is_hook || n!=1) return
+    printf "%s\t%s\n", name, pats[1]
+  }
+  /^### / { flush(); name=$0; sub(/^### +/,"",name); sub(/[[:space:]]+$/,"",name); is_example=0; mode=""; perm="" ; next }
+  /^[[:space:]]*<!--[[:space:]]*affordance-example[[:space:]]*-->[[:space:]]*$/ { is_example=1 }
+  /^- \*\*Mode\*\*:/ { m=$0; sub(/^- \*\*Mode\*\*:[[:space:]]*/,"",m); split(m,a," "); mode=a[1] }
+  /^- \*\*Permission\*\*:/ { perm=$0; sub(/^- \*\*Permission\*\*:[[:space:]]*/,"",perm) }
+  END { flush() }
+')
+[ -n "$DECLARED" ] || { echo "No matchable (non-example, non-hook) affordances declared."; exit 0; }
+
+# Observed tools and bash programs within the window (skip unparseable lines).
+CUTOFF=$(( TODAY_EPOCH - MAX_AGE * 86400 ))
+OBS_TOOLS=""
+OBS_PROGRAMS=""
+if [ -f "$FILE" ]; then
+  OBS_TOOLS=$(jq -rR --argjson cutoff "$CUTOFF" '
+    fromjson? | select(.ts != null and .tool != null)
+    | select((.ts | fromdateiso8601? // 0) >= $cutoff)
+    | .tool' "$FILE" 2>/dev/null | LC_ALL=C sort -u)
+  OBS_PROGRAMS=$(jq -rR --argjson cutoff "$CUTOFF" '
+    fromjson? | select(.ts != null and .tool == "Bash" and .program != null)
+    | select((.ts | fromdateiso8601? // 0) >= $cutoff)
+    | .program' "$FILE" 2>/dev/null | LC_ALL=C sort -u)
+fi
+
+findings=""
+while IFS=$'\t' read -r name pat; do
+  [ -z "$name" ] && continue
+  observed=0
+  case "$pat" in
+    Bash\(*)
+      # program = first token inside Bash( ... )
+      prog=$(printf '%s' "$pat" | sed -E 's/^Bash\(//; s/[[:space:]].*$//; s/\)$//')
+      printf '%s\n' "$OBS_PROGRAMS" | grep -qxF "$prog" && observed=1
+      ;;
+    mcp__*\*)
+      prefix="${pat%\*}"
+      printf '%s\n' "$OBS_TOOLS" | grep -qE "^$(printf '%s' "$prefix" | sed 's/[].[^$*\/]/\\&/g')" && observed=1
+      ;;
+    *)
+      printf '%s\n' "$OBS_TOOLS" | grep -qxF "$pat" && observed=1
+      ;;
+  esac
+  if [ "$observed" -eq 0 ]; then
+    findings+="DEAD: affordance '$name' ($pat) — no observed invocation in the last $MAX_AGE days"$'\n'
+  fi
+done <<< "$DECLARED"
+
+if [ -n "$findings" ]; then
+  printf '%s' "$findings" | LC_ALL=C sort
+  echo "(Bash matching is program-coarse; it cannot distinguish narrow from broad grants.)"
+else
+  echo "OK: every matchable affordance has a recent observed invocation."
+fi
+exit 0

--- a/ai-literacy-superpowers/scripts/harness-affordance-invocations.sh
+++ b/ai-literacy-superpowers/scripts/harness-affordance-invocations.sh
@@ -139,13 +139,20 @@ while IFS=$'\t' read -r name pat; do
   observed=0
   case "$pat" in
     Bash\(*)
-      # program = first token inside Bash( ... )
+      # program = first token inside Bash( ... ), basename'd to mirror the
+      # recorder (so a path-qualified declared pattern matches its invocation).
       prog=$(printf '%s' "$pat" | sed -E 's/^Bash\(//; s/[[:space:]].*$//; s/\)$//')
+      prog=$(basename -- "$prog" 2>/dev/null || printf '%s' "$prog")
       printf '%s\n' "$OBS_PROGRAMS" | grep -qxF "$prog" && observed=1
       ;;
     mcp__*\*)
+      # Glob prefix match (no regex escaping needed): mcp__server__* matches
+      # any observed tool starting with mcp__server__.
       prefix="${pat%\*}"
-      printf '%s\n' "$OBS_TOOLS" | grep -qE "^$(printf '%s' "$prefix" | sed 's/[].[^$*\/]/\\&/g')" && observed=1
+      while IFS= read -r t; do
+        [ -n "$t" ] || continue
+        case "$t" in "$prefix"*) observed=1; break ;; esac
+      done <<< "$OBS_TOOLS"
       ;;
     *)
       printf '%s\n' "$OBS_TOOLS" | grep -qxF "$pat" && observed=1

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -10,7 +10,7 @@
 
      Inspired by Birgitta Boeckeler's "Harness Engineering":
      https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html -->
-<!-- template-version: 0.56.0 -->
+<!-- template-version: 0.57.0 -->
 
 ## Context
 
@@ -410,6 +410,30 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 - **Enforcement**: deterministic
 - **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
 - **Auto-fix**: false (the fix is a human running /harness-affordance review <name>)
+
+### Affordance recorder freshness (LOCAL — per-machine only)
+
+- **What it checks**: Whether the gitignored
+  observability/affordance-invocations.json exists and its newest invocation
+  is within the threshold (default 7 days) — a proxy for whether the
+  PostToolUse recorder hook is operating. The invocation file is gitignored
+  and per-machine, so this is LOCAL observability (runs via /harness-gc on
+  your machine), not a CI control.
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-invocations.sh --check=freshness
+- **Auto-fix**: false
+
+### Affordance dead inventory (LOCAL — per-machine only)
+
+- **What it checks**: Each declared, non-example, non-hook affordance that has
+  had no observed invocation in the last 30 days (per your local recorder).
+  Bash matching is program-coarse and conservative. LOCAL only (gitignored
+  data).
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-invocations.sh --check=dead-inventory
+- **Auto-fix**: false
 -->
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-invocation-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-invocation-format.md
@@ -1,0 +1,76 @@
+---
+title: Affordance Invocation Format
+---
+# Affordance Invocation Format
+
+The PostToolUse recorder hook
+(`hooks/scripts/affordance-invocation-recorder.sh`) appends one tuple per
+affordance-relevant tool call to `observability/affordance-invocations.json`.
+This page is the **stable contract** downstream linters and dashboards consume.
+
+## Storage
+
+- **Path**: `observability/affordance-invocations.json`
+- **Content**: **NDJSON** — one JSON object per line (the `.json` extension is
+  kept for continuity with the affordance section's runtime-data reference;
+  the content is line-delimited, not a single array).
+- **Gitignored, per-machine.** The file is append-only and not committed, so
+  there is no cross-machine merge. It answers "did *my* sessions invoke this?".
+- **Bounded**: the recorder self-trims to the last 5000 lines.
+- **Append-only**: the recorder never rewrites existing lines, so the only
+  corruption mode is a partial final line; consumers skip any unparseable
+  line.
+
+## What is recorded
+
+Only **`Bash` and `mcp__*`** tool calls (the tools that map to affordances).
+Built-in file tools (`Read`, `Edit`, `Write`, `Grep`, …) are **not** recorded.
+
+## Tuple schema
+
+```json
+{"tool": "<string>", "program": "<string|null>", "invoker": "<string>", "session": "<string>", "ts": "<UTC ISO-8601>"}
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `tool` | string | The Claude Code tool name as received (`Bash`, `mcp__honeycomb__query`, …). The affordance identity for MCP and named tools. |
+| `program` | string or `null` | For `Bash` only, the command's **program name** — env-var prefixes stripped, path `basename`'d, and accepted only if it matches `^[A-Za-z0-9._-]+$`. `null` for non-Bash tools or any command whose first token is not a clean program name. |
+| `invoker` | string | The invoking agent/command if the payload exposes it, else `"unknown"` (best-effort; the dead-inventory question does not depend on it). |
+| `session` | string | The opaque session id, or `"unknown"`. |
+| `ts` | string | UTC ISO-8601 timestamp the hook stamps (`YYYY-MM-DDTHH:MM:SSZ`). |
+
+## Privacy guarantees
+
+The recorder records **no tool arguments, no file contents, no paths, and no
+user identity**. The `program` field is the program *name* only:
+
+- `GH_TOKEN=ghp_secret gh pr list` → `"program": "gh"` (the env-var prefix,
+  including the secret, is stripped).
+- `/Users/alice/private/deploy.sh --env prod` → `"program": "deploy.sh"` (the
+  path is reduced to its basename; the arguments are dropped).
+- `( echo hi ) | tee x` → `"program": null` (shell syntax is not a program
+  name).
+
+## Consuming the file
+
+The analyzer `scripts/harness-affordance-invocations.sh` reads it:
+
+- `--check=freshness` — is the newest `ts` within `--max-age-days` (default 7)?
+- `--check=dead-inventory` — does each declared, non-example, **non-hook**
+  affordance have a matching invocation within `--max-age-days` (default 30)?
+
+**Matching**: exact `tool` equality (or `mcp__server__*` prefix) for MCP/named
+tools; **program-coarse and conservative** for Bash — a `Bash(<prog> *)`
+affordance matches a tuple whose `program` equals `<prog>`, and an observed
+program marks every Bash affordance sharing it as observed (a false-alive,
+never a false-dead). Hook affordances are excluded (a PostToolUse recorder
+cannot observe hook firings).
+
+Both checks are **report-only** and, because the data file is gitignored, are
+**local per-machine observability** — they run via `/harness-gc` on your
+machine, not the CI cron.
+
+A downstream consumer should: read the file line by line, `JSON.parse` each
+line, **skip** lines that fail to parse, and treat field absence as `null` /
+`"unknown"`.

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-invocation-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-invocation-format.md
@@ -52,6 +52,16 @@ user identity**. The `program` field is the program *name* only:
 - `( echo hi ) | tee x` → `"program": null` (shell syntax is not a program
   name).
 
+**Accuracy note (fail-safe):** because the recorder extracts the program with
+grep/sed (no jq, to avoid a silent-no-op dependency), a command whose first
+token is preceded by a quoted segment (`"my tool" run`) or a quoted env value
+with a space (`FOO="a b" gh …`) records `"program": null` rather than the
+program. This **never leaks** (it errs to `null`), but it can cause the
+dead-inventory check to mark a genuinely-used Bash affordance as `DEAD`. Real
+programs are bare tokens (`gh`, `git`, `npx`), so this is uncommon; combined
+with the conservative, program-coarse Bash matching it means dead-inventory is
+a *report-only local advisory*, not an authoritative signal, for Bash.
+
 ## Consuming the file
 
 The analyzer `scripts/harness-affordance-invocations.sh` reads it:

--- a/docs/superpowers/objections/affordance-runtime-recorder-design-code.md
+++ b/docs/superpowers/objections/affordance-runtime-recorder-design-code.md
@@ -1,0 +1,84 @@
+---
+spec: docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
+date: 2026-06-17
+mode: code
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: risk
+    severity: medium
+    claim: "The self-trim's non-atomic read-then-mv (with a fixed $file.tmp name) races under concurrent PostToolUse hooks, reintroducing the concurrency hazard the append-only design avoided and able to lose committed lines."
+    evidence: "recorder trim: tail > \"$file.tmp\" && mv; fixed tmp name, no lock."
+    disposition: amend
+    disposition_rationale: "Use a unique tmp name ($file.$$.<rand>.tmp) so concurrent trims cannot clobber each other's tmp or read a half-written one. Trim is best-effort on a per-machine file; bounded line loss under a rare simultaneous trim is acceptable, but the half-written-tmp read and same-name clobber are removed."
+  - id: O2
+    category: implementation
+    severity: medium
+    claim: "The Layer-0 recorder test proves no-leak only for benign shapes; escaped-quote-in-first-token, embedded newline, hostile session_id, and emitted-JSON validity are unverified."
+    evidence: "test covers only easy inputs; never parses the emitted line as JSON."
+    disposition: amend
+    disposition_rationale: "Add adversarial recorder tests: a command with an escaped quote before the program, an embedded newline, a session_id carrying JSON metacharacters (must be sanitised to unknown), and an assertion that every emitted line parses as valid JSON (jq -e)."
+  - id: O3
+    category: risk
+    severity: medium
+    claim: "The `\"command\":\"[^\"]*\"` grep truncates at the first escaped quote, so a command whose program word follows a quoted segment records program:null — biasing dead-inventory toward false-DEAD (fail-safe for privacy, an accuracy bug)."
+    evidence: "grep [^\"]* stops at an escaped quote; the program becomes null."
+    disposition: acknowledge
+    disposition_rationale: "Fail-SAFE: it nulls, never leaks — the A2/A4 privacy guarantee is unaffected. Robust JSON-string parsing in grep/sed (no jq, per A6) is fragile, and a leading-quoted-segment command is uncommon (real programs are bare: gh, git, npx). Documented as a known accuracy limitation in the reference page (a false-null program may cause a false-DEAD); the dead-inventory output already warns Bash matching is coarse and errs toward not-flagging."
+  - id: O4
+    category: risk
+    severity: low
+    claim: "wc -l on every call plus a full-file tail near the cap makes per-call cost O(file size), contradicting the 'single append, negligible' claim."
+    evidence: "wc -l unconditional; full tail+mv every call while over cap."
+    disposition: amend
+    disposition_rationale: "Resolved with O1: gate the trim on an O(1) file-size check (stat -f%z / -c%s) against a byte cap, so the common path is a single append + one stat; the full tail+mv runs only when the file genuinely exceeds the byte cap."
+  - id: O5
+    category: implementation
+    severity: low
+    claim: "The hook matcher `mcp__.*` (unanchored regex) and the in-script `mcp__*` (anchored glob) use different match languages, so they disagree on a hypothetical `xmcp__y` tool."
+    evidence: "hooks.json matcher regex vs recorder case glob."
+    disposition: acknowledge
+    disposition_rationale: "The in-script case-gate (Bash|mcp__*) is the authoritative filter; the matcher is only a coarse pre-filter that at worst wastes a no-op spawn on a non-existent substring-mcp tool. No real tool name contains mcp__ as a non-prefix substring. Not worth changing the matcher (and over-anchoring a Claude Code matcher risks breaking it)."
+  - id: O6
+    category: risk
+    severity: low
+    claim: "A quoted env value containing a space (FOO=\"a b\" gh ...) is not stripped, so the program records null."
+    evidence: "the =[^[:space:]]* guard cannot span a quoted internal space."
+    disposition: acknowledge
+    disposition_rationale: "Fail-safe (nulls, never leaks); covered by the same documented accuracy-limitation note as O3. Quoted env-value prefixes are uncommon."
+  - id: O7
+    category: implementation
+    severity: low
+    claim: "The analyzer's MCP-prefix grep regex escaping omits \\, +, {, } — inert for the MCP naming charset but fragile if presented as general-purpose."
+    evidence: "sed escape set omits several metacharacters."
+    disposition: amend
+    disposition_rationale: "Replace the grep -E prefix regex with a shell glob prefix match (case \"$tool\" in \"$prefix\"*) — no regex, no escaping concern, exact prefix semantics."
+  - id: O8
+    category: implementation
+    severity: low
+    claim: "The analyzer derives the Bash program from the declared pattern without basename, so a path-form declared pattern (Bash(/usr/local/bin/foo *)) never matches its recorded invocation (program foo)."
+    evidence: "recorder basenames the program; analyzer takes the literal first token."
+    disposition: amend
+    disposition_rationale: "basename the analyzer-side program too, mirroring the recorder, so a path-qualified declared Bash pattern matches its observed program."
+---
+
+# Objection record — affordance runtime recorder (code mode)
+
+Eight objections; **no critical, no high**. The privacy-critical claim survived
+scrutiny — the diaboli could construct no input that emits a secret, path,
+argument, or invalid JSON (the strip-env → basename → `^[A-Za-z0-9._-]+$`
+allowlist → else-null pipeline is genuinely fail-safe, and every interpolated
+JSON field is shape-gated). Adjudicated 2026-06-17: five **amend** (unique-tmp
++ O(1)-gated trim, adversarial privacy tests, glob MCP-prefix, basename the
+analyzer program), three **acknowledge** (O3/O6 fail-safe accuracy limits
+documented; O5 matcher pre-filter harmless).
+
+## Explicitly not challenged
+
+- JSON validity of the emitted tuple (every field shape-gated or literal null).
+- The core no-secrets/no-args privacy property (fail-safe; verified).
+- The never-blocks / always-exit-0 guarantee.
+- The no-jq-in-recorder requirement (A6).
+- The analyzer's `-R 'fromjson?'` NDJSON tolerance and UTC date math (step-6 reuse).
+- Hook exclusion + anchored example-marker in the analyzer parser.
+- Gitignore / LOCAL-not-CI framing (A5 honesty met; no step-8 leak).

--- a/docs/superpowers/objections/affordance-runtime-recorder-design.md
+++ b/docs/superpowers/objections/affordance-runtime-recorder-design.md
@@ -1,0 +1,113 @@
+---
+spec: docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
+date: 2026-06-17
+mode: spec
+diaboli_model: claude-opus-4-8[1m]
+objections:
+  - id: O1
+    category: specification quality
+    severity: high
+    claim: "Changing the runtime-data filename from the committed .json to .ndjson breaks the O3 reference hardcoded in HARNESS.md, the parent spec, the explanation doc, and the step-3 spec."
+    evidence: "Spec names .ndjson; templates/HARNESS.md header + parent O3 + docs all say .json."
+    disposition: amend
+    disposition_rationale: "Keep the filename observability/affordance-invocations.json (the established O3 reference) with NDJSON content (one JSON object per line). The extension stays .json so the human-facing section-header pointer remains valid; the spec states the content is line-delimited JSON."
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The Bash 'program' = first whitespace word can leak secrets/paths (VAR=secret gh ..., /abs/path/script.sh), defeating the no-arguments/no-secrets guarantee."
+    evidence: "Only extraction rule is 'first whitespace-delimited word'; no normalisation."
+    disposition: amend
+    disposition_rationale: "Sanitise the program token: strip leading KEY=VALUE env-var prefixes, take the program word, basename it (a path becomes just the script name), and record it ONLY if it matches a safe program-name shape (^[A-Za-z0-9._-]+$). Anything else (quotes, slashes after basename, subshell/pipeline syntax) records program:null. The recorder never writes a raw path or an env assignment."
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "Program-equality Bash matching over-matches: Bash(gh *) and Bash(gh pr *) both match any program:'gh' tuple, contradicting the steps-4+5 string-equality contract and masking a dead narrow grant."
+    evidence: "Spec admits the gh-pr-vs-gh distinction cannot be made from the program alone."
+    disposition: amend
+    disposition_rationale: "Accept program-granular Bash matching as a documented limitation of the minimal-tuple choice, and make it CONSERVATIVE: an observed program marks EVERY Bash affordance sharing that program as observed (a false-alive, never a false-dead). The dead-inventory output states explicitly that Bash matching is program-coarse and does not distinguish narrow from broad grants — a report-only advisory that errs toward not-flagging. Exact matching holds for MCP/named tools."
+  - id: O4
+    category: risk
+    severity: high
+    claim: "'Records no arguments' is asserted but no mechanism enforces it; an env-var-prefixed or path-form first token writes a secret/path into the file."
+    evidence: "Privacy guarantee stated three times; only rule is 'first word'."
+    disposition: amend
+    disposition_rationale: "Resolved by O2's sanitisation (strip KEY=VALUE, basename, shape-allowlist, else null). The spec specifies the exact normalisation so the no-secrets property is delivered by code, not merely declared, with an acceptance scenario for the env-prefix and path-form cases."
+  - id: O5
+    category: risk
+    severity: high
+    claim: "Gitignoring the file means the freshness/dead-inventory checks only ever run on one developer's machine on demand — the local-only governance gap step 6 explicitly fixed by wiring gc.yml."
+    evidence: "Spec: 'run meaningfully only on a developer machine ... not the CI cron'."
+    disposition: amend
+    disposition_rationale: "Honest reframe (a direct consequence of the user-confirmed gitignored fork): the recorder and its checks are LOCAL, per-machine OBSERVABILITY, not a CI governance control — stated in the value proposition, not a footnote. Unlike step 6 (where HARNESS.md is committed so the cron could read it), here the DATA file is gitignored, so a gc.yml step would always self-skip and is deliberately NOT added. The checks run via the on-demand harness-gc agent locally. A future committed-aggregate step could add a team/CI view."
+  - id: O6
+    category: risk
+    severity: high
+    claim: "The jq dependency is a silent-no-op trap: no jq => recorder writes nothing silently => freshness reports stale forever and dead-inventory flags everything dead, with no breadcrumb."
+    evidence: "Spec: recorder exits silently if jq absent; existing hooks deliberately use grep/sed."
+    disposition: amend
+    disposition_rationale: "The RECORDER uses grep/sed + printf (no jq), matching the established hook baseline (markdownlint-check.sh) — removing the trap. The ANALYZER (a deterministic script, not a hook) may use jq, but reports a clear 'jq not installed' line rather than silently flagging everything, so its verdict is interpretable."
+  - id: O7
+    category: premise
+    severity: medium
+    claim: "The marquee 'invoker' field is best-effort and likely 'unknown', so the feature's differentiator may ship non-functional."
+    evidence: "Spec never verifies PostToolUse exposes the invoker."
+    disposition: amend
+    disposition_rationale: "Reframe the value around the dead-inventory question ('did this declared affordance fire?'), which does not depend on invoker. invoker is recorded best-effort as a bonus; the spec no longer presents 'which agent invoked it' as the headline. If a future payload reliably exposes the invoker, the field is already there."
+  - id: O8
+    category: risk
+    severity: medium
+    claim: "'NDJSON is concurrency-safe' is asserted; concurrent appends exceeding the atomic-append size can interleave mid-line, so corruption is not confined to the trailing line."
+    evidence: "No mention of PIPE_BUF / O_APPEND atomicity bounds."
+    disposition: amend
+    disposition_rationale: "Keep the tuple small (well under 512 bytes / PIPE_BUF, so a single O_APPEND write is atomic on POSIX), and have the analyzer skip ANY unparseable line, not only the trailing one. Both stated."
+  - id: O9
+    category: implementation
+    severity: medium
+    claim: "'Never delays the session' is overstated for a per-tool-call hook doing a jq spawn + append on every call."
+    evidence: "jq per call; PostToolUse fires on every tool."
+    disposition: amend
+    disposition_rationale: "Resolved largely by O6 (no jq in the recorder): the per-call cost is a grep/sed extraction + one short append, on par with the existing PreToolUse markdownlint hook. Stated as the cost, not asserted as negligible."
+  - id: O10
+    category: risk
+    severity: medium
+    claim: "The file grows unbounded with no compaction; the analyzer reads only the last N days, so old bytes are pure dead weight."
+    evidence: "Recorder appends, never rewrites; no rotation rule."
+    disposition: amend
+    disposition_rationale: "The recorder self-trims: when the file exceeds a line cap (e.g. 5000 lines), it keeps the last N lines (cheap tail) before/after appending, bounding size while retaining well more than the 30-day dead-inventory window for a normal machine."
+  - id: O11
+    category: specification quality
+    severity: medium
+    claim: "Hook affordances (Permission hooks.<Trigger>) are structurally unobservable by a PostToolUse recorder, so every Mode: hook affordance is always flagged dead inventory."
+    evidence: "Matching defined only for MCP/named tools and Bash programs; parent declares hook affordances."
+    disposition: amend
+    disposition_rationale: "Dead-inventory EXCLUDES Mode: hook affordances (a PostToolUse recorder cannot observe hook firings), consistent with steps-4+5 excluding hooks from the permission relation. Stated explicitly so a hook affordance is never mis-flagged as dead."
+  - id: O12
+    category: scope
+    severity: medium
+    claim: "The spec supersedes the parent's step-7 wording (SessionEnd, .json) without flagging the divergence the parent's downstream references depend on."
+    evidence: "Parent step-7: 'SessionEnd hook ... affordance-invocations.json'; this spec: PostToolUse, NDJSON."
+    disposition: amend
+    disposition_rationale: "Add an explicit note that this spec supersedes the parent's step-7 hook-surface wording (PostToolUse, user-confirmed) while KEEPING the .json filename (O1), so the parent's section-header reference and freshness-constraint exemplar stay coherent."
+---
+
+# Objection record — affordance runtime recorder (spec mode)
+
+Twelve objections (6 high, 6 medium); no critical. None re-opens the three
+user-confirmed forks (hook surface, gitignored storage, minimal tuple) — they
+are robustness/correctness refinements within them. All adjudicated 2026-06-17
+— every objection **amend**. The load-bearing fixes: keep the .json filename
+(O1); sanitise the Bash program token so the no-secrets guarantee is real
+(O2/O4); recorder uses grep/sed not jq, removing the silent-no-op trap (O6);
+exclude hooks from dead-inventory (O11); honest local-observability framing for
+the gitignored consequence (O5); conservative program-granular Bash matching
+(O3); bounded file via self-trim (O10).
+
+## Explicitly not challenged
+
+- The PostToolUse hook surface (user-confirmed; verified to expose tool_name).
+- Gitignored per-machine storage (user-confirmed answer to cross-machine merge).
+- The minimal tuple / no-arguments / no-identity privacy stance (the intent is
+  right; O2/O4 are that the design must deliver it, not that it is wrong).
+- The report-only, exit-0-always, --today-hermetic analyzer discipline.
+- The example-marker skip (inherited, anchored, from the step-6 code-mode fix).
+- NDJSON as the content shape for append-only event data.

--- a/docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
+++ b/docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
@@ -1,0 +1,161 @@
+# Spec: Affordance runtime invocation recorder (sequencing step 7)
+
+**Date**: 2026-06-17
+**Author**: Russ Miles + assistant
+**Parent design**: `docs/superpowers/specs/2026-04-26-harness-affordances-design.md`
+(O3 disposition — runtime data lives in `observability/`, never inlined into
+HARNESS.md)
+**Builds on**: step 3 (the `## Affordances` section) and the deterministic
+analyzer pattern from steps 4-6
+**Driving issue**: #203
+**Status**: design — awaiting spec-mode `/diaboli` and user review
+
+## Problem
+
+The affordance section declares what tools the agent *can* invoke. Nothing
+yet records what it *actually* invoked at runtime. Without that, two
+governance questions stay unanswerable: "did this declared affordance ever
+fire?" (dead-inventory detection) and "is the recorder even operating?"
+(observability health). The parent spec's O3 settled that this runtime data
+must **not** be inlined into HARNESS.md (humans own that file) — it lives in
+`observability/`, referenced by path from the affordance section.
+
+## Confirmed design decisions (user-adjudicated 2026-06-17)
+
+1. **Hook surface: PostToolUse.** It is the only event that reliably knows
+   `tool_name` per invocation (verified against the existing
+   `markdownlint-check.sh` PreToolUse hook, which reads the tool payload from
+   stdin JSON). `Stop`/`SessionEnd` hooks do not receive the per-tool list and
+   would have to parse the transcript — fragile. Per-call cost is a single
+   appended line; negligible.
+2. **Storage: gitignored, per-machine, append-only NDJSON** at
+   `observability/affordance-invocations.ndjson`. Gitignoring it dissolves the
+   cross-machine merge problem entirely: each developer's file answers "did MY
+   sessions invoke this?". NDJSON (one JSON object per line) is the
+   concurrency-safe shape for an append-only hook fired across overlapping
+   sessions.
+3. **Tuple is minimal (privacy).** Each line records only the tool identity,
+   the invoking surface, an opaque session id, and a UTC timestamp — **no tool
+   arguments** (they can carry secrets/paths) and **no user identity**.
+
+## The tuple format (the consumable contract)
+
+One NDJSON object per invocation:
+
+```json
+{"tool": "<tool_name>", "program": "<bash-program-or-null>", "invoker": "<agent-or-command-or-unknown>", "session": "<opaque-id>", "ts": "<UTC-ISO-8601>"}
+```
+
+- **`tool`** — the Claude Code tool name as received (`Bash`, `Edit`,
+  `mcp__honeycomb__query`, …). This is the affordance identity for MCP and
+  named tools.
+- **`program`** — for `Bash` only, the command's **program token** (the first
+  whitespace-delimited word, e.g. `gh`, `git`, `npx`); `null` for non-Bash
+  tools. This is the granularity an affordance pattern keys on
+  (`Bash(gh *)` → program `gh`). It is the program *name*, never the
+  arguments — the privacy boundary is "what was run", not "with what".
+- **`invoker`** — the invoking agent or command if the payload exposes it,
+  else `"unknown"`. Best-effort; the dead-inventory question works without it.
+- **`session`** — the opaque session id from the payload (or `"unknown"`).
+- **`ts`** — UTC ISO-8601 timestamp the hook stamps.
+
+This shape is the **stable contract** downstream linters/dashboards consume.
+The recorder appends; it never rewrites, so a partially-written final line
+(crash mid-append) is the only corruption mode, and consumers tolerate a
+trailing malformed line.
+
+## Components
+
+### The recorder hook — `hooks/scripts/affordance-invocation-recorder.sh`
+
+A PostToolUse hook (registered in `hooks/hooks.json`). It:
+
+1. Reads the tool payload from stdin.
+2. Extracts `tool_name`; derives `program` for Bash (first token of the
+   command, never the rest); best-effort `invoker` and `session`.
+3. Appends one NDJSON line to
+   `observability/affordance-invocations.ndjson` (creating the dir/file).
+4. **Never blocks, never errors loudly, never delays** — if `jq` is absent or
+   the payload is unparseable it exits 0 silently (observability is
+   best-effort; a recorder must not interfere with the session).
+
+Privacy: it records `tool`, `program` (Bash program name only), `invoker`,
+`session`, `ts`. It never writes tool arguments, file contents, or user
+identity.
+
+### The analyzer — `scripts/harness-affordance-invocations.sh`
+
+A deterministic, report-only analyzer (testable; takes a project dir and a
+`--today` override for hermetic tests). Two checks:
+
+- **`--check=freshness [--max-age-days=N]`** — is the NDJSON file present and
+  its newest `ts` within N days (default 7)? A stale or missing file means the
+  recorder is probably not operating. Report-only.
+- **`--check=dead-inventory [--max-age-days=N]`** — for each **declared**
+  non-example affordance, has any invocation in the last N days (default 30)
+  matched it? Matching: an MCP/named affordance matches a tuple whose `tool`
+  equals (or `mcp__server__*` prefix-matches) the pattern; a `Bash(<prog> *)`
+  affordance matches a tuple whose `program` equals `<prog>`. Unmatched
+  affordances are flagged as **dead inventory** (declared but never observed).
+
+Both exit 0 always (report-only); findings go to stdout, `LC_ALL=C`-sorted.
+
+### Gitignore + GC wiring
+
+- `.gitignore` (template + this repo): ignore
+  `observability/affordance-invocations.ndjson`.
+- Two **commented-opt-in** GC rules in `templates/HARNESS.md` (report-only,
+  weekly) pointing at the analyzer's two checks. Because the file is
+  gitignored, these run meaningfully only on a developer machine / the
+  on-demand `harness-gc` agent — **not** the CI cron (which has no file and
+  the analyzer self-skips). The GC-rule prose states this honestly.
+
+## Acceptance scenarios
+
+1. **Recorder appends a well-formed tuple** for a Bash `gh ...` call: one
+   NDJSON line with `tool:"Bash"`, `program:"gh"`, no arguments present.
+2. **Recorder is silent and harmless** when `jq` is absent or the payload is
+   unparseable (exit 0, no output, session unaffected).
+3. **No arguments leak** — a Bash call `gh pr create --title "secret"` records
+   `program:"gh"` and nothing of the title/args.
+4. **Freshness** — a file whose newest `ts` is older than the threshold (or a
+   missing file) is reported stale; a fresh file reports OK.
+5. **Dead inventory** — a declared affordance with no matching invocation in
+   the window is flagged; one with a matching invocation is not.
+6. **Matching granularity** — `Bash(gh *)` matches a `program:"gh"` tuple;
+   `mcp__honeycomb__*` matches a `tool:"mcp__honeycomb__query"` tuple; example
+   affordances are skipped.
+7. **Hermetic** — `--today` fixes "now"; the analyzer is deterministic.
+
+## Functional requirements
+
+- **FR1** A PostToolUse recorder hook appends a minimal NDJSON tuple per
+  invocation to a gitignored `observability/affordance-invocations.ndjson`,
+  recording no arguments and no user identity, and never blocking/erroring.
+- **FR2** The tuple format is the documented stable contract above.
+- **FR3** A deterministic analyzer provides freshness and dead-inventory
+  checks (report-only, `--today` hermetic), with the documented matching.
+- **FR4** The NDJSON path is gitignored (template + repo); two commented
+  opt-in GC rules reference the analyzer with honest "runs locally, not CI"
+  prose.
+- **FR5** Layer 0 tests cover the recorder's tuple shape + privacy (no args)
+  and the analyzer's freshness/dead-inventory/matching scenarios.
+- **FR6** Docs: a reference page for the tuple format and an explanation/how-to
+  update.
+
+## Risks and mitigations
+
+- **PostToolUse volume.** One small append per tool call; NDJSON append is
+  cheap and the file is gitignored (no commit churn). Acceptable.
+- **`invoker` may be unavailable in the payload.** Recorded best-effort as
+  `"unknown"`; the dead-inventory question (the primary value) does not depend
+  on it.
+- **Bash granularity.** Recording the program token (not args) means a
+  `Bash(gh pr *)` vs `Bash(gh *)` distinction cannot always be made from the
+  program name alone — matching is at program granularity for Bash. Documented
+  as a known coarseness; exact matching holds for MCP/named tools.
+- **Gitignored ⇒ no CI enforcement.** The two GC rules are local/advisory by
+  design (the file is per-machine). Stated honestly; a future committed-
+  aggregate step could add a team view.
+- **Partial final line on crash.** Consumers tolerate a trailing malformed
+  line; the analyzer skips unparseable lines.

--- a/docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
+++ b/docs/superpowers/specs/2026-06-17-affordance-runtime-recorder-design.md
@@ -8,7 +8,9 @@ HARNESS.md)
 **Builds on**: step 3 (the `## Affordances` section) and the deterministic
 analyzer pattern from steps 4-6
 **Driving issue**: #203
-**Status**: design — awaiting spec-mode `/diaboli` and user review
+**Status**: design — spec-mode `/diaboli` reviewed, all 12 dispositions
+adjudicated 2026-06-17 (see Adjudication); the three design forks were
+user-confirmed before spec; ready for implementation
 
 ## Problem
 
@@ -142,6 +144,60 @@ Both exit 0 always (report-only); findings go to stdout, `LC_ALL=C`-sorted.
   and the analyzer's freshness/dead-inventory/matching scenarios.
 - **FR6** Docs: a reference page for the tuple format and an explanation/how-to
   update.
+
+## Adjudication (post-diaboli, 2026-06-17)
+
+Spec-mode `/diaboli` raised twelve objections (6 high; record:
+`docs/superpowers/objections/affordance-runtime-recorder-design.md`). All
+adjudicated — every objection **amend**. None re-opened the three
+user-confirmed forks; they refine robustness/correctness within them. The
+binding refinements below supersede the wording above where they conflict.
+
+- **A1/A12 (O1/O12) — keep the `.json` filename.** The file stays
+  `observability/affordance-invocations.json` (the established O3 reference in
+  HARNESS.md, the parent spec, and the docs) with **NDJSON content** (one JSON
+  object per line). This spec supersedes the parent's step-7 *hook surface*
+  wording (PostToolUse, user-confirmed) while keeping the filename, so the
+  human-facing section-header pointer and the freshness exemplar stay valid.
+- **A2/A4 (O2/O4) — sanitise the Bash `program` token.** Strip leading
+  `KEY=VALUE` env-var prefixes, take the program word, **`basename`** it (a
+  path → just the script name), and record it **only if** it matches
+  `^[A-Za-z0-9._-]+$`; otherwise record `program:null`. The recorder never
+  writes a raw path, an env assignment, or pipeline/subshell syntax — the
+  no-secrets guarantee is enforced by this normalisation, with acceptance
+  scenarios for the env-prefix and path-form cases.
+- **A3 (O3) — conservative, program-coarse Bash matching.** Dead-inventory
+  matching is exact for MCP/named tools; for Bash it is program-granular and
+  **conservative** — an observed program marks **every** Bash affordance
+  sharing that program as observed (a false-alive, never a false-dead). The
+  output states that Bash matching does not distinguish narrow from broad
+  grants. This is a documented limitation of the minimal-tuple privacy choice.
+- **A5 (O5) — honest local-observability framing.** Because the data file is
+  gitignored (user-confirmed), the recorder and its checks are **per-machine
+  local observability, not a CI governance control**. Stated in the value
+  proposition. A `gc.yml` step is deliberately **not** added (it would always
+  self-skip with no file); the checks run via the on-demand `harness-gc` agent
+  and the commented opt-in GC rules. A future committed-aggregate step could
+  add a team/CI view.
+- **A6/A9 (O6/O9) — recorder uses grep/sed, no jq.** The recorder extracts
+  fields with grep/sed + `printf` (matching `markdownlint-check.sh`), removing
+  the jq silent-no-op trap; per-call cost is one extraction + one short append.
+  The **analyzer** (a script, not a hook) may use jq but prints a clear
+  `jq not installed` line rather than silently flagging everything.
+- **A7 (O7) — value is dead-inventory, invoker is a bonus.** The feature's
+  value is "did this declared affordance fire?", which does not depend on
+  `invoker`. `invoker` is recorded best-effort; the spec no longer presents
+  "which agent invoked it" as the headline.
+- **A8 (O8) — atomic small tuple + tolerant analyzer.** The tuple is kept well
+  under 512 bytes (PIPE_BUF) so a single `O_APPEND` write is atomic on POSIX;
+  the analyzer skips **any** unparseable line, not just the trailing one.
+- **A10 (O10) — bounded file.** The recorder self-trims: when the file exceeds
+  a line cap (5000), it retains the last N lines, bounding size while keeping
+  far more than the 30-day dead-inventory window on a normal machine.
+- **A11 (O11) — exclude hooks from dead-inventory.** A PostToolUse recorder
+  cannot observe hook firings, so `Mode: hook` affordances are **excluded**
+  from dead-inventory (never mis-flagged as dead), consistent with
+  steps-4+5 excluding hooks from the permission relation.
 
 ## Risks and mitigations
 

--- a/tdad_tests/layer0_deterministic/test-affordance-invocations.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-invocations.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# (SC2016 suppressed file-wide: the single-quoted HARNESS.md fixtures contain
+# literal markdown backticks — the affordance Permission field — that must not
+# expand. A file-level directive must precede the first command.)
+set -euo pipefail
+# Layer 0 test for harness-affordance-invocations.sh (step 7 analyzer).
+# Hermetic via --today + fixture project dirs.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+A="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/harness-affordance-invocations.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not installed — skipping analyzer test (matches the script's own jq guard)."
+  exit 0
+fi
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+run() { OUT=$("$A" "$@" 2>&1); }
+
+HARNESS='# H
+## Affordances
+### gh-cli
+- **Mode**: cli
+- **Permission**: `Bash(gh *)` (allowlist)
+### gh-pr-cli
+- **Mode**: cli
+- **Permission**: `Bash(gh pr *)` (allowlist)
+### git-cli
+- **Mode**: cli
+- **Permission**: `Bash(git *)` (allowlist)
+### honeycomb
+- **Mode**: central-mcp
+- **Permission**: `mcp__honeycomb__*` (allowlist)
+### a-hook
+- **Mode**: hook
+- **Permission**: `hooks.Stop` entry
+### example
+<!-- affordance-example -->
+- **Mode**: cli
+- **Permission**: `Bash(echo *)` (allowlist)
+## Status'
+
+mkproj() {
+  local d; d=$(mktemp -d); mkdir -p "$d/observability"
+  printf '%s\n' "$HARNESS" > "$d/HARNESS.md"
+  [ -n "${1:-}" ] && printf '%s\n' "$1" > "$d/observability/affordance-invocations.json"
+  printf '%s' "$d"
+}
+
+LOG='{"tool":"Bash","program":"gh","invoker":"unknown","session":"s","ts":"2026-06-15T10:00:00Z"}
+{"tool":"mcp__honeycomb__query","program":null,"invoker":"unknown","session":"s","ts":"2026-06-16T10:00:00Z"}
+this line is malformed and must be skipped'
+
+# Freshness: newest 2026-06-16, today 2026-06-17, threshold 7 -> OK.
+d=$(mkproj "$LOG"); run --check=freshness --today=2026-06-17 "$d"
+echo "$OUT" | grep -q "^OK: recorder active" || fail "fresh file should be OK: $OUT"
+rm -rf "$d"
+
+# Freshness: stale (today far future) -> STALE.
+d=$(mkproj "$LOG"); run --check=freshness --today=2026-09-01 "$d"
+echo "$OUT" | grep -q "^STALE:" || fail "old file should be STALE: $OUT"
+rm -rf "$d"
+
+# Freshness: no file -> STALE (recorder not operating).
+d=$(mkproj ""); run --check=freshness --today=2026-06-17 "$d"
+echo "$OUT" | grep -q "no invocation file" || fail "missing file should be STALE: $OUT"
+rm -rf "$d"
+
+# Dead-inventory: git DEAD; gh-cli + gh-pr-cli alive (conservative); honeycomb
+# alive; hook + example excluded; malformed line skipped.
+d=$(mkproj "$LOG"); run --check=dead-inventory --today=2026-06-17 "$d"
+echo "$OUT" | grep -q "DEAD: affordance 'git-cli'" || fail "git-cli should be DEAD: $OUT"
+echo "$OUT" | grep -q "gh-cli" && fail "gh-cli should be alive (gh observed): $OUT"
+echo "$OUT" | grep -q "gh-pr-cli" && fail "gh-pr-cli must be alive (conservative program match): $OUT"
+echo "$OUT" | grep -q "honeycomb" && fail "honeycomb should be alive (mcp observed): $OUT"
+echo "$OUT" | grep -q "a-hook" && fail "hook affordance must be excluded from dead-inventory: $OUT"
+echo "$OUT" | grep -q "example" && fail "example affordance must be skipped: $OUT"
+rm -rf "$d"
+
+# Dead-inventory: no file -> all matchable DEAD (gh, gh-pr, git, honeycomb).
+d=$(mkproj ""); run --check=dead-inventory --today=2026-06-17 "$d"
+for a in gh-cli gh-pr-cli git-cli honeycomb; do
+  echo "$OUT" | grep -q "DEAD: affordance '$a'" || fail "$a should be DEAD with no log: $OUT"
+done
+echo "$OUT" | grep -q "a-hook" && fail "hook must stay excluded even with no log: $OUT"
+rm -rf "$d"
+
+# Window: an invocation older than the window does not keep an affordance alive.
+d=$(mkproj '{"tool":"Bash","program":"git","invoker":"unknown","session":"s","ts":"2026-01-01T10:00:00Z"}')
+run --check=dead-inventory --today=2026-06-17 --max-age-days=30 "$d"
+echo "$OUT" | grep -q "DEAD: affordance 'git-cli'" || fail "a >30d-old git invocation should not keep git-cli alive: $OUT"
+rm -rf "$d"
+
+echo "All affordance-invocations tests passed."

--- a/tdad_tests/layer0_deterministic/test-affordance-recorder.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-recorder.sh
@@ -69,4 +69,34 @@ len=$(wc -c < "$(logfile "$d")" | tr -d ' ')
 [ "$len" -lt 512 ] || fail "tuple line should be < 512 bytes (got $len)"
 rm -rf "$d"
 
+# --- adversarial privacy cases (O2) ---
+
+# Escaped quote before the program: must never leak, program collapses to null.
+d=$(newproj)
+printf '%s\n' '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"\"secretword\" run --token abc"}}' | rec "$d"
+if [ -s "$(logfile "$d")" ]; then
+  grep -q 'secretword\|--token\|abc' "$(logfile "$d")" && fail "escaped-quote command must not leak: $(cat "$(logfile "$d")")"
+  grep -q '"program":null' "$(logfile "$d")" || fail "escaped-quote command should record program null"
+fi
+rm -rf "$d"
+
+# Hostile session_id carrying JSON metacharacters: must be sanitised to unknown.
+d=$(newproj)
+printf '%s\n' '{"session_id":"s\"},{\"x\":\"y","tool_name":"Bash","tool_input":{"command":"git status"}}' | rec "$d"
+grep -q '"session":"unknown"' "$(logfile "$d")" || fail "hostile session_id must sanitise to unknown: $(cat "$(logfile "$d")")"
+rm -rf "$d"
+
+# Every emitted line must be valid JSON (privacy + consumability contract).
+if command -v jq >/dev/null 2>&1; then
+  d=$(newproj)
+  for cmd in 'gh pr list' 'GH_TOKEN=ghp_x gh x' '/a/b/c.sh --flag' '( echo ) | tee f' '"q" run'; do
+    printf '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"%s"}}\n' "$cmd" | rec "$d"
+  done
+  printf '{"session_id":"s1","tool_name":"mcp__h__q","tool_input":{}}\n' | rec "$d"
+  while IFS= read -r line; do
+    printf '%s' "$line" | jq -e . >/dev/null 2>&1 || fail "emitted a non-JSON line: $line"
+  done < "$(logfile "$d")"
+  rm -rf "$d"
+fi
+
 echo "All affordance-recorder tests passed."

--- a/tdad_tests/layer0_deterministic/test-affordance-recorder.sh
+++ b/tdad_tests/layer0_deterministic/test-affordance-recorder.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for affordance-invocation-recorder.sh (step 7). Drives the
+# PostToolUse recorder with synthetic payloads and asserts the tuple shape and,
+# critically, the privacy guarantees (no secrets / args / paths leak).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R="$SCRIPT_DIR/../../ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+newproj() { local d; d=$(mktemp -d); printf '%s' "$d"; }
+rec() { CLAUDE_PROJECT_DIR="$1" bash "$R"; }   # reads payload on stdin
+logfile() { printf '%s/observability/affordance-invocations.json' "$1"; }
+
+# Normal Bash gh call -> tool Bash, program gh, no args.
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"gh pr create --title \"top secret\""}}' | rec "$d"
+grep -q '"tool":"Bash"' "$(logfile "$d")" || fail "should record tool Bash"
+grep -q '"program":"gh"' "$(logfile "$d")" || fail "should record program gh"
+grep -qE 'secret|--title|create' "$(logfile "$d")" && fail "must NOT record arguments: $(cat "$(logfile "$d")")"
+rm -rf "$d"
+
+# Env-var-prefixed secret -> the secret is stripped, program is gh.
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"GH_TOKEN=ghp_supersecret gh pr list"}}' | rec "$d"
+grep -q '"program":"gh"' "$(logfile "$d")" || fail "env-prefixed call should record program gh"
+grep -q 'ghp_supersecret' "$(logfile "$d")" && fail "SECRET LEAKED: $(cat "$(logfile "$d")")"
+rm -rf "$d"
+
+# Path-form program -> basename only, no path.
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"/Users/alice/private/deploy.sh --env prod"}}' | rec "$d"
+grep -q '"program":"deploy.sh"' "$(logfile "$d")" || fail "path-form should basename to deploy.sh"
+grep -qE '/Users|alice|private|prod' "$(logfile "$d")" && fail "PATH/ARGS LEAKED: $(cat "$(logfile "$d")")"
+rm -rf "$d"
+
+# Subshell/pipeline -> program null.
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"( echo hi ) | tee x"}}' | rec "$d"
+grep -q '"program":null' "$(logfile "$d")" || fail "shell syntax should record program null: $(cat "$(logfile "$d")")"
+rm -rf "$d"
+
+# MCP tool -> recorded with program null.
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"mcp__honeycomb__query","tool_input":{"q":"x"}}' | rec "$d"
+grep -q '"tool":"mcp__honeycomb__query"' "$(logfile "$d")" || fail "should record the MCP tool"
+rm -rf "$d"
+
+# Built-in file tool -> NOT recorded (no file created, or empty).
+d=$(newproj)
+echo '{"session_id":"s1","tool_name":"Edit","tool_input":{"file_path":"/secret/path.txt"}}' | rec "$d"
+if [ -f "$(logfile "$d")" ]; then
+  [ -s "$(logfile "$d")" ] && fail "built-in Edit must not be recorded: $(cat "$(logfile "$d")")"
+fi
+rm -rf "$d"
+
+# Malformed/empty payload -> silent, harmless (exit 0, nothing recorded).
+d=$(newproj)
+echo 'not json at all' | rec "$d"
+echo "" | rec "$d"
+if [ -f "$(logfile "$d")" ] && [ -s "$(logfile "$d")" ]; then fail "garbage payload must record nothing"; fi
+rm -rf "$d"
+
+# Tuple is small (atomic-append safe, well under PIPE_BUF 512).
+d=$(newproj)
+echo '{"session_id":"abcdef123456","tool_name":"Bash","tool_input":{"command":"git status"}}' | rec "$d"
+len=$(wc -c < "$(logfile "$d")" | tr -d ' ')
+[ "$len" -lt 512 ] || fail "tuple line should be < 512 bytes (got $len)"
+rm -rf "$d"
+
+echo "All affordance-recorder tests passed."

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -51,6 +51,8 @@ BASH_TEST_SCRIPTS = [
     "test-affordances-template",
     "test-affordance-check",
     "test-affordance-staleness",
+    "test-affordance-recorder",
+    "test-affordance-invocations",
 ]
 
 


### PR DESCRIPTION
Closes #203. Sequencing **step 7** — the affordance section's runtime backbone, the most architecturally consequential follow-up.

## Design forks (user-confirmed before spec)

- **Hook: PostToolUse** — the only event that reliably knows `tool_name` (verified against `markdownlint-check.sh`).
- **Storage: gitignored per-machine NDJSON** — dissolves the cross-machine merge problem.
- **Tuple: minimal** — no arguments, no user identity.

## What ships

- **`hooks/scripts/affordance-invocation-recorder.sh`** (PostToolUse, in `hooks.json`) — appends one minimal NDJSON tuple per `Bash`/`mcp__*` call to gitignored `observability/affordance-invocations.json`. **Privacy is enforced, not declared**: the Bash `program` strips env-var prefixes (`GH_TOKEN=… gh`→`gh`), `basename`s paths, and accepts only `^[A-Za-z0-9._-]+$` — else `null`. grep/sed (no jq), never blocks, O(1)-gated self-trim.
- **`scripts/harness-affordance-invocations.sh`** — report-only analyzer: `--check=freshness` and `--check=dead-inventory` (exact MCP/named matching; conservative program-coarse Bash matching; hooks excluded; `--today` hermetic; tolerates malformed lines).
- `.gitignore`, two **LOCAL** opt-in GC rules, a tuple-format **reference page**, Layer 0 tests. Minor bump 0.56.0 → 0.57.0.

## Spec-first + dual adversarial review

- **Spec-mode `/diaboli`**: 12 objections (6 high), all adjudicated before code — keep the `.json` filename (the existing O3 reference), **sanitise the Bash program token so the no-secrets guarantee is real** (env-prefix/path/secret cases verified), recorder uses grep/sed (no jq silent-no-op trap), exclude hooks from dead-inventory, and frame the gitignored consequence honestly (**local observability, not CI governance**).
- **Code-mode `/diaboli`**: 8 objections (**no high/critical** — the privacy property survived adversarial scrutiny). Fixed the self-trim concurrency race (unique tmp + O(1) size gate), the MCP-prefix regex (→ glob), and the analyzer/recorder basename asymmetry; added adversarial privacy tests (escaped-quote no-leak, hostile session sanitisation, every emitted line valid JSON). The fail-safe program-null accuracy limit (privacy always preserved) is documented.

## Out of scope

CI discovery automation (step 8, #204).