### PR TITLE
Dynamic Workflows S3 — harness-enforcer fan-out mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.59.0",
+  "plugin_version": "0.60.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.59.0"
+      "version": "0.60.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -60,3 +60,7 @@ jobs:
       - name: Run Layer 1 (structural)
         working-directory: tdad_tests
         run: pytest tests/test_layer1_structural.py -v
+
+      - name: Run Layer 1 (dynamic-workflows S3 enforcer fan-out)
+        working-directory: tdad_tests
+        run: pytest tests/test_s3_enforcer_fanout_structural.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.60.0 — 2026-06-22
+
+### dynamic-workflows: harness-enforcer fan-out mode (S3, #440)
+
+The highest-leverage slice of the epic — defeats the enforcer's "35 of 50
+constraints checked" lazy stop.
+
+- **`harness-enforcer` gains a "Workflow mode" section**: when the enforceable-
+  constraint count exceeds a threshold (**default 8, configurable per project
+  via an optional `fan-out-threshold` field in HARNESS.md**; strict `>`
+  trigger), the enforcer adapts `enforcer-fanout.workflow.js` to spawn **one
+  verifier subagent per rule** plus a **skeptic** persona, reconciled at a
+  **synthesis barrier** that waits for all N. At or below the threshold the
+  single-context path runs unchanged — no workflow, no extra compute.
+- **Count-equality guarantee (no silent drop)**: when it reports "all
+  constraints checked", verifier results equal the enforceable count (`unverified`
+  excluded). The first run records the skeptic's false-positive-reduction
+  observation in REFLECTION_LOG.md for human curation — an observation, never a
+  CI-verified metric.
+- **`verification-slots` SKILL.md** documents the **fan-out slot** as a
+  first-class agent-backed slot (one verifier per rule + skeptic + synthesis
+  barrier) producing the same pass/fail + `{file, line, message}` contract.
+- Workflow mode requires the Claude Code runtime; where it is absent the
+  enforcer falls back to single-context behaviour and never errors. Read-only /
+  propose-only — never writes a durable artefact (INV-1).
+- Deterministic structural checks (`test_s3_enforcer_fanout_structural.py`) gate
+  the declared workflow-mode contract in CI.
+
 ## 0.59.0 — 2026-06-22
 
 ### dynamic-workflows: template library + INV-1/INV-2 firewall (S2, #439)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.59.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.60.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.59.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.60.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/harness-enforcer.agent.md
+++ b/ai-literacy-superpowers/agents/harness-enforcer.agent.md
@@ -252,8 +252,9 @@ skill — adapt it, never run it verbatim) to:
    **all N** verifiers to return before producing the report.
 
 **Count-equality guarantee (no silent drop).** When the enforcer reports
-**"all constraints checked"** in workflow mode, the count of verifier
-results MUST equal the count of enforceable constraints. The synthesis
+**"all constraints checked"** in workflow mode, the count of
+**verifier results** MUST **equal** the count of enforceable constraints.
+The synthesis
 barrier is what makes this true: the report cannot form until every
 verifier has returned, so **no** enforceable constraint is **silently
 dropped**. A missing verifier is a reported error, not a silent pass.

--- a/ai-literacy-superpowers/agents/harness-enforcer.agent.md
+++ b/ai-literacy-superpowers/agents/harness-enforcer.agent.md
@@ -211,3 +211,68 @@ falsifiability test and three-frame translation method.
 - Report findings with exact file paths and line numbers
 - If a deterministic tool is not installed, report the constraint as
   failed with "tool not found" as the finding
+
+## Workflow mode (large harnesses, Claude Code only)
+
+When the number of enforceable constraints in scope **exceeds a
+threshold (default 8)**, single-context enforcement becomes the place
+where the enforcer's signature failure shows up: it tires and reports
+"all constraints checked" after actually checking only some. Above the
+threshold, escalate to **workflow mode** — a dynamic workflow that fans
+the work out so the lazy stop is structurally impossible.
+
+**Threshold and configurability.** The default threshold is **8**. It is
+**configurable per project** via an optional `fan-out-threshold` field in
+`HARNESS.md`; when that field is **absent**, the threshold **defaults**
+to 8. The trigger is strict: workflow mode engages only when the
+enforceable-constraint count is **greater than** the threshold
+(`count > threshold`) — a harness of exactly the threshold size stays on
+the **single-context** path.
+
+**Enforceable count.** "Enforceable" means constraints whose enforcement
+is `deterministic`, `agent`, or `deterministic + agent`. `unverified`
+constraints are **excluded** from the count (they are skipped, not
+checked), so they neither trigger fan-out nor inflate the verifier total.
+
+**Below the threshold.** At or below the threshold, behave exactly as
+today: the existing **single-context** verification process runs, **no
+workflow** is authored and **no extra compute** is spent. Workflow mode
+is an escalation for large harnesses, never the default.
+
+**Fan-out shape.** In workflow mode, **adapt** the shipped
+`enforcer-fanout.workflow.js` template (under the `dynamic-workflows`
+skill — adapt it, never run it verbatim) to:
+
+1. Spawn **one verifier subagent per rule** — each verifier gets a single
+   constraint and its own clean context window.
+2. Pass every candidate violation through a **skeptic** persona that
+   tries to refute it, suppressing false positives before they reach the
+   report.
+3. Reconcile all results at a **synthesis barrier** that waits for
+   **all N** verifiers to return before producing the report.
+
+**Count-equality guarantee (no silent drop).** When the enforcer reports
+**"all constraints checked"** in workflow mode, the count of verifier
+results MUST equal the count of enforceable constraints. The synthesis
+barrier is what makes this true: the report cannot form until every
+verifier has returned, so **no** enforceable constraint is **silently
+dropped**. A missing verifier is a reported error, not a silent pass.
+
+**Skeptic observation.** The skeptic's effect on the false-positive rate
+is observational, not a metric the harness verifies. The **first run** of
+workflow mode on a project records a short note in **REFLECTION_LOG.md**
+describing the false-positive reduction observed versus single-context
+enforcement, as raw material for human curation — an observation captured
+for humans, never promised as an automated guarantee.
+
+**Runtime scope — Claude Code only.** Workflow mode requires the **Claude
+Code** runtime; dynamic workflows are not transferable to Copilot CLI or
+other coding agents. Where the workflow runtime is absent, the enforcer
+**falls back** to its single-context behaviour and **never errors** — it
+simply checks constraints the way it always has.
+
+**Boundary (INV-1).** Workflow mode is **read-only** / propose-only: it
+reads HARNESS.md and the code and reports findings. It **never writes** a
+**durable artefact** (HARNESS.md, AGENTS.md, CLAUDE.md, MODEL_ROUTING.md)
+— the enforcer's tool set carries no Write or Edit, and discoveries flow
+to humans through REFLECTION_LOG.md, never straight into curated memory.

--- a/ai-literacy-superpowers/skills/verification-slots/SKILL.md
+++ b/ai-literacy-superpowers/skills/verification-slots/SKILL.md
@@ -74,6 +74,30 @@ reviews that comments explain reasoning rather than restating signatures
 
 Use `deterministic + agent` in the enforcement field and list both tools.
 
+## The Fan-out Slot
+
+The **fan-out slot** is a first-class agent-backed verification slot for
+large harnesses (Claude Code runtime only). Instead of one context
+checking every constraint — where the enforcer tends to tire and report
+"all constraints checked" after checking only some — the fan-out slot
+spawns **one verifier subagent per rule**, each with a single constraint
+and a clean context window, then passes every candidate violation through
+a **skeptic** persona that tries to refute it before it reaches the
+report.
+
+A **synthesis barrier** waits for all N verifiers to return and reconciles
+their results into the same uniform contract every slot produces:
+**pass/fail with `{file, line, message}` findings**. Because the report
+cannot form until every verifier has returned, the count of results
+equals the count of enforceable constraints — no rule is silently
+dropped. The slot is read-only and propose-only (INV-1): it reports
+findings and never writes a durable artefact.
+
+The `harness-enforcer` agent elects this slot automatically when the
+enforceable-constraint count exceeds its threshold (default 8); below it,
+the single-context path is used unchanged. The slot adapts the shipped
+`enforcer-fanout.workflow.js` template from the `dynamic-workflows` skill.
+
 ## Additional Resources
 
 ### Reference Files

--- a/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
@@ -72,7 +72,11 @@ The skill ships four templates under `skills/dynamic-workflows/workflows/`.
 Copy the closest one and adapt its prompts, model tiers, and token budget:
 
 - `enforcer-fanout.workflow.js` — one verifier per harness constraint,
-  skeptic-filtered (fan-out + adversarial verification).
+  skeptic-filtered (fan-out + adversarial verification). The
+  `harness-enforcer` agent already elects this template automatically when a
+  project's enforceable-constraint count exceeds its threshold (default 8),
+  so you rarely adapt this one by hand — it is the plugin dogfooding the
+  pattern.
 - `adversarial-review.workflow.js` — review in a context distinct from the
   implementer's, one verifier per CUPID/literate property.
 - `reflection-mining.workflow.js` — cluster reflections, vet candidates,

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -273,6 +273,13 @@ constraint from `HARNESS.md`, either executes a deterministic tool
 review. Output format is identical in both cases, so CI can treat
 all constraint results uniformly.
 
