### PR TITLE
Dynamic Workflows S4 — adversarial review + deep-research workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.60.0",
+  "plugin_version": "0.61.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.60.0"
+      "version": "0.61.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -64,3 +64,7 @@ jobs:
       - name: Run Layer 1 (dynamic-workflows S3 enforcer fan-out)
         working-directory: tdad_tests
         run: pytest tests/test_s3_enforcer_fanout_structural.py -v
+
+      - name: Run Layer 1 (dynamic-workflows S4 adversarial review + deep research)
+        working-directory: tdad_tests
+        run: pytest tests/test_s4_adversarial_deepresearch_structural.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.61.0 — 2026-06-22
+
+### dynamic-workflows: adversarial review + deep-research workflows (S4, #441)
+
+Reuses the proven S3 pattern across the four agents most exposed to
+self-preferential bias and agentic laziness.
+
+- **`code-reviewer` gains separate-context adversarial review** (D5): for
+  non-trivial diffs (default `> 2 files`, configurable via the HARNESS.md
+  `fan-out-threshold` field) it adapts `adversarial-review.workflow.js` so the
+  reviewer works in a context window distinct from the implementer's, each
+  CUPID + literate property checked by a dedicated verifier and findings
+  synthesised, not collapsed. `MAX_REVIEW_CYCLES=3` still holds.
+  **`advocatus-diaboli`** declares its role as the rubric-bearing adversary,
+  read-only trust boundary unchanged.
+- **`assessor` and `harness-auditor` gain deep-research mode** (D7): above a
+  repo file-count threshold (`> 300`, configurable via the HARNESS.md field)
+  they adapt `deep-assessment.workflow.js` to fan out by area, verify each
+  finding in a separate agent, and synthesise a cited report. The auditor adds
+  a **self-preference guard** — at least one verifier is adversarial to the
+  framework's own assumptions, so it cannot grade its own homework. Output stays
+  a timestamped artefact in the existing location/format.
+- All four are Claude-Code-only with a non-erroring single-context fallback;
+  INV-1 precision preserved (the ephemeral workflow proposes; the assessor/
+  auditor still write their own report artefacts, which are not the four durable
+  curated files). `commands/assess.md` and `commands/harness-audit.md` document
+  the large-repo workflow path. Deterministic structural checks
+  (`test_s4_adversarial_deepresearch_structural.py`) gate the declared contract.
+
 ## 0.60.0 — 2026-06-22
 
 ### dynamic-workflows: harness-enforcer fan-out mode (S3, #440)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.60.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.61.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.60.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.61.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
+++ b/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
@@ -109,3 +109,15 @@ Return:
 5. The mode used (`spec` or `code`)
 
 The orchestrator writes the file; you provide the content.
