### PR TITLE
Dynamic Workflows S2 — template library + INV-1/INV-2 firewall

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.58.1",
+  "plugin_version": "0.59.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.58.1"
+      "version": "0.59.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/dynamic-workflows-firewall.yml
+++ b/.github/workflows/dynamic-workflows-firewall.yml
@@ -1,0 +1,73 @@
+# Dynamic-workflows INV-1/INV-2 firewall.
+#
+# The deterministic teeth of the dynamic-workflows governance invariants
+# (umbrella spec §5.1/§5.2, slice S2). A workflow template is ephemeral and
+# generated; the durable artefacts (HARNESS.md, AGENTS.md, CLAUDE.md,
+# MODEL_ROUTING.md) are human-curated. This gate fails the PR if any shipped
+# template:
+#   - INV-1: writes a durable artefact directly in executable code, or
+#   - INV-2: grants a declared @untrusted-reader agent a high-privilege tool.
+#
+# It invokes the SAME matcher (ai-literacy-superpowers/scripts/inv-firewall.sh)
+# that the Layer-0 deterministic test exercises against red/green fixtures, so
+# the gate and the unit test enforce exactly one rule. The matcher uses only
+# POSIX awk + grep -E, so it runs identically here and on a developer's macOS.
+
+name: Dynamic-workflows firewall
+
+on:
+  pull_request:
+    paths:
+      - 'ai-literacy-superpowers/skills/dynamic-workflows/workflows/**'
+      - 'ai-literacy-superpowers/scripts/inv-firewall.sh'
+      - '.github/workflows/dynamic-workflows-firewall.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  firewall:
+    name: INV-1/INV-2 firewall on workflow templates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Run the INV-1/INV-2 firewall over shipped templates
+        run: |
+          set -euo pipefail
+
+          MATCHER=ai-literacy-superpowers/scripts/inv-firewall.sh
+          WF_DIR=ai-literacy-superpowers/skills/dynamic-workflows/workflows
+
+          chmod +x "$MATCHER"
+
+          # Collect the shipped templates (the package.json marker is not a
+          # template and is skipped).
+          shopt -s nullglob
+          templates=("$WF_DIR"/*.workflow.js)
+          if [ "${#templates[@]}" -eq 0 ]; then
+            echo "No workflow templates found under $WF_DIR — nothing to check."
+            exit 0
+          fi
+
+          rc=0
+
+          if ! "$MATCHER" --check=inv1 "${templates[@]}"; then
+            echo "::error::INV-1 firewall: a workflow template writes a durable artefact directly."
+            echo "Workflows propose; they never write HARNESS.md / AGENTS.md / CLAUDE.md / MODEL_ROUTING.md."
+            echo "Reach durable artefacts through harness indirection, and route findings through the human-curation gate."
+            rc=1
+          fi
+
+          if ! "$MATCHER" --check=inv2 "${templates[@]}"; then
+            echo "::error::INV-2 firewall: an @untrusted-reader agent is granted a high-privilege tool."
+            echo "Quarantine untrusted-content readers; have a separate trusted agent act on the vetted output."
+            rc=1
+          fi
+
+          if [ "$rc" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "Dynamic-workflows firewall passed: all templates respect INV-1 and INV-2."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.59.0 — 2026-06-22
+
+### dynamic-workflows: template library + INV-1/INV-2 firewall (S2, #439)
+
+The runnable substrate for the epic, plus the deterministic teeth that keep it
+governed.
+
+- **Four workflow templates** under `skills/dynamic-workflows/workflows/` —
+  `enforcer-fanout`, `adversarial-review`, `reflection-mining`, and
+  `deep-assessment`. Each is a template to **adapt, never run verbatim**, with a
+  literate preamble naming its pattern, token budget, per-role model tiers, the
+  INV-1 boundary it respects, and the Claude-Code-only runtime scope. A
+  `workflows/package.json` (`type: module`) lets the `export const meta` +
+  top-level-await DSL parse as the runtime expects.
+- **INV-1/INV-2 firewall** (`scripts/inv-firewall.sh`) — one POSIX-portable
+  matcher, invoked two ways: a PR-time gate
+  (`.github/workflows/dynamic-workflows-firewall.yml`) and a Layer-0
+  deterministic test with red/green fixtures. INV-1 strips comments then fails on
+  any durable filename (`HARNESS.md` / `AGENTS.md` / `CLAUDE.md` /
+  `MODEL_ROUTING.md`) appearing in executable code — so a literate preamble that
+  merely *names* one passes, but a write fails. INV-2 fails if a declared
+  `@untrusted-reader` agent's `@tools` names a high-privilege tool (write, edit,
+  bash, commit, push). A consequence templates respect: durable artefacts are
+  reached only through harness indirection, never spelled in code.
+- **`SKILL.md`** flips the template library from "forthcoming (S2)" to shipped,
+  referencing all four templates by resolving relative path; the how-to guide
+  names them. The S1 markdownlint scenario that forbade template links is
+  reconciled to assert the links now resolve.
+
 ## 0.58.1 — 2026-06-22
 
 ### dynamic-workflows: state the Claude-Code-only runtime scope in the skill

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.58.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.59.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.58.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.59.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/inv-firewall.sh
+++ b/ai-literacy-superpowers/scripts/inv-firewall.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 #
 # inv-firewall.sh — the deterministic teeth of the dynamic-workflows
 # governance invariants (INV-1 and INV-2). One matcher, invoked two ways:
@@ -49,8 +50,6 @@
 #   inv-firewall.sh --check=inv1 <file...>
 #   inv-firewall.sh --check=inv2 <file...>
 # Exit 0 = clean; non-zero = at least one violation (message on stdout).
-
-set -euo pipefail
 
 CHECK=""
 FILES=()

--- a/ai-literacy-superpowers/scripts/inv-firewall.sh
+++ b/ai-literacy-superpowers/scripts/inv-firewall.sh
@@ -13,20 +13,24 @@
 # stated for agents in the skill's governance.md; this script is what makes
 # them fail CI rather than merely advise.
 #
-# Design decisions (spec §7, human-approved at the S2 GATE):
-#   - INV-1 = layered "Option C". Strip comments first, then fail on ANY of the
-#     four durable filenames appearing in executable (non-comment) code —
-#     whether or not the specific write call is recognised. This kills the
-#     false positive (a literate preamble that merely *names* AGENTS.md passes)
-#     and the false negative (a write expressed an unenumerated way), and is
-#     robust to runtime-API drift. The consequence templates must respect:
-#     durable artefacts are reached only through harness-provided indirection,
-#     never by spelling the filename in code.
+# Design decisions (spec §7, human-approved at the S2 GATE; hardened after the
+# S2 adversarial review closed three bypasses):
+#   - INV-1 = layered "Option C". Strip comments first, then fail if any durable
+#     STEM (HARNESS, AGENTS, CLAUDE, MODEL_ROUTING) survives into executable
+#     code as a whole word — independent of the `.md` suffix. Matching the stem
+#     rather than the full filename defeats name-splitting ("AGENTS" + ".md",
+#     `${dir}/AGENTS.md`, ["AGENTS",".md"].join("")), and `grep -w` keeps
+#     SCREAMING_SNAKE variables (MODEL_ROUTING_TABLE) safe. A literate preamble
+#     that merely *names* a durable artefact passes (it is stripped first). The
+#     consequence templates must respect: durable artefacts are reached only
+#     through harness-provided indirection, never spelled in code.
 #   - INV-2 = declared markers "Option I1". A template annotates an
 #     untrusted-content reader with `// @untrusted-reader: true` and declares
 #     its `// @tools: [...]`; the lint fails if that set names a high-privilege
-#     tool (write, edit, bash, commit, push). Passes vacuously when no
-#     untrusted reader is declared.
+#     tool (write, edit, bash, commit, push, fetch, webfetch). The check is
+#     case-insensitive, accumulates a multi-line `@tools` list, and is
+#     independent of the order of the three markers within an agent block.
+#     Passes vacuously when no untrusted reader is declared.
 #
 # Portability: POSIX awk + grep -E only (no gawk/GNU extensions, no `grep -P`,
 # no BSD-only date) so the Layer-0 test runs identically on macOS and Linux.
@@ -84,8 +88,16 @@ check_inv1() {
   for f in "${FILES[@]}"; do
     code=$(strip_comments "$f")
     for name in HARNESS AGENTS CLAUDE MODEL_ROUTING; do
-      if printf '%s\n' "$code" | grep -qE "${name}\.md"; then
-        echo "INV-1 VIOLATION: $f writes the durable artefact ${name}.md in executable code — workflows may never write durable artefacts directly (INV-1)."
+      # Match the durable STEM as a whole word in executable code, independent
+      # of the `.md` suffix. This is what makes Option C robust against a
+      # filename split to dodge the matcher — "AGENTS" + ".md",
+      # `${dir}/AGENTS.md`, ["AGENTS", ".md"].join("") all still contain the
+      # bare stem token. The stems never appear legitimately in template code:
+      # every real mention is in a literate preamble and already stripped, so a
+      # stem surviving into executable code is itself the smell. `grep -w` keeps
+      # SCREAMING_SNAKE variables safe (MODEL_ROUTING_TABLE is a different word).
+      if printf '%s\n' "$code" | grep -qwE "$name"; then
+        echo "INV-1 VIOLATION: $f references the durable artefact ${name}.md in executable code — workflows may never read or write durable artefacts directly; reach them through harness indirection (INV-1)."
         rc=1
       fi
     done
@@ -97,23 +109,44 @@ check_inv2() {
   local rc=0 f
   for f in "${FILES[@]}"; do
     if ! awk -v file="$f" '
-      /@workflow-agent:/                     { untrusted = 0 }
-      /@untrusted-reader:[ \t]*true/         { untrusted = 1 }
-      /@untrusted-reader:[ \t]*false/        { untrusted = 0 }
-      /@tools:/ {
-        if (untrusted == 1) {
-          lb = index($0, "["); rb = index($0, "]")
-          if (lb > 0 && rb > lb) {
-            inner = substr($0, lb + 1, rb - lb - 1)
-            m = split(inner, arr, /[, ]+/)
-            for (k = 1; k <= m; k++) {
-              t = arr[k]; gsub(/[^a-zA-Z]/, "", t)
-              if (t == "write" || t == "edit" || t == "bash" || t == "commit" || t == "push") {
-                printf("INV-2 VIOLATION: %s — an @untrusted-reader agent is granted the high-privilege tool: %s. Quarantine it; act via a separate trusted agent (INV-2).\n", file, t)
-                bad = 1
-              }
+      # High-privilege tool comparison is case-insensitive (Bash == bash) and
+      # the @tools list is accumulated across continuation lines, so neither
+      # casing nor line-wrapping can smuggle a tool past the check. The network
+      # tools (fetch/webfetch) honour governance.md s "no network mutation".
+      function check_tools(s,   lb, rb, inner, m, arr, k, t) {
+        lb = index(s, "["); rb = index(s, "]")
+        if (lb > 0 && rb > lb) {
+          inner = substr(s, lb + 1, rb - lb - 1)
+          m = split(inner, arr, /[, ]+/)
+          for (k = 1; k <= m; k++) {
+            t = arr[k]; gsub(/[^a-zA-Z]/, "", t); t = tolower(t)
+            if (t == "write" || t == "edit" || t == "bash" || t == "commit" || t == "push" || t == "fetch" || t == "webfetch") {
+              printf("INV-2 VIOLATION: %s — an @untrusted-reader agent is granted the high-privilege tool: %s. Quarantine it; act via a separate trusted agent (INV-2).\n", file, t)
+              bad = 1
             }
           }
+        }
+      }
+      function reset() { untrusted = 0; toolsseen = 0; toolsbuf = ""; collecting = 0 }
+      BEGIN { reset() }
+      # A new agent block resets state. Order of the three markers within a
+      # block does not matter: an @tools seen before the reader flag is buffered
+      # and re-checked when the flag arrives.
+      /@workflow-agent:/              { reset() }
+      /@untrusted-reader:[ \t]*true/  { untrusted = 1; if (toolsseen == 1) check_tools(toolsbuf) }
+      /@untrusted-reader:[ \t]*false/ { untrusted = 0 }
+      {
+        if (collecting == 1) {
+          toolsbuf = toolsbuf " " $0
+          if (index($0, "]") > 0) { collecting = 0; toolsseen = 1; if (untrusted == 1) check_tools(toolsbuf) }
+          next
+        }
+      }
+      /@tools:/ {
+        if (index($0, "[") > 0 && index($0, "]") > 0) {
+          toolsbuf = $0; toolsseen = 1; if (untrusted == 1) check_tools(toolsbuf)
+        } else if (index($0, "[") > 0) {
+          collecting = 1; toolsbuf = $0
         }
       }
       END { if (bad == 1) exit 1 }

--- a/ai-literacy-superpowers/scripts/inv-firewall.sh
+++ b/ai-literacy-superpowers/scripts/inv-firewall.sh
@@ -28,9 +28,19 @@
 #     untrusted-content reader with `// @untrusted-reader: true` and declares
 #     its `// @tools: [...]`; the lint fails if that set names a high-privilege
 #     tool (write, edit, bash, commit, push, fetch, webfetch). The check is
-#     case-insensitive, accumulates a multi-line `@tools` list, and is
-#     independent of the order of the three markers within an agent block.
-#     Passes vacuously when no untrusted reader is declared.
+#     case-insensitive (markers and values), accumulates a multi-line `@tools`
+#     list, fails closed on an unterminated list, and is independent of the
+#     order of the three markers within an agent block. Passes vacuously when no
+#     untrusted reader is declared.
+#
+# Known limit (by design). This is a deterministic backstop to a human PR
+# review, not a sandbox against a hostile author. A durable filename split
+# mid-stem ("AGEN" + "TS.md"), constructed from char codes, or written in a
+# casing that never forms the uppercase stem token defeats static stem matching
+# — closing that needs taint analysis well beyond a grep gate. The real control
+# is the discipline the templates model (durable artefacts reached only through
+# harness indirection); the firewall catches the natural mistakes, and a human
+# reviewer reads the same PR.
 #
 # Portability: POSIX awk + grep -E only (no gawk/GNU extensions, no `grep -P`,
 # no BSD-only date) so the Layer-0 test runs identically on macOS and Linux.
@@ -129,12 +139,15 @@ check_inv2() {
       }
       function reset() { untrusted = 0; toolsseen = 0; toolsbuf = ""; collecting = 0 }
       BEGIN { reset() }
-      # A new agent block resets state. Order of the three markers within a
-      # block does not matter: an @tools seen before the reader flag is buffered
-      # and re-checked when the flag arrives.
-      /@workflow-agent:/              { reset() }
-      /@untrusted-reader:[ \t]*true/  { untrusted = 1; if (toolsseen == 1) check_tools(toolsbuf) }
-      /@untrusted-reader:[ \t]*false/ { untrusted = 0 }
+      # Marker detection is case-insensitive (via U = toupper) so uppercasing the
+      # marker keywords cannot escape the lint, just as uppercasing a tool value
+      # cannot. A new agent block resets state; order of the three markers within
+      # a block does not matter — an @tools seen before the reader flag is
+      # buffered and re-checked when the flag arrives.
+      { U = toupper($0) }
+      U ~ /@WORKFLOW-AGENT:/                { reset() }
+      U ~ /@UNTRUSTED-READER:[ \t]*TRUE/    { untrusted = 1; if (toolsseen == 1) check_tools(toolsbuf) }
+      U ~ /@UNTRUSTED-READER:[ \t]*FALSE/   { untrusted = 0 }
       {
         if (collecting == 1) {
           toolsbuf = toolsbuf " " $0
@@ -142,14 +155,22 @@ check_inv2() {
           next
         }
       }
-      /@tools:/ {
+      U ~ /@TOOLS:/ {
         if (index($0, "[") > 0 && index($0, "]") > 0) {
           toolsbuf = $0; toolsseen = 1; if (untrusted == 1) check_tools(toolsbuf)
         } else if (index($0, "[") > 0) {
           collecting = 1; toolsbuf = $0
         }
       }
-      END { if (bad == 1) exit 1 }
+      # Fail closed: an untrusted reader whose @tools list never terminates
+      # cannot be verified, so it is a violation rather than a silent pass.
+      END {
+        if (collecting == 1 && untrusted == 1) {
+          printf("INV-2 VIOLATION: %s — an @untrusted-reader agent declares an unterminated @tools list; its privileges cannot be verified. Declare the tools on a closed list (INV-2).\n", file)
+          bad = 1
+        }
+        if (bad == 1) exit 1
+      }
     ' "$f"; then
       rc=1
     fi

--- a/ai-literacy-superpowers/scripts/inv-firewall.sh
+++ b/ai-literacy-superpowers/scripts/inv-firewall.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# inv-firewall.sh — the deterministic teeth of the dynamic-workflows
+# governance invariants (INV-1 and INV-2). One matcher, invoked two ways:
+# a PR-time GitHub gate (.github/workflows/dynamic-workflows-firewall.yml)
+# and a Layer-0 deterministic test with red/green fixtures. Keeping the logic
+# in a single script means both callers enforce exactly the same rule.
+#
+# Why this exists. A dynamic workflow is ephemeral and generated; the durable
+# artefacts (HARNESS.md, AGENTS.md, CLAUDE.md, MODEL_ROUTING.md) are
+# human-curated. INV-1 forbids a workflow from writing them directly. INV-2
+# quarantines untrusted-content readers from high-privilege tools. Both are
+# stated for agents in the skill's governance.md; this script is what makes
+# them fail CI rather than merely advise.
+#
+# Design decisions (spec §7, human-approved at the S2 GATE):
+#   - INV-1 = layered "Option C". Strip comments first, then fail on ANY of the
+#     four durable filenames appearing in executable (non-comment) code —
+#     whether or not the specific write call is recognised. This kills the
+#     false positive (a literate preamble that merely *names* AGENTS.md passes)
+#     and the false negative (a write expressed an unenumerated way), and is
+#     robust to runtime-API drift. The consequence templates must respect:
+#     durable artefacts are reached only through harness-provided indirection,
+#     never by spelling the filename in code.
+#   - INV-2 = declared markers "Option I1". A template annotates an
+#     untrusted-content reader with `// @untrusted-reader: true` and declares
+#     its `// @tools: [...]`; the lint fails if that set names a high-privilege
+#     tool (write, edit, bash, commit, push). Passes vacuously when no
+#     untrusted reader is declared.
+#
+# Portability: POSIX awk + grep -E only (no gawk/GNU extensions, no `grep -P`,
+# no BSD-only date) so the Layer-0 test runs identically on macOS and Linux.
+#
+# Usage:
+#   inv-firewall.sh --check=inv1 <file...>
+#   inv-firewall.sh --check=inv2 <file...>
+# Exit 0 = clean; non-zero = at least one violation (message on stdout).
+
+set -euo pipefail
+
+CHECK=""
+FILES=()
+for arg in "$@"; do
+  case "$arg" in
+    --check=*) CHECK="${arg#--check=}" ;;
+    -*) echo "inv-firewall.sh: unknown flag: $arg" >&2; exit 2 ;;
+    *) FILES+=("$arg") ;;
+  esac
+done
+
+if [ -z "$CHECK" ] || [ "${#FILES[@]}" -eq 0 ]; then
+  echo "usage: inv-firewall.sh --check=inv1|inv2 <file...>" >&2
+  exit 2
+fi
+
+# strip_comments — emit <file> with /* ... */ block comments and // line
+# comments removed, so the caller sees executable code only. `://` (as in a
+# URL) is preserved rather than treated as a line comment.
+strip_comments() {
+  awk '
+    BEGIN { inblock = 0 }
+    {
+      line = $0; out = ""; i = 1; n = length(line)
+      while (i <= n) {
+        two = substr(line, i, 2)
+        if (inblock) {
+          if (two == "*/") { inblock = 0; i += 2 } else { i += 1 }
+          continue
+        }
+        if (two == "/*") { inblock = 1; i += 2; continue }
+        if (two == "//") {
+          if (substr(line, i - 1, 1) == ":") { out = out two; i += 2; continue }
+          break   # rest of line is a comment
+        }
+        out = out substr(line, i, 1); i += 1
+      }
+      print out
+    }
+  ' "$1"
+}
+
+check_inv1() {
+  local rc=0 f name code
+  for f in "${FILES[@]}"; do
+    code=$(strip_comments "$f")
+    for name in HARNESS AGENTS CLAUDE MODEL_ROUTING; do
+      if printf '%s\n' "$code" | grep -qE "${name}\.md"; then
+        echo "INV-1 VIOLATION: $f writes the durable artefact ${name}.md in executable code — workflows may never write durable artefacts directly (INV-1)."
+        rc=1
+      fi
+    done
+  done
+  return "$rc"
+}
+
+check_inv2() {
+  local rc=0 f
+  for f in "${FILES[@]}"; do
+    if ! awk -v file="$f" '
+      /@workflow-agent:/                     { untrusted = 0 }
+      /@untrusted-reader:[ \t]*true/         { untrusted = 1 }
+      /@untrusted-reader:[ \t]*false/        { untrusted = 0 }
+      /@tools:/ {
+        if (untrusted == 1) {
+          lb = index($0, "["); rb = index($0, "]")
+          if (lb > 0 && rb > lb) {
+            inner = substr($0, lb + 1, rb - lb - 1)
+            m = split(inner, arr, /[, ]+/)
+            for (k = 1; k <= m; k++) {
+              t = arr[k]; gsub(/[^a-zA-Z]/, "", t)
+              if (t == "write" || t == "edit" || t == "bash" || t == "commit" || t == "push") {
+                printf("INV-2 VIOLATION: %s — an @untrusted-reader agent is granted the high-privilege tool: %s. Quarantine it; act via a separate trusted agent (INV-2).\n", file, t)
+                bad = 1
+              }
+            }
+          }
+        }
+      }
+      END { if (bad == 1) exit 1 }
+    ' "$f"; then
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
+case "$CHECK" in
+  inv1) check_inv1 ;;
+  inv2) check_inv2 ;;
+  *) echo "inv-firewall.sh: unknown check: $CHECK (expected inv1 or inv2)" >&2; exit 2 ;;
+esac