+Above a configurable threshold (default 8 enforceable constraints), the
+enforcer escalates to **workflow mode** (Claude Code runtime only):
+it adapts the `enforcer-fanout.workflow.js` template to spawn one verifier
+subagent per rule plus a skeptic persona, reconciled at a synthesis
+barrier that guarantees no constraint is silently dropped. Below the
+threshold the single-context path runs unchanged.
+
 ### harness-gc
 
 - **Tools**: Read, Write, Edit, Glob, Grep, Bash

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md
@@ -1,0 +1,563 @@
+# Specification — Dynamic Workflows S3: harness-enforcer Fan-out Upgrade
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S3 of the Dynamic Workflows Alignment epic (D3 — flagged *highest leverage*)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S3)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/440>
+**Depends on:** S1 (#438, merged) — the `dynamic-workflows` skill + election rubric; S2 (#439, merged) — the `enforcer-fanout.workflow.js` template + the INV-1/INV-2 firewall
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s3-enforcer-fanout`
+
+> **Implementer note (read first).** This slice gives the existing `harness-enforcer`
+> agent a **workflow mode** and documents the **fan-out slot** as a first-class
+> verification slot. It ships **no new component** — it modifies one agent file and one
+> SKILL.md. It does **not** rewrite the `enforcer-fanout.workflow.js` template (S2 shipped
+> it); it **points the agent at it** and describes how the agent ADAPTs it per run. The
+> *exact* runtime function names for spawning subagents and coordinating a synthesis
+> barrier are **not authoritative in this spec** — consult
+> <https://code.claude.com/docs/en/workflows> as the source of truth and treat any call
+> shape here or in the template as ADAPTABLE pseudocode, not a frozen API.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code runtime
+> capability, **not transferable** to GitHub Copilot CLI or any other coding agent — those
+> trees have no workflow runtime. The plugin ships to both trees, so the workflow mode this
+> slice adds is **Claude-Code-gated**: where the runtime exists the enforcer can fan out;
+> where it does not (Copilot CLI, other agents) the workflow-mode section is **guidance
+> only** and the enforcer **falls back to its existing single-context behaviour — it must
+> never error or pretend to fan out**. The agent's workflow-mode section must restate this
+> boundary explicitly (umbrella §5.5 / slicing-record runtime-scope note). The precise
+> Copilot degradation *contract* (guidance-only vs omit) is open-question 4, resolved in
+> S7, and is **not** decided here.
+
+---
+
+## 1. Context and motivation
+
+The `harness-enforcer` is the plugin's unified verification engine: given the constraints
+in `HARNESS.md`, it runs each one (deterministic tool or agent-based review) in a **single
+context window** and reports pass/fail with `file:line` findings. That single-context shape
+is exactly the surface the umbrella spec names as **most exposed to agentic laziness** —
+the enforcer's signature failure is the *"35 of 50 constraints checked"* lazy stop: it
+tires, declares the job done after partial progress, and silently drops the rest.
+
+D3 is flagged the **highest-leverage, smallest-blast-radius** deliverable in both umbrella
+§4 and §6, and the slicing record records the `independence` lens: it is the
+pattern-proving ground S4 reuses, yet it ships standalone and delivers value before any
+other agent gains workflow mode.
+
+S3 gives the enforcer a **workflow mode**. When the count of commit-scoped enforceable
+constraints exceeds a **threshold (default 8, configurable per project — the resolved
+open-question 1)**, the enforcer authors/adapts the S2-shipped
+`enforcer-fanout.workflow.js` to:
+
+- **fan out** one verifier subagent **per HARNESS.md rule**, each in its own clean context
+  window (defeats the lazy stop — no single context carries all N checks);
+- run a **skeptic persona** that adversarially reviews each *candidate* violation to
+  suppress false positives;
+- hold a **synthesis barrier** that waits for **all N** verifier results before any report
+  can form — there is no "good enough" early stop.
+
+Below the threshold, the enforcer keeps its **current single-context behaviour, unchanged**
+— the default path for small `HARNESS.md` files is untouched, so no extra compute is spent
+where it is not warranted (umbrella §6, compute discipline; over-orchestration is a
+regression).
+
+The pattern is **fan-out-and-synthesize + adversarial verification** — the same shape the
+S2 `enforcer-fanout.workflow.js` template already encodes (its `Verify → Skeptic →
+Synthesize` phases, its load-bearing synthesis barrier, and its `checked == confirmed-after-
+skeptic` accounting). S3 wires the enforcer to that template; it does not invent a new one.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+1. **`harness-enforcer.agent.md` gains a "Workflow mode" section** stating:
+   - **The threshold** — default **8** commit-scoped enforceable constraints; **configurable
+     per project** (mechanism per §6, decided at the GATE).
+   - **The trigger** — workflow mode engages **only** when the count of commit-scoped
+     *enforceable* constraints (enforcement is `deterministic`, `agent`, or
+     `deterministic + agent`; **`unverified` constraints are excluded** from the count, as
+     they are skipped, not checked) **exceeds** the threshold.
+   - **The fan-out + skeptic + synthesis-barrier shape** — one verifier subagent **per
+     rule**; a skeptic persona that reviews each candidate violation; a synthesis barrier
+     that waits for **all N** before reporting.
+   - **The deterministic count-equality guarantee** — when the enforcer reports "all
+     constraints checked", the count of verifier **results** equals the count of
+     **enforceable** constraints. **No silent drop.** The guarantee is declared as an
+     explicit, checkable statement in the agent doc (see §5, the verification split).
+   - **How it adapts `enforcer-fanout.workflow.js`** — references the S2 template **by
+     relative path**, hands the enforceable-constraint inventory to it as input (never by
+     spelling a durable filename in workflow code — INV-1 / the firewall), and ADAPTs
+     prompts, per-role model tiers, and the token budget per run rather than running it
+     verbatim.
+   - **The Claude-Code-only runtime scope + the fallback** — workflow mode requires the
+     Claude Code runtime; on a tree without it the enforcer **falls back to its existing
+     single-context behaviour and never errors**.
+2. **`skills/verification-slots/SKILL.md` documents the fan-out slot** as a first-class,
+   **agent-backed** verification slot — one verifier per rule + a skeptic — taking its
+   place alongside the existing deterministic / agent / deterministic+agent / unverified
+   rows. The slot's contract output (pass/fail + `{file, line, message}` findings) is
+   **identical** to the existing slots — the synthesis barrier reconciles N verifier
+   results into the one uniform result shape, so hooks/CI/commands consume it unchanged.
+3. **The INV-1 boundary preserved.** Workflow mode is read-and-report only: the enforcer
+   stays read-only (its tool set is unchanged — `Read, Glob, Grep, Bash`, no `Write`/
+   `Edit`), the workflow only *reports*, and any keep-worthy discovery flows through the
+   human-curation gate. The §D3 false-positive-reduction observation is captured in a
+   `REFLECTION_LOG.md` entry on first run (a human-curated artefact), **not** written by the
+   workflow.
+4. **Supporting CI / version / docs surfaces** (see §7): the minor bump **`0.59.0 →
+   0.60.0`** across the five CI-enforced locations + the README table cell, and a how-to
+   touch-up now that the enforcer adopts a template.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred concern | Owning slice | Why not here |
+| --- | --- | --- |
+| `code-reviewer` / `assessor` / `harness-auditor` workflow modes | **S4 (#441)** | S3 proves the adversarial-verification pattern; S4 reuses it. S3 touches only `harness-enforcer` |
+| `orchestrator` classify-and-act routing | **S5 (#442)** | Riding open-question 2 |
+| `reflect --mine` mode + staging artefact | **S6 (#443)** | Riding open-question 3 |
+| README "Dynamic Workflows" prose section, advisory Stop hook, **Copilot degradation contract** | **S7 (#444)** | Per umbrella D9; open-question 4. S3 restates the Claude-Code-only boundary for its own behaviour but does **not** fix the degradation contract |
+| Skill-count badge | **unchanged** | S3 adds **no** new skill, agent, or command — only modifies two existing files. The component-count badges do not move |
+| Editing/rewriting `enforcer-fanout.workflow.js` | **S2 (#439, merged)** | S3 *adapts and points at* the template; per the AGENTS.md "consumer never mutates the contract it consumes" decision, S3 does not edit the shipped template |
+
+**Boundary rule.** S3 modifies exactly **two files** —
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md` and
+`ai-literacy-superpowers/skills/verification-slots/SKILL.md` — plus the version/docs
+surfaces in §7. It ships **no new component**, **no new CI workflow**, and **no edit to the
+S2 template**.
+
+---
+
+## 3. User story
+
+> **As an** engineer relying on the `harness-enforcer` to verify a large `HARNESS.md`,
+> **I want** the enforcer to fan out one verifier subagent per rule (with a skeptic pass)
+> whenever the enforceable-constraint count exceeds a per-project threshold, **so that** the
+> enforcer can no longer declare "all constraints checked" after silently dropping some —
+> the synthesis barrier forces every rule to be accounted for, while small harnesses keep
+> the cheap single-context path.
+
+This is the umbrella's **agentic-laziness** failure mode given teeth at the enforcer: the
+"35 of 50" lazy stop is structurally impossible once each rule has its own context and the
+report cannot form until all N return.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy:
+*deterministic* (CI-checkable / Layer-0–1 structural), *agent-backed* (a runtime / Layer-2–3
+behavioural property, checked by an agent), or *unverified* (declared intent). The tdd-agent
+should turn the deterministic and the structurally-assertable agent-backed scenarios into
+failing checks first. Scenarios trace to umbrella **D3 acceptance**.
+
+### From D3 — the fan-out behaviour
+
+**AC-1 *(agent-backed)* — N>8 enforceable constraints spawn exactly N verifiers behind a synthesis barrier.**
+**Given** a `HARNESS.md` with **N > 8** commit-scoped **enforceable** constraints and the
+Claude Code runtime present,
+**When** the enforcer runs in workflow mode,
+**Then** exactly **N** verifier subagents are spawned, **one per rule**, and the **synthesis
+barrier waits for all N** results before any report is produced.
+*(Slot note: this is a runtime/behavioural property — not deterministically assertable from a
+static file read. Its **structural shadow** is AC-5/AC-6, which assert the agent doc declares
+the per-rule fan-out and the all-N synthesis barrier. The behavioural assertion stands as a
+Layer-2/3 scenario the tdd-agent may add; the declared shape is the structural guarantee.)*
+
+**AC-2 *(agent-backed)* — the skeptic persona reduces false positives, recorded once.**
+**Given** a candidate violation flagged by a verifier,
+**When** the skeptic persona reviews it,
+**Then** a **false-positive reduction versus single-context enforcement is observable**, and
+**the first time workflow mode runs**, the observation is captured in a **`REFLECTION_LOG.md`
+entry** (a human-curated artefact — not written by the workflow).
+*(Slot note: inherently **observational / agent-backed** — false-positive reduction cannot be
+proven deterministically from a file read; see §6 decision 3. It must **not** be over-promised
+as a deterministic guarantee. Its structural shadow is AC-6, which asserts the agent doc
+declares the skeptic pass and the first-run REFLECTION_LOG obligation.)*
+
+**AC-3 *(deterministic, structural)* — the count-equality guarantee is declared, no silent drop.**
+**Given** `harness-enforcer.agent.md`,
+**When** the workflow-mode section is read,
+**Then** it **declares the count-equality guarantee in checkable language**: when the
+enforcer reports "all constraints checked", the count of **verifier results equals the count
+of enforceable constraints** — explicitly stating that an `unverified` constraint is *excluded
+from the enforceable count* (skipped, not checked) and that **no enforceable constraint is
+silently dropped**.
+*(Slot note: per §6 decision 2, the *runtime* count-equality is agent-backed/behavioural; what
+is **deterministically assertable in this repo's TDAD layers** is that the **guarantee is
+declared** — a structural assertion on the agent doc. The tdd-agent may also author a
+**fixture** — a small synthetic enforceable-constraint inventory — the behavioural scenario
+asserts `len(results) == len(enforceable)` against. Be realistic: the fixture exercises the
+*counting rule*, not a live fan-out.)*
+
+**AC-4 *(deterministic, structural)* — below-threshold keeps the static single-context path.**
+**Given** `harness-enforcer.agent.md`,
+**When** the workflow-mode section is read,
+**Then** it states that with **≤ 8** enforceable constraints (at or below the threshold) the
+enforcer keeps its **existing single-context behaviour** — **no workflow is authored, no
+verifier subagents are spawned, no extra compute is spent**. *(The default path is unchanged;
+the threshold is a strict `>` — exactly 8 stays single-context.)*
+
+### Structural declarations on the agent doc (the deterministic shadows of D3)
+
+**AC-5 *(deterministic, structural)* — workflow-mode section exists and declares the threshold + configurability.**
+**Given** `harness-enforcer.agent.md`,
+**When** it is read,
+**Then** it contains a **"Workflow mode"** section that declares the **default threshold of
+8** commit-scoped enforceable constraints and states the threshold is **configurable per
+project** via the §6-decided mechanism (named explicitly, not left as "somehow configurable").
+
+**AC-6 *(deterministic, structural)* — the fan-out + skeptic + synthesis-barrier + template adaptation are declared.**
+**Given** the workflow-mode section,
+**When** it is read,
+**Then** it declares **all** of: one verifier **per rule** (fan-out); a **skeptic persona**
+reviewing candidate violations to suppress false positives; a **synthesis barrier** that waits
+for **all N** before reporting; that it **adapts** `enforcer-fanout.workflow.js` **by relative
+path** (ADAPT, not run verbatim); and the **first-run REFLECTION_LOG** obligation for the
+false-positive-reduction observation.
+
+**AC-7 *(deterministic, structural)* — the Claude-Code-only scope + non-erroring fallback are declared.**
+**Given** the workflow-mode section,
+**When** it is read,
+**Then** it states that workflow mode **requires the Claude Code runtime** and that on a tree
+without it the enforcer **falls back to single-context behaviour and never errors** (umbrella
+§5.5 / runtime-scope note).
+
+### From D3 — the verification-slots documentation
+
+**AC-8 *(deterministic, structural)* — the fan-out slot is documented as a first-class agent-backed slot.**
+**Given** `skills/verification-slots/SKILL.md`,
+**When** it is read,
+**Then** it documents the **fan-out slot** as a first-class, **agent-backed** verification slot
+(one verifier per rule + a skeptic), placed alongside the existing
+deterministic / agent / deterministic+agent / unverified rows, and states that its output
+**conforms to the same pass/fail + `{file, line, message}` contract** — the synthesis barrier
+reconciles N verifier results into the one uniform result shape, so downstream
+hooks/CI/commands consume it unchanged.
+
+### Cross-cutting — INV-1
+
+**AC-9 *(deterministic, structural)* — workflow mode is propose-only; the enforcer stays read-only.**
+**Given** `harness-enforcer.agent.md`,
+**When** its frontmatter and workflow-mode section are read,
+**Then** the agent's `tools` list is **unchanged** (`Read, Glob, Grep, Bash` — no `Write`,
+no `Edit`), and the section states workflow mode **only reports**: any keep-worthy discovery
+flows through `REFLECTION_LOG.md → human curates` (INV-1), and the workflow **never writes a
+durable artefact**.
+
+---
+
+## 5. Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios in §8.
+
+- **FR-1.** `harness-enforcer.agent.md` contains a **"Workflow mode"** section. *(AC-5)*
+- **FR-2.** The section declares a **default threshold of 8** commit-scoped enforceable
+  constraints and states it is **configurable per project** via the §6-decided mechanism.
+  *(AC-5)*
+- **FR-3.** The section defines the **enforceable-constraint count** as constraints whose
+  enforcement is `deterministic`, `agent`, or `deterministic + agent`, **excluding**
+  `unverified`, and engages workflow mode only when that count is **strictly greater than**
+  the threshold. *(AC-3, AC-4)*
+- **FR-4.** The section declares the **fan-out (one verifier per rule)**, the **skeptic
+  persona**, and the **synthesis barrier that waits for all N** before reporting. *(AC-6;
+  structural shadow of AC-1)*
+- **FR-5.** The section declares the **count-equality guarantee** — verifier results ==
+  enforceable-constraint count, `unverified` excluded, **no silent drop** — in checkable
+  language. *(AC-3)*
+- **FR-6.** The section states that **≤ threshold** keeps the **existing single-context
+  behaviour** (no workflow, no extra compute). *(AC-4)*
+- **FR-7.** The section states it **adapts `enforcer-fanout.workflow.js` by relative path**
+  (ADAPT, not run verbatim) and hands the constraint inventory as input without spelling a
+  durable filename in workflow code (INV-1 / firewall). *(AC-6, AC-9)*
+- **FR-8.** The section states the **first-run REFLECTION_LOG obligation** for the
+  false-positive-reduction observation. *(AC-2 structural shadow, AC-6)*
+- **FR-9.** The section states the **Claude-Code-only runtime scope** and the **non-erroring
+  fallback** to single-context behaviour. *(AC-7)*
+- **FR-10.** The enforcer's `tools` list is **unchanged** (`Read, Glob, Grep, Bash`) and the
+  section states workflow mode is **propose-only / read-only** (INV-1). *(AC-9)*
+- **FR-11.** `skills/verification-slots/SKILL.md` documents the **fan-out slot** as a
+  first-class **agent-backed** slot whose output conforms to the existing pass/fail +
+  `{file, line, message}` contract. *(AC-8)*
+- **FR-12.** The plugin version is bumped **`0.59.0 → 0.60.0`** across all five CI-enforced
+  locations (§7.1), and the human-facing README plugin-table cell is updated. *(CI:
+  Version Check)*
+- **FR-13.** The how-to guide
+  `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` and the agents reference
+  entry are checked and updated for the new workflow mode (§7.3). *(docs-impact)*
+
+---
+
+## 6. Decisions surfaced at the GATE
+
+Per the AGENTS.md STYLE note, a recommendation is a **hypothesis for the spec-mode diaboli to
+stress**, not a default to confirm — most acutely where the slice touches a **closed contract**
+(here: a deterministic count-equality rule and a structural assertion on the agent doc). The
+three decisions below are surfaced for the human; the spec-writer recommends but does not
+silently choose.
+
+### Decision 1 — How is "configurable per project" expressed? (resolved open-question 1 mechanism)
+
+The threshold *value* is resolved at **8**. What is **not** yet decided is **how a project
+overrides it**. Three mechanisms:
+
+- **Option M1 — a documented `HARNESS.md` convention the agent reads (RECOMMENDED).** The
+  enforcer reads an optional, named field from `HARNESS.md` — e.g. a
+  `Workflow fan-out threshold: <N>` line in a `Workflow mode` block (or the existing
+  Constraints/Status preamble) — and falls back to **8** when absent. *Strength:* `HARNESS.md`
+  is already the enforcer's single source of truth (it reads constraints from there), it is a
+  **durable, human-curated** artefact (so the override is curated, consistent with INV-1 —
+  the human sets it, the workflow only reads it), and "the agent reads a documented field"
+  matches how every other per-project knob in this plugin works. No new file, no new schema.
+  *Weakness:* adds one optional convention to `HARNESS.md` that must be documented where
+  constraints are documented. *Diaboli should stress:* is a missing/garbled field handled by a
+  safe default (8) rather than an error? Does reading it risk the firewall (no — the enforcer
+  *reads* `HARNESS.md`; it is not a *workflow* spelling a durable filename in executable code,
+  so the INV-1 firewall does not apply to the agent's own read)?
+- **Option M2 — a value in `MODEL_ROUTING.md`'s workflow-election section.** S1 placed token
+  budgets and tiering there; the threshold is arguably "workflow-election policy" too.
+  *Weakness:* splits the enforcer's configuration across two durable files (constraints in
+  `HARNESS.md`, threshold in `MODEL_ROUTING.md`), and the threshold is about *this constraint
+  inventory*, which lives in `HARNESS.md`. Coupling it to the inventory's home is more
+  cohesive. *Tenable as a secondary home* if the human prefers all workflow-election policy in
+  one place.
+- **Option M3 — prose default in the agent doc only (no per-project override).** Ship **8** as
+  a hardcoded default with no override mechanism. *Rejected as the resolution:* the slicing
+  record's resolved disposition is explicitly "threshold = 8, **configurable per project**" —
+  M3 drops the configurability the human already dispositioned. Acceptable only if the human
+  *re-opens* and decides configurability is not worth a mechanism yet (then the agent doc
+  states "8, not yet configurable" honestly rather than implying a knob that does not exist).
+
+**Recommendation: M1** — a documented optional `HARNESS.md` field the agent reads, defaulting
+to 8 when absent. It keeps the enforcer's configuration in one curated place and honours the
+resolved disposition's configurability. The diaboli should confirm the missing-field default
+and that this does not smuggle the threshold into the firewall's scope.
+
+### Decision 2 — What is deterministically assertable vs agent-backed (the verification split)?
+
+The umbrella's D3 count-equality scenario is tagged *(deterministic)*, but **what is
+deterministically checkable in this repo's TDAD layers** needs care. This repo's deterministic
+layer reads files and matches structure; it does **not** spawn a live fan-out. So:
+
+- **Deterministically assertable (structural, Layer-0/1) — the declarations.** That the agent
+  doc **declares** the count-equality guarantee (AC-3), the threshold + configurability
+  (AC-5), the fan-out/skeptic/synthesis-barrier/template-adaptation (AC-6), the
+  Claude-Code-only scope + fallback (AC-7), and the read-only/propose-only boundary (AC-9);
+  and that `verification-slots/SKILL.md` documents the fan-out slot (AC-8). These are
+  file-read assertions a structural scenario checks mechanically — the **honest deterministic
+  shadow** of D3.
+- **Optionally assertable (behavioural fixture, Layer-2/3) — the counting rule.** The tdd-agent
+  *may* author a small **fixture** — a synthetic enforceable-constraint inventory (a mix of
+  `deterministic`/`agent`/`unverified`) — and assert that the *counting rule* yields
+  `enforceable count == N` with `unverified` excluded, exercising the no-silent-drop logic
+  against fixed input. This tests the **rule**, not a live fan-out.
+- **Agent-backed / behavioural only (not deterministic) — the live properties.** That a real
+  run spawns **exactly N** verifiers (AC-1) and that the skeptic **reduces false positives**
+  (AC-2) are runtime properties of an actual workflow on the Claude Code runtime. They are
+  **agent-backed**, observed at runtime, and (for AC-2) recorded once in `REFLECTION_LOG.md`.
+  They must **not** be promised as deterministic.
+
+**Recommendation:** the tdad-scenario set is **predominantly structural** (AC-3 through AC-9
+as Layer-0/1 file-read assertions), **optionally** carrying one behavioural fixture for the
+counting rule (AC-3's fixture form), with AC-1 and AC-2 standing as **declared agent-backed**
+behavioural scenarios. This is the realistic split: the repo deterministically checks *what
+the agent doc promises*, and the runtime delivers *the promise*. The diaboli should stress
+whether any property currently tagged structural actually requires a live run (it should not —
+each is a file-read), and whether the counting-rule fixture is worth the surface or whether the
+structural declaration of AC-3 suffices alone.
+
+### Decision 3 — The skeptic false-positive-reduction claim is agent-backed, not deterministic (confirm)
+
+The skeptic-persona claim — *"a documented false-positive reduction versus single-context
+enforcement is observable"* — is **inherently observational**. There is no deterministic file
+read that proves a *rate reduction*; it requires comparing real runs and is captured, the first
+time it runs, in a **`REFLECTION_LOG.md` entry** (a human-curated artefact, consistent with
+INV-1). **Confirm it is NOT over-promised as deterministic.** The deterministic surface is only
+AC-6's structural assertion that the agent doc *declares* the skeptic pass and the first-run
+REFLECTION_LOG obligation — the *effect* itself stays agent-backed/observational. The diaboli
+should reject any wording (in the agent doc or the scenarios) that implies the false-positive
+reduction is CI-checkable.
+
+### 6.1 Decision summary for the GATE
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| Threshold configurability mechanism | M1 `HARNESS.md` field / M2 `MODEL_ROUTING.md` / M3 prose-only no-override | **M1** — documented optional `HARNESS.md` field, default 8 when absent |
+| Count-equality verification split | all-deterministic / **structural-declaration + optional counting-rule fixture + agent-backed runtime** | **structural declarations are the deterministic shadow; live fan-out + skeptic stay agent-backed** |
+| Skeptic false-positive-reduction claim | deterministic / **agent-backed observational (REFLECTION_LOG, first run)** | **agent-backed only — must NOT be promised as deterministic** |
+
+---
+
+## 7. CI, version, and docs checklist
+
+### 7.1 Version bump — a behavioural change to an existing agent (minor)
+
+Adding workflow mode to `harness-enforcer` is a **behavioural addition to an existing agent**
+→ **minor bump `0.59.0 → 0.60.0`** (current version confirmed **`0.59.0`** in `plugin.json`,
+`README.md` badge + table cell, `CHANGELOG.md` top heading, and both `marketplace.json`
+`plugin_version` and the `ai-literacy-superpowers` `plugins[].version` entry). The
+`Version Check` CI enforces **five** locations (per CLAUDE.md / the live `version-check.yml`).
+Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical; `0.59.0` →
+   `0.60.0`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.60.0` (line 6; currently
+   `v0.59.0`)
+3. `CHANGELOG.md` — new top heading `## 0.60.0 — 2026-06-22`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (currently `0.59.0`; owned
+   by ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers` `plugins[].version` entry
+   (currently `0.59.0`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md` plugin-table
+row cell (`| v0.59.0 |` → `| v0.60.0 |`, line 31).
+
+> The marketplace listing `version` (`0.4.0`) does **not** change — S3 alters no listing
+> contract (no description/keyword/permission/plugins-array/source change). The component-count
+> badges (`Skills-36`, `Agents-16`, `Commands-28`) do **not** change — S3 adds no new component,
+> only modifies two existing files.
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.59\.0\|0\.59\.0' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+### 7.2 CI gates
+
+- **`spec-first-check`** — satisfied by **this spec being the first commit** on branch
+  `dynamic-workflows-s3-enforcer-fanout`. No exemption label; this is feature work.
+- **`tdad-scenario-check`** — S3 **modifies** an existing agent rather than adding a new
+  component. The gate fires on *added* components (per the TDAD-discipline spec), so it does
+  **not strictly force** a new scenario for a modification. **However**, this is a
+  **behavioural addition** and warrants a scenario. The `harness-enforcer` has **no scenario
+  directory yet** — `tdad_tests/scenarios/agents/harness-enforcer/` **does not exist**. The
+  **tdd-agent will create it** and author the structural scenarios (AC-3 through AC-9) and any
+  optional behavioural fixture (AC-3 counting-rule). Spec-writer **names** this so the tdd-agent
+  has an unambiguous home and assertion set; spec-writer does **not** create the directory or
+  any test file (spec-first discipline — no test files in this commit).
+- **`INV-1 firewall` (S2, existing)** — S3 modifies **no `*.workflow.js` template**, so the
+  firewall is **not triggered by new template content**. The enforcer's own *read* of
+  `HARNESS.md` is an agent behaviour, not a workflow spelling a durable filename in executable
+  code, so it is outside the firewall's scope. (If the tdd-agent's optional fixture is a
+  `.workflow.js`, it must itself pass the firewall — but the recommended fixture is a synthetic
+  constraint inventory, not a workflow.)
+- **`lint-markdown`** — the modified `harness-enforcer.agent.md`, `verification-slots/SKILL.md`,
+  this spec, and any touched docs page must pass markdownlint (PreToolUse hook + CI).
+- **`Choice cartographer` / objection gates** — this feature PR proceeds through the plugin's
+  own pipeline (spec → diaboli → adjudicate → plan → implement). Dispositions on any objection
+  record must be resolved before the plan-approval GATE, per the spec-first discipline.
+
+### 7.3 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Reference (`docs-reference-parity-check`) — no NEW component, so no new entry forced.**
+  S3 adds no new skill/agent/command, so the parity gate is satisfied with no new heading.
+  **But** the existing `### harness-enforcer` entry in
+  `docs/plugins/ai-literacy-superpowers/reference/agents.md` should be **updated** to mention
+  the new **workflow mode** (the threshold-gated fan-out) so the reference does not describe
+  only the single-context behaviour. This is a *consistency* update, not a parity requirement.
+- **How-to (touch-up).** The orientation guide
+  `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` currently lists
+  `enforcer-fanout.workflow.js` as a template to copy. Now that an **agent adopts it as a
+  documented mode**, add a short note that the `harness-enforcer` itself elects this template
+  above its threshold — turning the how-to from "templates you could adapt" toward "templates
+  the plugin's own agents already adapt", the dogfooding the umbrella §6 calls for.
+- **Explanation / tutorials.** None required — no existing explanation page describes the
+  enforcer's single-context behaviour as a fixed property that S3 would contradict; the
+  fan-out concept already lives in the skill's `references/patterns.md` (S1) and the
+  `enforcer-fanout` preamble (S2).
+
+---
+
+## 8. FR → acceptance-scenario mapping
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-5 | deterministic (structural) |
+| FR-2 | AC-5 | deterministic (structural) |
+| FR-3 | AC-3, AC-4 | deterministic (structural) |
+| FR-4 | AC-6 (structural shadow of AC-1) | deterministic (structural) / agent-backed (AC-1) |
+| FR-5 | AC-3 | deterministic (structural) + optional counting-rule fixture |
+| FR-6 | AC-4 | deterministic (structural) |
+| FR-7 | AC-6, AC-9 | deterministic (structural) |
+| FR-8 | AC-6 (and AC-2 structural shadow) | deterministic (structural) / agent-backed (AC-2 effect) |
+| FR-9 | AC-7 | deterministic (structural) |
+| FR-10 | AC-9 | deterministic (structural) |
+| FR-11 | AC-8 | deterministic (structural) |
+| FR-12 | (CI: Version Check) | deterministic |
+| FR-13 | (docs-impact; reference + how-to touch-up) | deterministic (presence) |
+
+**Agent-backed runtime scenarios** (not deterministic; see §6 decisions 2 and 3):
+
+- **AC-1** — exactly N verifiers + all-N synthesis barrier — runtime/behavioural; structural
+  shadow is AC-6/FR-4.
+- **AC-2** — skeptic false-positive reduction, recorded once in `REFLECTION_LOG.md` — agent-
+  backed / observational; structural shadow is AC-6/FR-8. **Not** over-promised as
+  deterministic (§6 decision 3).
+
+---
+
+## 9. Risks and open questions
+
+**Risks.**
+
+- *Threshold mis-set burns or under-protects compute.* Too low burns compute fanning out on
+  small harnesses; too high reinstates the lazy-stop risk. Mitigation: default **8** with a
+  documented per-project override (§6 decision 1); the `>` (strict) trigger keeps exactly-8
+  on the cheap path.
+- *Over-promising determinism.* The temptation is to tag the count-equality and skeptic
+  scenarios as fully CI-checkable. Mitigation: §6 decisions 2 and 3 fix the honest split —
+  structural *declarations* are deterministic; live fan-out and false-positive reduction are
+  agent-backed. The diaboli should reject any wording that overclaims.
+- *Firewall scope confusion.* The threshold-config mechanism (M1) has the enforcer **read**
+  `HARNESS.md`; a careless reading could think this trips the INV-1 firewall. Mitigation:
+  the firewall scopes to **`*.workflow.js` templates spelling a durable filename in executable
+  code**, not to an agent reading its own source of truth. S3 edits no template.
+- *Scenario-home omission.* `harness-enforcer` has no scenario directory; a behavioural
+  addition without one leaves the new mode unverified. Mitigation: §7.2 names the directory
+  the tdd-agent must create and the structural assertion set it must carry.
+- *Template drift.* The agent points at `enforcer-fanout.workflow.js` whose runtime call
+  shapes may drift from the authoritative docs. Mitigation: the agent ADAPTs the template and
+  defers function names to <https://code.claude.com/docs/en/workflows>; S3 does not freeze a
+  call signature.
+
+**Open questions.** None block S3. The umbrella open questions ride later slices (Q2 routing
+→ S5, Q3 staging → S6, Q4 Copilot → S7) and are out of scope (§2.2). **Open-question 1 (the
+threshold) is resolved at 8**; the only S3-internal decision is **how** "configurable per
+project" is expressed (§6 decision 1) — **surfaced for the GATE, not left open**: the spec
+recommends M1 and the human disposes.
+
+---
+
+## 10. References
+
+- Umbrella spec:
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+  (read-first runtime-scope note; §2 INV-1/INV-2; **D3**; §5; §6; §7 open-question 1).
+- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md`
+  (Runtime-scope section; **S3** entry — threshold = 8, configurable per project).
+- S1 spec (merged):
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md`.
+- S2 spec (merged):
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s2-templates-design.md`.
+- Shipped substrate S3 adapts:
+  - `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md` (the template-library table
+    naming `enforcer-fanout.workflow.js`).
+  - `ai-literacy-superpowers/skills/dynamic-workflows/workflows/enforcer-fanout.workflow.js`
+    (the `Verify → Skeptic → Synthesize` template, its synthesis barrier, and its
+    `checked`/`confirmed` accounting — the pattern S3 wires the enforcer to).
+  - `ai-literacy-superpowers/scripts/inv-firewall.sh` (the INV-1/INV-2 deterministic firewall;
+    untouched by S3).
+- Target files S3 modifies:
+  - `ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+  - `ai-literacy-superpowers/skills/verification-slots/SKILL.md`.
+- Runtime API (authoritative): <https://code.claude.com/docs/en/workflows>.
+- AGENTS.md decisions consulted: the "recommended option is a hypothesis for the diaboli"
+  STYLE note (closed-contract pre-listing); "a consumer never mutates the contract it
+  consumes" (S3 adapts but does not edit `enforcer-fanout.workflow.js`).

