### PR TITLE
Foreground Claude-Code-only runtime scope across slices + specs

### DIFF
--- a/docs/superpowers/slices/dynamic-workflows-alignment.md
+++ b/docs/superpowers/slices/dynamic-workflows-alignment.md
@@ -88,6 +88,28 @@ share a decision or an acceptance criterion rather than emitted one
 slice per D-number. The ordering follows the §6 dependency sequence
 and honours the highest-leverage / smallest-blast-radius signal on D3.
 
+## Runtime scope — Claude Code only (read before any slice)
+
+**Dynamic workflows are a Claude Code runtime capability** (the
+self-authored multi-agent harness substrate, trigger word `ultracode`).
+The runtime is **not** present in GitHub Copilot CLI or any other coding
+agent, and it is **not transferable** to them. This boundary applies to
+**every slice in this record**, not only the documentation slice:
+
+- **Where the runtime exists (Claude Code):** the workflow *modes* and
+  *templates* the slices add are executable.
+- **Where it does not (Copilot CLI, other agents):** the `dynamic-workflows`
+  skill and every workflow-mode section degrade to **guidance only** — the
+  knowledge (patterns, election rubric, INV-1/INV-2) is still readable, but
+  no workflow can be spawned. A workflow-mode agent on such a tree must fall
+  back to its existing static behaviour, never error or pretend to fan out.
+
+Each per-slice spec (S2–S7) must restate this boundary explicitly: any
+workflow-mode behaviour it adds is Claude-Code-gated, with a guidance-only
+fallback elsewhere. The precise Copilot degradation *contract* (guidance-only
+vs omit) is open-question 4 and is dispositioned in **S7**, but the
+Claude-Code-only nature itself is settled and binds all slices now.
+
 ## S1 — Foundational skill + election discipline (D1 + D8) — decision-boundary
 
 **Context.** D1 establishes the shared conceptual model (the six

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md
@@ -14,6 +14,17 @@
 > <https://code.claude.com/docs/en/workflows> before writing any template, and treat the
 > signatures there as authoritative over any pseudocode here. This spec governs *what* to build
 > and *how it must behave*, not the runtime API surface.
+>
+> **Runtime scope — Claude Code only (read first).** Dynamic workflows are a **Claude Code**
+> runtime capability and are **not transferable** to GitHub Copilot CLI or any other coding agent
+> — those trees have no workflow runtime. This plugin ships to both the Claude Code and Copilot CLI
+> trees, so every deliverable below is **Claude-Code-gated**: where the runtime exists the workflow
+> modes and templates execute; where it does not, the `dynamic-workflows` skill and every
+> workflow-mode section **degrade to guidance only** (the knowledge stays readable; no workflow is
+> spawned; workflow-mode agents fall back to their existing static behaviour and never error). This
+> is a settled, cross-cutting constraint (see §5.5) — the *precise* Copilot degradation contract
+> (guidance-only vs omit) is open-question 4, dispositioned in S7, but the Claude-Code-only nature
+> itself binds all slices now.
 
 ---
 
@@ -278,8 +289,14 @@ a panel of reviewers. Encode the discipline so the plugin reaches for workflows 
 3. The static pipeline remains the **default** for ordinary coding tasks; workflows are opt-in by
    classification or by explicit trigger.
 4. All three enforcement loops still hold: advisory hooks warn, CI blocks, scheduled GC/audit reports.
-5. The plugin works identically from the Claude Code and Copilot CLI trees where the runtime supports it;
-   where Copilot lacks the workflow runtime, the skill degrades to guidance only (document this clearly).
+5. *(Runtime scope — Claude Code only.)* Dynamic workflows are a Claude Code runtime feature and are
+   **not transferable** to Copilot CLI or other coding agents. The plugin works identically across the
+   Claude Code and Copilot CLI trees only **where the runtime supports workflows** (Claude Code); where
+   Copilot or another agent lacks the workflow runtime, the `dynamic-workflows` skill and every
+   workflow-mode section **degrade to guidance only** — knowledge stays readable, no workflow is
+   spawned, and workflow-mode agents fall back to their existing static behaviour rather than error.
+   Every per-slice spec (S1–S7) must restate this Claude-Code-gated boundary for the behaviour it adds;
+   the precise degradation contract (guidance-only vs omit the skill) is open-question 4, resolved in S7.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md
@@ -18,6 +18,16 @@
 > runtime function names for spawning subagents are **not** reproduced; consult
 > <https://code.claude.com/docs/en/workflows> as authoritative when S2 writes
 > templates.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code
+> runtime capability, **not transferable** to Copilot CLI or other coding
+> agents. This skill ships to both trees: the knowledge it carries (patterns,
+> election rubric, INV-1/INV-2) is readable everywhere, but a workflow can only
+> be *spawned* on Claude Code. On a tree without the runtime the skill is
+> guidance only. This boundary is settled and binds the skill; foregrounding it
+> in the shipped `SKILL.md` is recommended (a small patch may pull it forward
+> from S7, which owns the precise Copilot degradation *contract* —
+> open-question 4). See the umbrella spec's runtime-scope note and §5.5.
 
 ---
 


### PR DESCRIPTION
Makes explicit that **dynamic workflows are a Claude Code runtime capability — not transferable to GitHub Copilot CLI or other coding agents**, so the planning artefacts state it prominently rather than leaving it buried in the umbrella spec's §5.5 and deferred to S7.

## Why
The plugin ships to both the Claude Code and Copilot CLI trees. The workflow runtime only exists on Claude Code; everywhere else the `dynamic-workflows` skill and every workflow-mode section can only degrade to **guidance only**. This portability boundary binds *every* slice, not just the docs slice — so it belongs up front.

## Changes (docs/planning only — no plugin change, no version bump)
- **Slicing record** (`docs/superpowers/slices/dynamic-workflows-alignment.md`): new **"Runtime scope — Claude Code only (read before any slice)"** section that binds all slices and requires each per-slice spec (S2–S7) to restate the Claude-Code-gated boundary with a guidance-only fallback.
- **Umbrella spec** (`…-alignment-design.md`): a read-first runtime-scope note at the top and a strengthened §5.5.
- **S1 spec** (`…-s1-skill-design.md`): a runtime-scope note; flags that foregrounding it in the shipped `SKILL.md` is recommended (a small patch could pull it forward from S7).

The *precise* Copilot degradation contract (guidance-only vs omit the skill) remains S7's open-question 4; only the settled Claude-Code-only nature is foregrounded here.

## Follow-up (not in this PR)
The shipped S1 `SKILL.md` does not yet carry this note (S1 deferred the Copilot framing to S7). Bringing it forward is a small plugin patch (0.58.0 → 0.58.1) — happy to do it on request.