### PR TITLE
Dynamic Workflows S1 — foundational skill + election discipline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.57.0",
+  "plugin_version": "0.58.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.57.0"
+      "version": "0.58.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.58.0 — 2026-06-22
+
+### dynamic-workflows: foundational skill + election discipline (S1, #438)
+
+First slice of the Dynamic Workflows Alignment epic — the conceptual model the
+rest of the epic references.
+
+- **New `dynamic-workflows` skill** (`ai-literacy-superpowers/skills/dynamic-workflows/`):
+  `SKILL.md` plus `references/{patterns,when-not-to-use,governance}.md`. Knowledge
+  agents read, not a script they run — sibling to `harness-engineering` and
+  `context-engineering`. Names the six composable patterns (classify-and-act,
+  fan-out-and-synthesize, adversarial verification, generate-and-filter,
+  tournament, loop-until-done), each with a worked micro-example.
+- **Compute-discipline election rubric** (`references/when-not-to-use.md`): the
+  four-question test — long-running, massively parallel, highly structured, or
+  adversarial — with the default "if none apply, use the static pipeline", so
+  workflows are elected, not reflexive. Advisory guidance, not a CI gate.
+- **Governance invariants** (`references/governance.md`): INV-1 (ephemeral
+  proposes, durable curates — workflows never write `HARNESS.md` / `AGENTS.md` /
+  `CLAUDE.md` / `MODEL_ROUTING.md` directly) and INV-2 (quarantine
+  untrusted-content readers from high-privilege tools), restated for agents.
+- **`templates/MODEL_ROUTING.md`** gains a *workflow election* section: a
+  per-workflow token-budget convention and a model-routing-classifier idea
+  (Haiku/Sonnet/Opus tiering).
+- **Docs**: new how-to guide and `### dynamic-workflows` reference entry; skill
+  count reconciled to 36 (badge, plugin table, tree). Workflow *templates* and
+  the INV-1 CI firewall are deferred to S2 (#439); SKILL.md only forward-references
+  them.
+
 ## 0.57.0 — 2026-06-17
 
 ### planning: dynamic-workflows-alignment epic spec + carpaccio slicing (#438–#444)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.57.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.58.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-35-2E8B57?style=flat-square)](#skills-35)
+[![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
 [![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.57.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **35 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.58.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (35)
+### Skills (36)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -171,6 +171,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | docker-scout-audit | Docker image CVE triage and remediation |
 | harness-engineering | Foundational concepts — the three components, promotion ladder, enforcement timing |
 | context-engineering | Writing conventions precise enough for humans and LLMs to enforce |
+| dynamic-workflows | When/which/how to author ephemeral multi-agent workflows — six patterns, election rubric, INV-1/INV-2 governance |
 | constraint-design | Designing enforceable constraints with the verification slot model |
 | garbage-collection | Entropy-fighting patterns and the auto-fix safety rubric |
 | verification-slots | The unified interface for deterministic and agent-based checks |
@@ -406,7 +407,7 @@ ADVISORY LOOP (edit time — warn, do not block)
 │   ├── CLAUDE.md                       Workflow rules, conventions, disciplines
 │   ├── AGENTS.md                       Compound learning memory (human-curated)
 │   ├── MODEL_ROUTING.md                Model-tier guidance + token budgets
-│   └── Skills (35)                     Domain knowledge for agents
+│   └── Skills (36)                     Domain knowledge for agents
 │
 └── Commands
     ├── /reflect                        Capture post-task learnings

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: dynamic-workflows
+description: This skill should be used when an agent is deciding whether to author a dynamic workflow — a self-authored, ephemeral multi-agent harness — for a task. Use when the user asks about "dynamic workflows", "multi-agent harness", "fan-out", "subagents in parallel", "adversarial verification", "the ultracode trigger", "should I use a workflow", or when a task looks long-running, massively parallel, highly structured, or adversarial. Names the six composable patterns, the election rubric for when NOT to spend the extra compute, and the two governance invariants (INV-1 ephemeral-proposes, INV-2 quarantine).
+---
+
+# Dynamic Workflows
+
+A **dynamic workflow** is a self-authored, ephemeral multi-agent harness:
+a small program an agent writes for one task, runs once, and discards. It
+spawns subagents, gives each its own clean context window and model tier,
+optionally isolates them in worktrees, and coordinates their results. The
+capability and its patterns originate from Anthropic's "A harness for
+every task: dynamic workflows in Claude Code" (Shihipar & Bidasaria,
+2026); the runtime is triggered by the word `ultracode`.
+
+This skill is **knowledge agents read, not a script they run** — a
+sibling of [`harness-engineering`](../harness-engineering/SKILL.md) and
+[`context-engineering`](../context-engineering/SKILL.md). It answers three
+questions before any workflow is authored:
+
+1. **When** is a workflow warranted? — see
+   [`references/when-not-to-use.md`](references/when-not-to-use.md).
+2. **Which** pattern fits? — see
+   [`references/patterns.md`](references/patterns.md).
+3. **How** does the plugin's governance constrain it? — see
+   [`references/governance.md`](references/governance.md).
+
+## Static harness vs. dynamic workflow
+
+The plugin is, by default, a **static harness**: a fixed pipeline
+(`spec-writer → GATE → tdd-agent → implementer → code-reviewer →
+GUARDRAIL → integration-agent`) that must work for every task and
+therefore tends toward the generic. A static harness is the right tool
+for ordinary coding work, and it stays the default.
+
+A dynamic workflow is the opposite: generated per task, disposable, and
+able to hand each subagent a clean context window. That shape defeats
+three failure modes the static pipeline is exposed to when one context
+does too much:
+
+| Failure mode | What it looks like |
+| --- | --- |
+| **Agentic laziness** | Declaring a multi-part job done after partial progress (35 of 50 constraints checked) |
+| **Self-preferential bias** | An agent preferring its own output when asked to verify or judge it |
+| **Goal drift** | Losing fidelity to the original objective across turns, worsened by lossy compaction |
+
+Dynamic workflows are a **new execution substrate beneath the existing
+agents** — they do not replace them, and they do not weaken governance.
+
+## The six composable patterns
+
+Authored workflows compose six patterns. Each is worked through with a
+concrete micro-example in [`references/patterns.md`](references/patterns.md);
+in brief:
+
+- **classify-and-act** — route a task by type before doing it.
+- **fan-out-and-synthesize** — split work across parallel subagents, then
+  merge at a synthesis barrier.
+- **adversarial verification** — a separate agent tries to refute a result
+  before it is accepted.
+- **generate-and-filter** — over-generate candidates, then prune.
+- **tournament** — score independent attempts against a rubric, keep the
+  winner.
+- **loop-until-done** — iterate until a measurable completion test passes.
+
+## Elect deliberately — the discipline
+
+Workflows cost more tokens and suit complex, high-value tasks. Most
+coding tasks do not need a panel of reviewers. Before authoring one, run
+the four-question rubric in
+[`references/when-not-to-use.md`](references/when-not-to-use.md): is the
+task **long-running, massively parallel, highly structured, or
+adversarial**? If none apply, use the static pipeline. A workflow should
+be *elected*, never reflexive — over-orchestration is treated as a
+regression.
+
+Token budgets and model-tier routing for elected workflows live in the
+project's `MODEL_ROUTING.md` (the *workflow election* section).
+
+## The two governing invariants
+
+Both are stated in full, for agents, in
+[`references/governance.md`](references/governance.md):
+
+- **INV-1 — Ephemeral proposes, durable curates.** A workflow is
+  ephemeral; `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, and `MODEL_ROUTING.md`
+  are durable and human-curated. A workflow may **propose** changes to
+  them but may **never write them directly**. Discoveries flow through
+  `REFLECTION_LOG.md → human curates → AGENTS.md`.
+- **INV-2 — Quarantine.** Any workflow agent that reads untrusted or
+  public content (web pages, external issues, third-party PRs) is withheld
+  high-privilege tools. Acting on such information is done only by
+  separate, trusted agents in the same workflow.
+
+## The workflow template library (forthcoming — S2)
+
+A library of opinionated, habitat-aligned workflow *templates* (adapted
+per task, never run verbatim) ships with this skill in a follow-up slice
+(S2). When present, the templates will live under `workflows/` in this
+skill folder and be referenced from here. **Until S2 lands, this skill is
+reading material only** — there are no runnable templates to invoke yet,
+and nothing in this skill depends on one existing.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md
@@ -1,0 +1,76 @@
+# Governance for Dynamic Workflows
+
+Dynamic workflows are a new execution substrate, but they do not get new
+authority. Two invariants bind every workflow this plugin authors. They
+are non-negotiable: every template, and every agent operating in workflow
+mode, must preserve them. Both are restated here in full so an agent
+reasoning about a workflow can cite them directly.
+
+## INV-1 — Ephemeral proposes, durable curates
+
+> Dynamic workflows are **ephemeral and generated**. The project's
+> durable artefacts are **curated**. A workflow may **propose** changes to
+> a durable artefact but may **never write one directly**.
+
+The four durable, human-curated artefacts a workflow must never write are:
+
+- **`HARNESS.md`** — the declared constraints, verification slots, and GC
+  rules.
+- **`AGENTS.md`** — the curated, compounding rules the team has chosen to
+  keep.
+- **`CLAUDE.md`** — the project conventions and instructions.
+- **`MODEL_ROUTING.md`** — the model-tier and token-budget routing policy.
+
+Anything a workflow discovers that is worth keeping flows through the
+existing human-curation gate:
+
+```text
+REFLECTION_LOG.md  →  human curates  →  AGENTS.md
+```
+
+A workflow appends to `REFLECTION_LOG.md` (or to a dedicated staging
+artefact) and surfaces a vetted shortlist; a **human** decides what is
+promoted into the durable rule set. This is "agents propose; humans
+curate" applied at the harness layer rather than the rule layer. It is the
+load-bearing principle of the whole dynamic-workflows alignment: it
+protects the team's curated theory of the system (Naur) from ephemeral
+churn.
+
+**Why it is load-bearing.** If an ephemeral, per-task program could
+rewrite the durable artefacts, the curated theory of the system would
+erode one disposable workflow at a time, with no human in the loop. The
+firewall keeps the durable layer authoritative.
+
+> The deterministic *teeth* for INV-1 — a CI rule that greps workflow
+> templates for direct writes to these four paths and fails the build if
+> it finds one — is mechanised in a later slice (S2). This file states the
+> invariant as knowledge; the CI rule enforces it.
+
+## INV-2 — Quarantine
+
+> Any workflow agent that reads **untrusted or public content** — web
+> pages, external issues, third-party PRs, arbitrary fetched text — must
+> **not** be granted high-privilege actions.
+
+A subagent that ingests untrusted input is a potential carrier for
+injected instructions. Quarantine confines the blast radius: the agent
+that *reads* untrusted content is withheld high-privilege tools (no
+writes, no shell, no merge, no network mutation), and any action implied
+by that content is performed only by a **separate, trusted agent** in the
+same workflow that did not ingest the untrusted text. Reading and acting
+are split across the trust boundary so a prompt-injection in fetched
+content cannot reach into a privileged capability.
+
+> As with INV-1, the lint that enforces INV-2 on templates (verifying an
+> untrusted-content reader declares no high-privilege tools) lands with the
+> template library in S2. This file states the invariant for agents to
+> cite and design against now.
+
+## How the invariants compose
+
+A well-formed workflow that touches untrusted input *and* discovers
+something worth keeping does both: the untrusted reader stays low-privilege
+(INV-2), and whatever the workflow concludes is written only as a proposal
+to `REFLECTION_LOG.md` or a staging file for a human to curate (INV-1) —
+never straight into `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, or
+`MODEL_ROUTING.md`.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/references/patterns.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/references/patterns.md
@@ -1,0 +1,94 @@
+# Dynamic Workflow Patterns
+
+The six composable patterns an authored workflow draws on. Each section
+names the pattern and works it through a concrete, task-shaped
+micro-example — the example is what makes the pattern usable by an agent
+reasoning about a real task, not just a definition to recite. Real
+workflows compose several of these.
+
+The exact runtime functions for spawning and coordinating subagents are
+**not** reproduced here — consult <https://code.claude.com/docs/en/workflows>
+as authoritative before authoring a template.
+
+## classify-and-act
+
+**Shape.** Inspect the task, decide its *type*, then dispatch the branch
+that fits. The default branch does the ordinary thing; special branches
+exist only for the cases that benefit.
+
+**Micro-example.** A request arrives at the orchestrator. A cheap
+classifier agent reads it and labels it: *routine single-file edit* →
+the existing static pipeline (no extra compute); *naming or design
+question* → a `tournament`; *flaky test / incident* → root-cause
+investigation. The routine label is the common case and costs nothing
+beyond the classification step.
+
+## fan-out-and-synthesize
+
+**Shape.** Split a job into independent units, run one subagent per unit
+in parallel (each with a clean context window), then wait at a
+*synthesis barrier* until all return before reporting. The barrier is
+what defeats agentic laziness — there is no "good enough, stop at 35 of
+50" because the report cannot form until all N results are in.
+
+**Micro-example.** Enforcing 24 HARNESS.md constraints. Instead of one
+context checking all 24 (and tiring), the workflow spawns 24 verifier
+subagents, one per constraint. Each returns pass/fail with evidence. The
+synthesis step asserts it received exactly 24 results, then composes the
+report. A missing result is a visible error, not a silent drop.
+
+## adversarial verification
+
+**Shape.** After a result is produced, a *separate* agent — in a context
+window distinct from the producer's — tries to refute it against a
+rubric. Only claims that survive the refutation are accepted. The
+separation is what defeats self-preferential bias.
+
+**Micro-example.** An implementation passes its tests. A reviewing agent
+that never saw the implementer's reasoning is handed the diff plus the
+CUPID + literate-programming rubric and asked, "find where this fails
+each property." Each property gets a dedicated verifier; findings are
+synthesised, not collapsed into a single thumbs-up.
+
+## generate-and-filter
+
+**Shape.** Deliberately over-produce candidates, then prune to the ones
+worth keeping. Cheap breadth first, selective depth second.
+
+**Micro-example.** Mining `REFLECTION_LOG.md` for rules worth promoting.
+Parallel agents cluster the log and emit *every* candidate rule they can
+justify (generate). A second adversarial pass asks of each, "would this
+rule actually have prevented a real past mistake?" and drops the ones
+that would not (filter). The survivors become a shortlist a human curates
+— the workflow never writes the durable rule file itself (INV-1).
+
+## tournament
+
+**Shape.** Produce several independent attempts from different angles,
+score each against a rubric with judge agents, and keep the winner (often
+grafting the best ideas from the runners-up).
+
+**Micro-example.** Naming a new public API. Three agents each propose a
+naming scheme from a different stance — consistency-with-existing-code,
+readability-for-newcomers, future-extensibility. A rubric-bearing judge
+scores all three and selects, explaining the trade-off. Beats
+one-attempt-iterated when the solution space is wide and taste-based.
+
+## loop-until-done
+
+**Shape.** Repeat a step until a measurable completion test passes (or a
+budget is exhausted), rather than stopping after a fixed number of
+rounds. For unknown-size discovery, keep going until K consecutive rounds
+surface nothing new.
+
+**Micro-example.** A deep repository assessment fans out by area and
+accumulates findings; after each round a completeness critic asks "what
+area has not been scanned, what claim is unverified?" The loop continues
+until a round adds nothing, then synthesises the cited report. A simple
+"run three times" would miss the tail.
+
+> **Threshold note.** Some patterns switch on at a count threshold (for
+> example, fan-out mode for the enforcer once the constraint count is high
+> enough). The *value* of that threshold is a per-project decision made in
+> the slice that owns it — this reference deliberately states only that a
+> threshold exists, not its number.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/references/when-not-to-use.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/references/when-not-to-use.md
@@ -1,0 +1,57 @@
+# When *Not* to Use a Dynamic Workflow
+
+A dynamic workflow spends more tokens and more wall-clock than a single
+agent. It earns that cost only on tasks that genuinely need it. Most
+coding tasks do not. This is the compute-discipline rubric (D8): the
+mechanism that makes every workflow *elected*, not reflexive.
+
+## The four-question election rubric
+
+Before authoring a workflow, ask whether the task is any of:
+
+1. **Long-running** — would a single context drift or run out of room
+   before finishing? (Long repo scans, multi-stage migrations.)
+2. **Massively parallel** — does it split into many independent units that
+   could be checked at once? (One verifier per constraint, one reader per
+   area.)
+3. **Highly structured** — does it have a clear pipeline of stages with
+   defined hand-offs, where isolating each stage in its own context helps?
+4. **Adversarial** — does it benefit from a separate agent trying to
+   refute the result? (Review, judging, self-preference-prone checks.)
+
+**The default: if none of the four apply, use the static pipeline.** A
+task that is an ordinary single-file change, a small fix, or a quick
+lookup does not warrant a panel of subagents. Reaching for a workflow
+anyway is over-orchestration — treated as a regression, because the
+static pipeline must remain the default for ordinary work.
+
+## How to decline
+
+When a task fails the rubric, an agent should say so plainly and proceed
+on the static path — "none of the four discriminators apply; this is a
+routine change, so I am using the static pipeline rather than a workflow"
+— and cite this file. Declining is the correct, expected outcome for the
+common case, not a failure to be apologised for.
+
+## When it *does* apply
+
+If one or more questions apply, the task is a workflow candidate. Pick the
+matching pattern from [`patterns.md`](patterns.md), set a token budget and
+model tiering per the *workflow election* section of the project's
+`MODEL_ROUTING.md`, and honour the two invariants in
+[`governance.md`](governance.md) — above all INV-1: the workflow proposes,
+it never writes a durable artefact.
+
+> **Threshold note.** Some patterns (for example, switching the enforcer
+> into fan-out mode) turn on once a count crosses a threshold. That a
+> threshold exists is part of the rubric; its *numeric value* is decided
+> per project in the slice that owns the behaviour, and is deliberately
+> not fixed here.
+
+## What this rubric is *not*
+
+This is **advisory guidance an agent reads**, not a CI gate. The plugin
+does not deterministically enforce "a workflow was elected, not
+reflexive" — there is no check that fails a build for skipping the rubric.
+The discipline lives in the agent's reasoning and in human review, in
+keeping with "agents propose; humans curate."

--- a/ai-literacy-superpowers/templates/MODEL_ROUTING.md
+++ b/ai-literacy-superpowers/templates/MODEL_ROUTING.md
@@ -85,6 +85,11 @@ Suggested starting caps by workflow shape (adjust from observed usage):
 | Deep assessment / audit (fan-out by area) | 20 000 | Breadth across the repo, then a cited report |
 | Reflection mining (generate-and-filter) | 8 000 | Cluster, filter, shortlist — proposal only |
 
+These are illustrative starting defaults, not fixed values: the slice that
+ships a given workflow's behavioural mode may supersede its cap from observed
+usage, exactly as the fan-out *threshold* value is owned by the slice that
+ships fan-out mode rather than fixed here.
+
 ### Model-routing classifier
 
 For workflows whose subagents do not all need the same tier, front the

--- a/ai-literacy-superpowers/templates/MODEL_ROUTING.md
+++ b/ai-literacy-superpowers/templates/MODEL_ROUTING.md
@@ -57,3 +57,51 @@ Override the routing table when:
 
 Do not override silently — record the reason in the context object so the
 orchestrator can learn from it.
+
+## Workflow election
+
+A *dynamic workflow* (a self-authored, ephemeral multi-agent harness; see
+the `dynamic-workflows` skill) spends more tokens than a single agent and
+is elected deliberately, never reflexively. Elect a workflow only when the
+task is **long-running, massively parallel, highly structured, or
+adversarial**; if none apply, use the static pipeline. Routing decisions
+for an elected workflow live here.
+
+### Token-budget convention
+
+Every elected workflow declares an explicit **per-workflow token cap**
+before it runs — for example, *"use 10k tokens"* — so its compute is
+bounded and observable. A workflow that approaches its cap stops and
+reports rather than silently overspending. The cap is part of electing the
+workflow, not an afterthought: state it in the workflow's preamble
+alongside the pattern it uses.
+
+Suggested starting caps by workflow shape (adjust from observed usage):
+
+| Workflow shape | Per-workflow cap (tokens) | Rationale |
+| --- | --- | --- |
+| Enforcer fan-out (one verifier per rule) | 10 000 | Each verifier is small and focused |
+| Adversarial review (separate-context refute) | 12 000 | Per-property verifiers plus synthesis |
+| Deep assessment / audit (fan-out by area) | 20 000 | Breadth across the repo, then a cited report |
+| Reflection mining (generate-and-filter) | 8 000 | Cluster, filter, shortlist — proposal only |
+
+### Model-routing classifier
+
+For workflows whose subagents do not all need the same tier, front the
+workflow with a **model-routing-classifier**: a cheap classifier agent
+that researches the task's complexity, then routes each subagent role to
+the right tier.
+
+- **Haiku** — high-volume, mechanical, well-structured subagents (a single
+  constraint check, a single-file read).
+- **Sonnet** — the default working tier for most subagents.
+- **Opus** — the hardest reasoning roles (synthesis, adversarial judging,
+  ambiguous design calls).
+
+Routing down a tier is a cost win only when output quality holds; record
+any tier exception in the context object so the orchestrator can learn
+from it, exactly as for the static routing table above.
+
+> **Governance.** A workflow elected here proposes; it never writes this
+> file or any other durable artefact directly (INV-1). `MODEL_ROUTING.md`
+> changes are human-curated.

--- a/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
@@ -1,0 +1,89 @@
+---
+title: Decide Whether to Use a Dynamic Workflow
+---
+# Decide Whether to Use a Dynamic Workflow
+
+Orientation guide to the `dynamic-workflows` skill — the conceptual model
+for self-authored, ephemeral multi-agent harnesses. This guide helps you
+decide *whether* a task warrants a workflow and *which* pattern fits.
+
+> **Scope note.** This first release ships **reading material**, not a
+> runnable workflow you can invoke. The opinionated, adaptable workflow
+> *templates* arrive in a follow-up slice (S2). Until then, use this guide
+> and the skill to reason about workflows; there is no end-to-end runbook
+> to walk through yet.
+
+---
+
+## Prerequisites
+
+- The `ai-literacy-superpowers` plugin installed.
+- Familiarity with the static pipeline (`spec-writer → GATE → tdd-agent →
+  implementer → code-reviewer → GUARDRAIL → integration-agent`), which
+  remains the default for ordinary coding tasks.
+
+---
+
+## 1. Read the skill
+
+The `dynamic-workflows` skill is knowledge you read, not a script you run.
+It names the six composable patterns, the election rubric, and the two
+governance invariants. Its references are:
+
+- `references/patterns.md` — the six patterns with worked micro-examples.
+- `references/when-not-to-use.md` — the four-question election rubric.
+- `references/governance.md` — INV-1 and INV-2 in full.
+
+---
+
+## 2. Run the election rubric
+
+Before reaching for a workflow, ask whether the task is any of:
+
+1. **Long-running** — would one context drift or run out of room?
+2. **Massively parallel** — does it split into many independent units?
+3. **Highly structured** — does it have clear, isolable pipeline stages?
+4. **Adversarial** — does it benefit from a separate agent refuting the
+   result?
+
+**If none apply, use the static pipeline.** A routine single-file change
+does not warrant a panel of subagents — electing one anyway is
+over-orchestration.
+
+---
+
+## 3. Pick the matching pattern
+
+If the task is a workflow candidate, choose from `references/patterns.md`:
+classify-and-act, fan-out-and-synthesize, adversarial verification,
+generate-and-filter, tournament, or loop-until-done. Real workflows
+compose several.
+
+---
+
+## 4. Respect the invariants
+
+Two non-negotiable rules bind every workflow:
+
+- **INV-1 — Ephemeral proposes, durable curates.** A workflow may
+  **propose** changes to `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, and
+  `MODEL_ROUTING.md`, but never write them directly. Discoveries flow
+  through `REFLECTION_LOG.md → human curates → AGENTS.md`.
+- **INV-2 — Quarantine.** An agent that reads untrusted content (web
+  pages, external issues, third-party PRs) is withheld high-privilege
+  tools; a separate trusted agent acts on what it found.
+
+---
+
+## 5. Set a budget
+
+Elected workflows declare an explicit per-workflow token cap and model
+tiering up front — see the *workflow election* section of your project's
+`MODEL_ROUTING.md`.
+
+---
+
+## Related
+
+- Reference: [Skills](../reference/skills.md) → `dynamic-workflows`
+- Skill: `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md`

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -3,7 +3,7 @@ title: Skills
 ---
 # Skills
 
-The plugin ships 35 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
+The plugin ships 36 skills. Each skill is a focused unit of domain knowledge that Claude can invoke during a session. They are grouped below by category.
 
 ---
 
@@ -16,6 +16,10 @@ The conceptual foundation of the harness framework. Covers what a harness is, wh
 ### context-engineering
 
 Writing enforceable conventions for the Context section of HARNESS.md. Covers how to express rules that Claude will honour consistently rather than treat as advisory suggestions.
+
+### dynamic-workflows
+
+The conceptual model for self-authored, ephemeral multi-agent harnesses (dynamic workflows). Covers the six composable patterns (classify-and-act, fan-out-and-synthesize, adversarial verification, generate-and-filter, tournament, loop-until-done), the four-question election rubric for when *not* to spend the extra compute, and the two governance invariants — INV-1 (ephemeral proposes, durable curates) and INV-2 (quarantine untrusted-content readers). Knowledge agents read before electing a workflow; the runnable template library ships separately.
 
 ### constraint-design
 

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
@@ -292,18 +292,18 @@ grep -rn 'v0\.57\.0\|0\.57\.0' README.md .claude-plugin/marketplace.json \
 - **`lint-markdown`** — SKILL.md, the three references, and MODEL_ROUTING.md must
   pass markdownlint (AC-2). The PreToolUse hook catches violations at edit time.
 
-### 6.3 Skill-count badge — deliberate deferral to S7
+### 6.3 Skill-count badge — pulled into S1 at the GATE
 
 The README badge currently reads `Skills-35` (line 9) and the plugin-table cell
 reads "**35 skills**" (line 31). Landing this skill makes the true count **36**.
 
-**This is intentionally deferred to S7 (#444), not corrected in S1.** The
-slicing record assigns the badge/count update to S7 (D9). Confirmed against the
-live repo: the `Skills-35` badge is **not** grep-enforced by any CI workflow
-(no skill-count check exists in `.github/workflows/`), so leaving it stale does
-**not** redden CI. Recording the deferral here so a reviewer does not read the
-stale `35` as an S1 oversight. S7 will reconcile the badge and table to the
-filesystem count when the full epic lands.
+**GATE decision (Russ, 2026-06-22): pulled into S1, not deferred to S7.** The
+spec originally recommended deferring the badge/count update to S7 (D9) because
+it is not grep-enforced by any CI workflow (no skill-count check exists in
+`.github/workflows/`). At the plan-approval GATE the human chose to keep the
+badge honest per-slice, so S1 updates the `Skills-36` badge (line 9) and the
+"**36 skills**" plugin-table cell (line 31) in the same change that adds the
+skill. S7 no longer owns the skill-count reconciliation.
 
 ### 6.4 Docs-impact note (CLAUDE.md "Docs Site Review")
 
@@ -311,16 +311,16 @@ filesystem count when the full epic lands.
   `reference/skills.md` — see §6.2. Place it in a sensible category (a new
   "Dynamic Workflows" subsection or under "Harness Core"); the gate only checks
   the heading exists.
-- **How-to (judgement call — recommend deferring to S7).** A how-to guide under
+- **How-to (pulled into S1 at the GATE).** A how-to guide under
   `docs/plugins/ai-literacy-superpowers/how-to/` is *warranted in principle* for
-  a new skill, but a "how to use dynamic workflows" guide is not actionable until
-  the template library (S2) and the behavioural workflow modes (S3–S6) exist —
-  S1 ships *reading material*, not a runnable workflow a guide could walk a user
-  through. **Recommendation:** defer the how-to guide to S7 (alongside the README
-  "Dynamic Workflows" section and badge), where the full substrate exists to
-  document end-to-end. The reference entry (gated, required now) plus the SKILL.md
-  itself are sufficient for S1. *(Surface this to the human at the GATE as an
-  explicit decision, not a silent omission.)*
+  a new skill. The spec originally recommended deferring it to S7 because a
+  full "how to run a workflow" walkthrough is not actionable until the template
+  library (S2) and behavioural modes (S3–S6) exist. **GATE decision (Russ,
+  2026-06-22): pull it into S1.** S1 ships `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md`
+  as an **orientation guide** to the skill's conceptual model and election
+  rubric (reading material), explicitly noting that runnable workflow templates
+  arrive in S2 — not an end-to-end runbook. The guide names the `dynamic-workflows`
+  skill and points at its references.
 - **Explanation / tutorials.** None required for S1 — no existing explanation
   page references behaviour S1 changes (this is net-new).
 

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
@@ -1,0 +1,366 @@
+# Specification — Dynamic Workflows S1: Foundational Skill + Election Discipline
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S1 of the Dynamic Workflows Alignment epic (D1 + D8 clustered)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S1)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/438>
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s1-skill`
+
+> **Implementer note (read first).** This slice ships **knowledge that agents
+> read**, not a runtime they execute. No `*.workflow.js` files and no CI grep
+> rule land here — those belong to S2 (#439). The `dynamic-workflows` skill is a
+> sibling of `harness-engineering` and `context-engineering`: SKILL.md plus a
+> `references/` folder, loaded as context for an agent's reasoning. The exact
+> runtime function names for spawning subagents are **not** reproduced; consult
+> <https://code.claude.com/docs/en/workflows> as authoritative when S2 writes
+> templates.
+
+---
+
+## 1. Context and motivation
+
+The plugin is architecturally a **static harness** — a fixed pipeline
+(`spec-writer → GATE → tdd-agent → implementer(s) → code-reviewer → GUARDRAIL →
+integration-agent`). The Dynamic Workflows Alignment epic introduces *dynamic
+workflows* — ephemeral, per-task, disposable multi-agent harnesses — as a new
+execution substrate beneath the existing agents, governed by two invariants
+(INV-1 ephemeral-proposes / INV-2 quarantine).
+
+The epic is sliced into seven independently-shippable pieces. **S1 is the
+foundation** the other six reference. Per umbrella §6, the build order opens with
+**D1** (the foundational `dynamic-workflows` knowledge skill) and **D8** (the
+compute-discipline election rubric), clustered here because the skill is the
+vehicle and the election rubric is the decision the vehicle carries — separating
+them would ship a skill with no discipline, or a discipline with no home.
+
+S1 establishes:
+
+- the shared **conceptual model** — the six composable patterns, the decision
+  rubric, and INV-1/INV-2 restated for agents;
+- the **election discipline** — the compute-discipline rubric (D8) that makes
+  every later workflow *elected*, not reflexive, plus the `MODEL_ROUTING.md`
+  workflow-election section and token-budget convention.
+
+An agent that has read this skill can name *when* a workflow is warranted,
+*which* pattern fits, and *how* governance constrains it — before any template
+or behavioural change exists to run.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+1. **`ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md`** — YAML
+   frontmatter (`name`, `description` with trigger conditions), an introduction
+   to the six patterns, the decision rubric, and the two invariants. Shaped to
+   match `harness-engineering` / `context-engineering` SKILL.md. May
+   *forward-reference* the workflow template library as forthcoming (S2) but must
+   be valid and markdownlint-clean **without** depending on any file S2 adds.
+2. **`ai-literacy-superpowers/skills/dynamic-workflows/references/patterns.md`** —
+   the six composable patterns with worked micro-examples: classify-and-act,
+   fan-out-and-synthesize, adversarial verification, generate-and-filter,
+   tournament, loop-until-done.
+3. **`ai-literacy-superpowers/skills/dynamic-workflows/references/when-not-to-use.md`** —
+   the compute-discipline election rubric (D8): *does this task really need more
+   compute? is it long-running, massively parallel, highly structured, or
+   adversarial?* If none apply, use the static pipeline.
+4. **`ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md`** —
+   INV-1 (ephemeral proposes, durable curates — workflows may **never** write
+   `HARNESS.md` / `AGENTS.md` / `CLAUDE.md` / `MODEL_ROUTING.md` directly) and
+   INV-2 (quarantine untrusted-content readers from high-privilege tools),
+   restated for agents.
+5. **`ai-literacy-superpowers/templates/MODEL_ROUTING.md`** — extend with a
+   *workflow election* section and a **token-budget convention** (an explicit
+   per-workflow cap, e.g. "use 10k tokens"), plus the *model-routing-classifier*
+   idea (a classifier agent that researches complexity, then routes
+   Haiku/Sonnet/Opus tiers).
+6. **Supporting CI / docs surfaces** (see §6): the plugin version bump, the
+   `### dynamic-workflows` reference entry, the TDAD scenario, and the
+   reference-parity / docs-impact updates that the new skill obliges.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred concern | Owning slice | Why not here |
+| --- | --- | --- |
+| The `*.workflow.js` template library under `skills/dynamic-workflows/workflows/` | **S2 (#439)** | S1 ships no executable templates; SKILL.md only forward-references them |
+| The INV-1 CI **grep firewall** rule (§5.1 of umbrella) | **S2 (#439)** | The firewall has teeth only once templates exist to grep |
+| The INV-2 lint rule on templates | **S2 (#439)** | No templates to lint in S1 |
+| D3 fan-out threshold (= 8) | **S3 (#440)** | Riding open-question 1; not a skill-level decision |
+| D4 routing default (opt-in flag) | **S5 (#442)** | Riding open-question 2 |
+| D6 staging-artefact location (`REFLECTION_STAGING.md`) | **S6 (#443)** | Riding open-question 3 |
+| Skill-count badge correction (`35 → 36`) + README "Dynamic Workflows" section + advisory Stop hook + Copilot degradation | **S7 (#444)** | Per umbrella D9; see §6.3 deferral note |
+
+**Boundary rule.** S1's SKILL.md introduces the patterns and governance and may
+say the template library is *forthcoming*; it must not import, link as a runnable
+dependency, or assume the existence of any `.workflow.js` file. Keep S1 valid and
+lint-clean standalone.
+
+---
+
+## 3. User story
+
+> **As an** agent (or engineer) operating inside the ai-literacy-superpowers
+> harness, **I want** a single authoritative knowledge skill that names the
+> dynamic-workflow patterns, the rule for *when not* to spend extra compute, and
+> the two governance invariants, **so that** I can decide deliberately whether a
+> task warrants a workflow and, if so, which pattern fits — without reflexively
+> reaching for parallel agents or breaching the durable/ephemeral boundary.
+
+This is "agents propose; humans curate" applied at the harness layer. The skill
+is the shared vocabulary every later slice (S2–S7) references.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy:
+*deterministic* (CI-checkable), *agent-backed* (checked by an agent /
+Layer-2-3 TDAD), or *unverified* (declared intent). The tdd-agent should turn
+the deterministic and agent-backed scenarios into failing checks first.
+
+### From D1 — the foundational skill
+
+**AC-1 *(deterministic)*.**
+**Given** the plugin is installed,
+**When** skills are enumerated,
+**Then** `dynamic-workflows` appears and its `SKILL.md` frontmatter validates
+against the existing skill schema (non-empty `name: dynamic-workflows` and a
+non-empty `description`).
+
+**AC-2 *(deterministic)*.**
+**Given** `SKILL.md` and the three reference files,
+**When** markdownlint runs (existing PreToolUse hook + CI),
+**Then** they pass with no new violations.
+
+**AC-3 *(deterministic)*.**
+**Given** the `dynamic-workflows/references/patterns.md` file,
+**When** it is read,
+**Then** all six patterns are named and each carries a worked micro-example:
+classify-and-act, fan-out-and-synthesize, adversarial verification,
+generate-and-filter, tournament, loop-until-done.
+
+**AC-4 *(deterministic)*.**
+**Given** `dynamic-workflows/references/governance.md`,
+**When** it is read,
+**Then** it restates **INV-1** (workflows may never write `HARNESS.md`,
+`AGENTS.md`, `CLAUDE.md`, or `MODEL_ROUTING.md` directly; discoveries flow
+through `REFLECTION_LOG.md → human curates → AGENTS.md`) and **INV-2**
+(untrusted-content readers are withheld high-privilege tools), each named and
+stated in full.
+
+**AC-5 *(agent-backed)*.**
+**Given** a task that benefits from parallel, isolated subagents,
+**When** an agent consults `dynamic-workflows`,
+**Then** it can name the matching pattern and cite INV-1/INV-2.
+
+**AC-6 *(agent-backed, trigger)*.**
+**Given** a Claude session with the plugin loaded,
+**When** a user query about self-authored multi-agent harnesses, dynamic
+workflows, the `ultracode` trigger, fan-out/adversarial-verification patterns, or
+"when should I use a workflow" is sent,
+**Then** the model identifies `dynamic-workflows` as a skill to invoke
+(description carries the concept, not only literal tokens).
+
+### From D8 — the compute-discipline election rubric
+
+**AC-7 *(deterministic)*.**
+**Given** `dynamic-workflows/references/when-not-to-use.md`,
+**When** it is read,
+**Then** it states the election rubric as four discriminating questions — *is the
+task long-running, massively parallel, highly structured, or adversarial?* — and
+the default: **if none apply, use the static pipeline.**
+
+**AC-8 *(agent-backed)*.**
+**Given** a task that fails the election rubric (none of the four questions apply),
+**When** an agent considers a workflow,
+**Then** it declines and uses the static path, citing `when-not-to-use.md`.
+
+**AC-9 *(deterministic)*.**
+**Given** `templates/MODEL_ROUTING.md`,
+**When** it is read,
+**Then** it contains a **workflow-election** section, a **token-budget
+convention** that states an explicit per-workflow cap (e.g. "use 10k tokens"),
+and the **model-routing-classifier** idea (a classifier agent that researches
+complexity, then routes Haiku/Sonnet/Opus tiers).
+
+**AC-10 *(unverified, declared)*.**
+The election discipline is advisory guidance an agent reads, not a CI gate;
+deterministic enforcement of "a workflow was elected, not reflexive" is **not**
+shipped in S1 and is not implied by it. (Recorded so the absence is not mistaken
+for an oversight; no later slice promotes this to a gate either.)
+
+> **Note on the D3 threshold.** The constraint-count threshold (= 8) at which the
+> enforcer switches to fan-out mode is **not** decided in S1 — it rides on S3
+> (#440). `when-not-to-use.md` may mention that a fan-out threshold exists but
+> must not fix its value.
+
+---
+
+## 5. Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios in §7.
+
+- **FR-1.** A `dynamic-workflows` skill exists at
+  `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md` with valid YAML
+  frontmatter: `name: dynamic-workflows` and a non-empty `description` whose
+  trigger conditions cover dynamic workflows, self-authored multi-agent
+  harnesses, the `ultracode` trigger, the six patterns, and "when to use a
+  workflow."
+- **FR-2.** `SKILL.md` introduces the six composable patterns, the decision
+  rubric, and the two invariants, in the shape of the sibling knowledge skills
+  (`harness-engineering`, `context-engineering`) — knowledge agents read, not a
+  script they run.
+- **FR-3.** `references/patterns.md` names all six patterns (classify-and-act,
+  fan-out-and-synthesize, adversarial verification, generate-and-filter,
+  tournament, loop-until-done), each with a worked micro-example.
+- **FR-4.** `references/when-not-to-use.md` states the four-question election
+  rubric and the "if none apply, use the static pipeline" default, **without**
+  fixing the D3 fan-out threshold value.
+- **FR-5.** `references/governance.md` restates INV-1 and INV-2 for agents, each
+  named in full, INV-1 enumerating the four durable artefacts and the
+  human-curation flow.
+- **FR-6.** `templates/MODEL_ROUTING.md` gains a workflow-election section, an
+  explicit per-workflow token-budget convention, and the
+  model-routing-classifier idea (Haiku/Sonnet/Opus tiering).
+- **FR-7.** `SKILL.md` and all reference files pass markdownlint with no new
+  violations and contain no runnable dependency on any S2 `.workflow.js` file;
+  any reference to the template library is an explicit forward-reference.
+- **FR-8.** The plugin version is bumped `0.57.0 → 0.58.0` across all five
+  CI-enforced locations (§6.1), and the human-facing README plugin-table cell is
+  updated.
+- **FR-9.** A reference-page entry `### dynamic-workflows` is added to
+  `docs/plugins/ai-literacy-superpowers/reference/skills.md` (docs-reference-parity
+  gate).
+- **FR-10.** A TDAD scenario for the new skill is added under
+  `tdad_tests/scenarios/skills/dynamic-workflows/` with frontmatter `tier:` one
+  of `structural` / `trigger` / `behavioural` (tdad-scenario-check gate).
+
+---
+
+## 6. CI, version, and docs checklist
+
+### 6.1 Version bump — adding a skill is behavioural (minor)
+
+Adding a new skill is a behavioural change → **minor bump `0.57.0 → 0.58.0`**.
+The `Version Check` CI enforces **five** locations (per CLAUDE.md / the live
+`version-check.yml`). Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical;
+   currently `0.57.0`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.58.0`
+   (line 6; currently `v0.57.0`)
+3. `CHANGELOG.md` — new top heading `## 0.58.0 — 2026-06-22`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (currently
+   `0.57.0`; owned by ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers`
+   `plugins[].version` entry (currently `0.57.0`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md`
+plugin-table row cell (`| v0.57.0 |` → `| v0.58.0 |`, line 31).
+
+> The marketplace listing `version` (`0.4.0`) does **not** change — S1 alters no
+> listing contract (no description/keyword/permission/plugins-array change).
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.57\.0\|0\.57\.0' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+### 6.2 Component-coverage gates
+
+- **`docs-reference-parity-check`** — a new skill added at
+  `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md` requires a matching
+  `### dynamic-workflows` heading in
+  `docs/plugins/ai-literacy-superpowers/reference/skills.md`, **in the same PR**.
+- **`tdad-scenario-check`** — the new skill requires at least one TDAD scenario
+  at `tdad_tests/scenarios/skills/dynamic-workflows/<aspect>.md` whose frontmatter
+  declares `tier:` as `structural`, `trigger`, or `behavioural` (a `finding` tier
+  does not satisfy the gate). The tdd-agent authors this file. A **structural**
+  scenario (assert the six patterns, the four-question rubric, and INV-1/INV-2 are
+  all present — mirroring AC-3/AC-4/AC-7) is the natural first scenario; a
+  **trigger** scenario for AC-6 (description fires on workflow queries) is the
+  natural second.
+- **`spec-first-check`** — satisfied by this spec being the first commit on the
+  branch. No exemption label is needed; this is feature work.
+- **`lint-markdown`** — SKILL.md, the three references, and MODEL_ROUTING.md must
+  pass markdownlint (AC-2). The PreToolUse hook catches violations at edit time.
+
+### 6.3 Skill-count badge — deliberate deferral to S7
+
+The README badge currently reads `Skills-35` (line 9) and the plugin-table cell
+reads "**35 skills**" (line 31). Landing this skill makes the true count **36**.
+
+**This is intentionally deferred to S7 (#444), not corrected in S1.** The
+slicing record assigns the badge/count update to S7 (D9). Confirmed against the
+live repo: the `Skills-35` badge is **not** grep-enforced by any CI workflow
+(no skill-count check exists in `.github/workflows/`), so leaving it stale does
+**not** redden CI. Recording the deferral here so a reviewer does not read the
+stale `35` as an S1 oversight. S7 will reconcile the badge and table to the
+filesystem count when the full epic lands.
+
+### 6.4 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Reference (required, gated).** `### dynamic-workflows` entry in
+  `reference/skills.md` — see §6.2. Place it in a sensible category (a new
+  "Dynamic Workflows" subsection or under "Harness Core"); the gate only checks
+  the heading exists.
+- **How-to (judgement call — recommend deferring to S7).** A how-to guide under
+  `docs/plugins/ai-literacy-superpowers/how-to/` is *warranted in principle* for
+  a new skill, but a "how to use dynamic workflows" guide is not actionable until
+  the template library (S2) and the behavioural workflow modes (S3–S6) exist —
+  S1 ships *reading material*, not a runnable workflow a guide could walk a user
+  through. **Recommendation:** defer the how-to guide to S7 (alongside the README
+  "Dynamic Workflows" section and badge), where the full substrate exists to
+  document end-to-end. The reference entry (gated, required now) plus the SKILL.md
+  itself are sufficient for S1. *(Surface this to the human at the GATE as an
+  explicit decision, not a silent omission.)*
+- **Explanation / tutorials.** None required for S1 — no existing explanation
+  page references behaviour S1 changes (this is net-new).
+
+---
+
+## 7. FR → acceptance-scenario mapping
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-1, AC-6 | deterministic + agent-backed |
+| FR-2 | AC-5 | agent-backed |
+| FR-3 | AC-3 | deterministic |
+| FR-4 | AC-7 | deterministic |
+| FR-5 | AC-4 | deterministic |
+| FR-6 | AC-9 | deterministic |
+| FR-7 | AC-2 | deterministic |
+| FR-8 | (CI: Version Check) | deterministic |
+| FR-9 | (CI: docs-reference-parity-check) | deterministic |
+| FR-10 | AC-6 via TDAD scenario | deterministic (presence) + agent-backed (content) |
+
+Cross-cutting agent-backed behaviour AC-8 (decline a workflow that fails the
+rubric) maps to FR-4 and is verified by a Layer-2/3 TDAD behavioural scenario if
+the tdd-agent elects to add one; otherwise it stands as declared intent
+alongside AC-10.
+
+---
+
+## 8. Risks and open questions
+
+**Risks.**
+
+- *Forward-reference leakage.* SKILL.md could accidentally hard-link a
+  `.workflow.js` file S2 has not shipped, reddening markdownlint or misleading a
+  reader. Mitigation: FR-7's standalone-validity requirement; review every
+  template mention as an explicit "forthcoming (S2)" forward-reference.
+- *Election rubric overreach.* `when-not-to-use.md` could imply deterministic
+  enforcement that S1 does not ship. Mitigation: AC-10 records the advisory-only
+  status explicitly.
+- *Stale badge misread as oversight.* Mitigated by §6.3's explicit deferral note.
+
+**Open questions.** None block S1. The four umbrella open questions
+(Q1 threshold → S3, Q2 routing default → S5, Q3 staging → S6, Q4 Copilot → S7)
+all ride later slices and are explicitly out of scope here (§2.2).

--- a/tdad_tests/scenarios/skills/dynamic-workflows/declines-workflow-when-rubric-fails.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/declines-workflow-when-rubric-fails.md
@@ -1,0 +1,43 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: behavioural
+---
+
+# Scenario: agent declines a workflow when the election rubric fails (AC-8)
+
+## Given
+
+A task that fails the four-question election rubric — none of long-running,
+massively parallel, highly structured, or adversarial applies. For example:
+"Rename this one function and update its three call sites in the same file."
+The agent has the `dynamic-workflows` skill available to consult.
+
+## When
+
+The agent considers whether to spin up a workflow for the task and consults
+`dynamic-workflows` (specifically `references/when-not-to-use.md`).
+
+## Then
+
+- The agent DECLINES to elect a workflow.
+- The agent explicitly USES the static pipeline (the plugin's default
+  `spec-writer → GATE → tdd-agent → implementer → code-reviewer → GUARDRAIL →
+  integration-agent` path, or simply a single-pass edit for a change this
+  small).
+- The agent CITES `when-not-to-use.md` / the four-question rubric as the
+  reason, noting that none of the four discriminating questions applies.
+
+## Rubric
+
+This is the agent-backed behaviour from AC-8 / FR-4 (Layer 3, full SDK
+invocation). The pass condition is that the agent *refuses* the workflow and
+grounds the refusal in the rubric — the discipline is "workflows are elected,
+not reflexive", and an agent that reaches for parallel subagents on a trivial
+in-file rename has breached it.
+
+Reflexively electing a workflow here is the canonical failure (the §7
+over-orchestration risk made observable). An agent that declines but cannot
+say *why* (does not reference the four questions or the static-pipeline
+default) is a partial pass graded as a failure: the citation is what proves
+the decision came from the skill rather than chance.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/enumerates-and-frontmatter-validates.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/enumerates-and-frontmatter-validates.md
@@ -1,0 +1,38 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: dynamic-workflows enumerates and its frontmatter validates (AC-1)
+
+## Given
+
+The ai-literacy-superpowers plugin is installed and its skills are
+enumerated by the plugin component discovery (`runner.plugin.list_skills`).
+
+## When
+
+The skill inventory is walked and the `dynamic-workflows` skill is located.
+
+## Then
+
+- A skill named `dynamic-workflows` appears in the enumeration.
+- Its `SKILL.md` lives at
+  `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md` and exists.
+- Its frontmatter declares a non-empty `name: dynamic-workflows`.
+- Its frontmatter declares a non-empty `description`.
+
+## Rubric
+
+This is the deterministic schema check from AC-1 / FR-1. It is satisfied
+only when the skill physically exists and its frontmatter parses with both
+required keys filled. Until the skill is authored, the structural corpus
+check (`test_every_scenario_targets_an_existing_component`) fails because
+`find_component(name="dynamic-workflows", component_type="skill")` raises
+`LookupError` — that is the intended RED state for S1.
+
+A `description` that is present but does not carry the trigger concepts
+(dynamic workflows, multi-agent harnesses, the six patterns, "when to use a
+workflow") is a content regression caught by the trigger-tier scenario, not
+this one; here we assert only schema presence.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/governance-restates-inv1-and-inv2.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/governance-restates-inv1-and-inv2.md
@@ -1,0 +1,40 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: governance.md restates INV-1 and INV-2 in full (AC-4)
+
+## Given
+
+The file
+`ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md`.
+
+## When
+
+The file is read.
+
+## Then
+
+- **INV-1** is named and stated in full: ephemeral workflows propose, durable
+  artefacts are human-curated. Workflows may **never** write the four durable
+  artefacts directly — `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, and
+  `MODEL_ROUTING.md` are each enumerated by name — and discoveries flow
+  through the human-curation path `REFLECTION_LOG.md → human curates →
+  AGENTS.md`.
+- **INV-2** is named and stated in full: untrusted-content readers are
+  quarantined — withheld high-privilege tools — so a subagent that reads
+  untrusted input cannot also wield high-privilege capabilities.
+
+## Rubric
+
+This is the deterministic content check from AC-4 / FR-5. Each invariant must
+be (a) named by its INV-1 / INV-2 label and (b) stated in full, not merely
+referenced. For INV-1 the four durable artefacts must each be named and the
+`REFLECTION_LOG.md → human → AGENTS.md` curation flow must be present — these
+are the load-bearing specifics every later slice (S2–S7) references.
+
+The scenario does not assert any CI grep firewall rule exists — that is the
+S2 mechanisation of INV-1's *teeth* and is explicitly out of S1 scope. Here we
+assert only that the invariants are restated for agents as readable knowledge.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/how-to-guide-exists.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/how-to-guide-exists.md
@@ -1,0 +1,35 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: a dynamic-workflows how-to guide exists (S1 GATE pull-in)
+
+## Given
+
+The docs site directory
+`docs/plugins/ai-literacy-superpowers/how-to/`.
+
+## When
+
+The how-to guides are enumerated.
+
+## Then
+
+- A how-to guide for the `dynamic-workflows` skill exists under
+  `docs/plugins/ai-literacy-superpowers/how-to/` (e.g.
+  `dynamic-workflows.md`).
+- The guide references the `dynamic-workflows` skill by name.
+
+## Rubric
+
+The spec (§6.4) recommended deferring the how-to guide to S7, but the human
+pulled it into S1 at the GATE. This is a lightweight presence check: the
+guide file exists and names the skill. It does not assert the guide walks
+through any runnable workflow template (those are S2) — S1 ships reading
+material, so the guide is an orientation to the skill's conceptual model and
+election rubric, not an end-to-end runbook.
+
+Until the guide file is authored, this scenario is RED by absence of the
+file under the how-to directory.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md
@@ -1,0 +1,38 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: dynamic-workflows SKILL.md and references are markdownlint-clean (AC-2)
+
+## Given
+
+The `dynamic-workflows` skill's `SKILL.md` and its three reference files
+(`references/patterns.md`, `references/when-not-to-use.md`,
+`references/governance.md`) exist.
+
+## When
+
+markdownlint runs over them — via the existing PreToolUse hook at edit time
+and the `lint-markdown` CI workflow.
+
+## Then
+
+- `SKILL.md` passes markdownlint with no new violations.
+- `references/patterns.md` passes markdownlint with no new violations.
+- `references/when-not-to-use.md` passes markdownlint with no new violations.
+- `references/governance.md` passes markdownlint with no new violations.
+- None of the files contain a runnable dependency on any `.workflow.js`
+  file (the S2 template library); any mention of the template library is an
+  explicit "forthcoming (S2)" forward-reference, not a link to a file that
+  must exist.
+
+## Rubric
+
+This is the deterministic lint check from AC-2 / FR-7. The forward-reference
+clause is load-bearing: S1 must be lint-clean and valid *standalone*, with no
+broken link to a file S2 has not yet shipped. A markdown link to a
+non-existent `workflows/*.workflow.js` path would both mislead a reader and
+risk a broken-link lint failure — so the scenario fails if the skill imports
+or hard-links any template file.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/model-routing-gains-workflow-election.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/model-routing-gains-workflow-election.md
@@ -1,0 +1,38 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: MODEL_ROUTING.md gains workflow-election + token-budget + classifier (AC-9)
+
+## Given
+
+The template `ai-literacy-superpowers/templates/MODEL_ROUTING.md`, extended as
+part of the `dynamic-workflows` skill slice (S1).
+
+## When
+
+The file is read.
+
+## Then
+
+- It contains a **workflow-election** section — the election discipline (D8)
+  given a home in the routing template.
+- It states a **token-budget convention**: an explicit per-workflow cap (e.g.
+  "use 10k tokens"), so every elected workflow carries a bounded budget.
+- It describes the **model-routing-classifier** idea: a classifier agent that
+  researches task complexity, then routes across the Haiku / Sonnet / Opus
+  tiers.
+
+## Rubric
+
+This is the deterministic content check from AC-9 / FR-6. All three elements
+must be present: the workflow-election section, an explicit per-workflow
+token cap, and the classifier-tiering idea naming Haiku/Sonnet/Opus.
+
+This scenario is filed under the `dynamic-workflows` skill because the
+template extension is part of S1's skill slice — until the skill exists the
+structural corpus check reddens, and the MODEL_ROUTING.md additions are
+authored in the same slice. It does not assert the D4 routing default
+(opt-in vs on-by-default) — that rides on S5.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/names-pattern-and-cites-invariants.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/names-pattern-and-cites-invariants.md
@@ -1,0 +1,45 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: behavioural
+---
+
+# Scenario: agent names the matching pattern and cites INV-1/INV-2 (AC-5)
+
+## Given
+
+A task that benefits from parallel, isolated subagents — for example:
+"Review these 12 independent migration files; each can be checked
+independently and the findings synthesised into one report." The agent has
+the `dynamic-workflows` skill available to consult.
+
+## When
+
+The agent consults `dynamic-workflows` and reasons about how to approach the
+task.
+
+## Then
+
+- The agent NAMES the matching pattern from the six (here:
+  `fan-out-and-synthesize`) and explains why it fits the task's shape.
+- The agent CITES INV-1 — that any discoveries the workflow surfaces must
+  flow through the human-curation path (`REFLECTION_LOG.md → human →
+  AGENTS.md`) and the workflow may not write `HARNESS.md` / `AGENTS.md` /
+  `CLAUDE.md` / `MODEL_ROUTING.md` directly.
+- The agent CITES INV-2 — that any subagent reading untrusted content is
+  quarantined from high-privilege tools.
+
+## Rubric
+
+This is the agent-backed behaviour from AC-5 / FR-2 (Layer 3, full SDK
+invocation, ~$0.05–$0.20 per run). Acceptable answers name the *correct*
+pattern for the task's shape and ground the approach in *both* invariants by
+name. Naming a pattern without citing the invariants, or citing the
+invariants without selecting a fitting pattern, is a partial pass and should
+be graded as a failure — the skill's value is that an agent can do both from
+the single knowledge source.
+
+The grader is an LLM-as-judge against this rubric. The pattern need not be
+the literal string `fan-out-and-synthesize` if the agent names an equally
+defensible pattern for the task and justifies it, but it must be one of the
+six and must fit the task's independence/parallelism shape.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/patterns-cover-all-six-with-examples.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/patterns-cover-all-six-with-examples.md
@@ -1,0 +1,41 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: patterns.md names all six patterns with worked micro-examples (AC-3)
+
+## Given
+
+The file
+`ai-literacy-superpowers/skills/dynamic-workflows/references/patterns.md`.
+
+## When
+
+The file is read.
+
+## Then
+
+All six composable patterns are named, and each carries a worked
+micro-example (a concrete, task-shaped illustration, not just a definition):
+
+- classify-and-act
+- fan-out-and-synthesize
+- adversarial verification
+- generate-and-filter
+- tournament
+- loop-until-done
+
+## Rubric
+
+This is the deterministic content check from AC-3 / FR-3. "Named" means each
+of the six pattern labels appears as a heading or term in the file; "worked
+micro-example" means each pattern section illustrates the pattern against a
+concrete task rather than only restating its definition.
+
+A pattern listed without a micro-example fails the scenario — the worked
+example is what makes the pattern usable by an agent reasoning about a real
+task (and is what AC-5's agent-backed naming relies on). The file must not
+fix the D3 fan-out threshold value (= 8); it may mention that a threshold for
+fan-out mode exists, but stating a number is out of S1 scope (it rides on S3).

--- a/tdad_tests/scenarios/skills/dynamic-workflows/readme-skill-count-reflects-new-total.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/readme-skill-count-reflects-new-total.md
@@ -1,0 +1,36 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: README skill-count badge/text reflects the new total of 36 (S1 GATE pull-in)
+
+## Given
+
+The repository `README.md`, after the `dynamic-workflows` skill lands.
+
+## When
+
+The skills badge (line ~9, `img.shields.io/badge/Skills-...`) and the
+`ai-literacy-superpowers` plugin-table row (line ~31, "**N skills, ...**")
+are read.
+
+## Then
+
+- The shields.io skills badge reads `Skills-36` (not the stale `Skills-35`).
+- The plugin-table row text reads "**36 skills, ...**" (not "**35 skills**").
+
+## Rubric
+
+The spec (§6.3) deliberately deferred the badge/count correction to S7, but
+the human pulled it into S1 at the GATE — so for S1 the README must reflect
+the true filesystem count of 36 skills once `dynamic-workflows` is added.
+
+This is a lightweight count-consistency check, not CI-enforced (no
+skill-count grep workflow exists), so it is verified by reading the two
+README locations. It is RED while the README still reads `35`.
+
+The plugin-version bump (`0.57.0 → 0.58.0`) and the marketplace/plugin.json
+version locations are covered by the separate `Version Check` CI gate, not by
+this scenario.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/triggers-on-workflow-election-query.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/triggers-on-workflow-election-query.md
@@ -1,0 +1,68 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: trigger
+---
+
+# Scenario: dynamic-workflows triggers on workflow-election queries (AC-6)
+
+## Given
+
+A Claude session with the ai-literacy-superpowers plugin loaded — so all
+skill descriptions, including `dynamic-workflows`, are available for matching.
+
+## When
+
+Each of the following user queries is sent to the model in isolation:
+
+- "Should I use a workflow or a multi-agent harness for this task?"
+- "This task would benefit from running several isolated subagents in
+  parallel — how should I structure that?"
+- "What dynamic-workflow pattern fits a fan-out-and-synthesize problem?"
+- "Set up adversarial verification with a separate reviewer context for this
+  change"
+- "When is it worth spawning ephemeral subagents instead of doing this in one
+  pass?"
+- "How does the `ultracode` trigger relate to self-authored multi-agent
+  harnesses?"
+
+## Then
+
+For each query, the model should identify `dynamic-workflows` as a skill to
+invoke. At minimum the skill should appear in the list of skills the model
+says it would load to handle the request.
+
+The second and fifth queries are the hardest: they paraphrase the trigger
+condition ("parallel, isolated subagents", "when is it worth spawning
+ephemeral subagents") without using the skill name or the literal word
+"workflow" — testing whether the `description` carries the *concept* (the
+ephemeral multi-agent substrate and the election decision) rather than only
+literal tokens.
+
+## Rubric
+
+A single inference suffices: hand the model the plugin's skill descriptions
+and the query, ask "which skills would you invoke for this query?", and parse
+the response. No fixture state needed. This is AC-6 / FR-1's trigger surface.
+
+This catches description-drift early: if a future edit waters down the
+`description:` line until the multi-agent-substrate / election framing
+disappears, this scenario fails and surfaces the regression before it ships.
+
+## Distinction from sibling knowledge skills
+
+`harness-engineering` and `context-engineering` are also knowledge skills,
+and their descriptions overlap on the word "harness". The distinction the
+`dynamic-workflows` description must make discoverable:
+
+- `harness-engineering` answers "what is a harness / the conceptual
+  foundation of the plugin" — the *static* harness as a whole.
+- `context-engineering` answers "how do I write conventions / the Context
+  section of HARNESS.md" — curating the knowledge an LLM reads.
+- `dynamic-workflows` is specifically about the **ephemeral multi-agent
+  substrate** beneath the static agents and the **election rubric** for *when*
+  to spend compute on a workflow versus the static pipeline.
+
+A query about "should I spin up parallel subagents / which workflow pattern /
+when is a workflow warranted" must resolve to `dynamic-workflows`, not to its
+two siblings.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/when-not-to-use-states-election-rubric.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/when-not-to-use-states-election-rubric.md
@@ -1,0 +1,37 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: when-not-to-use.md states the four-question election rubric (AC-7)
+
+## Given
+
+The file
+`ai-literacy-superpowers/skills/dynamic-workflows/references/when-not-to-use.md`.
+
+## When
+
+The file is read.
+
+## Then
+
+- The compute-discipline election rubric is stated as four discriminating
+  questions: is the task **long-running**, **massively parallel**, **highly
+  structured**, or **adversarial**?
+- The default is stated explicitly: **if none of the four apply, use the
+  static pipeline.**
+- The file does **not** fix the D3 fan-out threshold value (= 8); it may note
+  that a fan-out threshold exists but must not state its number (that rides
+  on S3).
+
+## Rubric
+
+This is the deterministic content check from AC-7 / FR-4. All four
+discriminating questions must be present and the "if none apply, use the
+static pipeline" default must be explicit — the default is what makes a
+workflow *elected* rather than reflexive (the §7 over-orchestration risk).
+
+The no-threshold-value clause is a scope guardrail: stating "= 8" here would
+pre-empt S3's open-question-1 decision and is therefore a regression for S1.


### PR DESCRIPTION
## Summary

- Adds the foundational `dynamic-workflows` knowledge skill (SKILL.md plus references for patterns, when-not-to-use, and governance) — the conceptual model the rest of the Dynamic Workflows Alignment epic builds on.
- Adds a workflow-election section to `templates/MODEL_ROUTING.md`: a token-budget convention plus the Haiku/Sonnet/Opus model-routing-classifier.
- Adds a how-to guide, the `### dynamic-workflows` reference entry, and reconciles the skill count to 36.
- Scope discipline: workflow templates and the INV-1 CI firewall are deferred to S2 (#439) — SKILL.md only forward-references them. The two §7 open questions touching later slices (D3 threshold, etc.) are out of scope here.

## Test plan

- Confirm the `dynamic-workflows` skill renders and its references resolve.
- Verify `templates/MODEL_ROUTING.md` workflow-election section reads coherently (token-budget convention + model-routing-classifier).
- Verify the how-to guide and the `### dynamic-workflows` reference entry are present.
- Confirm the skill count reads 36 wherever counted.
- CI green: markdownlint, layer-0 + layer-1 TDAD, version-check (0.58.0), docs-reference-parity, tdad-scenario-check, spec-first.

## References

- Spec: `docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md`
- Epic / slicing record: `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`

Closes #438