--- a/tdad_tests/scenarios/agents/harness-enforcer/below-threshold-keeps-single-context.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/below-threshold-keeps-single-context.md
@@ -1,0 +1,52 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: ≤ 8 enforceable constraints keep the existing single-context path (AC-4 / FR-6)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+
+## When
+
+The workflow-mode section is read.
+
+## Then
+
+- The section states that with **≤ 8** enforceable constraints — at or
+  below the threshold — the enforcer keeps its **existing single-context
+  behaviour**.
+- The section states that on the below-threshold path **no workflow is
+  authored, no verifier subagents are spawned, and no extra compute is
+  spent** (the default path is untouched — over-orchestration on small
+  harnesses is a regression, umbrella §6).
+- The section makes the boundary unambiguous via the strict `>` trigger:
+  **exactly 8 stays single-context** (the phrase "single-context" or
+  "single context" appears in the below-threshold description).
+
+## Rubric
+
+Deterministic structural assertion (AC-4). The default path for small
+`HARNESS.md` files must be preserved and *declared* as preserved, so a
+reader and a CI check can both confirm the cheap path is intact. The
+load-bearing specifics:
+
+- The "≤ 8 / at-or-below keeps single-context" statement is present.
+- The "no workflow / no fan-out / no extra compute" guarantee is present
+  — this is the compute-discipline promise that distinguishes S3 from
+  blanket orchestration.
+
+The behavioural truth (an actual below-threshold run spends no extra
+compute) is agent-backed; the deterministic surface is that the agent doc
+*declares* the cheap path is kept.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`. RED now: there is no
+workflow-mode section, so no below-threshold single-context preservation
+statement exists in the agent doc.

--- a/tdad_tests/scenarios/agents/harness-enforcer/declares-claude-code-scope-and-fallback.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/declares-claude-code-scope-and-fallback.md
@@ -1,0 +1,49 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: Claude-Code-only runtime scope and non-erroring fallback are declared (AC-7 / FR-9)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+
+## When
+
+The workflow-mode section is read.
+
+## Then
+
+- The section states workflow mode **requires the Claude Code runtime**
+  (the phrase "Claude Code" appears tied to the runtime requirement).
+- The section states that on a tree **without** the runtime (e.g. GitHub
+  Copilot CLI or any other coding agent) the enforcer **falls back to its
+  existing single-context behaviour** (the phrase "falls back" / "fall
+  back" tied to "single-context" appears).
+- The section states the fallback **never errors** and the enforcer does
+  **not pretend to fan out** where the runtime is absent (the phrase
+  "never error" / "never errors" appears).
+
+## Rubric
+
+Deterministic structural assertion (AC-7), grounded in the umbrella §5.5
+runtime-scope note and the slicing-record "Runtime scope — Claude Code
+only" section. The plugin ships to multiple trees; the workflow mode is
+Claude-Code-gated, and the absence of the runtime must degrade gracefully
+to the existing static behaviour, never to an error.
+
+Note the boundary: S3 restates the Claude-Code-only nature for the
+enforcer's *own* behaviour. It does **not** decide the precise Copilot
+degradation *contract* (guidance-only vs omit) — that is open-question 4,
+owned by S7. The check asserts only the non-erroring single-context
+fallback, not any S7 contract specifics.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`. RED now: no workflow-mode
+section exists, so the Claude-Code-only requirement and the non-erroring
+single-context fallback are absent from the agent doc.