+
+## Role in the adversarial-review workflow
+
+When the `code-reviewer` runs in its separate-context **workflow mode**
+(the `adversarial-review.workflow.js` template), you are the
+**rubric-bearing adversary**: you evaluate the implementation against the
+CUPID + literate-programming rubric, one property per dedicated verifier,
+and return steel-manned objections for synthesis. This is the same charter
+you carry in spec and code mode — only the harness around you changes from
+an in-pipeline pass to a workflow verifier. Your **read-only trust
+boundary is unchanged**: you raise objections, you never write or fix, and
+the orchestrator (or the workflow's synthesis step) is what records them.

--- a/ai-literacy-superpowers/agents/assessor.agent.md
+++ b/ai-literacy-superpowers/agents/assessor.agent.md
@@ -362,3 +362,39 @@ cat REFLECTION_LOG.md reflections/archive/*.md 2>/dev/null
 ```
 
 Then split on `---` separators and process the combined stream.
+
+## Workflow mode (deep-research assessment, Claude Code only)
+
+On a large repository a single-context scan is where agentic laziness
+shows up — the assessor tires and stops well short of full coverage,
+then reports as if complete. Above a threshold, run assessment as a
+**deep-research dynamic workflow**.
+
+**Threshold.** Workflow mode engages when the repository **file count** is
+**`> 300`** (strict greater-than). The threshold is **configurable per
+project** via the optional `fan-out-threshold` field in `HARNESS.md`;
+when that field is **absent** it **defaults** to 300.
+
+**Shape.** Adapt the shipped `deep-assessment.workflow.js` template (under
+the `dynamic-workflows` skill — **adapt**, never verbatim):
+**fan out by area** across the repo, have each finding verified by a **separate agent**
+before synthesis (the **verif**ication step that guards against
+unsupported claims), and produce a **cited report** whose file:line
+citations survive synthesis.
+
+**Output invariant.** The result stays a **timestamped** artefact in the
+existing location and format — `assessments/YYYY-MM-DD-assessment.md` —
+with the existing assessment structure and README badge. Workflow mode
+changes how findings are gathered, not where the report lands.
+
+**Runtime scope — Claude Code only.** Workflow mode requires the **Claude
+Code** runtime; dynamic workflows are not transferable to Copilot CLI or
+other coding agents. Where the runtime is absent, the assessor
+**falls back** to its existing single-context scan and **never errors**.
+
+**Boundary (INV-1).** The `*.workflow.js` workflow itself **proposes**
+findings only; it never writes a **durable** curated artefact —
+`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, or `MODEL_ROUTING.md`. That is
+distinct from the assessor writing its own assessment report, which it
+continues to do: INV-1 protects the four curated artefacts, not the
+assessment.

--- a/ai-literacy-superpowers/agents/code-reviewer.agent.md
+++ b/ai-literacy-superpowers/agents/code-reviewer.agent.md
@@ -124,3 +124,40 @@ findings.
 - You do not fix the issues yourself.
 - You do not approve a merge — that is integration-agent's responsibility.
 - You do not invent findings to justify another review cycle.
+
+## Workflow mode (separate-context adversarial review, Claude Code only)
+
+For non-trivial reviews, run the review as a **dynamic workflow** so the
+reviewing agent operates in a **context window** distinct from the
+**implementer's** — the separation is what defeats self-preferential bias
+(an agent is reluctant to fault output from the same context that produced
+it).
+
+**Trigger.** Workflow mode engages only for **non-trivial** reviews —
+default **`> 2 files`** changed — so tiny diffs keep the cheap
+single-context review and do not summon a panel of subagents. The trigger
+is **configurable per project** via the optional `fan-out-threshold` field
+in `HARNESS.md` (the same knob the rest of the dynamic-workflows epic
+uses).
+
+**Shape.** Adapt the shipped `adversarial-review.workflow.js` template
+(under the `dynamic-workflows` skill — **adapt** it, never run it
+verbatim): each **CUPID** property and each **literate**-programming
+property is checked by its own **dedicated verifier** in a fresh context,
+with `Advocatus Diaboli` as the rubric-bearing adversary. Per-property
+findings are **synthesis**ed into one prioritised report — never
+**collapse**d into a single thumbs-up that hides the per-property detail.
+
+**Guardrail.** Review cycles still respect **MAX_REVIEW_CYCLES**=**3**.
+Workflow mode changes how a single review is performed, not how many
+review rounds the pipeline permits.
+
+**Runtime scope — Claude Code only.** Workflow mode requires the **Claude
+Code** runtime; dynamic workflows are not transferable to Copilot CLI or
+other coding agents. Where the runtime is absent, the reviewer
+**falls back** to its single-context review and **never errors**.
+
+**Boundary (INV-1).** Review is **propose**-only / **read-only**: it
+reports findings and never writes a **durable artefact** (HARNESS.md,
+AGENTS.md, CLAUDE.md, MODEL_ROUTING.md). The reviewer's tool set carries
+no Write or Edit.

--- a/ai-literacy-superpowers/agents/harness-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/harness-auditor.agent.md
@@ -172,3 +172,38 @@ For audits that require historical claims (e.g., "verify the harness
 status reflects the full reflection history"), explicitly opt in to
 reading both `REFLECTION_LOG.md` AND `reflections/archive/*.md`. State
 in your response which read mode you used and why.
+
+## Workflow mode (deep-research audit, Claude Code only)
+
+On a large project, auditing the whole harness in one context invites both
+agentic laziness and a subtler failure: the auditor grading its own
+framework's homework. Above a threshold, run the audit as a **deep-research
+dynamic workflow**.
+
+**Threshold.** Workflow mode engages when the repository **file count** is
+**`> 300`** (strict greater-than), **configurable per project** via the
+optional `fan-out-threshold` field in `HARNESS.md`; when **absent** it
+**defaults** to 300.
+
+**Shape.** Adapt the shipped `deep-assessment.workflow.js` template (under
+the `dynamic-workflows` skill — **adapt**, never verbatim): **fan out by
+area** across the harness surfaces, have each finding verified by a
+**separate agent** before synthesis (**verif**ication before a claim is
+reported), and produce a **cited report**.
+
+**Self-preference guard.** At least one verifier must be **adversarial**
+to the **framework**'s own **assumption**s — explicitly tasked with
+arguing that a declared enforcement does NOT hold, or that a constraint is
+theatre. The auditor must not grade its own homework; a dissenting
+verifier in a separate context is the structural guard against it.
+
+**Output invariant.** The result stays a **timestamped** report in the
+existing location and format: the deep-research workflow proposes findings,
+and the auditor then applies its existing, sanctioned **HARNESS.md
+Status** section and README **badge** updates exactly as it does today.
+Workflow mode changes how the audit is gathered, not what it writes.
+
+**Runtime scope — Claude Code only.** Workflow mode requires the **Claude
+Code** runtime; dynamic workflows are not transferable to Copilot CLI or
+other coding agents. Where the runtime is absent the auditor **falls back**
+to its existing single-context audit and **never errors**.

--- a/ai-literacy-superpowers/commands/assess.md
+++ b/ai-literacy-superpowers/commands/assess.md
@@ -244,3 +244,14 @@ Present a summary to the user:
 - Workflow changes accepted vs rejected
 - Top 3 recommendations for longer-term work
 - Link to the full assessment document
+
+## Large-repository workflow path (Claude Code only)
+
+On a repository above the deep-research threshold — **file count `> 300`**
+— the dispatched `assessor` elects its **workflow mode**: a deep-research
+dynamic workflow that fans out by area and adversarially verifies each
+finding before synthesis (see the assessor agent doc). This path requires
+the **Claude Code** runtime; on Copilot CLI or wherever the workflow
+runtime is absent, the assessor **falls back** to its single-context scan
+and the assessment proceeds unchanged. The output location and format are
+identical on either path.

--- a/ai-literacy-superpowers/commands/harness-audit.md
+++ b/ai-literacy-superpowers/commands/harness-audit.md
@@ -72,3 +72,15 @@ covering:
 
 If Path 1 is undeclared but `Promoted` lines exist in the active log,
 flag as drift — promotions are happening but archival isn't.
+
+## Large-repository workflow path (Claude Code only)
+
+On a repository above the deep-research threshold — **file count `> 300`**
+— the `harness-auditor` elects its **workflow mode**: a deep-research
+dynamic workflow that fans out by area, verifies each finding in a
+separate context, and includes a verifier adversarial to the framework's
+own assumptions (the self-audit guard; see the harness-auditor agent
+doc). This path requires the **Claude Code** runtime; where the workflow
+runtime is absent the auditor **falls back** to its single-context audit
+and the report proceeds unchanged. The HARNESS.md Status section and badge
+updates are identical on either path.

--- a/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
@@ -136,7 +136,8 @@ After completing these steps you have:
 
 On the Claude Code runtime, the `code-reviewer` agent elects a separate-context
 **workflow mode** for non-trivial diffs (default `> 2` files changed,
-configurable): it adapts `adversarial-review.workflow.js` so the reviewer judges
+configurable via the HARNESS.md `fan-out-threshold` field): it adapts
+`adversarial-review.workflow.js` so the reviewer judges
 the diff in a context distinct from the implementer's, with one dedicated
 verifier per CUPID property and `advocatus-diaboli` as the rubric-bearing
 adversary. This defeats self-preferential bias. Tiny diffs keep the cheap

--- a/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/review-code-with-cupid.md
@@ -131,3 +131,14 @@ After completing these steps you have:
 - A prioritised list of improvement opportunities
 - A concrete action for each weak property
 - Optionally, a documented CUPID Status in the README for tracking over time
+
+## Separate-context review for non-trivial diffs
+
+On the Claude Code runtime, the `code-reviewer` agent elects a separate-context
+**workflow mode** for non-trivial diffs (default `> 2` files changed,
+configurable): it adapts `adversarial-review.workflow.js` so the reviewer judges
+the diff in a context distinct from the implementer's, with one dedicated
+verifier per CUPID property and `advocatus-diaboli` as the rubric-bearing
+adversary. This defeats self-preferential bias. Tiny diffs keep the cheap
+single-context review; where the workflow runtime is absent the reviewer falls
+back to single-context and never errors.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-a-harness-audit.md
@@ -133,3 +133,14 @@ For a multi-period trend view across all stored snapshots:
 
 Use `--trends` at the start of quarterly reviews to see whether constraint coverage
 and enforcement ratios have improved or declined over time.
+
+## Large repositories: deep-research mode
+
+On a repository above the deep-research threshold (file count `> 300`,
+configurable via the optional `fan-out-threshold` field in `HARNESS.md`) and on
+the Claude Code runtime, the `harness-auditor` elects a **workflow mode**: it
+adapts `deep-assessment.workflow.js` to fan out by area and verify each finding
+in a separate agent — including a verifier adversarial to the framework's own
+assumptions, so the auditor cannot grade its own homework. The HARNESS.md Status
+section and README badge output are unchanged. Where the workflow runtime is
+absent, the auditor falls back to its single-context audit and never errors.

--- a/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/run-an-assessment.md
@@ -142,3 +142,16 @@ Add this to your `CLAUDE.md` operating cadence:
 
 - Quarterly: run `/assess` to re-assess AI literacy level
 ```
+
+---
+
+## Large repositories: deep-research mode
+
+On a repository above the deep-research threshold (file count `> 300`,
+configurable via the optional `fan-out-threshold` field in `HARNESS.md`) and on
+the Claude Code runtime, the assessor elects a **workflow mode**: it adapts
+`deep-assessment.workflow.js` to fan out by area, verify each finding in a
+separate agent, and synthesise a cited report — robust against the agentic
+laziness that truncates long single-context scans. The output stays the same
+timestamped `assessments/YYYY-MM-DD-assessment.md`. Where the workflow runtime is
+absent, the assessor falls back to its single-context scan and never errors.

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -122,6 +122,11 @@ failure implication belong in the choice-cartographer's record (see
 below). The two agents form a complete partition of findings worth
 surfacing about a spec.
 
+In the `code-reviewer`'s separate-context workflow mode it also serves as
+the **rubric-bearing adversary** — evaluating the implementation against
+the CUPID + literate rubric, one property per verifier — with its
+read-only trust boundary unchanged.
+
 ### choice-cartographer
 
 - **Tools**: Read, Glob, Grep
@@ -209,6 +214,12 @@ Programming. Returns either PASS or a prioritised list of findings.
 Does not modify any files. Its output either unblocks integration
 or drives another revision cycle.
 
+For non-trivial diffs (default `> 2` files, configurable) on the Claude
+Code runtime, it elects a separate-context **workflow mode** (adapting
+`adversarial-review.workflow.js`) so the reviewer judges the diff in a
+context distinct from the implementer's — one verifier per CUPID/literate
+property, with `advocatus-diaboli` as the rubric-bearing adversary.
+
 ### integration-agent
 
 - **Tools**: Read, Write, Edit, Bash
@@ -257,6 +268,13 @@ what the project actually has. Detects drift in both directions:
 rules declared but not enforced, and enforcement present but not
 declared. Updates the Status section of `HARNESS.md` with audit
 results.
+
+Above a repo file-count threshold (`> 300`, configurable) on the Claude
+Code runtime, it elects a deep-research **workflow mode** (adapting
+`deep-assessment.workflow.js`): fan out by area, verify each finding in a
+separate agent, and include a verifier adversarial to the framework's own
+assumptions — the self-preference guard so the auditor cannot grade its
+own homework. The Status-section and badge output is unchanged.
 
 ### harness-enforcer
 
@@ -313,6 +331,13 @@ reflections, conventions, CI integration), asks clarifying
 questions where evidence is ambiguous, and produces a timestamped
 assessment document with a level determination. Updates the README
 with a literacy level badge.
+
+Above a repo file-count threshold (`> 300`, configurable) on the Claude
+Code runtime, it elects a deep-research **workflow mode** (adapting
+`deep-assessment.workflow.js`): fan out by area, verify each finding in a
+separate agent, and synthesise a cited report — robust against the
+agentic laziness that truncates long single-context scans. The timestamped
+assessment output and badge are unchanged.
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -214,8 +214,9 @@ Programming. Returns either PASS or a prioritised list of findings.
 Does not modify any files. Its output either unblocks integration
 or drives another revision cycle.
 
-For non-trivial diffs (default `> 2` files, configurable) on the Claude
-Code runtime, it elects a separate-context **workflow mode** (adapting
+For non-trivial diffs (default `> 2` files, configurable via the HARNESS.md
+`fan-out-threshold` field) on the Claude Code runtime, it elects a
+separate-context **workflow mode** (adapting
 `adversarial-review.workflow.js`) so the reviewer judges the diff in a
 context distinct from the implementer's — one verifier per CUPID/literate
 property, with `advocatus-diaboli` as the rubric-bearing adversary.

--- a/docs/superpowers/specs/2026-06-22-dynamic-workflows-s4-adversarial-deepresearch-design.md
+++ b/docs/superpowers/specs/2026-06-22-dynamic-workflows-s4-adversarial-deepresearch-design.md
@@ -1,0 +1,642 @@
+# Specification — Dynamic Workflows S4: Adversarial Review + Deep-Research Assessment/Audit
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S4 of the Dynamic Workflows Alignment epic (D5 + D7 — clustered)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S4)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/441>
+**Depends on:** S1 (#438, merged) — the `dynamic-workflows` skill + election rubric; S2 (#439, merged) — the `adversarial-review.workflow.js` + `deep-assessment.workflow.js` templates + the INV-1/INV-2 firewall; S3 (#440, merged) — the proven adversarial-verification *pattern* and the structural-content test shape S4 reuses
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s4-adversarial-deepresearch`
+
+> **Implementer note (read first).** This slice gives **four existing agents** a
+> **workflow mode** and documents the workflow path in **two commands**. It ships **no new
+> component** — it modifies four agent files and two command files (plus version/docs
+> surfaces). It does **not** rewrite the S2-shipped templates
+> (`adversarial-review.workflow.js`, `deep-assessment.workflow.js`); it **points the agents
+> at them** and describes how each agent ADAPTs the template per run. The *exact* runtime
+> function names for spawning subagents, parallel fan-out, and synthesis barriers are **not
+> authoritative in this spec** — consult <https://code.claude.com/docs/en/workflows> as the
+> source of truth and treat any call shape here or in the templates as ADAPTABLE pseudocode,
+> not a frozen API.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code runtime
+> capability, **not transferable** to GitHub Copilot CLI or any other coding agent — those
+> trees have no workflow runtime. The plugin ships to both trees, so **every** workflow mode
+> this slice adds is **Claude-Code-gated**: where the runtime exists the agents can fan out
+> into separate contexts; where it does not (Copilot CLI, other agents) each workflow-mode
+> section is **guidance only** and the agent **falls back to its existing single-context
+> behaviour — it must never error or pretend to fan out**. Each of the four agents' workflow-
+> mode sections must restate this boundary explicitly (umbrella §5.5 / slicing-record runtime-
+> scope note). The precise Copilot degradation *contract* (guidance-only vs omit) is
+> open-question 4, resolved in S7, and is **not** decided here.
+
+---
+
+## 1. Context and motivation
+
+S3 proved the **adversarial-verification + fan-out-and-synthesize** pattern on the
+`harness-enforcer`: one verifier subagent per item, in its own clean context, behind a
+synthesis barrier that waits for all of them. S4 takes that proven shape and applies it
+**uniformly** (the slicing-record disposition: *"apply the adversarial-verification shape
+uniformly across the self-preference-exposed agents; specialise only where an agent demands
+it"*) to the four agents the umbrella names as most exposed to **self-preferential bias** and
+**agentic laziness**:
+
+| Agent | Failure mode it is exposed to | What S4 adds |
+| --- | --- | --- |
+| `code-reviewer` | self-preferential bias (judging output from the same context that produced it) | D5: a **separate-context** review mode — one dedicated verifier per CUPID + literate property, synthesised |
+| `advocatus-diaboli` | (the adversary) | D5: declares its role as the **rubric-bearing adversary** in that workflow, without breaking its read-only trust boundary |
+| `assessor` | agentic laziness (long repo scans, the "35 of 50" lazy stop) | D7: above a repo-size threshold, **fan out by area**, adversarially verify each finding, synthesise a **cited report** |
+| `harness-auditor` | agentic laziness **+ self-audit bias** (grading its own framework) | D7: the deep-research shape **plus** at least one verifier **adversarial to the framework's own assumptions** |
+
+The two D-clusters share **one acceptance shape** — *a verifier operates in a context window
+distinct from the producing context; each rubric property or repo area is checked by a
+dedicated verifier; findings are synthesised, not collapsed*. That shared shape is why the
+slicing record clusters them into one slice (acceptance-criterion lens) rather than emitting
+three near-identical slices.
+
+S4 wires each agent to its S2 template; it invents no new template and edits no template (per
+the AGENTS.md "a consumer never mutates the contract it consumes" decision). Below their
+trigger, all four agents keep their **current behaviour, unchanged** — the default path is
+untouched, honouring umbrella §6/§7 compute discipline (over-orchestration is a regression).
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+**D5 — `code-reviewer` + `advocatus-diaboli`:**
+
+1. **`code-reviewer.agent.md` gains a "Workflow mode" section** stating:
+   - **The trigger** — a **non-trivial** review (see §6 decision 3): workflow mode engages
+     only for a review above a size signal; trivial diffs keep the existing single-context
+     review. Respects `MAX_REVIEW_CYCLES=3`.
+   - **The separate-context property** — the reviewing agent operates in a **context window
+     distinct from the implementer's**, so it is not judging output from the context that
+     produced it (defeats self-preferential bias).
+   - **The per-property fan-out** — each **CUPID** property (Composable, Unix-philosophy,
+     Predictable, Idiomatic, Domain-based) and each **literate-programming** property is
+     checked by a **dedicated verifier**, and the findings are **synthesised, not collapsed**
+     into a single thumbs-up.
+   - **How it adapts `adversarial-review.workflow.js`** — references the S2 template **by
+     relative path**, hands the diff in as input (never spelling a durable filename in
+     workflow code — INV-1 / the firewall), and ADAPTs prompts, per-role model tiers, and the
+     token budget per run rather than running it verbatim.
+   - **The Claude-Code-only runtime scope + non-erroring fallback** — on a tree without the
+     runtime, the reviewer **falls back to its existing single-context review and never
+     errors**.
+   - **The INV-1 boundary** — the reviewer's tool set stays unchanged (`Read, Glob, Grep,
+     Bash` — no `Write`/`Edit`); workflow mode **only proposes findings**; it never writes a
+     durable artefact.
+2. **`advocatus-diaboli.agent.md` declares its workflow role** — a short addition stating
+   that, in the `adversarial-review` workflow, the diaboli is the **rubric-bearing
+   adversary** (the agent that evaluates the diff against the CUPID + literate rubric), and
+   that this role **does not relax its existing read-only trust boundary** (`Read, Glob, Grep`
+   only; no Write/Bash; dispositions remain the human's job). The existing spec-mode/code-mode
+   charter is unchanged.
+
+**D7 — `assessor` + `harness-auditor`:**
+
+3. **`assessor.agent.md` gains a "Workflow mode" section** stating:
+   - **The trigger** — a repo **above a size threshold** (see §6 decision 1): workflow mode
+     engages only for large repos; small repos keep the existing single-context scan.
+   - **The deep-research shape** — **fan out by area**, **adversarially verify each finding**
+     in a **separate agent** before synthesis, produce a **cited report** (file:line
+     citations preserved through synthesis; a completeness pass guards the tail of findings).
+   - **How it adapts `deep-assessment.workflow.js`** — by relative path, ADAPT not verbatim,
+     diff/area inventory handed in as input.
+   - **The Claude-Code-only runtime scope + non-erroring fallback** — falls back to the
+     existing single-context Phase 1–6 scan and never errors where the runtime is absent.
+   - **The output-location/format invariant** — the assessment output **remains a timestamped
+     artefact in the existing location** (`assessments/YYYY-MM-DD-assessment.md`) **with the
+     existing template format**. Workflow mode changes *how* the report is produced (fan-out +
+     verify), not *what* it is or *where* it lands.
+   - **The INV-1 boundary, stated precisely** — the assessor **legitimately writes its own
+     assessment report artefact** to the existing location (its tool set already includes
+     `Write`/`Edit`, and the assessment doc is **not** one of the four durable curated
+     artefacts INV-1 protects). What workflow mode must **not** do is write the **durable
+     curated artefacts** — `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md` — except
+     through the existing curation/adjustment gates the agent already runs. The *workflow* (the
+     `*.workflow.js` fan-out) proposes findings only; the **agent** then writes its own report.
+4. **`harness-auditor.agent.md` gains a "Workflow mode" section** stating everything in (3)
+   **plus the self-preference guard**: at least one verifier must be **adversarial to the
+   framework's own assumptions** (the auditor must not grade its own homework). The output-
+   location invariant for the auditor is its existing **HARNESS.md Status section** update and
+   **README badge** update — workflow mode keeps those exact write targets and formats. INV-1
+   precision: the auditor already (and only) writes the **HARNESS.md Status section** and the
+   **README badge line** — these are its existing, narrowly-scoped writes, not a full durable-
+   artefact rewrite; the workflow itself proposes findings only and the agent performs those
+   two scoped writes as today.
+5. **`commands/assess.md` and `commands/harness-audit.md` document the workflow path** — a
+   short note that, for a large repo (above the §6 threshold) on the Claude Code runtime, the
+   dispatched agent elects its deep-research workflow mode (fan-out by area + adversarial
+   verification + cited report), with the same output and a non-erroring fallback elsewhere.
+
+6. **Supporting CI / version / docs surfaces** (see §7): the minor bump **`0.60.0 → 0.61.0`**
+   across the five CI-enforced locations + the README table cell, and reference/how-to touch-
+   ups now that four agents adopt templates.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred concern | Owning slice | Why not here |
+| --- | --- | --- |
+| `harness-enforcer` workflow mode | **S3 (#440, merged)** | The pattern S4 reuses; S4 does not re-touch the enforcer |
+| `orchestrator` classify-and-act routing | **S5 (#442)** | Riding open-question 2 |
+| `reflect --mine` mode + staging artefact | **S6 (#443)** | Riding open-question 3 |
+| README "Dynamic Workflows" prose section, advisory Stop hook, **Copilot degradation contract** | **S7 (#444)** | Per umbrella D9; open-question 4. S4 restates the Claude-Code-only boundary for its own behaviour but does **not** fix the degradation contract |
+| Skill-count / component-count badges | **unchanged** | S4 adds **no** new skill, agent, or command — only modifies six existing files. The component-count badges do not move |
+| Editing/rewriting `adversarial-review.workflow.js` or `deep-assessment.workflow.js` | **S2 (#439, merged)** | S4 *adapts and points at* the templates; per the AGENTS.md "consumer never mutates the contract it consumes" decision, S4 does not edit either shipped template |
+
+**Boundary rule.** S4 modifies exactly **six files** —
+`agents/code-reviewer.agent.md`, `agents/advocatus-diaboli.agent.md`,
+`agents/assessor.agent.md`, `agents/harness-auditor.agent.md`, `commands/assess.md`,
+`commands/harness-audit.md` — plus the version/docs surfaces in §7. It ships **no new
+component**, **no new CI workflow** (it *wires a new test file into the existing*
+`tdad-tests-fast.yml`), and **no edit to either S2 template**.
+
+---
+
+## 3. User stories
+
+> **As an** engineer whose implementation is being reviewed, **I want** the `code-reviewer`
+> to review a non-trivial change in a **context window distinct from the one that wrote the
+> code**, with each CUPID and literate property checked by its own verifier, **so that** the
+> review cannot rubber-stamp its own reasoning — self-preferential bias is defeated
+> structurally, while trivial diffs keep the cheap single-context path.
+
+> **As a** team running an AI-literacy assessment or a harness audit on a large repo, **I
+> want** the `assessor` / `harness-auditor` to **fan out by area** and **adversarially verify
+> each finding in a separate agent** before synthesising a cited report, **so that** a long
+> scan can no longer declare itself done after partial progress — and, for the auditor, so
+> that the framework cannot grade its own homework — while the report still lands as the same
+> timestamped artefact in the same place.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy:
+*deterministic* (CI-checkable / Layer-0–1 structural), *agent-backed* (a runtime / Layer-2–3
+behavioural property), or *unverified* (declared intent). Scenarios trace to umbrella **D5**
+and **D7** acceptance. The tdd-agent turns the deterministic and structurally-assertable
+agent-backed scenarios into failing checks first.
+
+### D5 — code-reviewer adversarial review
+
+**AC-1 *(agent-backed; structural shadow AC-2)* — review runs in a separate context window.**
+**Given** an implementation and the Claude Code runtime present,
+**When** review runs in workflow mode,
+**Then** the reviewing agent operates in a **context window distinct from the implementer's**.
+*(Slot note: separate-context is a runtime property — not assertable from a static file read.
+Its structural shadow is AC-2/AC-3 declaring the separate-context property and the per-property
+fan-out. The behavioural assertion stands as a Layer-2/3 scenario the tdd-agent may add.)*
+
+**AC-2 *(deterministic, structural)* — workflow-mode section exists and declares separate-context + non-trivial trigger.**
+**Given** `code-reviewer.agent.md`,
+**When** it is read,
+**Then** it contains a **"Workflow mode"** section declaring that review runs in a **context
+window distinct from the implementer's**, engaged only for a **non-trivial** review (the §6
+decision-3 trigger, named explicitly — not "somehow large").
+
+**AC-3 *(deterministic, structural)* — per-property dedicated verifiers, synthesised not collapsed.**
+**Given** the workflow-mode section,
+**When** it is read,
+**Then** it declares that **each CUPID property and each literate-programming property is
+checked by a dedicated verifier** and that findings are **synthesised, not collapsed**, and
+that it **adapts `adversarial-review.workflow.js` by relative path** (ADAPT, not verbatim).
+
+**AC-4 *(unverified, declared)* — review cycles respect MAX_REVIEW_CYCLES=3.**
+**Given** review runs in workflow mode,
+**When** findings drive revision cycles,
+**Then** the pipeline's **`MAX_REVIEW_CYCLES=3`** GUARDRAIL still holds — workflow mode does
+not multiply review cycles.
+*(Slot note: declared intent — the guardrail lives in the orchestrator/pipeline, not provable
+from the reviewer doc alone. The structural shadow is AC-3's section stating the guardrail
+holds.)*
+
+**AC-5 *(deterministic, structural)* — advocatus-diaboli declares its rubric-bearing-adversary role without relaxing its trust boundary.**
+**Given** `advocatus-diaboli.agent.md`,
+**When** it is read,
+**Then** it states that in the `adversarial-review` workflow the diaboli is the **rubric-
+bearing adversary** evaluating the diff against the CUPID + literate rubric, and that its
+**read-only trust boundary is unchanged** (`tools` remains `Read, Glob, Grep` — no `Write`,
+no `Bash`; dispositions remain the human's).
+
+### D7 — deep-research assessment + audit
+
+**AC-6 *(agent-backed; structural shadow AC-7)* — above-threshold repo fans out by area, each finding verified by a separate agent before synthesis.**
+**Given** a repo above the size threshold and the Claude Code runtime present,
+**When** assessment (or audit) runs in workflow mode,
+**Then** findings **fan out by area** and **each finding is verified by a separate agent
+before synthesis**.
+*(Slot note: runtime/behavioural. Its structural shadow is AC-7/AC-8 declaring the threshold,
+the fan-out-by-area, and the per-finding separate-agent verification.)*
+
+**AC-7 *(deterministic, structural)* — assessor workflow-mode section declares the threshold + deep-research shape.**
+**Given** `assessor.agent.md`,
+**When** it is read,
+**Then** it contains a **"Workflow mode"** section declaring the **repo-size threshold** (the
+§6 decision-1 metric + default + configurability mechanism, named explicitly), the **fan-out-
+by-area** shape, the **per-finding separate-agent adversarial verification**, the **cited
+report**, that it **adapts `deep-assessment.workflow.js` by relative path**, and the
+**Claude-Code-only scope + non-erroring fallback** to the existing single-context scan.
+
+**AC-8 *(deterministic, structural)* — auditor workflow-mode section declares the same shape PLUS the self-preference guard.**
+**Given** `harness-auditor.agent.md`,
+**When** it is read,
+**Then** it contains a **"Workflow mode"** section declaring everything in AC-7 **plus** that
+**at least one verifier is adversarial to the framework's own assumptions** (the self-
+preference guard — the auditor must not grade its own homework).
+
+**AC-9 *(deterministic, structural)* — assessment output stays a timestamped artefact in the existing location/format.**
+**Given** the assessor (and auditor) workflow-mode sections,
+**When** they are read,
+**Then** each states that workflow mode's output **remains a timestamped artefact in the
+existing location with the existing format** — for the assessor,
+`assessments/YYYY-MM-DD-assessment.md` in the existing template; for the auditor, the existing
+**HARNESS.md Status section** + **README badge** update — workflow mode changes how the report
+is produced, not what it is or where it lands.
+
+**AC-10 *(deterministic, structural)* — commands document the workflow path for large repos.**
+**Given** `commands/assess.md` and `commands/harness-audit.md`,
+**When** they are read,
+**Then** each documents that, **above the threshold** on the **Claude Code runtime**, the
+dispatched agent elects its **deep-research workflow mode** (fan-out by area + adversarial
+verification + cited report), with the **same output** and a **non-erroring fallback**
+elsewhere.
+
+### Cross-cutting — INV-1 (the precise boundary)
+
+**AC-11 *(deterministic, structural)* — read/propose-only agents stay read-only; report-writing agents write only their own report.**
+**Given** the four agents' frontmatter and workflow-mode sections,
+**When** they are read,
+**Then**:
+- `code-reviewer` and `advocatus-diaboli` keep **read-only** tool sets (no `Write`/`Edit`/
+  `Bash` beyond their existing lists) and their workflow modes **only propose findings**;
+- `assessor` and `harness-auditor` retain their existing `Write`/`Edit` tools **for their own
+  artefacts only** — the assessment report (assessor) and the HARNESS.md Status section +
+  README badge (auditor); and each section states the **`*.workflow.js` workflow itself
+  proposes findings only and never writes a durable curated artefact** (`HARNESS.md`,
+  `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`) — the prohibition is on those four, **not** on
+  the assessment report. *(This is the precision the task flags: do not wrongly forbid the
+  assessor from writing its assessment.)*
+
+---
+
+## 5. Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios in §8.
+
+- **FR-1.** `code-reviewer.agent.md` contains a **"Workflow mode"** section. *(AC-2)*
+- **FR-2.** The section declares the **separate-context** property (reviewer's context window
+  distinct from the implementer's) and the **non-trivial trigger** (§6 decision 3, named).
+  *(AC-2; structural shadow of AC-1)*
+- **FR-3.** The section declares **one dedicated verifier per CUPID + literate property**,
+  findings **synthesised not collapsed**, and **adapts `adversarial-review.workflow.js` by
+  relative path**. *(AC-3; structural shadow of AC-1)*
+- **FR-4.** The section states **`MAX_REVIEW_CYCLES=3`** still holds in workflow mode. *(AC-4)*
+- **FR-5.** The section states the **Claude-Code-only scope** and the **non-erroring fallback**
+  to single-context review, and that workflow mode is **propose-only / read-only** (INV-1).
+  *(AC-2, AC-11)*
+- **FR-6.** `advocatus-diaboli.agent.md` declares its **rubric-bearing-adversary** role in the
+  `adversarial-review` workflow with its **read-only trust boundary unchanged**. *(AC-5)*
+- **FR-7.** `assessor.agent.md` contains a **"Workflow mode"** section declaring the **repo-
+  size threshold** (§6 decision-1 metric + default + configurability, named), **fan-out-by-
+  area**, **per-finding separate-agent adversarial verification**, the **cited report**, the
+  **adapt-by-relative-path** of `deep-assessment.workflow.js`, and the **Claude-Code-only
+  scope + non-erroring fallback**. *(AC-7; structural shadow of AC-6)*
+- **FR-8.** `harness-auditor.agent.md` contains a **"Workflow mode"** section declaring
+  everything in FR-7 **plus** the **self-preference guard** (≥1 verifier adversarial to the
+  framework's own assumptions). *(AC-8; structural shadow of AC-6)*
+- **FR-9.** Both `assessor` and `harness-auditor` workflow-mode sections state the **output
+  stays a timestamped artefact in the existing location/format** (assessor:
+  `assessments/YYYY-MM-DD-assessment.md`; auditor: HARNESS.md Status + README badge). *(AC-9)*
+- **FR-10.** `commands/assess.md` and `commands/harness-audit.md` document the **workflow path
+  for large repos** (above-threshold + Claude Code runtime → deep-research mode; same output;
+  non-erroring fallback). *(AC-10)*
+- **FR-11.** The **INV-1 precision** is declared: `code-reviewer`/`advocatus-diaboli` stay
+  read-only and propose-only; `assessor`/`harness-auditor` write **only their own report
+  artefacts**, and the **workflow itself** never writes a durable curated artefact
+  (HARNESS.md/AGENTS.md/CLAUDE.md/MODEL_ROUTING.md). *(AC-11)*
+- **FR-12.** The plugin version is bumped **`0.60.0 → 0.61.0`** across all five CI-enforced
+  locations (§7.1), and the human-facing README plugin-table cell is updated. *(CI: Version
+  Check)*
+- **FR-13.** The how-to guide(s) and the agents reference entries for the four agents are
+  checked and updated for the new workflow modes (§7.3). *(docs-impact)*
+
+---
+
+## 6. Decisions surfaced at the GATE
+
+Per the AGENTS.md STYLE note, a recommendation is a **hypothesis for the spec-mode diaboli to
+stress**, not a default to confirm. The three decisions below are surfaced for the human; the
+spec-writer recommends but does not silently choose.
+
+### Decision 1 — The D7 repo-size threshold: metric, default value, and configurability mechanism
+
+D7 says "above a size threshold" but fixes neither metric nor value nor override. Mirroring the
+S3 M1 pattern (the resolved threshold mechanism for the enforcer), three sub-choices:
+
+**Metric.** Options:
+
+- **(a) file count scanned (RECOMMENDED)** — the assessor/auditor already enumerate files and
+  signals across the repo; "number of files in scope" is the most direct proxy for the scan
+  length that triggers agentic laziness, and it is cheap to compute before electing the
+  workflow.
+- (b) constraint count — natural for the *auditor* (it scans HARNESS.md constraints) but a poor
+  proxy for the *assessor* (which scans the whole repo, not just constraints). Splitting the
+  metric per agent would break the "uniform shape" disposition.
+- (c) LOC — noisy (generated files, vendored code inflate it) and not what either agent
+  actually iterates over.
+
+**Default value.** **300 files (RECOMMENDED)** — large enough that a single-context scan is the
+cheap, correct path for small/medium repos (so we do not over-orchestrate), low enough that a
+genuinely large monorepo trips the deep-research mode. The diaboli should stress whether 300 is
+evidence-based or arbitrary; it is a **starting default**, explicitly tunable.
+
+**Configurability mechanism.** Options (mirror S3 decision 1):
+
+- **M1 — a documented optional `HARNESS.md` field (RECOMMENDED), e.g.
+  `Deep-research threshold: <N>`**, defaulting to 300 when absent. *Strength:* same curated-
+  durable home and same "agent reads a documented field" shape S3 chose for the enforcer
+  threshold — one consistent knob style across the epic; missing/garbled field safe-defaults
+  rather than errors. *Diaboli should stress:* is the assessor's threshold conceptually a
+  HARNESS.md concern (HARNESS governs enforcement, not assessment), or would
+  `MODEL_ROUTING.md`'s workflow-election section (M2) be a more cohesive home for *all*
+  workflow-election policy?
+- M2 — a value in `MODEL_ROUTING.md`'s workflow-election section (S1 placed token budgets/
+  tiering there). *Tenable* and arguably more cohesive for assessment (which is not a HARNESS
+  enforcement concern); the cost is splitting from S3's HARNESS.md precedent.
+- M3 — prose default in the agent docs only (no override). *Acceptable only if* the human
+  decides per-project configurability is not worth a mechanism yet; then the docs say "300, not
+  yet configurable" honestly.
+
+**Recommendation:** metric = **file count**, default = **300**, mechanism = **M1 optional
+`HARNESS.md` field**, defaulting to 300 when absent — for cross-epic consistency with S3. The
+diaboli should stress the M1-vs-M2 home (HARNESS.md governs enforcement; is assessment-scan
+policy a HARNESS concern?) and whether 300 is the right starting value.
+
+### Decision 2 — The verification split (deterministic structural vs agent-backed behavioural)
+
+Mirroring S3 decision 2: this repo's deterministic layer **reads files and matches structure**;
+it does **not** spawn a live fan-out or open a second context window. So:
+
+- **Deterministically assertable (structural, Layer-0/1) — the declarations.** That each agent
+  doc **declares**: the workflow-mode section exists (AC-2, AC-7, AC-8); the separate-context
+  property + non-trivial trigger (AC-2); per-property dedicated verifiers + synthesised-not-
+  collapsed + adapt-by-relative-path (AC-3); the diaboli's rubric-bearing-adversary role +
+  unchanged trust boundary (AC-5); the repo-size threshold + fan-out-by-area + per-finding
+  separate-agent verification + cited report + Claude-Code scope + fallback (AC-7); the self-
+  preference guard (AC-8); the existing-location/format invariant (AC-9); the command workflow-
+  path note (AC-10); and the INV-1 precision (AC-11). These are file-read assertions a
+  structural test checks mechanically — the **honest deterministic shadow** of D5+D7.
+- **Agent-backed / behavioural only (not deterministic) — the live properties.** That a real
+  run actually opens a **separate context window** (AC-1), and that an above-threshold run
+  **fans out by area with per-finding separate-agent verification** (AC-6), are runtime
+  properties of an actual workflow on the Claude Code runtime. They are **agent-backed**,
+  observed at runtime, and must **not** be promised as deterministic.
+- **Unverified / declared (AC-4)** — `MAX_REVIEW_CYCLES=3` holding under workflow mode is a
+  pipeline-level guardrail, declared in the reviewer doc; its structural shadow is the section
+  stating it holds, but the guarantee itself lives in the orchestrator.
+
+**Recommendation:** the tdad-scenario set is **predominantly structural** (AC-2, AC-3, AC-5,
+AC-7, AC-8, AC-9, AC-10, AC-11 as Layer-0/1 file-read assertions), with AC-1 and AC-6 standing
+as **declared agent-backed** behavioural scenarios and AC-4 as **unverified/declared**. This is
+the same realistic split S3 landed. The diaboli should stress whether any property currently
+tagged structural actually requires a live run (it should not — each is a file-read), and
+whether the separate-context property of AC-1 risks being over-promised as deterministic (it
+must not).
+
+### Decision 3 — The D5 trigger: when does code-reviewer use workflow mode?
+
+D5 must avoid the umbrella §7 over-orchestration risk — spinning up a panel of per-property
+verifiers (≈12k tokens per the template preamble) on a one-line diff is exactly the waste the
+discipline gate forbids. Options:
+
+- **Option T1 — always use workflow mode.** *Rejected:* multiplies cost on every trivial diff
+  and contradicts §6/§7 compute discipline.
+- **Option T2 — non-trivial reviews only, by a size signal (RECOMMENDED).** Workflow mode
+  engages only when the diff is **non-trivial** — above a small size signal (e.g. files-changed
+  or hunks-changed above a low bound, default **> 2 files changed** OR a substantive single-
+  file change, named in the agent doc and tunable). Trivial diffs (typo, one-liner, formatting)
+  keep the existing single-context review. *Strength:* mirrors the S3 "strict `>` threshold,
+  cheap default path below it" shape; keeps the per-property panel for the reviews that warrant
+  it. *Diaboli should stress:* the exact size signal and whether "> 2 files" is the right bound
+  or should be expressed as a configurable field consistent with decision 1's mechanism.
+- Option T3 — the orchestrator decides (defer the trigger to S5's classifier). *Rejected for
+  S4:* S5's routing is opt-in and later; S4 must ship a self-contained trigger so the reviewer
+  works standalone, exactly as S3's enforcer carries its own threshold.
+
+**Recommendation:** **T2** — non-trivial reviews only, default **> 2 files changed (or a
+substantive single-file change)**, named in the agent doc and configurable by the same
+mechanism chosen in decision 1 (so the epic carries one consistent knob style). The diaboli
+should stress the bound and confirm a trivial diff demonstrably stays on the cheap path.
+
+### 6.1 Decision summary for the GATE
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| D7 repo-size threshold | metric (file count / constraint count / LOC); default value; mechanism (M1 HARNESS.md / M2 MODEL_ROUTING.md / M3 prose) | **file count; default 300; M1 optional `HARNESS.md` field**, default 300 when absent — consistent with S3 |
+| Verification split | all-deterministic / **structural declarations + agent-backed live properties** | **structural declarations are the deterministic shadow; live separate-context + live fan-out stay agent-backed; MAX_REVIEW_CYCLES stays unverified/declared** |
+| D5 trigger | T1 always / **T2 non-trivial only** / T3 orchestrator-decides | **T2 — non-trivial only, default `> 2 files changed`, configurable by decision-1's mechanism** |
+
+---
+
+## 7. CI, version, and docs checklist
+
+### 7.1 Version bump — a behavioural change to existing agents/commands (minor)
+
+Adding workflow mode to four existing agents and documenting it in two commands is a
+**behavioural addition to existing components** → **minor bump `0.60.0 → 0.61.0`** (current
+version confirmed **`0.60.0`** in `plugin.json`). The `Version Check` CI enforces **five**
+locations (per CLAUDE.md / the live `version-check.yml`). Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical; `0.60.0` →
+   `0.61.0`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.61.0` (currently `v0.60.0`)
+3. `CHANGELOG.md` — new top heading `## 0.61.0 — 2026-06-22`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (currently `0.60.0`; owned by
+   ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers` `plugins[].version` entry
+   (currently `0.60.0`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md` plugin-table
+row cell (`| v0.60.0 |` → `| v0.61.0 |`).
+
+> The marketplace listing `version` does **not** change — S4 alters no listing contract (no
+> description/keyword/permission/plugins-array/source change). The component-count badges
+> (Skills/Agents/Commands) do **not** change — S4 adds no new component, only modifies six
+> existing files.
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.60\.0\|0\.60\.0' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+If a rebase surfaces a `plugin_version` conflict from a non-`ai-literacy-superpowers` PR, take
+main's value verbatim (CLAUDE.md Marketplace-versioning rule) — this PR owns the top-level
+pointer only because it bumps this plugin.
+
+### 7.2 CI gates
+
+- **`spec-first-check`** — satisfied by **this spec being the first commit** on branch
+  `dynamic-workflows-s4-adversarial-deepresearch`. No exemption label; this is feature work.
+- **`tdad-scenario-check`** — S4 **modifies** existing agents/commands rather than adding new
+  components. The gate fires on *added* components, so it does **not strictly force** new
+  scenarios for a modification. **However**, this is a behavioural addition and warrants
+  scenarios. `code-reviewer` has **no scenario directory yet**
+  (`tdad_tests/scenarios/agents/code-reviewer/` does not exist); `advocatus-diaboli`,
+  `assessor`, and `harness-auditor` likewise need directories for the new declarations. The
+  **tdd-agent will create these directories** and author the structural scenarios (AC-2, AC-3,
+  AC-5, AC-7, AC-8, AC-9, AC-10, AC-11), mirroring the S3 scenario set under
+  `tdad_tests/scenarios/agents/harness-enforcer/`. Spec-writer **names** these so the tdd-agent
+  has unambiguous homes; spec-writer does **not** create any directory or test file (spec-first
+  discipline — no test files in this commit).
+- **The deterministic content test** — the tdd-agent authors a new
+  `tdad_tests/tests/test_s4_adversarial_deepresearch_structural.py`, mirroring
+  `test_s3_enforcer_fanout_structural.py` (a `_workflow_section(...)` helper that slices the
+  "Workflow mode" heading per agent file; phrase assertions per AC), and **wires it into the
+  existing `.github/workflows/tdad-tests-fast.yml`** as a new step (a sibling of the existing
+  `Run Layer 1 (dynamic-workflows S3 enforcer fan-out)` step). Spec-writer **notes** this; the
+  tdd-agent authors and wires it. **Do not author tests in this commit.**
+- **`INV-1 firewall` (S2, existing)** — S4 modifies **no `*.workflow.js` template**, so the
+  firewall is **not triggered by new template content**. The agents' own *reads* and the
+  assessor/auditor writing **their own report artefacts** are agent behaviours, not a workflow
+  spelling a durable curated filename in executable code, so they are outside the firewall's
+  scope. (If the tdd-agent adds any fixture that is a `.workflow.js`, it must itself pass the
+  firewall — but the recommended fixtures are structural scenarios, not workflows.)
+- **`lint-markdown`** — the four modified agent docs, the two modified command docs, this spec,
+  and any touched docs page must pass markdownlint (PreToolUse hook + CI).
+- **`Choice cartographer` / objection gates** — this feature PR proceeds through the plugin's
+  own pipeline (spec → diaboli → adjudicate → plan → implement). Dispositions on any objection
+  record must be resolved before the plan-approval GATE.
+
+### 7.3 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Reference (`docs-reference-parity-check`) — no NEW component, so no new entry forced.** S4
+  adds no new skill/agent/command, so the parity gate is satisfied with no new heading. **But**
+  the existing `### code-reviewer`, `### advocatus-diaboli`, `### assessor`, and
+  `### harness-auditor` entries in `docs/plugins/ai-literacy-superpowers/reference/agents.md`
+  should be **updated** to mention the new **workflow mode** so the reference does not describe
+  only the single-context behaviour. This is a *consistency* update, not a parity requirement.
+- **How-to (touch-up).** `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md`
+  (the orientation guide) should note that `code-reviewer`, `assessor`, and `harness-auditor`
+  now elect `adversarial-review.workflow.js` / `deep-assessment.workflow.js` above their
+  triggers — extending the S3 dogfooding line ("templates the plugin's own agents already
+  adapt"). The existing `how-to/review-code-with-cupid.md` and `how-to/run-an-assessment.md` /
+  `how-to/run-a-harness-audit.md` should each gain a short "for large changes/repos, the agent
+  elects its workflow mode" note. Consistency touch-ups, not new pages.
+- **Explanation / tutorials.** None required — the adversarial-verification and deep-research
+  concepts already live in the skill's `references/patterns.md` (S1) and the
+  `adversarial-review` / `deep-assessment` preambles (S2). No existing explanation page
+  describes these agents' single-context behaviour as a fixed property S4 would contradict.
+
+---
+
+## 8. FR → acceptance-scenario mapping
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-2 | deterministic (structural) |
+| FR-2 | AC-2 (structural shadow of AC-1) | deterministic (structural) / agent-backed (AC-1) |
+| FR-3 | AC-3 (structural shadow of AC-1) | deterministic (structural) / agent-backed (AC-1) |
+| FR-4 | AC-4 | unverified (declared) |
+| FR-5 | AC-2, AC-11 | deterministic (structural) |
+| FR-6 | AC-5 | deterministic (structural) |
+| FR-7 | AC-7 (structural shadow of AC-6) | deterministic (structural) / agent-backed (AC-6) |
+| FR-8 | AC-8 (structural shadow of AC-6) | deterministic (structural) / agent-backed (AC-6) |
+| FR-9 | AC-9 | deterministic (structural) |
+| FR-10 | AC-10 | deterministic (structural) |
+| FR-11 | AC-11 | deterministic (structural) |
+| FR-12 | (CI: Version Check) | deterministic |
+| FR-13 | (docs-impact; reference + how-to touch-up) | deterministic (presence) |
+
+**Agent-backed runtime scenarios** (not deterministic; see §6 decision 2):
+
+- **AC-1** — review runs in a context window distinct from the implementer's — runtime/
+  behavioural; structural shadow is AC-2/AC-3 (FR-2/FR-3).
+- **AC-6** — above-threshold fan-out-by-area with per-finding separate-agent verification —
+  runtime/behavioural; structural shadow is AC-7/AC-8 (FR-7/FR-8).
+
+**Unverified / declared:**
+
+- **AC-4** — `MAX_REVIEW_CYCLES=3` holds under workflow mode — declared; structural shadow is
+  AC-3's section statement (FR-4). Must **not** be over-promised as deterministic.
+
+---
+
+## 9. Risks and open questions
+
+**Risks.**
+
+- *Over-orchestration (umbrella §7).* The temptation is to fan out a per-property panel or a
+  deep-research scan on every review/assessment. Mitigation: §6 decision 3's non-trivial
+  trigger and decision 1's repo-size threshold keep the cheap single-context path the default
+  below the bound — exactly the S3 "strict threshold, cheap default" shape.
+- *INV-1 mis-application.* The honest hazard here is **over-restricting** the assessor/auditor:
+  INV-1 forbids the four durable curated artefacts, **not** the assessment report or the
+  auditor's existing HARNESS.md-Status / README-badge writes. Mitigation: §2.1(3–4) and AC-11
+  state the precise boundary — the *workflow* proposes findings only; the *agent* writes its
+  own report as today. The diaboli should reject any wording that forbids the assessor from
+  writing its assessment.
+- *Over-promising determinism.* Separate-context (AC-1) and live fan-out (AC-6) are agent-
+  backed; tagging them deterministic would overclaim. Mitigation: §6 decision 2 fixes the
+  honest split, as in S3.
+- *Scenario-home omission.* None of the four agents has a workflow-mode scenario directory; a
+  behavioural addition without one leaves the new modes unverified. Mitigation: §7.2 names the
+  directories the tdd-agent must create, the structural assertion set, the new content test
+  file, and its `tdad-tests-fast.yml` wiring.
+- *Template drift.* The agents point at S2 templates whose runtime call shapes may drift from
+  the authoritative docs. Mitigation: the agents ADAPT the templates and defer function names to
+  <https://code.claude.com/docs/en/workflows>; S4 freezes no call signature and edits no
+  template.
+- *Uniform-shape over-reach.* The disposition is "uniform shape, specialise only where an agent
+  demands it." The auditor's **self-preference guard** (AC-8) is the one demanded
+  specialisation; the assessor does not carry it. Mitigation: AC-7 vs AC-8 keep the shared shape
+  shared and the one specialisation explicit.
+
+**Open questions.** None block S4. Umbrella open questions ride later slices (Q2 routing → S5,
+Q3 staging → S6, Q4 Copilot → S7) and are out of scope (§2.2). The S4-internal decisions (the
+repo-size threshold metric/value/mechanism, the verification split, the D5 trigger) are
+**surfaced for the GATE in §6, not left open** — the spec recommends and the human disposes.
+
+---
+
+## 10. References
+
+- Umbrella spec:
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+  (read-first runtime-scope note; §2 INV-1/INV-2; **D5**; **D7**; §5; §6; §7).
+- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md`
+  (Runtime-scope section; **S4** entry — uniform adversarial-verification shape, specialise
+  only where demanded).
+- Proven precedent (S3, merged):
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md`;
+  `ai-literacy-superpowers/agents/harness-enforcer.agent.md` (the "Workflow mode" section
+  pattern); `tdad_tests/tests/test_s3_enforcer_fanout_structural.py` (the deterministic
+  structural-content test pattern); `tdad_tests/scenarios/agents/harness-enforcer/` (the
+  scenario-file shape); `.github/workflows/tdad-tests-fast.yml` (the test-wiring pattern).
+- Shipped templates S4 adapts:
+  - `ai-literacy-superpowers/skills/dynamic-workflows/workflows/adversarial-review.workflow.js`
+    (D5 — separate-context review, per-property verifiers, synthesise-not-collapse).
+  - `ai-literacy-superpowers/skills/dynamic-workflows/workflows/deep-assessment.workflow.js`
+    (D7 — fan-out-by-area, per-finding adversarial verify, cited report; the auditor variant's
+    framework-assumption-challenging verifier).
+  - `ai-literacy-superpowers/scripts/inv-firewall.sh` (the INV-1/INV-2 firewall; untouched).
+- Target files S4 modifies:
+  - `ai-literacy-superpowers/agents/code-reviewer.agent.md`
+  - `ai-literacy-superpowers/agents/advocatus-diaboli.agent.md`
+  - `ai-literacy-superpowers/agents/assessor.agent.md`
+  - `ai-literacy-superpowers/agents/harness-auditor.agent.md`
+  - `ai-literacy-superpowers/commands/assess.md`
+  - `ai-literacy-superpowers/commands/harness-audit.md`
+- Runtime API (authoritative): <https://code.claude.com/docs/en/workflows>.
+- AGENTS.md decisions consulted: the "recommended option is a hypothesis for the diaboli"
+  STYLE note; "a consumer never mutates the contract it consumes" (S4 adapts but does not edit
+  the S2 templates).

--- a/tdad_tests/scenarios/agents/advocatus-diaboli/declares-rubric-bearing-adversary-role.md
+++ b/tdad_tests/scenarios/agents/advocatus-diaboli/declares-rubric-bearing-adversary-role.md
@@ -1,0 +1,51 @@
+---
+component: advocatus-diaboli
+component_type: agent
+tier: structural
+---
+
+# Scenario: the diaboli declares its rubric-bearing-adversary role in the adversarial-review workflow without relaxing its trust boundary (AC-5 / FR-6)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/advocatus-diaboli.agent.md` — its body text
+and its frontmatter `tools`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- It states that in the **`adversarial-review`** workflow the diaboli is the
+  **rubric-bearing adversary** — the agent that evaluates the diff against
+  the CUPID + literate rubric. The token `adversarial-review` and the phrase
+  "rubric-bearing adversary" both appear. Keep "rubric-bearing adversary"
+  **on one line** (the content test asserts it as one substring).
+- It states this role **does not relax its existing read-only trust
+  boundary** — dispositions remain the human's job.
+- The frontmatter `tools` remains **read-only**: `Read, Glob, Grep` only —
+  **no `Write`, no `Edit`, no `Bash`**. This is already true today and must
+  **stay** true.
+
+## Rubric
+
+Deterministic structural assertion (AC-5, umbrella D5). The diaboli is the
+adversary in the adversarial-review workflow, and S4's only addition is the
+*declaration* of that role. The load-bearing guarantee is that the
+declaration does **not** widen the diaboli's tool boundary: the read-only
+trust boundary is what makes the human-cognition gate on dispositions real.
+The existing spec-mode/code-mode charter is unchanged.
+
+The tool-set check is GREEN today and must STAY green — asserting it here
+guards against a workflow-mode edit accidentally granting Write/Bash.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4AdvocatusDiaboliWorkflowRole`). The rubric-bearing-adversary
+declaration is RED now (the agent doc does not yet mention the
+`adversarial-review` workflow or the rubric-bearing-adversary role); the
+read-only tool assertion is GREEN now and stays green.

--- a/tdad_tests/scenarios/agents/assessor/declares-output-invariant-and-inv1-precision.md
+++ b/tdad_tests/scenarios/agents/assessor/declares-output-invariant-and-inv1-precision.md
@@ -1,0 +1,60 @@
+---
+component: assessor
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section preserves the timestamped-artefact output and states the precise INV-1 boundary (AC-9, AC-11 / FR-9, FR-11)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/assessor.agent.md` — its workflow-mode
+section and its frontmatter `tools`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- The workflow-mode section states the output **remains a timestamped
+  artefact in the existing location/format** — the word "timestamped"
+  appears, and the existing location `assessments/` (i.e.
+  `assessments/YYYY-MM-DD-assessment.md`) is named. Workflow mode changes
+  *how* the report is produced (fan-out + verify), not *what* it is or
+  *where* it lands.
+- The section states the **`*.workflow.js` workflow itself proposes
+  findings only** and **never writes a durable curated artefact** — the
+  word "durable" co-occurs with a propose-only statement and with **at
+  least two** of the four named artefacts `HARNESS.md`, `AGENTS.md`,
+  `CLAUDE.md`, `MODEL_ROUTING.md`. The prohibition is on **those four**.
+- The frontmatter `tools` **retains** `Write` and `Edit` — the assessor
+  **legitimately writes its own assessment report** (which is **not** one
+  of the four durable curated artefacts). Workflow mode must **not** be
+  read as forbidding the assessor from writing its assessment. This stays
+  GREEN.
+
+## Rubric
+
+Deterministic structural assertion of AC-9 (output invariant) and AC-11
+(the precise INV-1 boundary). The honest hazard the spec flags (§9) is
+**over-restricting** the assessor: INV-1 forbids only the four durable
+curated artefacts, **not** the assessment doc. So this scenario asserts two
+things in tension — (a) the workflow proposes findings only and never writes
+the four curated artefacts, and (b) the assessor **keeps** its `Write`/`Edit`
+tools for its own report. A scenario that forbade the assessor from writing
+its assessment would be wrong; this one does not.
+
+The durable-curated prohibition is asserted as the word "durable" plus a
+propose-only term plus ≥2 of the four named artefacts co-occurring, so a
+reasonable line-wrap of the four-artefact list still passes while keeping the
+assertion load-bearing (not a single trivially-satisfiable keyword).
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4AssessorWorkflowMode`). The output-invariant and durable-curated
+declarations are RED now (no workflow-mode section); the Write/Edit-retained
+tool assertion is GREEN now and stays green.

--- a/tdad_tests/scenarios/agents/assessor/declares-threshold-and-deep-research-shape.md
+++ b/tdad_tests/scenarios/agents/assessor/declares-threshold-and-deep-research-shape.md
@@ -1,0 +1,64 @@
+---
+component: assessor
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares the file-count threshold and the deep-research shape (AC-7 / FR-7)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/assessor.agent.md`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- A section titled **`Workflow mode`** (a level-2 or level-3 heading
+  containing the phrase "Workflow mode") is present.
+- It declares the **repo-size threshold**: repo **file count `> 300`**
+  (strict greater-than). The literal `> 300` and the metric "file count"
+  both appear. Keep `> 300` **unwrapped** on one line.
+- It states the threshold is **configurable** via the **optional
+  `HARNESS.md` field** (the §6 decision-1 M1 mechanism), defaulting to
+  **300 when absent** (a missing/garbled field safe-defaults, never
+  errors).
+- It declares the deep-research shape: **fan out by area**, each finding
+  **verified by a separate agent** before synthesis, producing a **cited
+  report** (file:line citations preserved through synthesis). The phrases
+  "separate agent" and "cited report" appear, each **on one line**.
+- It states it **adapts `deep-assessment.workflow.js` by relative path**
+  (ADAPT, not verbatim) — the filename and "adapt" both appear.
+- It states the **Claude-Code-only scope** and the **non-erroring
+  fallback** to the existing single-context Phase 1–6 scan ("Claude Code",
+  "falls back", "never errors" appear).
+
+## Rubric
+
+Deterministic structural shadow of AC-6 (umbrella D7). What is checkable
+from a static file read is that the agent doc *declares* the threshold and
+the fan-out/verify/cited-report shape — not that a live run fans out (that
+is the agent-backed property AC-6, declared in
+`runtime-fans-out-by-area-with-verification.md`, not wired here). The
+load-bearing specifics:
+
+- The literal `> 300` default and the file-count metric (the cheap-default
+  boundary: small/medium repos stay single-context — the over-orchestration
+  guard).
+- The configurability mechanism is **named** (optional `HARNESS.md` field),
+  consistent with S3 and with the code-reviewer trigger — one knob style
+  across the epic.
+- The fan-out-by-area + per-finding separate-agent verification + cited
+  report co-occur — a long scan can no longer declare itself done after
+  partial progress (the "35 of 50" lazy stop).
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4AssessorWorkflowMode`). RED now: no workflow-mode section exists in
+`assessor.agent.md`, so the threshold / fan-out / verification / cited-report
+/ template-adapt / scope-and-fallback declarations are all absent.

--- a/tdad_tests/scenarios/agents/assessor/runtime-fans-out-by-area-with-verification.md
+++ b/tdad_tests/scenarios/agents/assessor/runtime-fans-out-by-area-with-verification.md
@@ -1,0 +1,47 @@
+---
+component: assessor
+component_type: agent
+tier: behavioural
+fixture: large-repo-inventory
+---
+
+# Scenario: an above-threshold repo fans out by area with per-finding separate-agent verification (AC-6, agent-backed)
+
+## Given
+
+A repo **above the file-count threshold** (`> 300` files) and the **Claude
+Code runtime present**.
+
+## When
+
+The assessor runs in workflow mode against that repo.
+
+## Then
+
+- Findings **fan out by area** — each area is scanned by its own agent, so
+  no single long scan can declare itself done after partial progress.
+- **Each finding is verified by a separate agent before synthesis**, and
+  the synthesised report preserves file:line citations (a completeness pass
+  guards the tail of findings).
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-threshold-and-deep-research-shape.md` (AC-7), which asserts the
+agent doc *declares* the threshold, the fan-out-by-area, the per-finding
+separate-agent verification, and the cited report.
+
+A judge evaluating a live run confirms (a) the scan fans out by area and
+(b) every finding passes through a separate verifier agent before the
+synthesis barrier. This requires the Claude Code workflow runtime; on a tree
+without it the assessor falls back to its existing single-context Phase 1–6
+scan (see `declares-threshold-and-deep-research-shape.md`).
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadow declares. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/agents/code-reviewer/declares-claude-code-scope-and-propose-only.md
+++ b/tdad_tests/scenarios/agents/code-reviewer/declares-claude-code-scope-and-propose-only.md
@@ -1,0 +1,56 @@
+---
+component: code-reviewer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares Claude-Code-only scope, non-erroring fallback, and propose-only/read-only boundary (AC-2, AC-11 / FR-5)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/code-reviewer.agent.md` — its workflow-mode
+section and its frontmatter `tools`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- The workflow-mode section states workflow mode **requires the Claude Code
+  runtime** (the phrase "Claude Code" appears tied to the runtime).
+- It states that on a tree **without** the runtime the reviewer **falls
+  back to its existing single-context review** and **never errors** (the
+  phrases "fall back"/"falls back" and "never error"/"never errors"
+  appear; it does not pretend to fan out).
+- It states workflow mode is **propose-only / read-only** and **never
+  writes a durable artefact** (INV-1) — the phrase "durable artefact"
+  appears tied to a propose-only / read-only / never-writes statement.
+  Keep "durable artefact" **unwrapped**.
+- The frontmatter `tools` stays **read-only**: no `Write`, no `Edit` (it
+  remains `Read, Glob, Grep, Bash`). This is already true today and must
+  **stay** true.
+
+## Rubric
+
+Deterministic structural assertion (AC-2 runtime scope + AC-11 INV-1
+precision), grounded in the umbrella §5.5 runtime-scope note and the
+slicing-record "Runtime scope — Claude Code only" section. The reviewer is a
+propose-only agent; workflow mode adds fan-out, not write capability. The
+Claude-Code-gated mode must degrade to the existing static single-context
+review, never to an error. S4 restates the Claude-Code-only nature for the
+reviewer's *own* behaviour; it does **not** decide the precise Copilot
+degradation contract (open-question 4, owned by S7).
+
+The tool-set check is GREEN today (the list already excludes Write/Edit)
+and must STAY green through S4 — it is the agent-level INV-1 enforcement.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4CodeReviewerWorkflowMode` for the section declarations,
+`TestS4CodeReviewerReadOnlyToolSet` for the tool boundary). The section
+declarations are RED now (no workflow-mode section); the read-only tool
+assertion is GREEN now and stays green.

--- a/tdad_tests/scenarios/agents/code-reviewer/declares-per-property-verifiers-synthesised.md
+++ b/tdad_tests/scenarios/agents/code-reviewer/declares-per-property-verifiers-synthesised.md
@@ -1,0 +1,54 @@
+---
+component: code-reviewer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares per-property dedicated verifiers, synthesised-not-collapsed, adapting the template (AC-3 / FR-3)
+
+## Given
+
+The workflow-mode section of
+`ai-literacy-superpowers/agents/code-reviewer.agent.md`.
+
+## When
+
+The section is read.
+
+## Then
+
+- It declares that **each CUPID property** (Composable, Unix-philosophy,
+  Predictable, Idiomatic, Domain-based) and **each literate-programming
+  property** is checked by a **dedicated verifier** — the terms "CUPID",
+  "literate", and "dedicated verifier" all appear. Keep "dedicated
+  verifier" **on one line**.
+- It states that findings are **synthesised, not collapsed** into a single
+  thumbs-up — both "synthesis" and "collapse" appear so the contrast is
+  explicit (asserting "synthesis" alone would not capture the guarantee).
+- It states it **adapts `adversarial-review.workflow.js` by relative
+  path** — the filename `adversarial-review.workflow.js` and the word
+  "adapt" both appear (ADAPT, not run verbatim; per-role model tiers and
+  token budget tuned per run).
+- It states the **`MAX_REVIEW_CYCLES=3`** GUARDRAIL still holds in workflow
+  mode — workflow mode does not multiply review cycles. Keep
+  `MAX_REVIEW_CYCLES` **unwrapped**.
+
+## Rubric
+
+Deterministic structural shadow of AC-1's fan-out (umbrella D5). The
+load-bearing guarantee is the *per-property fan-out plus the
+synthesise-not-collapse barrier* — a single thumbs-up that hides which
+property failed is exactly the self-preferential collapse this defeats. The
+test asserts the synthesise/collapse contrast as two tokens, the template
+filename verbatim (filenames are wrap-safe), and `MAX_REVIEW_CYCLES` as one
+token. AC-4 (the guardrail actually holding) is unverified/declared — the
+guardrail lives in the orchestrator/pipeline; the structural shadow is the
+section *stating* it holds.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4CodeReviewerWorkflowMode`). RED now: no workflow-mode section
+exists, so the per-property-verifier, synthesise-not-collapse,
+template-adapt, and MAX_REVIEW_CYCLES declarations are all absent.

--- a/tdad_tests/scenarios/agents/code-reviewer/declares-separate-context-and-non-trivial-trigger.md
+++ b/tdad_tests/scenarios/agents/code-reviewer/declares-separate-context-and-non-trivial-trigger.md
@@ -1,0 +1,66 @@
+---
+component: code-reviewer
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares separate-context review and the non-trivial trigger (AC-2 / FR-1, FR-2)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/code-reviewer.agent.md`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- A section titled **`Workflow mode`** (a level-2 or level-3 heading
+  containing the phrase "Workflow mode") is present.
+- The section declares the **separate-context property** — the reviewing
+  agent operates in a **context window distinct from the implementer's**,
+  so it is not judging output from the context that produced it. Keep the
+  phrase "context window" **on one line** (the content test asserts
+  "context window" and "implementer" as separate tokens, so wrapping
+  between "context" and "window" would break the check).
+- The section declares the **non-trivial trigger**: workflow mode engages
+  only for a **non-trivial** review — default **`> 2 files` changed** (or a
+  substantive single-file change). Trivial diffs (typo, one-liner,
+  formatting) keep the existing single-context review. Keep `> 2 files`
+  **unwrapped** on one line.
+- The section states the trigger is **configurable** via the **optional
+  `HARNESS.md` field** (the §6 decision-1 M1 mechanism — one consistent
+  knob style across the epic), not left as "somehow tunable".
+
+## Rubric
+
+This is the deterministic structural shadow of AC-1 (umbrella D5). What is
+checkable from a static file read is that the agent doc *declares* the
+separate-context property and the non-trivial trigger — not that a live
+run actually opens a second context window (that is the agent-backed
+property AC-1, declared in
+`runtime-runs-in-separate-context-window.md`, not wired here). The
+load-bearing specifics a deterministic check verifies:
+
+- "context window" + "implementer" co-occur (the separate-context
+  guarantee), asserted as independent tokens so a reasonable line-wrap
+  still passes — but the implementer must keep "context window" itself
+  unwrapped.
+- The literal `> 2 files` default is present (the cheap-default boundary:
+  a trivial diff demonstrably stays single-context, defeating the
+  over-orchestration risk).
+- The configurability mechanism is **named** — an optional `HARNESS.md`
+  field — consistent with S3's enforcer threshold.
+
+The scenario must **not** be read as asserting any live context-window
+split occurs — only that the contract is declared in checkable language.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4CodeReviewerWorkflowMode`). RED now because the agent doc contains
+no "Workflow mode" section (`grep -n "Workflow mode"` returns nothing), so
+none of the separate-context / trigger / configurability phrases exist yet.

--- a/tdad_tests/scenarios/agents/code-reviewer/runtime-runs-in-separate-context-window.md
+++ b/tdad_tests/scenarios/agents/code-reviewer/runtime-runs-in-separate-context-window.md
@@ -1,0 +1,49 @@
+---
+component: code-reviewer
+component_type: agent
+tier: behavioural
+fixture: non-trivial-diff
+---
+
+# Scenario: a non-trivial review runs in a context window distinct from the implementer's (AC-1, agent-backed)
+
+## Given
+
+A **non-trivial** implementation diff (above the trigger — `> 2 files`
+changed) and the **Claude Code runtime present**.
+
+## When
+
+The code-reviewer runs in workflow mode against that diff.
+
+## Then
+
+- The reviewing agent operates in a **context window distinct from the
+  implementer's** — it does not inherit the producing context's reasoning.
+- Each CUPID property and each literate-programming property is checked by
+  a **dedicated verifier** subagent; the findings are **synthesised** into
+  one report, **not collapsed** into a single thumbs-up.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-separate-context-and-non-trivial-trigger.md` (AC-2) plus
+`declares-per-property-verifiers-synthesised.md` (AC-3), which assert the
+agent doc *declares* the separate-context property and the per-property
+fan-out.
+
+A judge evaluating a live run confirms (a) the review context window is
+distinct from the implementer's and (b) one verifier exists per CUPID +
+literate property behind a synthesis barrier. This requires the Claude Code
+workflow runtime; it cannot be run on a tree without it (where the reviewer
+falls back to single-context — see
+`declares-claude-code-scope-and-propose-only.md`).
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadows declare. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/agents/harness-auditor/declares-output-invariant-and-inv1-precision.md
+++ b/tdad_tests/scenarios/agents/harness-auditor/declares-output-invariant-and-inv1-precision.md
@@ -1,0 +1,58 @@
+---
+component: harness-auditor
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section preserves the existing HARNESS.md-Status + README-badge output and states the precise INV-1 boundary (AC-9, AC-11 / FR-9, FR-11)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-auditor.agent.md` — its
+workflow-mode section and its frontmatter `tools`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- The workflow-mode section states the output **remains a timestamped
+  artefact in the existing location/format** — the word "timestamped"
+  appears — and that the auditor's existing write targets are the
+  **HARNESS.md Status section** and the **README badge** ("status" and
+  "badge" both appear). Workflow mode keeps those exact write targets and
+  formats.
+- The section states the **`*.workflow.js` workflow itself proposes
+  findings only** and **never writes a durable curated artefact** — the
+  word "durable" co-occurs with a propose-only statement and with **at
+  least two** of the four named artefacts `HARNESS.md`, `AGENTS.md`,
+  `CLAUDE.md`, `MODEL_ROUTING.md`.
+- The frontmatter `tools` **retains** `Write` and `Edit` — the auditor's
+  existing, narrowly-scoped writes (the HARNESS.md Status section + the
+  README badge line) are legitimate and unchanged. Workflow mode must
+  **not** be read as forbidding them. This stays GREEN.
+
+## Rubric
+
+Deterministic structural assertion of AC-9 (output invariant) and AC-11
+(the precise INV-1 boundary), for the auditor. The same over-restriction
+hazard the spec flags (§9) applies: the auditor already (and only) writes
+the HARNESS.md Status section and the README badge line — these are its
+existing narrowly-scoped writes, **not** a full durable-artefact rewrite.
+The *workflow* proposes findings only; the *agent* performs those two scoped
+writes as today.
+
+The durable-curated prohibition is asserted as the word "durable" plus a
+propose-only term plus ≥2 of the four named artefacts co-occurring (wrap-safe
+yet load-bearing). The Write/Edit-retained tool assertion guards against an
+over-zealous workflow-mode edit stripping the auditor's legitimate writes.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4HarnessAuditorWorkflowMode`). The output-invariant and
+durable-curated declarations are RED now (no workflow-mode section); the
+Write/Edit-retained tool assertion is GREEN now and stays green.

--- a/tdad_tests/scenarios/agents/harness-auditor/declares-threshold-deep-research-and-self-preference-guard.md
+++ b/tdad_tests/scenarios/agents/harness-auditor/declares-threshold-deep-research-and-self-preference-guard.md
@@ -1,0 +1,51 @@
+---
+component: harness-auditor
+component_type: agent
+tier: structural
+---
+
+# Scenario: the workflow-mode section declares the deep-research shape PLUS the self-preference guard (AC-8 / FR-8)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/harness-auditor.agent.md`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- A section titled **`Workflow mode`** (a level-2 or level-3 heading
+  containing the phrase "Workflow mode") is present.
+- It declares **everything the assessor declares** (AC-7): the repo
+  **file count `> 300`** threshold (strict, `> 300` unwrapped),
+  configurable via the **optional `HARNESS.md` field** (default 300 when
+  absent), **fan out by area**, each finding **verified by a separate
+  agent** before synthesis, a **cited report**, **adapts
+  `deep-assessment.workflow.js` by relative path**, and the
+  **Claude-Code-only scope + non-erroring fallback**.
+- **Plus the self-preference guard** (the one demanded specialisation): at
+  least one verifier is **adversarial to the framework's own assumptions**
+  — the auditor must not grade its own homework. The words "adversarial",
+  "framework", and "assumption" co-occur in the section.
+
+## Rubric
+
+Deterministic structural shadow of AC-6 (umbrella D7) **plus** the auditor's
+single specialisation. The disposition is "uniform shape, specialise only
+where an agent demands it" — the self-preference guard is that one
+specialisation (the auditor grades its own framework, so a verifier
+adversarial to the framework's assumptions is the guard against self-audit
+bias). The shared shape (threshold + fan-out + per-finding verification +
+cited report + scope + fallback) is asserted by the same shared helper used
+for the assessor; the auditor adds the guard on top.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4HarnessAuditorWorkflowMode`). RED now: no workflow-mode section
+exists in `harness-auditor.agent.md`, so the deep-research shape and the
+self-preference-guard declarations are all absent.

--- a/tdad_tests/scenarios/agents/harness-auditor/runtime-fans-out-with-framework-adversarial-verifier.md
+++ b/tdad_tests/scenarios/agents/harness-auditor/runtime-fans-out-with-framework-adversarial-verifier.md
@@ -1,0 +1,47 @@
+---
+component: harness-auditor
+component_type: agent
+tier: behavioural
+fixture: large-repo-inventory
+---
+
+# Scenario: an above-threshold audit fans out by area with a framework-adversarial verifier (AC-6 + self-preference guard, agent-backed)
+
+## Given
+
+A repo **above the file-count threshold** (`> 300` files) and the **Claude
+Code runtime present**.
+
+## When
+
+The harness-auditor runs in workflow mode against that repo.
+
+## Then
+
+- Findings **fan out by area** and **each finding is verified by a separate
+  agent before synthesis**, producing a cited report (as for the assessor).
+- **At least one verifier challenges the framework's own assumptions** — a
+  live verifier is adversarial to the framework, so the auditor cannot grade
+  its own homework.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-threshold-deep-research-and-self-preference-guard.md` (AC-8),
+which asserts the agent doc *declares* the deep-research shape plus the
+self-preference guard.
+
+A judge evaluating a live run confirms (a) the audit fans out by area with
+per-finding separate-agent verification and (b) at least one verifier is
+genuinely adversarial to the framework's assumptions (not a rubber stamp).
+This requires the Claude Code workflow runtime; on a tree without it the
+auditor falls back to its existing single-context behaviour.
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadow declares. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/commands/assess/documents-large-repo-workflow-path.md
+++ b/tdad_tests/scenarios/commands/assess/documents-large-repo-workflow-path.md
@@ -1,0 +1,46 @@
+---
+component: assess
+component_type: command
+tier: structural
+---
+
+# Scenario: /assess documents the large-repo deep-research workflow path (AC-10 / FR-10)
+
+## Given
+
+The file
+`ai-literacy-superpowers/commands/assess.md`.
+
+## When
+
+The command doc is read.
+
+## Then
+
+- It documents that, for a repo **above the threshold** (`> 300` files) on
+  the **Claude Code runtime**, the dispatched assessor agent elects its
+  **deep-research workflow mode** (fan-out by area + adversarial
+  verification + cited report). The phrase "workflow mode", the literal
+  `> 300`, and "Claude Code" all appear, each **unwrapped** on one line.
+- It documents that the **output is the same** timestamped assessment
+  artefact in the same location, and that there is a **non-erroring
+  fallback** elsewhere (the term "fall back"/"falls back"/"fallback"
+  appears).
+
+## Rubric
+
+Deterministic structural assertion (AC-10). The command is the
+human-facing entry point; it must point at the agent's workflow-mode
+election above the threshold so a reader sees the large-repo path without
+reading the agent doc. The assertion is load-bearing: it requires the
+threshold value, the runtime gate, and the fallback to co-occur — not a
+single keyword. The command does not re-decide the threshold; it documents
+the path the agent owns.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4CommandsDocumentWorkflowPath`). RED now: `commands/assess.md` does
+not yet document the workflow path (no "workflow mode" / `> 300` / Claude
+Code note).

--- a/tdad_tests/scenarios/commands/harness-audit/documents-large-repo-workflow-path.md
+++ b/tdad_tests/scenarios/commands/harness-audit/documents-large-repo-workflow-path.md
@@ -1,0 +1,44 @@
+---
+component: harness-audit
+component_type: command
+tier: structural
+---
+
+# Scenario: /harness-audit documents the large-repo deep-research workflow path (AC-10 / FR-10)
+
+## Given
+
+The file
+`ai-literacy-superpowers/commands/harness-audit.md`.
+
+## When
+
+The command doc is read.
+
+## Then
+
+- It documents that, for a repo **above the threshold** (`> 300` files) on
+  the **Claude Code runtime**, the dispatched harness-auditor agent elects
+  its **deep-research workflow mode** (fan-out by area + adversarial
+  verification + cited report, including the framework-adversarial
+  verifier). The phrase "workflow mode", the literal `> 300`, and "Claude
+  Code" all appear, each **unwrapped** on one line.
+- It documents that the **output is the same** (the existing HARNESS.md
+  Status section + README badge update) and that there is a **non-erroring
+  fallback** elsewhere (the term "fall back"/"falls back"/"fallback"
+  appears).
+
+## Rubric
+
+Deterministic structural assertion (AC-10), the auditor command sibling of
+the `/assess` scenario. The command documents the path the auditor owns; it
+does not re-decide the threshold. The assertion requires the threshold
+value, the runtime gate, and the fallback to co-occur — load-bearing, not a
+single keyword.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s4_adversarial_deepresearch_structural.py`
+(`TestS4CommandsDocumentWorkflowPath`). RED now: `commands/harness-audit.md`
+does not yet document the workflow path.

--- a/tdad_tests/tests/test_s4_adversarial_deepresearch_structural.py
+++ b/tdad_tests/tests/test_s4_adversarial_deepresearch_structural.py
@@ -1,0 +1,517 @@
+"""Layer 1 structural content checks for dynamic-workflows S4.
+
+These tests are the *deterministic mechanism* behind the structural
+scenarios authored at ``scenarios/agents/{code-reviewer,advocatus-diaboli,
+assessor,harness-auditor}/`` and ``scenarios/commands/{assess,harness-audit}/``
+for slice S4 (the adversarial-review + deep-research workflow-mode upgrade
+across four existing agents + two commands).
+
+Per the spec's §6 decision 2 (the verification split), this repo's
+deterministic layer reads files and matches structure — it does **not**
+spawn a live fan-out or open a second context window. So what is
+deterministically asserted here is that each agent doc / command **declares**
+the workflow-mode contract (D5 separate-context + non-trivial trigger;
+D7 file-count threshold + fan-out-by-area + per-finding separate-agent
+verification + cited report; Claude-Code-only scope + non-erroring
+fallback; the existing-location/format invariant; INV-1 precision). The
+live properties (AC-1 separate context window, AC-6 live fan-out) are
+agent-backed and live as ``behavioural`` scenarios, not wired here.
+
+RED state (before S4 implements): none of the four agent docs has a
+"Workflow mode" section and neither command documents the large-repo /
+non-trivial workflow path, so every declaration assertion below fails on
+missing content — RED for the right reason (missing content, not a
+malformed scenario or an unresolvable component; all six components
+already exist).
+
+Line-wrap note (the trap that bit S3 twice): a required two-word phrase
+that an implementer might wrap across a line is NOT asserted as a single
+substring. Where a guarantee needs two terms to co-occur, they are
+asserted as two independent ``in`` checks on the lowercased section so a
+wrapped phrase still passes. Single load-bearing tokens (filenames,
+``> 300``, ``> 2``, ``harness.md``) are wrap-safe and asserted directly.
+
+Spec: docs/superpowers/specs/2026-06-22-dynamic-workflows-s4-adversarial-deepresearch-design.md
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+def _component_text(
+    plugin_path: Path, name: str, component_type: str
+) -> str:
+    component = plugin_runner.find_component(
+        plugin_path, name=name, component_type=component_type
+    )
+    return component.path.read_text(encoding="utf-8")
+
+
+def _workflow_section(plugin_path: Path, name: str, component_type: str) -> str:
+    """Return the text from the 'Workflow mode' heading to the next
+    same-or-higher-level heading, lowercased. Empty string if absent."""
+    text = _component_text(plugin_path, name, component_type)
+    m = re.search(
+        r"^(#{2,4})\s+.*workflow mode.*$", text, re.IGNORECASE | re.MULTILINE
+    )
+    if not m:
+        return ""
+    level = len(m.group(1))
+    start = m.end()
+    rest = text[start:]
+    nxt = re.search(rf"^#{{1,{level}}}\s+\S", rest, re.MULTILINE)
+    end = nxt.start() if nxt else len(rest)
+    return rest[:end].lower()
+
+
+# ---------------------------------------------------------------------------
+# D5 — code-reviewer: separate-context adversarial review
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS4CodeReviewerWorkflowMode:
+    """Structural shadows of AC-1..AC-4 — code-reviewer.agent.md must
+    *declare* the separate-context adversarial-review workflow-mode
+    contract (scenarios under ``scenarios/agents/code-reviewer/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _workflow_section(plugin_path, "code-reviewer", "agent")
+
+    def test_workflow_mode_section_exists(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert section, (
+            "code-reviewer.agent.md must contain a 'Workflow mode' section "
+            "(AC-2 / FR-1). None found."
+        )
+
+    def test_declares_separate_context_window(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # Wrap-safe: assert the two load-bearing terms co-occur rather than
+        # the joined phrase "context window distinct from the implementer".
+        assert "context window" in section and "implementer" in section and (
+            "distinct" in section or "separate" in section
+        ), (
+            "Workflow-mode section must declare the reviewing agent operates "
+            "in a context window distinct/separate from the implementer's "
+            "(AC-2 / FR-2; the separate-context property). Keep "
+            "'context window' unwrapped on one line."
+        )
+
+    def test_declares_non_trivial_trigger_two_files(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "non-trivial" in section and "> 2 files" in section, (
+            "Workflow-mode section must declare the non-trivial trigger — "
+            "workflow mode engages only for non-trivial reviews, default "
+            "`> 2 files` changed (AC-2 / FR-2, §6 decision 3 / T2). Keep "
+            "'> 2 files' unwrapped."
+        )
+
+    def test_declares_trigger_configurable_via_harness_field(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "harness.md" in section and "configur" in section, (
+            "Workflow-mode section must state the non-trivial trigger is "
+            "configurable via the optional HARNESS.md field (AC-2 / FR-2, "
+            "§6 decision 1 M1, one consistent knob across the epic)."
+        )
+
+    def test_declares_per_property_dedicated_verifier(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "cupid" in section and "literate" in section and (
+            "dedicated verifier" in section
+        ), (
+            "Workflow-mode section must declare each CUPID property and each "
+            "literate-programming property is checked by a dedicated "
+            "verifier (AC-3 / FR-3). Keep 'dedicated verifier' unwrapped."
+        )
+
+    def test_declares_synthesised_not_collapsed(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "synthesis" in section and "collapse" in section, (
+            "Workflow-mode section must state findings are synthesised, NOT "
+            "collapsed into a single thumbs-up (AC-3 / FR-3). Assert the "
+            "synthesise-not-collapse contrast, not just the word "
+            "'synthesis'."
+        )
+
+    def test_declares_adapts_template_by_relative_path(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "adversarial-review.workflow.js" in section and (
+            "adapt" in section
+        ), (
+            "Workflow-mode section must state it ADAPTs "
+            "adversarial-review.workflow.js by relative path — ADAPT, not "
+            "verbatim (AC-3 / FR-3)."
+        )
+
+    def test_declares_max_review_cycles_respected(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "max_review_cycles" in section and "3" in section, (
+            "Workflow-mode section must state MAX_REVIEW_CYCLES=3 still "
+            "holds in workflow mode (AC-4 / FR-4). Keep 'MAX_REVIEW_CYCLES' "
+            "unwrapped."
+        )
+
+    def test_declares_claude_code_scope_and_fallback(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "claude code" in section and (
+            "fall back" in section or "falls back" in section
+        ) and ("never error" in section), (
+            "Workflow-mode section must state the Claude-Code-only runtime "
+            "scope and the non-erroring fallback to single-context review "
+            "(AC-2 / FR-5)."
+        )
+
+    def test_declares_propose_only_never_writes_durable(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "durable artefact" in section and (
+            "propose" in section or "never write" in section or (
+                "does not write" in section
+            ) or "read-only" in section
+        ), (
+            "Workflow-mode section must state workflow mode is "
+            "propose-only / read-only and never writes a durable artefact "
+            "(AC-11 / FR-5 / INV-1). Keep 'durable artefact' unwrapped."
+        )
+
+
+@pytest.mark.structural
+class TestS4CodeReviewerReadOnlyToolSet:
+    """AC-11 / FR-5: the code-reviewer's tool set must stay read-only (no
+    Write/Edit). GREEN today and must STAY green through S4."""
+
+    def test_tools_no_write_no_edit(self, plugin_path: Path) -> None:
+        component = plugin_runner.find_component(
+            plugin_path, name="code-reviewer", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert "Write" not in tools and "Edit" not in tools, (
+            f"code-reviewer must stay read-only (INV-1, AC-11); tools must "
+            f"not include Write/Edit. Got {tools!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# D5 — advocatus-diaboli: the rubric-bearing adversary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS4AdvocatusDiaboliWorkflowRole:
+    """Structural shadow of AC-5 — advocatus-diaboli.agent.md must declare
+    its rubric-bearing-adversary role in the adversarial-review workflow
+    without relaxing its read-only trust boundary
+    (scenarios under ``scenarios/agents/advocatus-diaboli/``)."""
+
+    def test_declares_rubric_bearing_adversary_role(
+        self, plugin_path: Path
+    ) -> None:
+        text = _component_text(
+            plugin_path, "advocatus-diaboli", "agent"
+        ).lower()
+        assert "adversarial-review" in text and (
+            "rubric-bearing adversary" in text
+        ), (
+            "advocatus-diaboli.agent.md must declare that in the "
+            "adversarial-review workflow it is the rubric-bearing adversary "
+            "evaluating the diff against the CUPID + literate rubric "
+            "(AC-5 / FR-6). Keep 'rubric-bearing adversary' unwrapped."
+        )
+
+    def test_trust_boundary_unchanged_read_only(
+        self, plugin_path: Path
+    ) -> None:
+        # The existing read-only boundary must stay green: no Write/Edit/Bash.
+        component = plugin_runner.find_component(
+            plugin_path, name="advocatus-diaboli", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert (
+            "Write" not in tools
+            and "Edit" not in tools
+            and "Bash" not in tools
+        ), (
+            f"advocatus-diaboli must keep its read-only trust boundary "
+            f"unchanged (AC-5 / FR-6); tools must remain read-only with no "
+            f"Write/Edit/Bash. Got {tools!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# D7 — assessor + harness-auditor: deep-research, fan-out-by-area
+# ---------------------------------------------------------------------------
+
+
+def _assert_deep_research_shape(section: str, agent_label: str) -> None:
+    """Shared D7 declaration assertions for both assessor and auditor.
+
+    Each guarantee is asserted as wrap-safe co-occurring tokens, never a
+    joined two-word phrase the implementer might wrap.
+    """
+    assert "> 300" in section, (
+        f"{agent_label} workflow-mode section must declare the file-count "
+        f"threshold `> 300` (strict greater-than) (AC-7 / FR-7, §6 decision "
+        f"1). Keep '> 300' unwrapped."
+    )
+    assert "file count" in section or "files" in section, (
+        f"{agent_label} workflow-mode section must name the metric as repo "
+        f"file count (AC-7 / FR-7)."
+    )
+    assert "harness.md" in section and "configur" in section, (
+        f"{agent_label} workflow-mode section must state the threshold is "
+        f"configurable via the optional HARNESS.md field (AC-7 / FR-7, "
+        f"§6 decision 1 M1)."
+    )
+    assert "absent" in section or "default" in section, (
+        f"{agent_label} workflow-mode section must state the field defaults "
+        f"to 300 when absent (AC-7 / §9 safe-default)."
+    )
+    assert "fan out by area" in section or "fan-out by area" in section or (
+        "fan out" in section and "area" in section
+    ), (
+        f"{agent_label} workflow-mode section must declare fan-out by area "
+        f"(AC-7 / FR-7)."
+    )
+    assert "separate agent" in section and "verif" in section, (
+        f"{agent_label} workflow-mode section must declare each finding is "
+        f"verified by a separate agent before synthesis (AC-7 / FR-7). Keep "
+        f"'separate agent' unwrapped."
+    )
+    assert "cited report" in section, (
+        f"{agent_label} workflow-mode section must declare a cited report "
+        f"(file:line citations preserved through synthesis) (AC-7 / FR-7). "
+        f"Keep 'cited report' unwrapped."
+    )
+    assert "deep-assessment.workflow.js" in section and "adapt" in section, (
+        f"{agent_label} workflow-mode section must state it ADAPTs "
+        f"deep-assessment.workflow.js by relative path (AC-7 / FR-7)."
+    )
+    assert "claude code" in section and (
+        "fall back" in section or "falls back" in section
+    ) and ("never error" in section), (
+        f"{agent_label} workflow-mode section must state the Claude-Code-only "
+        f"scope and the non-erroring fallback to the existing single-context "
+        f"scan (AC-7 / FR-7)."
+    )
+
+
+def _assert_output_location_invariant(section: str, agent_label: str) -> None:
+    assert "timestamped" in section, (
+        f"{agent_label} workflow-mode section must state the output stays a "
+        f"timestamped artefact in the existing location/format (AC-9 / FR-9). "
+        f"Keep 'timestamped' present."
+    )
+
+
+@pytest.mark.structural
+class TestS4AssessorWorkflowMode:
+    """Structural shadow of AC-7 / AC-9 / AC-11 — assessor.agent.md must
+    declare the deep-research workflow-mode contract
+    (scenarios under ``scenarios/agents/assessor/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _workflow_section(plugin_path, "assessor", "agent")
+
+    def test_workflow_mode_section_exists(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert section, (
+            "assessor.agent.md must contain a 'Workflow mode' section "
+            "(AC-7 / FR-7). None found."
+        )
+
+    def test_declares_deep_research_shape(self, plugin_path: Path) -> None:
+        _assert_deep_research_shape(self._section(plugin_path), "assessor")
+
+    def test_declares_output_location_invariant(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        _assert_output_location_invariant(section, "assessor")
+        assert "assessments/" in section, (
+            "assessor workflow-mode section must state the assessment output "
+            "stays in the existing location `assessments/YYYY-MM-DD-"
+            "assessment.md` (AC-9 / FR-9). Keep 'assessments/' present."
+        )
+
+    def test_declares_workflow_proposes_only_not_durable_curated(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # The *workflow* proposes findings only and never writes one of the
+        # four durable curated artefacts; the *agent* still writes its own
+        # report. We assert the durable-curated prohibition co-occurs with
+        # at least two of the four named artefacts (wrap-safe).
+        named = sum(
+            t in section
+            for t in ("harness.md", "agents.md", "claude.md", "model_routing.md")
+        )
+        assert "durable" in section and "propose" in section and named >= 2, (
+            "assessor workflow-mode section must state the *.workflow.js "
+            "workflow itself proposes findings only and never writes a "
+            "durable curated artefact (HARNESS.md/AGENTS.md/CLAUDE.md/"
+            "MODEL_ROUTING.md) (AC-11 / FR-11) — the prohibition is on those "
+            "four, NOT on the assessment report the agent legitimately "
+            "writes."
+        )
+
+    def test_tools_retain_write_for_own_report(
+        self, plugin_path: Path
+    ) -> None:
+        # AC-11 precision: the assessor LEGITIMATELY writes its own report,
+        # so Write/Edit must REMAIN (do not forbid). This stays green.
+        component = plugin_runner.find_component(
+            plugin_path, name="assessor", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert "Write" in tools and "Edit" in tools, (
+            f"assessor must retain Write/Edit for its own assessment report "
+            f"(AC-11 / FR-11 — INV-1 forbids only the four durable curated "
+            f"artefacts, not the assessment doc). Got {tools!r}"
+        )
+
+
+@pytest.mark.structural
+class TestS4HarnessAuditorWorkflowMode:
+    """Structural shadow of AC-8 / AC-9 / AC-11 — harness-auditor.agent.md
+    must declare everything the assessor does PLUS the self-preference
+    guard (scenarios under ``scenarios/agents/harness-auditor/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _workflow_section(plugin_path, "harness-auditor", "agent")
+
+    def test_workflow_mode_section_exists(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert section, (
+            "harness-auditor.agent.md must contain a 'Workflow mode' section "
+            "(AC-8 / FR-8). None found."
+        )
+
+    def test_declares_deep_research_shape(self, plugin_path: Path) -> None:
+        _assert_deep_research_shape(
+            self._section(plugin_path), "harness-auditor"
+        )
+
+    def test_declares_self_preference_guard(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        # The one demanded specialisation: >=1 verifier adversarial to the
+        # framework's own assumptions. Wrap-safe co-occurring tokens.
+        assert "adversarial" in section and "assumption" in section and (
+            "framework" in section
+        ), (
+            "harness-auditor workflow-mode section must declare the "
+            "self-preference guard: at least one verifier is adversarial to "
+            "the framework's own assumptions (the auditor must not grade its "
+            "own homework) (AC-8 / FR-8)."
+        )
+
+    def test_declares_output_location_invariant(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        _assert_output_location_invariant(section, "harness-auditor")
+        # Auditor's existing write targets: HARNESS.md Status section + badge.
+        assert "status" in section and "badge" in section, (
+            "harness-auditor workflow-mode section must state the output "
+            "stays the existing HARNESS.md Status section + README badge "
+            "update (AC-9 / FR-9). Keep 'status' and 'badge' present."
+        )
+
+    def test_tools_retain_write_for_own_writes(
+        self, plugin_path: Path
+    ) -> None:
+        component = plugin_runner.find_component(
+            plugin_path, name="harness-auditor", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert "Write" in tools and "Edit" in tools, (
+            f"harness-auditor must retain Write/Edit for its existing "
+            f"HARNESS.md Status + README badge writes (AC-11 / FR-11). "
+            f"Got {tools!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — commands document the large-repo / non-trivial workflow path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS4CommandsDocumentWorkflowPath:
+    """Structural shadow of AC-10 — commands/assess.md and
+    commands/harness-audit.md must document the large-repo deep-research
+    workflow path (scenarios under ``scenarios/commands/{assess,
+    harness-audit}/``)."""
+
+    def _text(self, plugin_path: Path, name: str) -> str:
+        return _component_text(plugin_path, name, "command").lower()
+
+    def test_assess_documents_workflow_path(self, plugin_path: Path) -> None:
+        text = self._text(plugin_path, "assess")
+        assert "workflow mode" in text and "> 300" in text and (
+            "claude code" in text
+        ), (
+            "commands/assess.md must document that above the threshold "
+            "(`> 300` files) on the Claude Code runtime the dispatched agent "
+            "elects its deep-research workflow mode (AC-10 / FR-10). Keep "
+            "'> 300' and 'workflow mode' unwrapped."
+        )
+
+    def test_assess_documents_fallback(self, plugin_path: Path) -> None:
+        text = self._text(plugin_path, "assess")
+        assert "fall back" in text or "falls back" in text or (
+            "fallback" in text
+        ), (
+            "commands/assess.md must document the non-erroring fallback "
+            "elsewhere (AC-10 / FR-10)."
+        )
+
+    def test_harness_audit_documents_workflow_path(
+        self, plugin_path: Path
+    ) -> None:
+        text = self._text(plugin_path, "harness-audit")
+        assert "workflow mode" in text and "> 300" in text and (
+            "claude code" in text
+        ), (
+            "commands/harness-audit.md must document that above the "
+            "threshold (`> 300` files) on the Claude Code runtime the "
+            "auditor elects its deep-research workflow mode (AC-10 / FR-10). "
+            "Keep '> 300' and 'workflow mode' unwrapped."
+        )
+
+    def test_harness_audit_documents_fallback(
+        self, plugin_path: Path
+    ) -> None:
+        text = self._text(plugin_path, "harness-audit")
+        assert "fall back" in text or "falls back" in text or (
+            "fallback" in text
+        ), (
+            "commands/harness-audit.md must document the non-erroring "
+            "fallback elsewhere (AC-10 / FR-10)."
+        )


### PR DESCRIPTION
## Summary

- `code-reviewer` gains a separate-context **adversarial workflow mode** for non-trivial diffs (> 2 files, configurable via the HARNESS.md `fan-out-threshold` field) adapting `adversarial-review.workflow.js`, with `advocatus-diaboli` declared as the rubric-bearing adversary.
- `assessor` + `harness-auditor` gain a **deep-research workflow mode** above a repo file-count threshold (> 300, same `fan-out-threshold` field) adapting `deep-assessment.workflow.js`: fan out by area, verify each finding in a separate agent, emit a cited report. The auditor adds a self-preference guard. INV-1 precision is preserved — the workflow proposes, agents still write their own report artefacts. Claude-Code-only with a non-erroring fallback.
- Documentation: `commands/assess.md` + `commands/harness-audit.md` document the large-repo path; `reference/agents.md` (4 entries) and three how-tos updated.
- Deterministic structural checks (`test_s4_adversarial_deepresearch_structural.py`) wired into the fast CI; minor bump 0.60.0 → 0.61.0.

## Test plan

- CI: confirm the new "Run Layer 1 (dynamic-workflows S4 …)" step inside the TDAD-fast job is green (77/77 deterministic).
- Confirm `Version Check` passes across all five enforced locations at 0.61.0.
- Manually verify `/assess` and `/harness-audit` render the large-repo workflow path in their command docs.
- Confirm the adversarial-review mode triggers only above the configured `fan-out-threshold` and falls back cleanly outside Claude Code.

## References

- Spec: `docs/superpowers/specs/2026-06-22-dynamic-workflows-s4-adversarial-deepresearch-design.md` (first commit on the branch → spec-first satisfied)
- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S4)

Closes #441