### PR TITLE
State Claude-Code-only runtime scope in the dynamic-workflows skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.58.0",
+  "plugin_version": "0.58.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.58.0"
+      "version": "0.58.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.58.1 — 2026-06-22
+
+### dynamic-workflows: state the Claude-Code-only runtime scope in the skill
+
+- **`skills/dynamic-workflows/SKILL.md`** gains a "Runtime scope — Claude Code
+  only" section: dynamic workflows are a Claude Code runtime capability, **not
+  transferable** to GitHub Copilot CLI or other coding agents. The skill is
+  knowledge everywhere, runtime only on Claude Code; on a tree without the
+  workflow runtime it is guidance only — readable, but no workflow can be
+  spawned, and an agent there falls back to its static behaviour rather than
+  erroring. Brought forward from S7 so the boundary is clear in the artefact
+  agents actually read; the precise Copilot degradation *contract* (guidance-only
+  vs omit) remains S7's open question.
+- The `dynamic-workflows` how-to guide carries the same runtime-scope note.
+
 ## 0.58.0 — 2026-06-22
 
 ### dynamic-workflows: foundational skill + election discipline (S1, #438)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.58.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.58.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.58.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.58.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
@@ -25,6 +25,25 @@ questions before any workflow is authored:
 3. **How** does the plugin's governance constrain it? — see
    [`references/governance.md`](references/governance.md).
 
+## Runtime scope — Claude Code only
+
+Dynamic workflows are a **Claude Code runtime capability** and are **not
+transferable** to GitHub Copilot CLI or any other coding agent — those
+trees have no workflow runtime. This plugin ships to both the Claude Code
+and Copilot CLI trees, so this skill is **knowledge everywhere, runtime
+only on Claude Code**:
+
+- **On Claude Code:** workflows can be authored and spawned; the patterns,
+  election rubric, and templates are executable.
+- **On Copilot CLI or any other agent:** there is no workflow runtime, so
+  this skill is **guidance only** — the patterns and governance below are
+  still worth reading, but no workflow can be spawned. An agent on such a
+  tree must fall back to its existing static behaviour; it must never error
+  or pretend to fan out.
+
+Read the rest of this skill as a reasoning model that applies everywhere;
+act on it as a runtime only where Claude Code provides one.
+
 ## Static harness vs. dynamic workflow
 
 The plugin is, by default, a **static harness**: a fixed pipeline

--- a/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
@@ -12,6 +12,11 @@ decide *whether* a task warrants a workflow and *which* pattern fits.
 > *templates* arrive in a follow-up slice (S2). Until then, use this guide
 > and the skill to reason about workflows; there is no end-to-end runbook
 > to walk through yet.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code
+> runtime capability and are **not transferable** to GitHub Copilot CLI or
+> other coding agents. On a tree without the workflow runtime this skill is
+> guidance only — readable knowledge, but no workflow can be spawned.
 
 ---
 


### PR DESCRIPTION
Brings the **Claude-Code-only runtime boundary** forward into the artefact agents actually read — the shipped `dynamic-workflows` SKILL.md — rather than leaving it only in the planning docs and S7.

## Why
Dynamic workflows are a **Claude Code runtime capability, not transferable** to GitHub Copilot CLI or other coding agents. The plugin ships to both trees, so an agent reading this skill on Copilot needs to know up front that it is **guidance only** there — readable knowledge, but no workflow can be spawned, and it should fall back to static behaviour rather than error.

## Changes (doc-only → patch bump 0.58.0 → 0.58.1)
- **`skills/dynamic-workflows/SKILL.md`** — new "Runtime scope — Claude Code only" section near the top.
- **`how-to/dynamic-workflows.md`** — the same runtime-scope note in the scope callout.
- Patch bump across the five CI-enforced version locations + the README table cell.

The precise Copilot degradation *contract* (guidance-only vs omit the skill) remains S7's open-question 4; this only states the settled Claude-Code-only nature. Follows the just-merged planning-doc work (#448).

Structural TDAD suite green (16/16); markdownlint clean; version consistent.