--- a/tdad_tests/scenarios/agents/harness-enforcer/declares-count-equality-no-silent-drop.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/declares-count-equality-no-silent-drop.md
@@ -1,0 +1,73 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+fixture: enforceable-constraint-inventory
+---
+
+# Scenario: the count-equality guarantee is declared — no silent drop (AC-3 / FR-3, FR-5)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`, and (for the
+optional counting-rule fixture) a small synthetic
+enforceable-constraint inventory mixing `deterministic`, `agent`, and
+`unverified` enforcement values.
+
+## When
+
+The workflow-mode section is read (structural); and the counting rule it
+declares is applied to the fixture inventory (optional behavioural-fixture
+form).
+
+## Then
+
+**Structural (deterministic, the primary assertion):**
+
+- The section declares the **count-equality guarantee in checkable
+  language**: when the enforcer reports **"all constraints checked"**, the
+  count of **verifier results equals the count of enforceable
+  constraints** (the phrase "all constraints checked" and a
+  results-equal-enforceable statement both appear).
+- The section defines the **enforceable count** as constraints whose
+  enforcement is `deterministic`, `agent`, or `deterministic + agent`,
+  and **explicitly excludes `unverified`** constraints (they are skipped,
+  not checked — the word "unverified" and "exclud"/"excluded" appear
+  together).
+- The section states **no enforceable constraint is silently dropped**
+  (the phrase "no silent drop" / "silently drop" appears) — the all-N
+  synthesis barrier makes the "35 of 50 checked" lazy stop structurally
+  impossible.
+
+**Optional counting-rule fixture (behavioural — exercises the rule, not a
+live fan-out):**
+
+- Given the fixture inventory with `D` deterministic + `A` agent +
+  `U` unverified constraints, the declared counting rule yields
+  **enforceable count `== D + A`** (the `U` unverified are excluded), and
+  the asserted relation `len(results) == len(enforceable)` holds against
+  that fixed input.
+
+## Rubric
+
+Per §6 decision 2, the *runtime* count-equality is agent-backed; what is
+**deterministically assertable in this repo's TDAD layers** is that the
+**guarantee is declared**. The primary assertion is structural (a file
+read). The fixture form is *optional* and tests the **counting rule** on
+fixed synthetic input — it does **not** spawn a real fan-out and must not
+be read as doing so.
+
+The check must reject any wording that promises the *runtime* equality is
+CI-proven on live input — the deterministic surface is the declaration and
+the counting rule, not the fan-out itself.
+
+## Evaluation
+
+The structural half is evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py` (file-read phrase
+assertions). RED now: no "all constraints checked" count-equality
+guarantee, no `unverified`-excluded definition, and no "no silent drop"
+statement exist in the agent doc. The optional fixture is a synthetic
+inventory the implementer may add under `fixtures/`; it is not required
+for the scenario to be RED — the structural declaration alone is RED.

--- a/tdad_tests/scenarios/agents/harness-enforcer/declares-fanout-skeptic-synthesis-shape.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/declares-fanout-skeptic-synthesis-shape.md
@@ -1,0 +1,71 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the fan-out + skeptic + synthesis-barrier + template adaptation are declared (AC-6 / FR-4, FR-7, FR-8)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+
+## When
+
+The workflow-mode section is read.
+
+## Then
+
+The section declares **all** of the following (this is the structural
+shadow of the runtime AC-1 fan-out behaviour):
+
+- **Fan-out, one verifier per rule** — one verifier subagent **per
+  HARNESS.md rule**, each in its own clean context window (the phrase
+  "one verifier per rule" / "per rule" / "per HARNESS.md rule" appears).
+- **Skeptic persona** — a skeptic persona that **adversarially reviews
+  each candidate violation** to suppress false positives (the word
+  "skeptic" appears).
+- **Synthesis barrier waiting for all N** — a synthesis barrier that waits
+  for **all N** verifier results before any report can form, with no
+  "good enough" early stop (the phrase "synthesis barrier" and "all N" /
+  "all-N" appear).
+- **Template adaptation by relative path** — the section references
+  `enforcer-fanout.workflow.js` **by relative path** and states the
+  enforcer **ADAPTs** it per run (prompts, per-role model tiers, token
+  budget) rather than running it verbatim (the words "adapt"/"ADAPT" and
+  the relative path containing `enforcer-fanout.workflow.js` both appear,
+  with the path being a relative reference under the
+  `dynamic-workflows` skill, not a bare filename).
+- **First-run REFLECTION_LOG obligation** — the skeptic
+  false-positive-reduction observation is recorded once in
+  `REFLECTION_LOG.md` on first run (the phrase "REFLECTION_LOG" and
+  "first run" / "first time" appear together with the skeptic claim).
+
+## Rubric
+
+Deterministic structural assertion (AC-6) — the honest deterministic
+shadow of the runtime fan-out (AC-1) and the skeptic effect (AC-2). What a
+file read can verify is that the agent doc *declares* the fan-out shape,
+the skeptic pass, the all-N synthesis barrier, the ADAPT-by-relative-path
+relationship to the S2 template, and the first-run REFLECTION_LOG
+obligation. It cannot verify a live run spawns exactly N verifiers — that
+is AC-1, agent-backed.
+
+Two boundary conditions the check must honour:
+
+- The template reference must be a **relative path** (ADAPT, not edit) —
+  consistent with the AGENTS.md "a consumer never mutates the contract it
+  consumes" decision; S3 points at but never edits the S2 template.
+- The first-run REFLECTION_LOG obligation must be stated as the route the
+  *observation* takes — it must **not** be phrased as a deterministic
+  guarantee that a false-positive reduction is CI-checkable (§6 decision
+  3). The reduction itself stays agent-backed/observational.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`. RED now: the agent doc has
+no workflow-mode section and never mentions "skeptic", "synthesis
+barrier", "enforcer-fanout.workflow.js", or the first-run REFLECTION_LOG
+obligation.