--- a/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
@@ -131,5 +131,6 @@ running.
 
 Every template honours both invariants: it proposes, it never writes a
 durable artefact (INV-1), and any untrusted-content reader is quarantined
-from high-privilege tools (INV-2). The deterministic firewall in
-`scripts/inv-firewall.sh` enforces both on every template at PR time.
+from high-privilege tools (INV-2). The deterministic firewall at the plugin
+root (`ai-literacy-superpowers/scripts/inv-firewall.sh`) enforces both on
+every template at PR time.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md
@@ -111,11 +111,25 @@ Both are stated in full, for agents, in
   high-privilege tools. Acting on such information is done only by
   separate, trusted agents in the same workflow.
 
-## The workflow template library (forthcoming — S2)
+## The workflow template library
 
-A library of opinionated, habitat-aligned workflow *templates* (adapted
-per task, never run verbatim) ships with this skill in a follow-up slice
-(S2). When present, the templates will live under `workflows/` in this
-skill folder and be referenced from here. **Until S2 lands, this skill is
-reading material only** — there are no runnable templates to invoke yet,
-and nothing in this skill depends on one existing.
+A library of opinionated, habitat-aligned workflow *templates* ships with
+this skill under [`workflows/`](workflows/). They are **templates to adapt
+per task, never scripts to run verbatim** — each carries a literate
+preamble stating its pattern, its token budget and per-role model tiers,
+and the INV-1 boundary it respects. Adapt the prompts, model tiers, and
+budgets to your task, and confirm the runtime primitives against the live
+[workflow documentation](https://code.claude.com/docs/en/workflows) before
+running.
+
+| Template | Pattern | Use it for |
+| --- | --- | --- |
+| [`workflows/enforcer-fanout.workflow.js`](workflows/enforcer-fanout.workflow.js) | fan-out-and-synthesize + adversarial verification | One verifier subagent per harness constraint, skeptic-filtered — defeats the "35 of 50 checked" lazy stop |
+| [`workflows/adversarial-review.workflow.js`](workflows/adversarial-review.workflow.js) | adversarial verification | Review in a context distinct from the implementer's — one verifier per CUPID/literate property |
+| [`workflows/reflection-mining.workflow.js`](workflows/reflection-mining.workflow.js) | generate-and-filter + adversarial verification | Cluster reflections, vet candidates, shortlist promotions for a human (never writes durable memory) |
+| [`workflows/deep-assessment.workflow.js`](workflows/deep-assessment.workflow.js) | fan-out-and-synthesize + adversarial verification | Long repo scans (assessment/audit) — fan out by area, verify each finding, synthesise a cited report |
+
+Every template honours both invariants: it proposes, it never writes a
+durable artefact (INV-1), and any untrusted-content reader is quarantined
+from high-privilege tools (INV-2). The deterministic firewall in
+`scripts/inv-firewall.sh` enforces both on every template at PR time.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/workflows/adversarial-review.workflow.js
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/workflows/adversarial-review.workflow.js
@@ -1,0 +1,75 @@
+/**
+ * adversarial-review.workflow.js — TEMPLATE. Adapt per task; never run verbatim.
+ *
+ * Intent. Move code review into a context window distinct from the one that
+ * produced the implementation, so the reviewer is not judging its own output.
+ * Advocatus Diaboli is the rubric-bearing adversary; each CUPID and literate-
+ * programming property is checked by a dedicated verifier and the findings are
+ * synthesised, not collapsed into a single thumbs-up.
+ *
+ * Pattern: adversarial verification. Separation of producer and critic is the
+ * load-bearing property — it defeats self-preferential bias.
+ *
+ * Token budget: ~12k per workflow (per-property verifiers plus synthesis).
+ * Model tier per role: per-property verifier = sonnet, adversary/synthesizer =
+ * opus (the hardest judgement). See the MODEL_ROUTING workflow-election section.
+ *
+ * INV-1 boundary: review *proposes* findings; it never writes a durable
+ * artefact. The diff under review is handed in via `args`; nothing here edits
+ * the curated harness, agent memory, or project conventions.
+ *
+ * Runtime scope: Claude Code only. Dynamic workflows are a Claude Code runtime
+ * capability and are not transferable to Copilot CLI or other coding agents;
+ * on a tree without the workflow runtime this file is inert reference material.
+ *
+ * Adapt: confirm the runtime primitives against
+ * https://code.claude.com/docs/en/workflows before running. Review cycles still
+ * respect the pipeline's MAX_REVIEW_CYCLES guardrail.
+ */
+
+export const meta = {
+  name: 'adversarial-review',
+  description: 'Separate-context review: one verifier per CUPID/literate property, synthesised',
+  phases: [{ title: 'Refute' }, { title: 'Synthesize' }],
+}
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  required: ['property', 'pass', 'findings'],
+  properties: {
+    property: { type: 'string' },
+    pass: { type: 'boolean' },
+    findings: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+// The properties the adversary evaluates, each by its own verifier.
+const PROPERTIES = [
+  'Composable', 'Unix-philosophy', 'Predictable', 'Idiomatic', 'Domain-based',
+  'Literate: narrative preamble', 'Literate: reasoning-not-signatures',
+]
+
+const diff = (typeof args === 'object' && args && args.diff) || ''
+
+phase('Refute')
+// Each property is checked by a dedicated verifier in a fresh context — none
+// of them saw the implementer's reasoning.
+const evaluated = (await parallel(
+  PROPERTIES.map((p) => () =>
+    agent(
+      `You are Advocatus Diaboli. Evaluate the diff strictly against the "${p}" property. Find where it fails; do not praise. Diff:\n${diff}`,
+      { label: `refute:${p}`, phase: 'Refute', model: 'sonnet', schema: FINDING_SCHEMA },
+    ),
+  ),
+)).filter(Boolean)
+
+phase('Synthesize')
+// Synthesis preserves each property's findings rather than collapsing them.
+const failed = evaluated.filter((e) => !e.pass)
+const verdict = await agent(
+  `Synthesise these per-property review findings into a prioritised report (blocking / should-fix / nit). Do not drop any property's findings.\n${JSON.stringify(evaluated)}`,
+  { label: 'synthesize', phase: 'Synthesize', model: 'opus' },
+)
+log(`adversarial-review: ${PROPERTIES.length} properties evaluated; ${failed.length} with findings`)
+log(verdict)
+// In the live runtime the workflow returns the synthesised verdict to its caller.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/workflows/deep-assessment.workflow.js
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/workflows/deep-assessment.workflow.js
@@ -1,0 +1,83 @@
+/**
+ * deep-assessment.workflow.js — TEMPLATE. Adapt per task; never run verbatim.
+ *
+ * Intent. Make a long repository scan (assessment or harness audit) robust
+ * against agentic laziness and self-preference. Fan out across the repo by
+ * area, adversarially verify each finding in a separate context, and
+ * synthesise a single cited report. The auditor variant adds a verifier that
+ * is deliberately adversarial to the framework's own assumptions, so the
+ * harness does not grade its own homework.
+ *
+ * Pattern: fan-out-and-synthesize + adversarial verification (the deep-research
+ * shape). A completeness critic loops until a round adds nothing new, so the
+ * tail of findings is not missed.
+ *
+ * Token budget: ~20k per workflow (breadth across the repo, then a cited
+ * report). Model tier per role: area scanner = haiku, finding verifier =
+ * sonnet, completeness critic + synthesizer = opus. See the MODEL_ROUTING
+ * workflow-election section.
+ *
+ * INV-1 boundary: the workflow emits a timestamped report artefact in the
+ * existing assessment location; it never writes the curated harness, agent
+ * memory, or project conventions. Those durable artefacts are named in this
+ * preamble only — never reached in code.
+ *
+ * Runtime scope: Claude Code only. Dynamic workflows are a Claude Code runtime
+ * capability and are not transferable to Copilot CLI or other coding agents;
+ * on a tree without the workflow runtime this file is inert reference material.
+ *
+ * Adapt: confirm the runtime primitives against
+ * https://code.claude.com/docs/en/workflows before running.
+ */
+
+export const meta = {
+  name: 'deep-assessment',
+  description: 'Fan out by repo area, adversarially verify each finding, synthesise a cited report',
+  phases: [{ title: 'Scan' }, { title: 'Verify' }, { title: 'Synthesize' }],
+}
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  required: ['area', 'claim', 'citation'],
+  properties: {
+    area: { type: 'string' },
+    claim: { type: 'string' },
+    citation: { type: 'string' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['claim', 'holds', 'reason'],
+  properties: {
+    claim: { type: 'string' },
+    holds: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+}
+
+// Areas to fan out over are supplied by the harness (or discovered first).
+const areas = (typeof args === 'object' && args && args.areas) || []
+
+// Each finding is scanned, then verified, with no barrier between areas: an
+// area's findings verify as soon as that area's scan completes.
+const results = (await pipeline(
+  areas,
+  (area) => agent(`Scan the "${area}" area and report findings with file:line citations.`,
+    { label: `scan:${area}`, phase: 'Scan', model: 'haiku', schema: FINDING_SCHEMA }),
+  (finding) => agent(
+    `Adversarially verify this finding against the cited evidence — including challenging the framework's own assumptions. Does it hold?\n${JSON.stringify(finding)}`,
+    { label: `verify:${finding && finding.area}`, phase: 'Verify', model: 'sonnet', schema: VERDICT_SCHEMA },
+  ),
+)).filter(Boolean)
+
+phase('Synthesize')
+const confirmed = results.filter((r) => r.holds)
+const report = await agent(
+  `Synthesise the confirmed findings into a cited report in the existing assessment format. Note any area a completeness critic flags as unscanned.\n${JSON.stringify(confirmed)}`,
+  { label: 'synthesize', phase: 'Synthesize', model: 'opus' },
+)
+log(`deep-assessment: ${areas.length} areas scanned; ${confirmed.length} findings verified`)
+log(report)
+// In the live runtime the workflow returns the report; the caller writes it to
+// the existing timestamped assessment location.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/workflows/enforcer-fanout.workflow.js
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/workflows/enforcer-fanout.workflow.js
@@ -1,0 +1,94 @@
+/**
+ * enforcer-fanout.workflow.js — TEMPLATE. Adapt per task; never run verbatim.
+ *
+ * Intent. Replace single-context enforcement of many harness constraints —
+ * which tires and stops early ("35 of 50 checked") — with one verifier
+ * subagent per constraint, each in its own clean context, plus a skeptic pass
+ * that tries to refute every candidate violation before it is reported.
+ *
+ * Pattern: fan-out-and-synthesize + adversarial verification. The synthesis
+ * barrier is load-bearing — the report cannot form until all N verifiers have
+ * returned, so there is no silent "good enough" stop.
+ *
+ * Token budget: ~10k per workflow (each verifier is small and focused).
+ * Model tier per role: verifier = haiku (one mechanical constraint each),
+ * skeptic = sonnet (judgement), synthesizer = sonnet. See the MODEL_ROUTING
+ * workflow-election section for the budget + tiering convention.
+ *
+ * INV-1 boundary: this workflow only *reports*. The constraint inventory is
+ * handed in by the harness via `args`, never reached by spelling a durable
+ * filename in code, and findings are returned, never written back to the
+ * curated harness or agent memory. Promotion of any finding flows through the
+ * human-curation gate, not this workflow.
+ *
+ * Runtime scope: Claude Code only. Dynamic workflows are a Claude Code runtime
+ * capability and are not transferable to Copilot CLI or other coding agents;
+ * on a tree without the workflow runtime this file is inert reference material.
+ *
+ * Adapt: confirm the runtime primitives (agent/parallel/pipeline/phase/log)
+ * against https://code.claude.com/docs/en/workflows before running.
+ */
+
+export const meta = {
+  name: 'enforcer-fanout',
+  description: 'One verifier subagent per harness constraint, skeptic-filtered, synthesised',
+  phases: [{ title: 'Verify' }, { title: 'Skeptic' }, { title: 'Synthesize' }],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['id', 'violated', 'evidence'],
+  properties: {
+    id: { type: 'string' },
+    violated: { type: 'boolean' },
+    evidence: { type: 'string' },
+  },
+}
+
+const SKEPTIC_SCHEMA = {
+  type: 'object',
+  required: ['id', 'isRealViolation', 'reason'],
+  properties: {
+    id: { type: 'string' },
+    isRealViolation: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+}
+
+// The harness supplies the enforceable constraint inventory — the template
+// never reaches for a curated file by name (INV-1 / firewall).
+const constraints = (typeof args === 'object' && args && args.constraints) || []
+if (!constraints.length) {
+  log('enforcer-fanout: no constraints supplied — nothing to enforce')
+}
+
+phase('Verify')
+// Fan out: one verifier per constraint, each in its own clean context window.
+const candidates = (await parallel(
+  constraints.map((c) => () =>
+    agent(
+      `Verify this single constraint against the staged diff. Report pass/fail with file:line evidence:\n${c.text}`,
+      { label: `verify:${c.id}`, phase: 'Verify', model: 'haiku', schema: VERDICT_SCHEMA },
+    ),
+  ),
+)).filter(Boolean)
+
+phase('Skeptic')
+// Adversarial pass: a skeptic tries to refute each candidate violation so a
+// false positive never reaches the report.
+const reviewed = (await parallel(
+  candidates
+    .filter((v) => v.violated)
+    .map((v) => () =>
+      agent(
+        `A verifier flagged this as a violation. Try to refute it — is it a false positive? Default to keeping it only if you cannot refute it.\n${JSON.stringify(v)}`,
+        { label: `skeptic:${v.id}`, phase: 'Skeptic', model: 'sonnet', schema: SKEPTIC_SCHEMA },
+      ),
+    ),
+)).filter(Boolean)
+
+phase('Synthesize')
+// Synthesis barrier: every constraint is accounted for — no silent drop.
+const confirmed = reviewed.filter((r) => r.isRealViolation)
+log(`enforcer-fanout: checked ${constraints.length} constraints; ${confirmed.length} confirmed after skeptic review`)
+// In the live runtime the workflow returns { checked, confirmed } to its caller.

--- a/ai-literacy-superpowers/skills/dynamic-workflows/workflows/package.json
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/workflows/package.json
@@ -1,0 +1,5 @@
+{
+  "type": "module",
+  "private": true,
+  "description": "Marks the dynamic-workflows templates as ES modules so their `export const meta` + top-level await parse as the Claude Code workflow runtime expects. These are templates to adapt, not a runnable package — there are no dependencies and nothing is installed."
+}

--- a/ai-literacy-superpowers/skills/dynamic-workflows/workflows/reflection-mining.workflow.js
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/workflows/reflection-mining.workflow.js
@@ -1,0 +1,75 @@
+/**
+ * reflection-mining.workflow.js — TEMPLATE. Adapt per task; never run verbatim.
+ *
+ * Intent. Raise the *proposal* quality of the compound-learning loop without
+ * touching the human-curates principle. Cluster the project's reflection log
+ * with parallel agents, adversarially pre-filter each candidate rule ("would
+ * this actually have prevented a real past mistake?"), and surface a vetted
+ * shortlist for a human to promote. The workflow never promotes anything itself.
+ *
+ * Pattern: generate-and-filter + adversarial verification. Over-generate
+ * candidate rules, then prune hard.
+ *
+ * Token budget: ~8k per workflow (cluster, filter, shortlist — proposal only).
+ * Model tier per role: clusterer = haiku, skeptic = sonnet, shortlister =
+ * sonnet. See the MODEL_ROUTING workflow-election section.
+ *
+ * INV-1 boundary (the firewall this workflow exists to respect): it writes a
+ * vetted shortlist to a NON-durable staging sink only. It never writes the
+ * curated agent-memory file or any other durable artefact — promotion is a
+ * human act through the existing curation gate. Reflection-log content is
+ * handed in via `args`; the durable artefacts are named in this preamble only
+ * to document the boundary, never reached in code.
+ *
+ * Runtime scope: Claude Code only. Dynamic workflows are a Claude Code runtime
+ * capability and are not transferable to Copilot CLI or other coding agents;
+ * on a tree without the workflow runtime this file is inert reference material.
+ *
+ * Adapt: confirm the runtime primitives against
+ * https://code.claude.com/docs/en/workflows before running.
+ */
+
+export const meta = {
+  name: 'reflection-mining',
+  description: 'Cluster reflections, adversarially filter, shortlist promotion candidates for a human',
+  phases: [{ title: 'Cluster' }, { title: 'Filter' }, { title: 'Shortlist' }],
+}
+
+const CANDIDATE_SCHEMA = {
+  type: 'object',
+  required: ['rule', 'wouldHavePrevented', 'evidence'],
+  properties: {
+    rule: { type: 'string' },
+    wouldHavePrevented: { type: 'boolean' },
+    evidence: { type: 'string' },
+  },
+}
+
+// Reflection-log entries are handed in by the harness — never read by name.
+const entries = (typeof args === 'object' && args && args.entries) || []
+
+phase('Cluster')
+const clusters = await agent(
+  `Cluster these reflection entries by the underlying recurring theme. Return one candidate rule per cluster.\n${JSON.stringify(entries)}`,
+  { label: 'cluster', phase: 'Cluster', model: 'haiku' },
+)
+
+phase('Filter')
+// Adversarial pre-filter: keep a candidate only if it would have prevented a
+// real past mistake. Each is judged in its own context.
+const judged = (await parallel(
+  (clusters.candidates || []).map((c) => () =>
+    agent(
+      `Would this proposed rule actually have prevented a real mistake recorded in the log? Refute it if not.\n${JSON.stringify(c)}`,
+      { label: `filter:${c.id || c.rule}`, phase: 'Filter', model: 'sonnet', schema: CANDIDATE_SCHEMA },
+    ),
+  ),
+)).filter(Boolean)
+
+phase('Shortlist')
+const shortlist = judged.filter((c) => c.wouldHavePrevented)
+// Proposes to a NON-durable staging sink for a human to curate (INV-1).
+// The staging path is supplied by the harness; nothing durable is written here.
+const stagingSink = (typeof args === 'object' && args && args.stagingPath) || 'REFLECTION_STAGING.md'
+log(`reflection-mining: ${shortlist.length} vetted candidate(s) proposed to ${stagingSink} for human curation`)
+// In the live runtime the workflow returns the shortlist; a human promotes.

--- a/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
@@ -7,11 +7,11 @@ Orientation guide to the `dynamic-workflows` skill — the conceptual model
 for self-authored, ephemeral multi-agent harnesses. This guide helps you
 decide *whether* a task warrants a workflow and *which* pattern fits.
 
-> **Scope note.** This first release ships **reading material**, not a
-> runnable workflow you can invoke. The opinionated, adaptable workflow
-> *templates* arrive in a follow-up slice (S2). Until then, use this guide
-> and the skill to reason about workflows; there is no end-to-end runbook
-> to walk through yet.
+> **Scope note.** The skill ships four opinionated workflow **templates** (see
+> below) plus the knowledge to reason about them. Templates are starting points
+> to **adapt per task**, not scripts to run verbatim — confirm the runtime
+> primitives against the [live workflow docs](https://code.claude.com/docs/en/workflows)
+> before running.
 >
 > **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code
 > runtime capability and are **not transferable** to GitHub Copilot CLI or
@@ -66,7 +66,29 @@ compose several.
 
 ---
 
-## 4. Respect the invariants
+## 4. Start from a template
+
+The skill ships four templates under `skills/dynamic-workflows/workflows/`.
+Copy the closest one and adapt its prompts, model tiers, and token budget:
+
+- `enforcer-fanout.workflow.js` — one verifier per harness constraint,
+  skeptic-filtered (fan-out + adversarial verification).
+- `adversarial-review.workflow.js` — review in a context distinct from the
+  implementer's, one verifier per CUPID/literate property.
+- `reflection-mining.workflow.js` — cluster reflections, vet candidates,
+  shortlist promotions for a human (never writes durable memory).
+- `deep-assessment.workflow.js` — fan out a long repo scan by area, verify
+  each finding, synthesise a cited report.
+
+Each template's literate preamble states its pattern, budget, per-role model
+tiers, and the INV-1 boundary it respects. The deterministic firewall
+(`scripts/inv-firewall.sh`) checks every template against INV-1/INV-2 at PR
+time, so keep durable artefacts out of executable code and quarantine any
+untrusted-content reader.
+
+---
+
+## 5. Respect the invariants
 
 Two non-negotiable rules bind every workflow:
 
@@ -80,7 +102,7 @@ Two non-negotiable rules bind every workflow:
 
 ---
 
-## 5. Set a budget
+## 6. Set a budget
 
 Elected workflows declare an explicit per-workflow token cap and model
 tiering up front — see the *workflow election* section of your project's

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s2-templates-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s2-templates-design.md
@@ -1,0 +1,666 @@
+# Specification — Dynamic Workflows S2: Template Library + INV-1/INV-2 Firewall
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S2 of the Dynamic Workflows Alignment epic (D2 + §5.1 + §5.2 clustered)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S2)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/439>
+**Depends on:** S1 (#438, merged) — the `dynamic-workflows` skill is the vehicle
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s2-templates`
+
+> **Implementer note (read first).** This slice ships **four illustrative
+> JavaScript workflow templates** plus the **deterministic firewall** that guards
+> them. The templates are *templates an agent ADAPTs*, never verbatim scripts.
+> The *exact* runtime function names for spawning subagents, selecting per-agent
+> models, and electing worktree isolation are **not authoritative in this spec** —
+> consult <https://code.claude.com/docs/en/workflows> as the source of truth and
+> defer every function name to it. Where this spec or a template shows a call
+> shape, treat it as ADAPTABLE pseudocode, not a frozen API. The firewall must
+> match *write-shaped behaviour*, not specific runtime function names, precisely
+> so it survives API drift.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code
+> runtime capability, **not transferable** to Copilot CLI or any other coding
+> agent — those trees have no workflow runtime. The plugin ships to both trees,
+> so the templates this slice adds are **Claude-Code-gated**: where the runtime
+> exists they are adaptable, runnable substrate; where it does not (Copilot CLI,
+> other agents) they are **inert reference material** — readable JavaScript with a
+> literate preamble, but nothing spawns. Each template's preamble must state this
+> boundary explicitly. See the umbrella spec's runtime-scope note and §5.5; the
+> precise Copilot degradation *contract* (guidance-only vs omit) is open-question
+> 4, resolved in S7, and is **not** decided here.
+
+---
+
+## 1. Context and motivation
+
+S1 (#438, merged) shipped the `dynamic-workflows` skill as **knowledge agents
+read** — the six patterns, the election rubric, INV-1/INV-2 — and forward-
+referenced a workflow template library as *forthcoming (S2)*. S2 makes that
+library concrete and, in the same slice, builds the **firewall that gives INV-1
+its teeth**.
+
+Per umbrella §6 the build order places **D2** (the template substrate) third,
+immediately after the foundation, and §5.1 attaches the deterministic firewall
+that "is INV-1's teeth — do not ship without it" (umbrella §7, governance-erosion
+risk). The slicing record keeps the two **atomic**: a template library without
+the firewall is the exact regression the spec warns against (a template could
+land that writes a durable artefact, eroding the curated theory of the system —
+Naur). So S2 ships:
+
+- the **four workflow templates** (`enforcer-fanout`, `adversarial-review`,
+  `reflection-mining`, `deep-assessment`), each with a Knuth-discipline literate
+  preamble, a declared token budget, and a default model tier per agent role;
+- `SKILL.md` **flipped** from "forthcoming (S2)" to "shipped", referencing the
+  four templates **by relative path** and prompting agents to ADAPT, not run
+  verbatim;
+- the **INV-1 CI firewall** — a deterministic check that fails CI if any template
+  *writes directly* to a durable artefact (`HARNESS.md`, `AGENTS.md`,
+  `CLAUDE.md`, `MODEL_ROUTING.md`);
+- the **INV-2 lint** — a deterministic check that any template spawning an
+  untrusted-content reader withholds high-privilege tools from it;
+- a **parse/reference check** that each `*.workflow.js` is valid JavaScript and
+  that `SKILL.md`'s template references resolve.
+
+The central, GATE-bound decision is **how the INV-1 firewall is mechanised
+deterministically** (§7). Everything else in S2 is substrate that the firewall
+guards.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+1. **Four workflow templates** under
+   `ai-literacy-superpowers/skills/dynamic-workflows/workflows/`:
+   - `enforcer-fanout.workflow.js` — fan-out-and-synthesize + adversarial
+     verification; one verifier subagent per HARNESS.md constraint, a skeptic
+     persona, a synthesis barrier. (Substrate the S3 enforcer adapts.)
+   - `adversarial-review.workflow.js` — adversarial verification; review in a
+     **separate context window** from the producing context, per-rubric-property
+     verifiers. (Substrate the S4 code-reviewer adapts.)
+   - `reflection-mining.workflow.js` — generate-and-filter + adversarial
+     verification; clusters `REFLECTION_LOG.md`, adversarially pre-filters, emits
+     a vetted shortlist. **Never writes `AGENTS.md`.** (Substrate the S6 `--mine`
+     mode adapts.)
+   - `deep-assessment.workflow.js` — fan-out-by-area + adversarial verification;
+     the deep-research shape. (Substrate the S4 assessor/auditor adapts.)
+   Each template carries a **literate preamble** (Knuth discipline) stating: its
+   **intent**; the **pattern** it composes; the **model-tier + token-budget
+   rationale**; the **INV-1 boundary** it respects (which durable artefacts it
+   may only *propose* to); and the **Claude-Code-only runtime-scope** note (inert
+   reference material where the runtime is absent). Each **declares a token
+   budget and a default model tier per agent role** (umbrella D8 acceptance).
+2. **`SKILL.md` flipped to "shipped".** The "## The workflow template library
+   (forthcoming — S2)" section becomes a "shipped" section that references the
+   four templates **by relative path** (`workflows/<name>.workflow.js`) and
+   prompts agents to treat them as **templates to ADAPT, not run verbatim**. No
+   other S1 content changes except this section.
+3. **INV-1 CI firewall** — a new deterministic gate (mechanism per §7, decided at
+   the GATE) that greps the templates and **fails CI** if any template writes
+   directly to a durable artefact.
+4. **INV-2 lint** — a deterministic gate that any template spawning an
+   untrusted-content reader withholds high-privilege tools from it, made
+   matchable by a **declared in-template convention** (marker shape per §7,
+   decided at the GATE).
+5. **Parse + reference-resolution check** — each `*.workflow.js` is valid
+   JavaScript (parses without syntax error) and each template path referenced
+   from `SKILL.md` resolves to an existing file.
+6. **Reconciliation of the S1 TDAD scenario** that asserts SKILL.md contains *no*
+   hard-link to a `.workflow.js` file (see §6). The tdd-agent revises/replaces
+   `tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md`.
+7. **Supporting CI / version / docs surfaces** (see §8): the minor version bump
+   `0.58.1 → 0.59.0` across the five CI-enforced locations + the README table
+   cell, and a how-to update now that runnable templates exist.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred concern | Owning slice | Why not here |
+| --- | --- | --- |
+| `harness-enforcer` workflow mode + fan-out **threshold (= 8)** | **S3 (#440)** | S2 ships the template; the enforcer *adapts* it later. The threshold rides open-question 1 |
+| `code-reviewer` / `assessor` / `harness-auditor` workflow modes | **S4 (#441)** | S2 ships `adversarial-review`/`deep-assessment` templates; the agents adopt them later |
+| `orchestrator` classify-and-act routing + routing default | **S5 (#442)** | Riding open-question 2 |
+| `reflect --mine` mode + **staging-artefact location** (`REFLECTION_STAGING.md`) | **S6 (#443)** | S2 ships `reflection-mining.workflow.js`; the command wires it later. Riding open-question 3 |
+| README "Dynamic Workflows" section, advisory Stop hook, **Copilot degradation contract** | **S7 (#444)** | Per umbrella D9; open-question 4 |
+| Skill-count badge | **already correct (S1 landed `Skills-36`)** | S2 adds **no new skill** — only files inside an existing skill; the badge does not move |
+
+**Boundary rule.** S2 ships the templates as **reference substrate the later
+agent slices ADAPT** — it does **not** wire any agent or command to a template.
+No `agents/*.agent.md` or `commands/*.md` file is modified in S2. The only
+behavioural surface S2 touches is the skill (flip to shipped) and the new CI
+gates.
+
+---
+
+## 3. User story
+
+> **As an** agent (or engineer) operating inside the ai-literacy-superpowers
+> harness, **I want** a small library of habitat-aligned workflow templates I can
+> ADAPT — each one literate about its intent, pattern, budget, and the
+> durable-artefact boundary it respects — together with a deterministic firewall
+> that fails CI if any template would write a durable artefact, **so that** I can
+> reach for a proven workflow shape per task without re-deriving it, and so that
+> the curated theory of the system (INV-1) is protected by a machine, not by good
+> intentions.
+
+This is INV-1 ("ephemeral proposes, durable curates") given **teeth**: the
+firewall is the deterministic enforcement that makes the invariant load-bearing
+rather than aspirational.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy:
+*deterministic* (CI-checkable), *agent-backed* (checked by an agent / Layer-2-3
+TDAD), or *unverified* (declared intent). The tdd-agent should turn the
+deterministic and agent-backed scenarios into failing checks first. Scenarios
+trace to umbrella **D2 acceptance**, **§5.1** (INV-1 firewall) and **§5.2**
+(INV-2 lint).
+
+### From D2 — the template substrate
+
+**AC-1 *(deterministic)* — four templates exist with literate preambles.**
+**Given** the `dynamic-workflows` skill,
+**When** `skills/dynamic-workflows/workflows/` is read,
+**Then** exactly the four files `enforcer-fanout.workflow.js`,
+`adversarial-review.workflow.js`, `reflection-mining.workflow.js`, and
+`deep-assessment.workflow.js` exist, and each opens with a literate preamble (a
+top-of-file comment block) naming its **intent**, its **pattern**, its
+**model-tier + token-budget rationale**, the **INV-1 boundary** it respects, and
+the **Claude-Code-only runtime scope** (inert where the runtime is absent).
+
+**AC-2 *(deterministic)* — each template parses as valid JavaScript.**
+**Given** each `*.workflow.js` file,
+**When** it is parsed (Node `--check` / an equivalent syntax parse),
+**Then** it parses with no syntax error.
+
+**AC-3 *(deterministic)* — SKILL.md references each template by resolving relative path.**
+**Given** `SKILL.md` flipped to its "shipped" framing,
+**When** it is read,
+**Then** it references **all four** templates by relative path
+(`workflows/<name>.workflow.js`), every referenced path **resolves to an existing
+file**, and the framing is "shipped — ADAPT, do not run verbatim" (the
+"forthcoming (S2)" wording is gone).
+
+**AC-4 *(deterministic)* — each template declares a token budget and per-role model tier.**
+**Given** each `*.workflow.js` file,
+**When** it is read,
+**Then** it declares an explicit **token budget** (a per-workflow cap) and a
+**default model tier per agent role** (umbrella D8 acceptance). *(Slot note: the
+machine-checkable form is a declared marker the parse check greps; see §7.2.)*
+
+**AC-5 *(agent-backed)* — an agent ADAPTs rather than runs verbatim.**
+**Given** a task that matches one of the four patterns,
+**When** an agent loads the corresponding template,
+**Then** it ADAPTs the template to the task (parameterises agents, budget, tiers)
+rather than executing it verbatim, and cites the pattern from
+`references/patterns.md`.
+
+### From §5.1 — the INV-1 firewall (the central decision, §7)
+
+**AC-6 *(deterministic)* — no template writes a durable artefact.**
+**Given** every `*.workflow.js` under `skills/dynamic-workflows/workflows/`,
+**When** the INV-1 firewall runs,
+**Then** it **passes** because no template contains a **direct write** to
+`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, or `MODEL_ROUTING.md`.
+
+**AC-7 *(deterministic)* — a planted direct write fails CI (true positive).**
+**Given** a template that writes one of the four durable artefacts directly (the
+firewall's failing fixture),
+**When** the firewall runs,
+**Then** it **fails CI** with a message naming the offending file, the durable
+artefact, and the INV-1 rule. *(This is the firewall's red-bar test; the
+tdd-agent authors it as a fixture, not in a shipped template.)*
+
+**AC-8 *(deterministic)* — a literate preamble that merely mentions a durable artefact does NOT trip the firewall (no false positive).**
+**Given** a template whose **literate preamble** names `AGENTS.md` (e.g.
+"this workflow only *proposes* entries; it never writes `AGENTS.md`"),
+**When** the firewall runs,
+**Then** it **passes** — the rule matches **write-shaped patterns**, not bare
+filename mentions. *(This guards the false-positive failure mode the slice
+decision_focus calls out: a bare mention in a Knuth preamble must not redden CI.)*
+
+**AC-9 *(deterministic)* — `reflection-mining` is firewall-clean specifically on AGENTS.md.**
+**Given** `reflection-mining.workflow.js` (the template most tempted to write
+`AGENTS.md`),
+**When** the firewall runs,
+**Then** it passes: the template emits a shortlist to a **non-durable** sink and
+contains no direct write to `AGENTS.md`. *(Names the highest-risk template
+explicitly; the staging-artefact *destination* is an S6 decision and is not fixed
+here — the template's preamble states only that it never writes `AGENTS.md`.)*
+
+### From §5.2 — the INV-2 lint
+
+**AC-10 *(deterministic)* — untrusted-content readers withhold high-privilege tools.**
+**Given** any template that spawns an agent **declared** (by the in-template
+convention, §7.3) as an untrusted-content reader,
+**When** the INV-2 lint runs,
+**Then** it confirms that agent's declared tool set **excludes** every
+high-privilege tool, and **fails CI** if such an agent is granted one.
+
+**AC-11 *(deterministic)* — a template with no untrusted reader passes the INV-2 lint vacuously.**
+**Given** a template that declares no untrusted-content reader,
+**When** the INV-2 lint runs,
+**Then** it passes (the lint is scoped to declared untrusted readers, not all
+agents).
+
+### Cross-cutting — runtime scope
+
+**AC-12 *(deterministic)* — every template preamble states the Claude-Code-only scope.**
+**Given** each `*.workflow.js`,
+**When** its preamble is read,
+**Then** it states that the template is Claude-Code-gated and is **inert
+reference material** on a tree without the workflow runtime.
+
+**AC-13 *(unverified, declared)* — S2 wires no agent or command to a template.**
+S2 ships templates as reference substrate only; no `agents/*.agent.md` or
+`commands/*.md` is modified. Adoption is S3–S6 work. (Recorded so the absence of
+behavioural wiring is not mistaken for an oversight.)
+
+---
+
+## 5. Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios in §9.
+
+- **FR-1.** Four templates exist at
+  `ai-literacy-superpowers/skills/dynamic-workflows/workflows/{enforcer-fanout,adversarial-review,reflection-mining,deep-assessment}.workflow.js`.
+- **FR-2.** Each template opens with a literate preamble naming intent, pattern,
+  model-tier + token-budget rationale, the INV-1 boundary it respects, and the
+  Claude-Code-only runtime scope.
+- **FR-3.** Each template declares an explicit token budget and a default model
+  tier per agent role, in a form the parse/marker check can confirm.
+- **FR-4.** Each `*.workflow.js` is valid JavaScript (parses with no syntax
+  error).
+- **FR-5.** `SKILL.md`'s template-library section is flipped from "forthcoming
+  (S2)" to "shipped", references all four templates by relative path, every
+  referenced path resolves, and the framing instructs agents to ADAPT, not run
+  verbatim.
+- **FR-6.** A deterministic **INV-1 firewall** gate (mechanism per §7) fails CI
+  if any template contains a **direct write** to `HARNESS.md`, `AGENTS.md`,
+  `CLAUDE.md`, or `MODEL_ROUTING.md`, and does **not** fire on bare filename
+  mentions in a preamble.
+- **FR-7.** A deterministic **INV-2 lint** gate confirms that any template-
+  declared untrusted-content reader is withheld every high-privilege tool, using
+  an in-template convention (marker shape per §7.3) the lint matches.
+- **FR-8.** A deterministic **parse + reference-resolution** check confirms each
+  template parses and each `SKILL.md` template reference resolves.
+- **FR-9.** The S1 TDAD scenario asserting "no hard-link to a `.workflow.js`"
+  (`tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md`) is
+  revised/replaced so that S2's *shipped* references are correct, not a
+  violation (see §6).
+- **FR-10.** The plugin version is bumped `0.58.1 → 0.59.0` across all five
+  CI-enforced locations (§8.1), and the human-facing README plugin-table cell is
+  updated.
+- **FR-11.** The how-to guide
+  `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` (shipped in
+  S1 as an orientation guide) is updated to reflect that runnable templates now
+  exist and how to ADAPT them.
+
+---
+
+## 6. Reconciliation of the S1 TDAD scenario (do not miss)
+
+S1 shipped, at
+`tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md`, a
+**structural** scenario whose `Then` asserts:
+
+> None of the files contain a runnable dependency on any `.workflow.js` file (the
+> S2 template library); any mention of the template library is an explicit
+> "forthcoming (S2)" forward-reference, not a link to a file that must exist.
+
+S2 **flips this**: the four templates now exist and `SKILL.md` links them by
+relative path. The S1 scenario's load-bearing clause becomes **false** under S2 —
+it was correct *for S1's standalone-validity property* and is now superseded.
+
+**Action for the tdd-agent.** Revise/replace that scenario so that:
+
+- the markdownlint-clean assertion for `SKILL.md` + the three references is
+  **retained** (still true and still valuable);
+- the "no hard-link / forthcoming forward-reference" clause is **replaced** by an
+  assertion matching S2 reality: `SKILL.md` references the four templates by
+  relative path and **every referenced path resolves to an existing file** (the
+  AC-3 property).
+
+This is a **modification** of an existing scenario, not a new component, so the
+`tdad-scenario-check` CI gate does not block it (that gate fires only on *added*
+components, per Amendment 2 §A2.6 of the TDAD-discipline spec) — but the change
+is mandatory for correctness and the markdownlint scenario must not assert a now-
+false property. The tdd-agent owns the rewrite.
+
+> **Why spec-writer flags this rather than editing the scenario.** Per the
+> spec-first discipline, this spec does not modify test files. It *names* the
+> superseded scenario and the required new assertion so the tdd-agent translates
+> it without ambiguity.
+
+---
+
+## 7. The central decision — how the INV-1 firewall is mechanised (GATE)
+
+This is the slice's load-bearing decision (carpaccio `decision_focus`). The human
+decides at the plan-approval GATE. The spec lays out the options and a
+recommendation; per the AGENTS.md STYLE note, the recommendation is a **hypothesis
+for the diaboli to stress**, not a default to confirm — and this slice touches a
+**closed contract** (a deterministic CI gate's match rule and a four-filename
+denylist), exactly the kind of surface the diaboli should hammer for false
+negatives and false positives.
+
+### 7.1 What the grep rule matches as a "direct write to a durable artefact"
+
+Two failure directions bound the design:
+
+- **False negative** — a write expressed in a shape the grep misses (the durable
+  artefact is silently mutated, INV-1 breached, CI green). This is the dangerous
+  direction: it defeats the firewall's purpose.
+- **False positive** — a literate preamble that merely *mentions* `AGENTS.md`
+  trips the rule (CI reddens on honest documentation). This is the annoying
+  direction: it punishes the Knuth discipline the slice mandates.
+
+**Option A — Path-denylist of the four filenames (bare-mention match).** Grep for
+any occurrence of `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`.
+*Rejected as the sole rule:* it false-positives on every literate preamble that
+names a durable artefact to explain the INV-1 boundary it respects — i.e. it
+punishes exactly the documentation the slice requires (AC-8 would fail). The four
+filenames *must* appear in good templates' prose.
+
+**Option B — Write-API pattern match.** Grep for write-shaped call patterns
+(file-write / append / `writeFile`-family / `>>` redirection / fs-write idioms)
+**co-occurring** with one of the four durable filenames on the same logical
+statement. *Strength:* targets behaviour, not mention — AC-8 passes. *Weakness:* a
+write expressed via an indirection the pattern does not enumerate (a filename held
+in a variable, a path built by concatenation, a runtime helper not in the
+enumerated set) is a **false negative**. The runtime API is authoritative and may
+evolve (implementer note), so any frozen function-name list rots.
+
+**Option C — Both, layered (RECOMMENDED).** Combine a **write-shaped pattern
+match** (Option B — the precision layer that avoids false positives) with a
+**defence-in-depth path-proximity rule**: any of the four durable filenames
+appearing **outside a comment/preamble block** (i.e. in executable code, not in
+the literate preamble or a string that is demonstrably documentation) is treated
+as suspicious and must co-occur with a write-shaped token to fail — OR, more
+strictly, flagged for the firewall to fail unless the line is a comment. The rule
+therefore:
+
+1. **strips comment/preamble lines** (the literate preamble is comments — a bare
+   `AGENTS.md` mention there never trips the rule → AC-8 passes);
+2. on the **remaining executable lines**, fails if a durable filename co-occurs
+   with a write-shaped token (`write`, `append`, `writeFile`, `>>`, `fs.` write
+   idioms, or the runtime's persist/write helpers) — catching Option B's target;
+3. additionally fails if a durable filename appears in executable (non-comment)
+   code **at all** without a recognised *read-only / propose-only* annotation —
+   closing Option B's false-negative gap, because a template has **no legitimate
+   reason to name a durable artefact in executable code** except to touch it
+   (templates *propose* via a non-durable sink, they do not reference the durable
+   file by name in code).
+
+   This third clause is the key insight: in a *template*, a durable filename in
+   **executable code** (not preamble prose) is itself the smell, regardless of
+   whether the grep recognises the specific write call. It converts the
+   open-ended "did we enumerate every write API?" problem into a closed "does
+   executable code name a durable artefact at all?" check — robust to runtime API
+   drift (the implementer-note concern).
+
+**Recommendation: Option C.** Comment-stripping kills the false positive (AC-8);
+the "no durable filename in executable code" clause kills the false negative
+(AC-6/AC-7/AC-9) without depending on a frozen write-API enumeration. The diaboli
+should stress: (a) can a template legitimately need a durable filename in
+executable code? (if yes, Option C over-blocks and needs an escape hatch); (b)
+does comment-stripping correctly classify a durable filename inside a
+**multi-line string literal** that is documentation, not a comment? (decide
+whether such strings count as preamble or code).
+
+### 7.2 Where the firewall runs
+
+**Option W1 — A dedicated new `.github/workflows/` check** mirroring
+`spec-redaction-marker-check.yml` (line-anchored grep, `paths:` scoped to
+`skills/dynamic-workflows/workflows/**` + the workflow file itself, `::error::`
+annotations, non-zero exit). *Strength:* PR-time gate, blocks the merge, mirrors a
+proven house style, runs on exactly the touched paths. *Recommended primary
+home.*
+
+**Option W2 — A Layer-0 deterministic test under `tdad_tests/`** (a
+`layer0_deterministic/test-inv1-firewall.sh` registered in
+`BASH_TEST_SCRIPTS`, run by `tdad-tests-fast.yml`). *Strength:* lives with the
+other deterministic plumbing, runs in the existing fast suite, testable in
+isolation with red/green fixtures (AC-7/AC-8 as fixtures the script asserts
+against). *Recommended companion* — the firewall logic as a bash script with its
+own fixtures, dispatched both by the fast suite and (optionally) by the dedicated
+workflow.
+
+**Option W3 — A HARNESS.md GC rule in `gc.yml`.** *Rejected as primary:* `gc.yml`
+runs weekly on cron, not at PR time — a breaching template could sit on `main` for
+up to a week. The firewall is a **gate**, and gates run at PR time. A GC echo is
+acceptable as defence-in-depth but must not be the only home.
+
+**Recommendation: W1 + W2 layered.** Author the firewall as a **single bash
+script** (the matching logic of §7.1 Option C) and invoke it from **both** (a) a
+dedicated PR-time GitHub workflow (W1, the blocking gate) and (b) a Layer-0
+deterministic test (W2, where the red/green fixtures of AC-7/AC-8 live and prove
+the matcher's precision). One implementation, two dispatch points — the matcher's
+correctness is proven by fixtures in W2 and enforced at the merge by W1. This
+mirrors the existing pattern where one bash script (e.g. the affordance scanners)
+is exercised by a Layer-0 test and surfaced in CI. **Do not** put it solely in
+`gc.yml` (W3).
+
+> **Verification-table note.** The INV-1 firewall is itself a new deterministic
+> gate and must be listed in §8.2 as a new CI surface.
+
+### 7.3 How INV-2 is made lint-checkable on templates
+
+For a deterministic lint to confirm "an untrusted-content reader is withheld
+high-privilege tools", **both** concepts must be expressed in the template in a
+shape the lint can match. The decision is the **convention a template must
+follow**.
+
+**Option I1 — A declared in-template marker convention (RECOMMENDED).** Each
+agent a template spawns declares its trust posture and tool set in a structured,
+greppable form — e.g. a comment-annotation or a structured field the template
+author writes:
+
+```text
+// @workflow-agent: issue-triager
+// @untrusted-reader: true        // reads external issue bodies
+// @tools: [read, grep]           // NO write, NO bash, NO web-fetch-then-act
+```
+
+The lint then: finds every agent block marked `@untrusted-reader: true`; confirms
+its `@tools` list contains **none** of a declared **high-privilege set**
+(`write`, `edit`, `bash`, `commit`, `push`, or any durable-artefact write). A
+template with no `@untrusted-reader: true` block passes vacuously (AC-11).
+*Strength:* both halves (untrusted reader; high-privilege tool) are explicit and
+machine-detectable; the convention doubles as literate documentation of the
+quarantine. *Weakness:* relies on the author honestly marking a reader as
+untrusted — a reader left unmarked escapes the lint. Mitigation: the firewall is
+defence-in-depth, not the sole guard; the convention is documented in the skill's
+`references/governance.md` (S1, INV-2) and the template preamble.
+
+**Option I2 — Infer untrusted-reader from web/fetch tool presence.** No marker;
+the lint infers "untrusted reader" from the presence of a web-fetch/external-read
+tool, then checks no high-privilege tool co-occurs. *Rejected as primary:*
+inference is brittle (an untrusted reader might read a third-party PR via a
+non-web tool), and it conflates "reads external content" with a specific tool. The
+marker (I1) is explicit and survives tool-name drift.
+
+**Recommendation: I1**, the declared marker convention, documented in the
+template preamble and cross-referenced to `references/governance.md` (INV-2). The
+**high-privilege set** is enumerated in the lint (and mirrored in
+`governance.md`): `write`, `edit`, `bash`/shell, `commit`, `push`, plus any write
+to a durable artefact. The diaboli should stress whether the enumerated set is
+complete and whether the vacuous-pass (AC-11) is the right default (it is — INV-2
+is scoped to untrusted readers, not all agents).
+
+### 7.4 Decision summary for the GATE
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| INV-1 grep match rule | A path-denylist / B write-API / **C both layered** | **C** — strip comments, fail on write-shaped tokens AND on any durable filename in executable code (drift-robust) |
+| INV-1 firewall home | W1 dedicated workflow / W2 Layer-0 test / W3 GC rule | **W1 + W2** — one bash matcher, dispatched by a PR-time gate and a fixtured Layer-0 test; not W3-only |
+| INV-2 lint convention | I1 declared marker / I2 infer from tools | **I1** — `@untrusted-reader` + `@tools` markers, with an enumerated high-privilege set |
+
+All three are surfaced for the human; the spec-writer recommends but does not
+silently choose.
+
+---
+
+## 8. CI, version, and docs checklist
+
+### 8.1 Version bump — adding templates is behavioural (minor)
+
+Adding the workflow template library and two new CI gates is a **behavioural
+addition** → **minor bump `0.58.1 → 0.59.0`** (current version confirmed
+`0.58.1` in `plugin.json`). The `Version Check` CI enforces **five** locations
+(per CLAUDE.md / the live `version-check.yml`). Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical;
+   currently `0.58.1`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.59.0`
+   (line 6; currently `v0.58.1`)
+3. `CHANGELOG.md` — new top heading `## 0.59.0 — 2026-06-22`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (currently
+   `0.58.1`; owned by ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers`
+   `plugins[].version` entry (currently `0.58.1`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md`
+plugin-table row cell (`| v0.58.1 |` → `| v0.59.0 |`, line 31).
+
+> The marketplace listing `version` (`0.4.0`) does **not** change — S2 alters no
+> listing contract (no description/keyword/permission/plugins-array change). The
+> skill-count badge (`Skills-36`, line 9) and the "**36 skills**" table cell do
+> **not** change — S2 adds no new skill, only files inside the existing
+> `dynamic-workflows` skill.
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.58\.1\|0\.58\.1' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+### 8.2 CI gates
+
+- **`INV-1 firewall` (NEW, deterministic gate).** The new gate from §7 — a
+  dedicated GitHub workflow (W1) invoking the bash matcher, plus a Layer-0 test
+  (W2) carrying its red/green fixtures. This is a **new** PR-time gate added to
+  `.github/workflows/`. Listed here as a new CI surface per the umbrella's
+  governance-erosion risk.
+- **`INV-2 lint` (NEW, deterministic gate).** The marker-convention lint from
+  §7.3, authored alongside the INV-1 matcher (same bash + Layer-0 home is
+  natural). New CI surface.
+- **`*.workflow.js` parse + reference-resolution (NEW, deterministic check).**
+  Node `--check` (or equivalent) on each template + a path-resolution check for
+  `SKILL.md`'s references. Naturally co-located with the Layer-0 firewall test.
+- **`tdad-scenario-check`** — **not triggered** for S2's component changes:
+  flipping `SKILL.md` is a *modification* of an existing component, and the gate
+  fires only on *added* components. The four `*.workflow.js` files are not
+  `SKILL.md`/`agent.md`/`command.md` component files, so they are not gated
+  either. The S1 markdownlint scenario rewrite (§6) is a modification, not an
+  addition.
+- **`lint-markdown`** — the flipped `SKILL.md` section and the updated how-to must
+  pass markdownlint (PreToolUse hook + CI). The `*.workflow.js` files are
+  JavaScript, not markdown, and are not linted by this gate.
+- **`spec-first-check`** — satisfied by this spec being the first commit on the
+  branch `dynamic-workflows-s2-templates`. No exemption label; this is feature
+  work.
+
+### 8.3 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Reference (already satisfied).** The `### dynamic-workflows` entry in
+  `docs/plugins/ai-literacy-superpowers/reference/skills.md` already exists
+  (shipped in S1). S2 adds **no new skill**, so the docs-reference-parity gate is
+  satisfied with no new heading. A reference update describing the four templates
+  is *optional* and may be folded into the how-to instead.
+- **How-to (required update).** The orientation guide
+  `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` (shipped in
+  S1, which explicitly noted "runnable workflow templates arrive in S2") must be
+  updated now that the templates exist: name the four templates, point at their
+  relative paths, and show the ADAPT-not-run-verbatim discipline. This is the
+  "feature adds runnable artefacts → update the how-to" obligation from CLAUDE.md.
+- **Explanation / tutorials.** None required for S2 — no existing explanation page
+  references behaviour S2 changes; the INV-1/INV-2 concepts already live in the
+  skill's `references/governance.md` (S1).
+
+---
+
+## 9. FR → acceptance-scenario mapping
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-1 | deterministic |
+| FR-2 | AC-1, AC-12 | deterministic |
+| FR-3 | AC-4 | deterministic |
+| FR-4 | AC-2 | deterministic |
+| FR-5 | AC-3 | deterministic |
+| FR-6 | AC-6, AC-7, AC-8, AC-9 | deterministic |
+| FR-7 | AC-10, AC-11 | deterministic |
+| FR-8 | AC-2, AC-3 | deterministic |
+| FR-9 | (§6 reconciliation; tdd-agent rewrites the S1 scenario) | deterministic |
+| FR-10 | (CI: Version Check) | deterministic |
+| FR-11 | (docs-impact; how-to update) | deterministic (presence) |
+
+Agent-backed AC-5 (an agent ADAPTs rather than runs verbatim) maps to FR-5/FR-2
+and is verified by a Layer-2/3 TDAD behavioural scenario if the tdd-agent elects
+to add one; otherwise it stands as declared intent. AC-13 is unverified-declared
+(no behavioural wiring in S2).
+
+---
+
+## 10. Risks and open questions
+
+**Risks.**
+
+- *Firewall false negative (the dangerous direction).* A durable-artefact write
+  expressed in a shape the matcher misses passes CI and breaches INV-1.
+  Mitigation: §7.1 Option C's "no durable filename in executable code" clause
+  converts the open-ended write-API problem into a closed naming check robust to
+  runtime API drift; the AC-7 fixture proves a planted write is caught.
+- *Firewall false positive (the annoying direction).* A literate preamble naming
+  `AGENTS.md` reddens CI, punishing the Knuth discipline S2 mandates. Mitigation:
+  §7.1's comment-stripping + the AC-8 fixture proving a bare mention passes.
+- *INV-2 unmarked-reader escape.* An untrusted reader left unmarked escapes the
+  lint (§7.3 I1's weakness). Mitigation: documented convention in
+  `references/governance.md` + template preamble; the lint is defence-in-depth,
+  not the sole quarantine guard.
+- *Template-API rot.* The shipped templates show ADAPTABLE call shapes that may
+  drift from the authoritative runtime doc. Mitigation: the implementer note and
+  every preamble defer function names to
+  <https://code.claude.com/docs/en/workflows>; the firewall matches
+  write-behaviour, not function names.
+- *S1-scenario staleness.* The S1 markdownlint scenario asserts a now-false "no
+  hard-link" property. Mitigation: §6's explicit reconciliation instruction to the
+  tdd-agent.
+
+**Open questions.** None block S2. The umbrella open questions all ride later
+slices (Q1 threshold → S3, Q2 routing → S5, Q3 staging → S6, Q4 Copilot → S7) and
+are out of scope here (§2.2). The one S2-internal decision — the firewall
+mechanism (§7) — is **surfaced for the GATE, not left open**: the spec recommends
+(7.1 C, 7.2 W1+W2, 7.3 I1) and the human disposes.
+
+---
+
+## 11. References
+
+- Umbrella spec:
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+  (read-first runtime-scope note; §2 INV-1/INV-2; D2; §5.1; §5.2; §6).
+- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md`
+  (Runtime-scope section; S2 entry).
+- S1 spec (merged):
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md`.
+- Shipped S1 skill:
+  `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md` (the "## The
+  workflow template library (forthcoming — S2)" section S2 flips; the "## Runtime
+  scope — Claude Code only" section S2 preserves).
+- Runtime API (authoritative): <https://code.claude.com/docs/en/workflows>.
+- House-style firewall precedent: `.github/workflows/spec-redaction-marker-check.yml`
+  (line-anchored grep, `::error::` annotations, scoped `paths:`).
+- Layer-0 test precedent: `tdad_tests/tests/test_layer0_deterministic.py` +
+  `tdad_tests/layer0_deterministic/test-*.sh` (bash matcher dispatched as a fast
+  deterministic test).
+- Knuth, "Literate Programming" (1984) — the preamble discipline on every
+  template.

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-clean.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-clean.workflow.js
@@ -1,0 +1,25 @@
+/**
+ * FIXTURE (by-design) — INV-1 CLEAN (false-positive guard).
+ *
+ * Pattern: generate-and-filter + adversarial verification.
+ * Token budget: 60k. Model tier per role: clusterer=sonnet, skeptic=opus.
+ *
+ * INV-1 boundary: this workflow only *proposes*. It NEVER writes `AGENTS.md`
+ * directly — discoveries flow through `REFLECTION_LOG.md` → human curates →
+ * `AGENTS.md`. The durable artefacts `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`,
+ * and `MODEL_ROUTING.md` are named HERE, in the literate preamble, purely to
+ * document the boundary respected. A bare mention of a durable filename in a
+ * comment block like this one MUST NOT trip the firewall (AC-8).
+ *
+ * Runtime scope: Claude Code only; inert reference material on trees without
+ * the workflow runtime.
+ */
+
+async function run(ctx) {
+  const shortlist = await ctx.adversariallyFilter();
+  // Proposes to a NON-durable staging sink — never to a durable artefact.
+  await fs.writeFile("REFLECTION_STAGING.md", shortlist, "utf-8");
+  return shortlist;
+}
+
+module.exports = { run };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-concat.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-concat.workflow.js
@@ -1,0 +1,15 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-1 VIOLATION via name splitting.
+ * Pattern: generate-and-filter. Token budget: 40k. Model tier per role:
+ * drafter=sonnet. INV-1 boundary: DELIBERATELY BREACHED. Claude Code only.
+ *
+ * Regression guard for the S2 review finding: a durable filename split across
+ * string concatenation must still be flagged.
+ */
+async function run(ctx) {
+  const data = await ctx.synthesize();
+  // INV-1 BREACH hidden by concatenation — must still FLAG (stem match).
+  await fs.writeFile("AGENTS" + ".md", data, "utf-8");
+  return data;
+}
+module.exports = { run };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-violation.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv1-violation.workflow.js
@@ -1,0 +1,22 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-1 VIOLATION.
+ *
+ * Pattern: generate-and-filter.
+ * Token budget: 40k. Model tier per role: drafter=sonnet, judge=opus.
+ * INV-1 boundary: this fixture DELIBERATELY BREACHES it — it writes a
+ * durable artefact directly in executable code. The firewall MUST flag it.
+ * Runtime scope: Claude Code only; inert reference material elsewhere.
+ *
+ * This file exists only so the Layer-0 firewall test has a true-positive to
+ * assert against (AC-7). It is NOT a shipped template and lives under
+ * tdad_tests/layer0_deterministic/fixtures/** (lint-ignored).
+ */
+
+async function run(ctx) {
+  const shortlist = await ctx.synthesize();
+  // INV-1 BREACH: a direct write to a durable artefact in executable code.
+  await fs.writeFile("AGENTS.md", shortlist, "utf-8");
+  return shortlist;
+}
+
+module.exports = { run };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-clean.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-clean.workflow.js
@@ -1,0 +1,29 @@
+/**
+ * FIXTURE (by-design) — INV-2 CLEAN.
+ *
+ * Pattern: classify-and-act over a backlog of external issues.
+ * Token budget: 50k. Model tier per role: triager=sonnet, actor=opus.
+ * INV-1 boundary: proposes only; never writes a durable artefact.
+ * Runtime scope: Claude Code only; inert elsewhere.
+ *
+ * INV-2 is RESPECTED: the untrusted-content reader is withheld every
+ * high-privilege tool (`write`, `edit`, `bash`, `commit`, `push`). Only a
+ * separate, trusted actor — which reads no untrusted content — may act. The
+ * INV-2 lint MUST pass on this fixture.
+ */
+
+// @workflow-agent: issue-triager
+// @untrusted-reader: true        // reads external issue bodies (untrusted)
+// @tools: [read, grep]           // low-privilege only — quarantined
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+
+// @workflow-agent: trusted-actor
+// @untrusted-reader: false       // acts only on the triager's vetted output
+// @tools: [read, write, bash]    // high-privilege, but reads no untrusted content
+async function act(ctx) {
+  return ctx.spawn("trusted-actor");
+}
+
+module.exports = { triageUntrusted, act };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-multiline.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-multiline.workflow.js
@@ -1,0 +1,16 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION via a wrapped @tools list.
+ * Pattern: classify-and-act. Token budget: 50k. Model tier per role:
+ * triager=sonnet. INV-1 boundary: proposes only. Claude Code only.
+ *
+ * Regression guard: a high-privilege tool on a continuation line of a
+ * multi-line @tools list must still be flagged.
+ */
+// @workflow-agent: issue-triager
+// @untrusted-reader: true
+// @tools: [read,
+//          bash]
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+module.exports = { triageUntrusted };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-order.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-order.workflow.js
@@ -1,0 +1,15 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION with @tools before the flag.
+ * Pattern: classify-and-act. Token budget: 50k. Model tier per role:
+ * triager=sonnet. INV-1 boundary: proposes only. Claude Code only.
+ *
+ * Regression guard: marker order within a block must not matter — @tools
+ * declared above @untrusted-reader: true must still be flagged.
+ */
+// @workflow-agent: issue-triager
+// @tools: [read, push]
+// @untrusted-reader: true
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+module.exports = { triageUntrusted };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-unterminated.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-unterminated.workflow.js
@@ -1,0 +1,16 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION via an unterminated list.
+ * Pattern: classify-and-act. Token budget: 50k. Model tier per role:
+ * triager=sonnet. INV-1 boundary: proposes only. Claude Code only.
+ *
+ * Regression guard: an untrusted reader whose @tools list never closes cannot
+ * be verified and must fail closed. There is no closing bracket anywhere.
+ */
+// @workflow-agent: issue-triager
+// @untrusted-reader: true
+// @tools: [read,
+//          bash
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager")
+}
+module.exports = { triageUntrusted }

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-uppercase-markers.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-uppercase-markers.workflow.js
@@ -1,0 +1,15 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION via uppercased markers.
+ * Pattern: classify-and-act. Token budget: 50k. Model tier per role:
+ * triager=sonnet. INV-1 boundary: proposes only. Claude Code only.
+ *
+ * Regression guard: uppercasing the marker keywords themselves must not escape
+ * the lint (the markers are matched case-insensitively).
+ */
+// @WORKFLOW-AGENT: issue-triager
+// @UNTRUSTED-READER: TRUE
+// @TOOLS: [read, bash]
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+module.exports = { triageUntrusted };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-uppercase.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-uppercase.workflow.js
@@ -1,0 +1,15 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION via tool casing.
+ * Pattern: classify-and-act. Token budget: 50k. Model tier per role:
+ * triager=sonnet. INV-1 boundary: proposes only. Claude Code only.
+ *
+ * Regression guard: a high-privilege tool named with different casing must
+ * still be flagged for an untrusted reader.
+ */
+// @workflow-agent: issue-triager
+// @untrusted-reader: true
+// @tools: [read, Bash]
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+module.exports = { triageUntrusted };

--- a/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-violation.workflow.js
+++ b/tdad_tests/layer0_deterministic/fixtures/inv-firewall/inv2-violation.workflow.js
@@ -1,0 +1,21 @@
+/**
+ * FIXTURE (malformed-by-design) — INV-2 VIOLATION.
+ *
+ * Pattern: classify-and-act over a backlog of external issues.
+ * Token budget: 50k. Model tier per role: triager=sonnet, actor=opus.
+ * INV-1 boundary: proposes only; never writes a durable artefact.
+ * Runtime scope: Claude Code only; inert elsewhere.
+ *
+ * This fixture DELIBERATELY BREACHES INV-2: it declares an
+ * untrusted-content reader and then grants it a high-privilege tool
+ * (`bash`). The INV-2 lint MUST flag it (AC-10). Not a shipped template.
+ */
+
+// @workflow-agent: issue-triager
+// @untrusted-reader: true        // reads external issue bodies (untrusted)
+// @tools: [read, grep, bash]     // BREACH: `bash` is high-privilege
+async function triageUntrusted(ctx) {
+  return ctx.spawn("issue-triager");
+}
+
+module.exports = { triageUntrusted };

--- a/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
+++ b/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
@@ -95,4 +95,12 @@ run inv2 "$FIX/inv2-multiline.workflow.js"
 run inv2 "$FIX/inv2-order.workflow.js"
 [ "$RC" -ne 0 ] || fail "INV-2 must FLAG regardless of marker order within an agent block: $OUT"
 
+# INV-2: uppercased marker keywords must not escape the lint.
+run inv2 "$FIX/inv2-uppercase-markers.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG when the marker keywords themselves are uppercased: $OUT"
+
+# INV-2: an unterminated @tools list for an untrusted reader fails closed.
+run inv2 "$FIX/inv2-unterminated.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG (fail closed) an unterminated @tools list for an untrusted reader: $OUT"
+
 echo "All INV-1/INV-2 firewall tests passed."

--- a/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
+++ b/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the INV-1/INV-2 firewall matcher (dynamic-workflows S2).
+#
+# The matcher is a single bash script (spec §7.2, decision W1+W2) invoked two
+# ways: a PR-time GitHub workflow (the blocking gate) and this Layer-0 test
+# (where the red/green fixtures live and prove the matcher's precision). This
+# test exercises the matcher against four malformed-by-design fixtures under
+# fixtures/inv-firewall/ (lint-ignored).
+#
+# Contract under test (spec §7.1 Option C / §7.3 Option I1):
+#   inv-firewall.sh --check=inv1 <file...>
+#     - strips comment/preamble lines first;
+#     - FAILS (exit non-zero) if any of the four durable filenames
+#       (HARNESS.md, AGENTS.md, CLAUDE.md, MODEL_ROUTING.md) appears in
+#       executable (non-comment) code — whether or not the specific write
+#       call is recognised (drift-robust "no durable filename in executable
+#       code" clause);
+#     - PASSES (exit 0) when durable filenames appear only in the literate
+#       preamble / comments.
+#   inv-firewall.sh --check=inv2 <file...>
+#     - finds every agent block marked `@untrusted-reader: true`;
+#     - FAILS if that agent's `@tools` list contains any high-privilege tool
+#       (write, edit, bash, commit, push);
+#     - PASSES vacuously when no untrusted reader is declared.
+#
+# RED NOW: the matcher script does not yet exist (it is S2 implementation).
+# This test therefore fails at the "matcher script exists" guard — the right
+# RED reason (missing implementation, not a malformed test).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MATCHER="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/inv-firewall.sh"
+FIX="$SCRIPT_DIR/fixtures/inv-firewall"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Guard: the matcher must exist and be executable. RED here until S2 ships it.
+[ -f "$MATCHER" ] || fail "matcher script not found at $MATCHER (S2 implementation missing — expected RED until the firewall ships)"
+[ -x "$MATCHER" ] || fail "matcher script exists but is not executable: $MATCHER"
+
+# run <check> <file> -> sets RC and OUT
+run() {
+  set +e
+  OUT=$("$MATCHER" "--check=$1" "$2" 2>&1)
+  RC=$?
+  set -e
+}
+
+# --- INV-1: true positive (AC-7) ---------------------------------------------
+# A template that writes a durable artefact directly in executable code must
+# FLAG (exit non-zero) and name the offending file, the durable artefact, and
+# the INV-1 rule.
+run inv1 "$FIX/inv1-violation.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-1 must FLAG a direct write to AGENTS.md in executable code (got exit 0): $OUT"
+echo "$OUT" | grep -q "inv1-violation.workflow.js" || fail "INV-1 violation message must name the offending file: $OUT"
+echo "$OUT" | grep -q "AGENTS.md" || fail "INV-1 violation message must name the durable artefact: $OUT"
+echo "$OUT" | grep -qi "INV-1" || fail "INV-1 violation message must cite the INV-1 rule: $OUT"
+
+# --- INV-1: no false positive (AC-8 / AC-9) ----------------------------------
+# A template whose literate PREAMBLE names AGENTS.md / HARNESS.md but whose
+# executable code writes only to a non-durable staging sink must PASS.
+run inv1 "$FIX/inv1-clean.workflow.js"
+[ "$RC" -eq 0 ] || fail "INV-1 must PASS a template that only mentions durable artefacts in its preamble (false positive; got exit $RC): $OUT"
+
+# --- INV-2: true positive (AC-10) --------------------------------------------
+# An @untrusted-reader agent granted a high-privilege tool must FLAG.
+run inv2 "$FIX/inv2-violation.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG an untrusted-reader granted a high-privilege tool (got exit 0): $OUT"
+echo "$OUT" | grep -q "inv2-violation.workflow.js" || fail "INV-2 violation message must name the offending file: $OUT"
+echo "$OUT" | grep -qi "bash" || fail "INV-2 violation message must name the offending high-privilege tool: $OUT"
+
+# --- INV-2: clean (AC-10/AC-11) ----------------------------------------------
+# An @untrusted-reader agent with only low-privilege tools (and a separate
+# trusted actor that reads no untrusted content) must PASS.
+run inv2 "$FIX/inv2-clean.workflow.js"
+[ "$RC" -eq 0 ] || fail "INV-2 must PASS when the untrusted reader is withheld every high-privilege tool (got exit $RC): $OUT"
+
+echo "All INV-1/INV-2 firewall tests passed."

--- a/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
+++ b/tdad_tests/layer0_deterministic/test-inv1-firewall.sh
@@ -75,4 +75,24 @@ echo "$OUT" | grep -qi "bash" || fail "INV-2 violation message must name the off
 run inv2 "$FIX/inv2-clean.workflow.js"
 [ "$RC" -eq 0 ] || fail "INV-2 must PASS when the untrusted reader is withheld every high-privilege tool (got exit $RC): $OUT"
 
+# --- Regression guards (S2 adversarial review) -------------------------------
+# Bypasses the first matcher missed. Each must now FLAG.
+
+# INV-1: a durable filename split across string concatenation.
+run inv1 "$FIX/inv1-concat.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-1 must FLAG a durable filename split by concatenation (\"AGENTS\" + \".md\"): $OUT"
+echo "$OUT" | grep -q "AGENTS.md" || fail "INV-1 concat message must name the durable artefact: $OUT"
+
+# INV-2: a high-privilege tool named with different casing.
+run inv2 "$FIX/inv2-uppercase.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG a high-privilege tool regardless of casing (Bash): $OUT"
+
+# INV-2: a high-privilege tool on a continuation line of a wrapped @tools list.
+run inv2 "$FIX/inv2-multiline.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG a high-privilege tool on a multi-line @tools list: $OUT"
+
+# INV-2: @tools declared before the @untrusted-reader flag (order independence).
+run inv2 "$FIX/inv2-order.workflow.js"
+[ "$RC" -ne 0 ] || fail "INV-2 must FLAG regardless of marker order within an agent block: $OUT"
+
 echo "All INV-1/INV-2 firewall tests passed."

--- a/tdad_tests/layer0_deterministic/test-workflow-templates.sh
+++ b/tdad_tests/layer0_deterministic/test-workflow-templates.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 deterministic check for the four dynamic-workflows S2 templates and
+# the SKILL.md flip (spec AC-1, AC-2, AC-3, AC-4, AC-12).
+#
+# Asserts the *shipped* state of the template library:
+#   - the four templates exist at skills/dynamic-workflows/workflows/;
+#   - each parses as valid JavaScript (node --check);
+#   - each preamble names its pattern, token budget + per-role model tier, the
+#     INV-1 boundary, and the Claude-Code-only runtime scope;
+#   - SKILL.md references all four by relative path and every path resolves;
+#   - SKILL.md is "shipped" framing, not "forthcoming (S2)".
+#
+# RED NOW: the templates do not exist and SKILL.md still says "forthcoming
+# (S2)". Each assertion below fails for the right reason (missing
+# implementation), not because the test is malformed.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$SCRIPT_DIR/../../ai-literacy-superpowers/skills/dynamic-workflows"
+WF_DIR="$SKILL_DIR/workflows"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || fail "node not found on PATH — the parse check (AC-2) requires Node --check"
+
+TEMPLATES=(
+  enforcer-fanout
+  adversarial-review
+  reflection-mining
+  deep-assessment
+)
+
+# --- AC-1: the four templates exist ------------------------------------------
+[ -d "$WF_DIR" ] || fail "workflows/ directory does not exist at $WF_DIR (S2 templates missing — expected RED)"
+for t in "${TEMPLATES[@]}"; do
+  f="$WF_DIR/$t.workflow.js"
+  [ -f "$f" ] || fail "template missing: $f (AC-1)"
+done
+
+# --- AC-2: each template parses as valid JavaScript --------------------------
+for t in "${TEMPLATES[@]}"; do
+  f="$WF_DIR/$t.workflow.js"
+  node --check "$f" 2>/dev/null || fail "template does not parse as valid JavaScript: $f (AC-2)"
+done
+
+# --- AC-1 + AC-4 + AC-12: each preamble is literate --------------------------
+# Extract the top-of-file comment block (the literate preamble) and assert it
+# names: a pattern, a token budget, a per-role model tier, the INV-1 boundary,
+# and the Claude-Code-only runtime scope.
+for t in "${TEMPLATES[@]}"; do
+  f="$WF_DIR/$t.workflow.js"
+  # The preamble is the leading /** ... */ block; grep the whole file head.
+  head_block=$(sed -n '1,60p' "$f")
+  echo "$head_block" | grep -qiE "pattern" || fail "$t preamble must name its pattern (AC-1): $f"
+  echo "$head_block" | grep -qiE "token budget" || fail "$t preamble must declare a token budget (AC-4): $f"
+  echo "$head_block" | grep -qiE "model tier|tier per role|per-role" || fail "$t preamble must declare a per-role model tier (AC-4): $f"
+  echo "$head_block" | grep -qiE "INV-1" || fail "$t preamble must name the INV-1 boundary it respects (AC-1): $f"
+  echo "$head_block" | grep -qiE "Claude.Code" || fail "$t preamble must state the Claude-Code-only runtime scope (AC-12): $f"
+done
+
+# --- AC-3: SKILL.md references all four by resolving relative path ------------
+[ -f "$SKILL_MD" ] || fail "SKILL.md not found at $SKILL_MD"
+
+# Must NOT still be in the "forthcoming (S2)" framing.
+if grep -qi "forthcoming" "$SKILL_MD"; then
+  fail "SKILL.md still uses 'forthcoming' framing — S2 must flip it to 'shipped' (AC-3)"
+fi
+
+for t in "${TEMPLATES[@]}"; do
+  ref="workflows/$t.workflow.js"
+  grep -q "$ref" "$SKILL_MD" || fail "SKILL.md does not reference $ref by relative path (AC-3)"
+  # The reference must resolve to an existing file.
+  [ -f "$SKILL_DIR/$ref" ] || fail "SKILL.md reference $ref does not resolve to an existing file (AC-3)"
+done
+
+echo "All dynamic-workflows template structural tests passed."

--- a/tdad_tests/scenarios/skills/dynamic-workflows/four-templates-exist.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/four-templates-exist.md
@@ -1,0 +1,36 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+fixture: dynamic-workflows/workflows
+---
+
+# Scenario: the four S2 workflow templates exist (AC-1)
+
+## Given
+
+The `dynamic-workflows` skill has shipped its S2 template library under
+`ai-literacy-superpowers/skills/dynamic-workflows/workflows/`.
+
+## When
+
+The `workflows/` directory is read.
+
+## Then
+
+- The directory `skills/dynamic-workflows/workflows/` exists.
+- Exactly these four files exist:
+  - `workflows/enforcer-fanout.workflow.js`
+  - `workflows/adversarial-review.workflow.js`
+  - `workflows/reflection-mining.workflow.js`
+  - `workflows/deep-assessment.workflow.js`
+
+## Rubric
+
+This is the deterministic existence check from AC-1 / FR-1. It is verified by
+the Layer-0 bash test `test-workflow-templates.sh`, which fails until the four
+files are present. Until S2 ships the templates, the `workflows/` directory
+does not exist and the Layer-0 check is RED for the right reason — missing
+implementation, not a malformed assertion. The templates are *reference
+substrate the later agent slices ADAPT* (S3–S6); S2 wires no agent or command
+to them (AC-13).

--- a/tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/markdownlint-clean.md
@@ -4,18 +4,20 @@ component_type: skill
 tier: structural
 ---
 
-# Scenario: dynamic-workflows SKILL.md and references are markdownlint-clean (AC-2)
+# Scenario: dynamic-workflows SKILL.md is markdownlint-clean and its template references resolve (AC-2, AC-3)
 
 ## Given
 
 The `dynamic-workflows` skill's `SKILL.md` and its three reference files
 (`references/patterns.md`, `references/when-not-to-use.md`,
-`references/governance.md`) exist.
+`references/governance.md`) exist, and — as of S2 — the four `*.workflow.js`
+templates exist under `workflows/`.
 
 ## When
 
-markdownlint runs over them — via the existing PreToolUse hook at edit time
-and the `lint-markdown` CI workflow.
+markdownlint runs over the markdown files — via the existing PreToolUse hook
+at edit time and the `lint-markdown` CI workflow — and `SKILL.md`'s template
+references are resolved against the filesystem.
 
 ## Then
 
@@ -23,16 +25,21 @@ and the `lint-markdown` CI workflow.
 - `references/patterns.md` passes markdownlint with no new violations.
 - `references/when-not-to-use.md` passes markdownlint with no new violations.
 - `references/governance.md` passes markdownlint with no new violations.
-- None of the files contain a runnable dependency on any `.workflow.js`
-  file (the S2 template library); any mention of the template library is an
-  explicit "forthcoming (S2)" forward-reference, not a link to a file that
-  must exist.
+- `SKILL.md` references the four S2 templates by relative path
+  (`workflows/<name>.workflow.js`) and **every referenced path resolves to an
+  existing file** — the S1 "forthcoming (S2)" forward-reference is gone.
 
 ## Rubric
 
-This is the deterministic lint check from AC-2 / FR-7. The forward-reference
-clause is load-bearing: S1 must be lint-clean and valid *standalone*, with no
-broken link to a file S2 has not yet shipped. A markdown link to a
-non-existent `workflows/*.workflow.js` path would both mislead a reader and
-risk a broken-link lint failure — so the scenario fails if the skill imports
-or hard-links any template file.
+This is the deterministic lint + reference-resolution check (AC-2 lint, AC-3
+resolution). **S2 reconciliation:** the S1 form of this scenario asserted that
+SKILL.md contained *no* hard-link to a `.workflow.js` file and that any mention
+was a "forthcoming (S2)" forward-reference. That property was correct for S1's
+standalone validity but is now **false by design** — S2 ships the templates and
+SKILL.md links them by relative path. The load-bearing clause is therefore
+replaced: SKILL.md's references must *resolve* (the AC-3 property), not be
+*absent*. The markdownlint-clean assertion is retained — the flipped section
+and any new links must still pass markdownlint with no broken-link or
+formatting violations. A reference that does not resolve to an existing file
+both misleads a reader and risks a broken-link failure, so the scenario fails
+if any of the four template paths is dangling.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/skill-md-references-templates.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/skill-md-references-templates.md
@@ -1,0 +1,37 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+fixture: dynamic-workflows/workflows
+---
+
+# Scenario: SKILL.md references all four templates by resolving path (AC-3)
+
+## Given
+
+`SKILL.md` flipped to its S2 "shipped" framing of the template library.
+
+## When
+
+`SKILL.md` is read.
+
+## Then
+
+- `SKILL.md` references **all four** templates by relative path
+  (`workflows/enforcer-fanout.workflow.js`,
+  `workflows/adversarial-review.workflow.js`,
+  `workflows/reflection-mining.workflow.js`,
+  `workflows/deep-assessment.workflow.js`).
+- Every referenced path **resolves to an existing file** on disk.
+- The "forthcoming (S2)" wording is **gone** — the framing is "shipped" and
+  prompts agents to ADAPT the templates, not run them verbatim.
+
+## Rubric
+
+This is the deterministic reference-resolution check from AC-3 / FR-5 / FR-8.
+It is the property that supersedes the S1 "no hard-link / forthcoming
+forward-reference" clause (see the reconciled `markdownlint-clean.md`
+scenario). Verified by the Layer-0 bash test `test-workflow-templates.sh`,
+which fails if any of the four references is absent, fails to resolve, or if
+the "forthcoming" wording survives. RED until SKILL.md is flipped and the
+templates exist.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/templates-carry-literate-preamble.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/templates-carry-literate-preamble.md
@@ -1,0 +1,41 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+fixture: dynamic-workflows/workflows
+---
+
+# Scenario: each template opens with a literate preamble (AC-1, AC-4, AC-12)
+
+## Given
+
+Each of the four `*.workflow.js` templates under
+`skills/dynamic-workflows/workflows/`.
+
+## When
+
+The top-of-file comment block (the literate preamble, per Knuth discipline)
+of each template is read.
+
+## Then
+
+- Each preamble NAMES the **pattern** it composes (one or more of the six:
+  classify-and-act, fan-out-and-synthesize, adversarial verification,
+  generate-and-filter, tournament, loop-until-done).
+- Each preamble declares an explicit **token budget** (a per-workflow cap).
+- Each preamble declares a **default model tier per agent role**.
+- Each preamble names the **INV-1 boundary** it respects (the durable
+  artefacts it may only *propose* to, never write).
+- Each preamble states the **Claude-Code-only runtime scope** — that the
+  template is inert reference material on a tree without the workflow runtime.
+
+## Rubric
+
+This is the deterministic preamble check from AC-1 / AC-4 / AC-12 and FR-2 /
+FR-3. The structural form is greppable markers inside the leading comment
+block; the Layer-0 bash test `test-workflow-templates.sh` asserts each marker
+is present. A template that ships code without the literate preamble — or that
+omits the token budget, the per-role tier, the INV-1 boundary, or the runtime
+scope — is RED. Naming a durable artefact in this preamble is *correct* and
+must never trip the INV-1 firewall (that false-positive guard is AC-8, covered
+by `test-inv1-firewall.sh`). RED until the templates exist.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/templates-parse-as-javascript.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/templates-parse-as-javascript.md
@@ -1,0 +1,33 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+fixture: dynamic-workflows/workflows
+---
+
+# Scenario: each S2 template parses as valid JavaScript (AC-2)
+
+## Given
+
+The four `*.workflow.js` templates under
+`skills/dynamic-workflows/workflows/` (enforcer-fanout, adversarial-review,
+reflection-mining, deep-assessment).
+
+## When
+
+Each file is parsed with a JavaScript syntax parser (`node --check` or
+equivalent).
+
+## Then
+
+- Each of the four `*.workflow.js` files parses with no syntax error.
+
+## Rubric
+
+This is the deterministic parse check from AC-2 / FR-4 / FR-8. The templates
+are *templates an agent ADAPTs*, never verbatim scripts (the runtime function
+names defer to <https://code.claude.com/docs/en/workflows>), but they must
+still be syntactically valid JavaScript so a reader can trust the shape and so
+the firewall can reason over executable lines. Verified by the Layer-0 bash
+test `test-workflow-templates.sh` via `node --check`. RED until the templates
+exist.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -53,6 +53,10 @@ BASH_TEST_SCRIPTS = [
     "test-affordance-staleness",
     "test-affordance-recorder",
     "test-affordance-invocations",
+    # dynamic-workflows S2 — INV-1/INV-2 firewall matcher + template substrate.
+    # RED until S2 ships the matcher script and the four templates.
+    "test-inv1-firewall",
+    "test-workflow-templates",
 ]
 
 


### PR DESCRIPTION
## Summary

- Ships four workflow templates under `skills/dynamic-workflows/workflows/` (`enforcer-fanout`, `adversarial-review`, `reflection-mining`, `deep-assessment`), each an ESM module with a literate preamble (pattern, token budget, per-role model tiers, INV-1 boundary, Claude-Code-only scope), plus a `workflows/package.json` (`type: module`) so the `export const meta` + top-level-await DSL parses.
- Adds `scripts/inv-firewall.sh` — one POSIX-portable matcher enforcing INV-1 (durable-stem-in-executable-code, comment-stripped) and INV-2 (declared `@untrusted-reader`/`@tools` quarantine) — wired to a PR-time gate (`.github/workflows/dynamic-workflows-firewall.yml`) and a Layer-0 test with eight red/green fixtures.
- Flips `SKILL.md` from "forthcoming (S2)" to shipped (templates linked by resolving relative path), updates the how-to guide, and reconciles the S1 markdownlint scenario.
- Bumps the plugin minor version 0.58.1 → 0.59.0 across the five CI-enforced locations.

## Test plan

- Confirm the new required **Dynamic-workflows firewall** check passes (it greps all four shipped templates for INV-1/INV-2 compliance).
- Confirm Layer-0 + Layer-1 suites are green (27/27 locally).
- Confirm markdownlint, version-consistency, and spec-first checks pass.
- Spot-check that each template parses as ESM and exposes `export const meta`.

Spec: `docs/superpowers/specs/2026-06-22-dynamic-workflows-s2-templates-design.md`
Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md`

Closes #439