--- a/tdad_tests/scenarios/agents/harness-enforcer/declares-first-run-reflection-log-obligation.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/declares-first-run-reflection-log-obligation.md
@@ -1,0 +1,57 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the first-run REFLECTION_LOG obligation is declared, and the skeptic claim is NOT over-promised as deterministic (AC-2 declaration / FR-8)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+
+## When
+
+The workflow-mode section is read.
+
+## Then
+
+- The section states the skeptic persona's **false-positive reduction**
+  versus single-context enforcement is captured **once**, the **first time
+  workflow mode runs**, as a **`REFLECTION_LOG.md` entry** — a
+  human-curated artefact, **not written by the workflow** (the phrases
+  "REFLECTION_LOG", "first run" / "first time", and "skeptic" /
+  "false positive" co-occur in the section).
+- The claim is phrased as **observational / agent-backed** — the section
+  does **not** assert the false-positive reduction is deterministic,
+  CI-checkable, or guaranteed. Wording such as "deterministic
+  false-positive reduction" or "CI verifies the reduction" must be
+  **absent** (§6 decision 3).
+
+## Rubric
+
+This is the structural *declaration* of AC-2. The deterministic surface is
+narrow and the spec is emphatic about its limit (§6 decision 3): a file
+read can verify only that the agent doc *declares* the skeptic pass and
+the first-run REFLECTION_LOG obligation. The *effect* — an actual
+false-positive rate reduction — is inherently observational and stays
+agent-backed; no deterministic file read proves a rate reduction.
+
+The check is therefore two-sided:
+
+- **Presence:** the first-run REFLECTION_LOG obligation tied to the
+  skeptic observation is declared.
+- **Absence:** no wording over-promises the reduction as deterministic /
+  CI-checkable. This guards the §9 "over-promising determinism" risk —
+  the diaboli rejects any phrasing that implies the reduction is
+  CI-proven.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py` (a presence assertion on the
+first-run REFLECTION_LOG phrasing plus a negative assertion that no
+over-promising determinism phrase appears). RED now: the agent doc has no
+workflow-mode section, so the first-run REFLECTION_LOG obligation is
+entirely absent.

--- a/tdad_tests/scenarios/agents/harness-enforcer/declares-threshold-and-configurability.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/declares-threshold-and-configurability.md
@@ -1,0 +1,61 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares the default-8 threshold and per-project configurability (AC-5 / FR-1, FR-2)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- A section titled **`Workflow mode`** (a level-2 or level-3 heading
+  containing the phrase "Workflow mode") is present.
+- The section declares a **default threshold of `8`** commit-scoped
+  enforceable constraints — the literal value `8` appears alongside the
+  word "threshold".
+- The section states the threshold is **configurable per project** via an
+  **optional `HARNESS.md` field the enforcer reads** (the §6 decision-1
+  M1 mechanism, named explicitly — not left as "somehow configurable").
+- The section states that when the field is **absent the default is `8`**
+  (missing/garbled field falls back to 8 rather than erroring).
+- The trigger is a **strict `>`** (greater-than) comparison: workflow mode
+  engages only when the enforceable-constraint count **exceeds** the
+  threshold — the section uses "exceeds", "greater than", or the `>`
+  symbol, not "≥" or "at least".
+
+## Rubric
+
+This is the deterministic structural shadow of AC-5 (umbrella D3). What is
+checkable from a static file read is that the agent doc *declares* the
+threshold and its configurability mechanism — not that a live run honours
+it (that is the agent-backed property AC-1 shadows). The load-bearing
+specifics a deterministic check verifies:
+
+- The literal default value `8` is present and tied to the threshold.
+- The configurability mechanism is **named** — an optional `HARNESS.md`
+  field — so a reviewer can see *how* a project overrides it, not merely
+  that it is "configurable".
+- The absent → 8 default is stated, because a missing-field error would
+  be a regression (§9 risk: garbled field must safe-default).
+- The strict `>` trigger is stated, because exactly-8 must stay on the
+  cheap single-context path (the AC-4 boundary).
+
+The scenario must **not** be read as asserting any live threshold read
+occurs — only that the contract is declared in checkable language.
+
+## Evaluation
+
+This scenario is evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`, which reads the target file
+and asserts the phrases above are present. It is RED now because the agent
+doc contains no "Workflow mode" section (`grep -n "Workflow mode"` returns
+nothing), so none of the threshold/configurability phrases exist yet.

--- a/tdad_tests/scenarios/agents/harness-enforcer/runtime-skeptic-reduces-false-positives.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/runtime-skeptic-reduces-false-positives.md
@@ -1,0 +1,45 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: behavioural
+---
+
+# Scenario: the skeptic persona reduces false positives, recorded once (AC-2, agent-backed / observational)
+
+## Given
+
+A candidate violation flagged by a verifier subagent during a live
+workflow-mode run on the Claude Code runtime.
+
+## When
+
+The skeptic persona adversarially reviews the candidate.
+
+## Then
+
+- A **false-positive reduction versus single-context enforcement is
+  observable** across real runs.
+- The **first time** workflow mode runs, the observation is captured in a
+  **`REFLECTION_LOG.md` entry** — a human-curated artefact, **not written
+  by the workflow**.
+
+## Rubric
+
+Inherently **observational / agent-backed** (§6 decision 3): there is no
+deterministic file read that proves a *rate reduction* — it requires
+comparing real runs. Its **structural shadow** is
+`declares-first-run-reflection-log-obligation.md` (AC-2 declaration /
+FR-8), which asserts the agent doc *declares* the skeptic pass and the
+first-run REFLECTION_LOG obligation.
+
+This claim must **not** be over-promised as deterministic anywhere — not
+in the agent doc and not in this scenario. The deterministic surface is
+only the *declaration*; the effect itself stays observational.
+
+## Status
+
+**Declared, not wired** as a deterministic check — not part of the
+Layer-0/1 RED set. It stands as the agent-backed runtime promise whose
+deterministic shadow is the first-run REFLECTION_LOG declaration. Any
+wording (here or in the agent doc) implying the false-positive reduction
+is CI-checkable is to be rejected.

--- a/tdad_tests/scenarios/agents/harness-enforcer/runtime-spawns-n-verifiers-behind-barrier.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/runtime-spawns-n-verifiers-behind-barrier.md
@@ -1,0 +1,45 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: behavioural
+fixture: enforceable-constraint-inventory
+---
+
+# Scenario: N>8 enforceable constraints spawn exactly N verifiers behind a synthesis barrier (AC-1, agent-backed)
+
+## Given
+
+A `HARNESS.md` with **N > 8** commit-scoped **enforceable** constraints
+and the **Claude Code runtime present**.
+
+## When
+
+The enforcer runs in workflow mode against that harness.
+
+## Then
+
+- Exactly **N** verifier subagents are spawned, **one per rule**.
+- The **synthesis barrier waits for all N** results before any report is
+  produced — no report can form from a partial set.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-fanout-skeptic-synthesis-shape.md` (AC-6), which asserts the
+agent doc *declares* the per-rule fan-out and the all-N synthesis barrier.
+
+A judge evaluating a live run confirms (a) the verifier count equals the
+enforceable-constraint count and (b) no report is emitted before all N
+return. This requires the Claude Code workflow runtime; it cannot be run
+on a tree without it (where the enforcer falls back to single-context —
+see AC-7).
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadows (AC-5/AC-6) declare. It must **not** be promised as
+CI-checkable.

--- a/tdad_tests/scenarios/agents/harness-enforcer/stays-read-only-propose-only.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/stays-read-only-propose-only.md
@@ -1,0 +1,60 @@
+---
+component: harness-enforcer
+component_type: agent
+tier: structural
+---
+
+# Scenario: workflow mode is propose-only; the enforcer stays read-only (AC-9 / FR-10, INV-1)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-enforcer.agent.md` — both its
+frontmatter and its workflow-mode section.
+
+## When
+
+The frontmatter `tools` list and the workflow-mode section are read.
+
+## Then
+
+- The frontmatter `tools` list is **unchanged**: it contains exactly
+  `Read`, `Glob`, `Grep`, `Bash` — and **no `Write`** and **no `Edit`**.
+  (The literal `tools: ["Read", "Glob", "Grep", "Bash"]` is the current
+  state; adding workflow mode must not widen it.)
+- The workflow-mode section states workflow mode is **read-and-report
+  only** / **propose-only**: the enforcer reads and reports, and any
+  keep-worthy discovery flows through the human-curation gate
+  `REFLECTION_LOG.md → human curates` (INV-1).
+- The section states the workflow **never writes a durable artefact**
+  (the phrase "never writes" / "does not write" tied to "durable
+  artefact" appears) — the §D3 false-positive-reduction observation is
+  recorded via the curation gate, not written by the workflow.
+
+## Rubric
+
+Deterministic structural assertion of the cross-cutting INV-1 boundary
+(AC-9). Two surfaces are checked:
+
+- **Frontmatter `tools`** — a hard, exact check: the set must remain
+  `{Read, Glob, Grep, Bash}` with no write capability. This is the
+  load-bearing INV-1 enforcement at the agent level: a read-only tool set
+  makes a durable write impossible regardless of prose.
+- **Prose** — the section must *declare* the propose-only boundary and the
+  human-curation flow, so the contract is legible, not merely implied by
+  the absent `Write` tool.
+
+The firewall scope note (§9): the enforcer *reading* `HARNESS.md` (for
+its threshold field) is an agent behaviour, not a `*.workflow.js` template
+spelling a durable filename in executable code — so it is outside the
+INV-1 firewall's scope and does not contradict the read-only boundary.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`. The `tools` exact-set
+check passes today (the list is already correct) — but the prose
+propose-only / "never writes a durable artefact" declaration is **absent**
+(no workflow-mode section), so the scenario as a whole is RED until the
+section is authored. This is RED for the right reason: the missing
+declaration, not a malformed tools list.

--- a/tdad_tests/scenarios/agents/harness-enforcer/verification-slots-documents-fanout-slot.md
+++ b/tdad_tests/scenarios/agents/harness-enforcer/verification-slots-documents-fanout-slot.md
@@ -1,0 +1,59 @@
+---
+component: verification-slots
+component_type: skill
+tier: structural
+---
+
+# Scenario: the fan-out slot is documented as a first-class agent-backed slot (AC-8 / FR-11)
+
+## Given
+
+The file
+`ai-literacy-superpowers/skills/verification-slots/SKILL.md`.
+
+## When
+
+The skill's slot documentation is read.
+
+## Then
+
+- The SKILL.md documents a **fan-out slot** as a **first-class,
+  agent-backed** verification slot (the phrase "fan-out" / "fan out"
+  appears in a slot description, and it is named agent-backed).
+- The fan-out slot is described as **one verifier per rule + a skeptic**
+  (the phrases "one verifier per rule" / "per rule" and "skeptic" appear).
+- The fan-out slot is placed **alongside the existing
+  deterministic / agent / deterministic + agent / unverified rows** — it
+  takes its place in the enforcement table / slot list rather than being
+  documented in isolation.
+- The SKILL.md states the slot's output **conforms to the same pass/fail +
+  `{file, line, message}` contract** as the existing slots — the synthesis
+  barrier reconciles N verifier results into the **one uniform result
+  shape**, so downstream hooks/CI/commands consume it unchanged (the
+  phrase "pass/fail" and the `{file, line, message}` finding shape appear
+  tied to the fan-out slot).
+
+## Rubric
+
+Deterministic structural assertion (AC-8 / FR-11). The decisive property
+is that the fan-out slot is **not** a new contract — its result shape is
+identical to every existing slot, so the rest of the system (hooks, CI,
+commands) is untouched. The check verifies both that the slot is
+documented as a first-class peer of the existing rows and that its output
+contract is explicitly stated as the same `pass/fail + {file, line,
+message}` shape.
+
+This is the only S3 scenario targeting `verification-slots` rather than
+the agent doc; it is grouped under the `harness-enforcer/` scenario home
+because S3's two modified files are a single behavioural change, but it
+correctly resolves against `component: verification-slots`,
+`component_type: skill`.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s3_enforcer_fanout_structural.py`, which reads
+`skills/verification-slots/SKILL.md`. RED now: the SKILL.md's enforcement
+table lists only `deterministic`, `agent`, `deterministic + agent`, and
+`unverified` rows; it contains no "fan-out" slot and never mentions
+"skeptic" or "synthesis barrier".

--- a/tdad_tests/tests/test_s3_enforcer_fanout_structural.py
+++ b/tdad_tests/tests/test_s3_enforcer_fanout_structural.py
@@ -94,11 +94,12 @@ class TestS3WorkflowModeDeclared:
         self, plugin_path: Path
     ) -> None:
         section = _agent_workflow_section(plugin_path)
-        assert "harness.md" in section and (
-            "configur" in section
+        assert "harness.md" in section and "configur" in section and (
+            "fan-out-threshold" in section
         ), (
             "Workflow-mode section must state the threshold is "
-            "configurable per project via an optional HARNESS.md field "
+            "configurable per project via the optional HARNESS.md "
+            "`fan-out-threshold` field, named explicitly "
             "(AC-5 / FR-2, §6 decision M1)."
         )
 
@@ -178,11 +179,14 @@ class TestS3WorkflowModeDeclared:
         self, plugin_path: Path
     ) -> None:
         section = _agent_workflow_section(plugin_path)
-        assert "all constraints checked" in section, (
+        assert "all constraints checked" in section and (
+            "verifier results" in section
+        ) and "equal" in section, (
             "Workflow-mode section must declare the count-equality "
             "guarantee in checkable language: when it reports 'all "
-            "constraints checked', verifier results == enforceable count "
-            "(AC-3 / FR-5)."
+            "constraints checked', the count of verifier results must "
+            "equal the enforceable count (AC-3 / FR-5) — assert the "
+            "equality clause, not just the trigger phrase."
         )
 
     def test_declares_unverified_excluded_from_count(

--- a/tdad_tests/tests/test_s3_enforcer_fanout_structural.py
+++ b/tdad_tests/tests/test_s3_enforcer_fanout_structural.py
@@ -1,0 +1,326 @@
+"""Layer 1 structural content checks for dynamic-workflows S3.
+
+These tests are the *deterministic mechanism* behind the structural
+scenarios authored at
+``scenarios/agents/harness-enforcer/`` for slice S3 (the harness-enforcer
+fan-out upgrade). Each test reads a target file
+(``agents/harness-enforcer.agent.md`` or
+``skills/verification-slots/SKILL.md``) and asserts that the declarations
+the scenarios promise are present in checkable language.
+
+Per the spec's §6 decision 2 (the verification split), this repo's
+deterministic layer reads files and matches structure — it does **not**
+spawn a live fan-out. So what is deterministically asserted here is that
+the agent doc **declares** the workflow-mode contract (threshold,
+configurability, fan-out/skeptic/synthesis-barrier, count-equality,
+Claude-Code-only scope, read-only boundary) and that ``verification-slots``
+documents the fan-out slot. The live properties (AC-1 exactly-N verifiers,
+AC-2 false-positive reduction) are agent-backed and live as ``behavioural``
+scenarios, not wired here.
+
+RED state (before S3 implements): ``agents/harness-enforcer.agent.md`` has
+no "Workflow mode" section and ``verification-slots/SKILL.md`` has no
+fan-out slot, so every assertion below fails on a missing declaration —
+RED for the right reason (missing content, not a malformed scenario or an
+unresolvable component).
+
+Spec: docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+def _agent_text(plugin_path: Path) -> str:
+    component = plugin_runner.find_component(
+        plugin_path, name="harness-enforcer", component_type="agent"
+    )
+    return component.path.read_text(encoding="utf-8")
+
+
+def _agent_workflow_section(plugin_path: Path) -> str:
+    """Return the text from the 'Workflow mode' heading to the next
+    same-or-higher-level heading, lowercased. Empty string if absent."""
+    text = _agent_text(plugin_path)
+    m = re.search(r"^(#{2,4})\s+.*workflow mode.*$", text, re.IGNORECASE | re.MULTILINE)
+    if not m:
+        return ""
+    level = len(m.group(1))
+    start = m.end()
+    # Find the next heading at the same or higher level.
+    rest = text[start:]
+    nxt = re.search(rf"^#{{1,{level}}}\s+\S", rest, re.MULTILINE)
+    end = nxt.start() if nxt else len(rest)
+    return rest[:end].lower()
+
+
+def _skill_text(plugin_path: Path) -> str:
+    component = plugin_runner.find_component(
+        plugin_path, name="verification-slots", component_type="skill"
+    )
+    return component.path.read_text(encoding="utf-8").lower()
+
+
+@pytest.mark.structural
+class TestS3WorkflowModeDeclared:
+    """Structural shadows of D3 — the agent doc must *declare* the
+    workflow-mode contract (scenarios under
+    ``scenarios/agents/harness-enforcer/``)."""
+
+    def test_workflow_mode_section_exists(self, plugin_path: Path) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert section, (
+            "harness-enforcer.agent.md must contain a 'Workflow mode' "
+            "section (AC-5 / FR-1). None found."
+        )
+
+    def test_declares_default_8_threshold(self, plugin_path: Path) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "threshold" in section and "8" in section, (
+            "Workflow-mode section must declare a default threshold of 8 "
+            "(AC-5 / FR-2)."
+        )
+
+    def test_declares_configurable_via_harness_field(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "harness.md" in section and (
+            "configur" in section
+        ), (
+            "Workflow-mode section must state the threshold is "
+            "configurable per project via an optional HARNESS.md field "
+            "(AC-5 / FR-2, §6 decision M1)."
+        )
+
+    def test_declares_absent_field_defaults_to_8(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "absent" in section or "default" in section, (
+            "Workflow-mode section must state the field defaults to 8 when "
+            "absent (AC-5 / §9 safe-default risk)."
+        )
+
+    def test_declares_strict_greater_than_trigger(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "exceed" in section or "greater than" in section or ">" in section, (
+            "Workflow-mode section must declare a strict > trigger — "
+            "exactly 8 stays single-context (AC-4)."
+        )
+
+    def test_declares_below_threshold_single_context(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "single-context" in section or "single context" in section, (
+            "Workflow-mode section must state ≤ threshold keeps the "
+            "existing single-context behaviour (AC-4 / FR-6)."
+        )
+
+    def test_declares_no_extra_compute_below_threshold(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "no workflow" in section or "no extra compute" in section or (
+            "no verifier" in section
+        ), (
+            "Workflow-mode section must state the below-threshold path "
+            "spends no extra compute / authors no workflow (AC-4 / FR-6)."
+        )
+
+    def test_declares_fanout_one_verifier_per_rule(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "per rule" in section or "per harness.md rule" in section, (
+            "Workflow-mode section must declare fan-out: one verifier per "
+            "rule (AC-6 / FR-4)."
+        )
+
+    def test_declares_skeptic_persona(self, plugin_path: Path) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "skeptic" in section, (
+            "Workflow-mode section must declare the skeptic persona "
+            "(AC-6 / FR-4)."
+        )
+
+    def test_declares_synthesis_barrier_all_n(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "synthesis barrier" in section and "all n" in section, (
+            "Workflow-mode section must declare a synthesis barrier that "
+            "waits for all N before reporting (AC-6 / FR-4)."
+        )
+
+    def test_declares_adapts_template_by_relative_path(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "enforcer-fanout.workflow.js" in section and "adapt" in section, (
+            "Workflow-mode section must state it ADAPTs "
+            "enforcer-fanout.workflow.js by relative path (AC-6 / FR-7)."
+        )
+
+    def test_declares_count_equality_guarantee(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "all constraints checked" in section, (
+            "Workflow-mode section must declare the count-equality "
+            "guarantee in checkable language: when it reports 'all "
+            "constraints checked', verifier results == enforceable count "
+            "(AC-3 / FR-5)."
+        )
+
+    def test_declares_unverified_excluded_from_count(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "unverified" in section and "exclud" in section, (
+            "Workflow-mode section must define the enforceable count as "
+            "excluding `unverified` constraints (AC-3 / FR-3)."
+        )
+
+    def test_declares_no_silent_drop(self, plugin_path: Path) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "silent" in section and "drop" in section, (
+            "Workflow-mode section must state no enforceable constraint is "
+            "silently dropped (AC-3 / FR-5)."
+        )
+
+    def test_declares_first_run_reflection_log(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "reflection_log" in section and (
+            "first run" in section or "first time" in section
+        ), (
+            "Workflow-mode section must declare the first-run "
+            "REFLECTION_LOG obligation for the skeptic observation "
+            "(AC-2 declaration / FR-8)."
+        )
+
+    def test_does_not_overpromise_deterministic_reduction(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        forbidden = [
+            "deterministic false-positive",
+            "deterministic false positive",
+            "ci-checkable false-positive",
+            "ci verifies the reduction",
+        ]
+        hit = [p for p in forbidden if p in section]
+        assert not hit, (
+            "The skeptic false-positive reduction must NOT be promised as "
+            f"deterministic / CI-checkable (§6 decision 3). Found: {hit}"
+        )
+
+    def test_declares_claude_code_runtime_requirement(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "claude code" in section, (
+            "Workflow-mode section must state workflow mode requires the "
+            "Claude Code runtime (AC-7 / FR-9)."
+        )
+
+    def test_declares_non_erroring_fallback(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert ("fall back" in section or "falls back" in section) and (
+            "never error" in section
+        ), (
+            "Workflow-mode section must state the enforcer falls back to "
+            "single-context behaviour and never errors where the runtime "
+            "is absent (AC-7 / FR-9)."
+        )
+
+    def test_declares_propose_only_never_writes_durable(
+        self, plugin_path: Path
+    ) -> None:
+        section = _agent_workflow_section(plugin_path)
+        assert "durable artefact" in section and (
+            "never write" in section or "does not write" in section or (
+                "propose-only" in section
+            ) or "read-only" in section or "read and report" in section
+        ), (
+            "Workflow-mode section must state workflow mode is "
+            "propose-only / read-only and never writes a durable artefact "
+            "(AC-9 / FR-10 / INV-1)."
+        )
+
+
+@pytest.mark.structural
+class TestS3ReadOnlyToolSet:
+    """AC-9 / FR-10: the enforcer's tool set must stay read-only — the
+    INV-1 enforcement at the agent level. This check is GREEN today (the
+    list is already correct) and must STAY green through S3."""
+
+    def test_tools_unchanged_no_write_no_edit(
+        self, plugin_path: Path
+    ) -> None:
+        component = plugin_runner.find_component(
+            plugin_path, name="harness-enforcer", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert "Write" not in tools and "Edit" not in tools, (
+            f"harness-enforcer must stay read-only (INV-1, AC-9); tools "
+            f"must not include Write/Edit. Got {tools!r}"
+        )
+        for required in ("Read", "Glob", "Grep", "Bash"):
+            assert required in tools, (
+                f"harness-enforcer tools must retain {required!r}; "
+                f"got {tools!r}"
+            )
+
+
+@pytest.mark.structural
+class TestS3VerificationSlotsFanoutSlot:
+    """AC-8 / FR-11: verification-slots/SKILL.md must document the fan-out
+    slot as a first-class agent-backed slot with the uniform contract."""
+
+    def test_documents_fanout_slot(self, plugin_path: Path) -> None:
+        text = _skill_text(plugin_path)
+        assert "fan-out" in text or "fan out" in text, (
+            "verification-slots/SKILL.md must document the fan-out slot "
+            "(AC-8 / FR-11)."
+        )
+
+    def test_fanout_slot_names_verifier_per_rule_and_skeptic(
+        self, plugin_path: Path
+    ) -> None:
+        text = _skill_text(plugin_path)
+        assert "per rule" in text and "skeptic" in text, (
+            "The fan-out slot must be described as one verifier per rule "
+            "plus a skeptic (AC-8 / FR-11)."
+        )
+
+    def test_fanout_slot_uniform_contract(self, plugin_path: Path) -> None:
+        text = _skill_text(plugin_path)
+        # The uniform result shape: pass/fail + {file, line, message}. The
+        # existing SKILL already states pass/fail + the finding shape, so
+        # the load-bearing new assertion is that the fan-out slot is tied
+        # to it. We require the fan-out term to co-occur with the contract.
+        assert ("fan-out" in text or "fan out" in text) and (
+            "synthesis barrier" in text
+        ) and "pass/fail" in text, (
+            "The fan-out slot must state its output conforms to the same "
+            "pass/fail + {file, line, message} contract, with the "
+            "synthesis barrier reconciling N results into one shape "
+            "(AC-8 / FR-11)."
+        )


### PR DESCRIPTION
## Summary

- `harness-enforcer` gains a **Workflow mode** section: above a threshold (default 8, configurable via an optional `fan-out-threshold` field in HARNESS.md; strict `>`), it adapts `enforcer-fanout.workflow.js` to spawn one verifier subagent per rule plus a skeptic persona, reconciled at a synthesis barrier with a **count-equality / no-silent-drop** guarantee. The single-context path is unchanged at or below the threshold.
- Claude-Code-only with a non-erroring fallback; read-only / propose-only (never writes a durable artefact — INV-1). It adapts the S2-shipped template by reference and does not mutate the contract it consumes.
- `verification-slots/SKILL.md` documents the fan-out slot as a first-class agent-backed slot (one verifier per rule + skeptic + synthesis barrier) producing the same pass/fail + `{file, line, message}` contract.
- Deterministic structural checks (`tests/test_s3_enforcer_fanout_structural.py`) wired into the fast CI gate the declared workflow-mode contract. Minor bump 0.59.0 → 0.60.0; reference/agents.md + how-to updated.

## Test plan

- Confirm the new "Run Layer 1 (dynamic-workflows S3 enforcer fan-out)" step runs green inside the TDAD-fast job.
- Verify the deterministic structural suite passes (locally 23 S3 + 27 base = 50/50).
- Verify markdownlint is clean and version-consistency passes (0.60.0 across all five CI-enforced locations).

## References

- Spec: `docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md`
- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S3)
- Depends on S1 (#438, merged) and S2 (#439, merged). Follow-up #452 tracks the CI structural-gating gap (out of scope here).

Closes #440