### PR TITLE
Dynamic Workflows S5 — orchestrator classify-and-act routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.61.0",
+  "plugin_version": "0.62.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.61.0"
+      "version": "0.62.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -68,3 +68,7 @@ jobs:
       - name: Run Layer 1 (dynamic-workflows S4 adversarial review + deep research)
         working-directory: tdad_tests
         run: pytest tests/test_s4_adversarial_deepresearch_structural.py -v
+
+      - name: Run Layer 1 (dynamic-workflows S5 orchestrator routing)
+        working-directory: tdad_tests
+        run: pytest tests/test_s5_orchestrator_routing_structural.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.62.0 — 2026-06-23
+
+### dynamic-workflows: orchestrator classify-and-act routing (S5, #442)
+
+The largest behavioural slice — deliberately conservative. A classifier front
+runs before the pipeline and routes by task type, but only when explicitly
+opted in.
+
+- **`orchestrator` gains a "Task classification" step** before the pipeline.
+  Non-static routing is **opt-in** via an optional `orchestrator-routing` field
+  in HARNESS.md (**default off**); when off — and for ordinary coding tasks and
+  any ambiguous classification — the existing **static pipeline runs unchanged
+  with no extra compute**. Treat drift toward "everything is a workflow" as a
+  regression.
+- **Four routes** when enabled: static (ordinary coding), tournament
+  (design/naming/taste, rubric-bearing judge), root-cause (debugging/incident,
+  ≥3 hypotheses from disjoint evidence + verifier/refuter panel), and triage
+  (large backlogs under INV-2 quarantine — untrusted content read by
+  low-privilege agents, trusted agents act). Each adapts the relevant
+  `*.workflow.js` template.
+- **The Plan Approval GATE and `MAX_REVIEW_CYCLES=3` GUARDRAIL hold on every
+  route** — routing changes which pipeline runs, never the human-cognition gates.
+  Claude-Code-only with a non-erroring static fallback; every route is
+  propose-only (INV-1).
+- **`/superpowers-status`** surfaces routing posture (opt-in/off-by-default vs
+  enabled) and the last route taken when traceable, else `unavailable`.
+- Deterministic structural checks (`test_s5_orchestrator_routing_structural.py`)
+  gate the declared contract.
+
 ## 0.61.0 — 2026-06-22
 
 ### dynamic-workflows: adversarial review + deep-research workflows (S4, #441)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.61.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.62.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.61.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.62.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -67,9 +67,10 @@ on by default.
 
 **Static is the sole default.** The existing **static pipeline** (`spec-writer →
 GATE → tdd-agent → implementer → code-reviewer → GUARDRAIL → integration-agent`)
-is the **default** and runs unchanged in three cases alike: when the flag is
-**flag off**; for ordinary coding tasks; and for any **ambiguous** classification.
-In all three the classifier selects the static path and spends **no extra compute** —
+is the **default** and runs unchanged in three cases alike — a **flag-off**
+project (routing disabled), ordinary coding tasks, and any **ambiguous**
+classification. In all three the classifier selects the static path and spends
+**no extra compute** —
 treat any drift toward "everything is a workflow" as a regression.
 
 **The four routes.** When routing is enabled, classify by task type and **adapt**

--- a/ai-literacy-superpowers/agents/orchestrator.agent.md
+++ b/ai-literacy-superpowers/agents/orchestrator.agent.md
@@ -52,6 +52,50 @@ repeating it — for example, by dispatching deterministic checks
 earlier in the pipeline, or by briefing subagents about known
 pitfalls.
 
+## Task classification (opt-in routing, Claude Code only)
+
+Before the pipeline runs, classify the task to decide which pipeline serves it.
+This classification is part of your **first action** on every task and selects
+which path runs *before* any pipeline dispatch — it does not add an agent into
+the chain.
+
+**Opt-in flag (default off).** Non-static routing is enabled only when the
+optional **`orchestrator-routing`** field is set to `enabled` in **HARNESS.md**.
+When that field is **absent** or unset, routing is **off** and the classifier is
+a no-op. This is the conservative first-release posture: routing is opt-in, never
+on by default.
+
+**Static is the sole default.** The existing **static pipeline** (`spec-writer →
+GATE → tdd-agent → implementer → code-reviewer → GUARDRAIL → integration-agent`)
+is the **default** and runs unchanged in three cases alike: when the flag is
+**flag off**; for ordinary coding tasks; and for any **ambiguous** classification.
+In all three the classifier selects the static path and spends **no extra compute** —
+treat any drift toward "everything is a workflow" as a regression.
+
+**The four routes.** When routing is enabled, classify by task type and **adapt**
+the relevant `*.workflow.js` template by **relative path** (adapt, never run
+verbatim):
+
+1. **Static route** — ordinary coding tasks take the existing **static pipeline** (the default).
+2. **Tournament route** — design / naming / taste-based tasks route to a tournament scored by a **rubric-bearing judge**.
+3. **Root-cause route** — debugging / flaky-test / incident tasks route to **root-cause** investigation: at least **3** independent **hypotheses** drawn from **disjoint evidence**, each examined by a **verif**ier / **refut**er panel.
+4. **Triage route** — large backlogs route to triage-at-scale under **INV-2 quarantine**: untrusted or public content (external issues, third-party PRs) is read only by **low-privilege** agents, and only separate **trusted** agents act on what they find.
+
+**Gates and guardrails hold on every route.** The **Plan Approval** **gate** and
+the **MAX_REVIEW_CYCLES**=**3** **guardrail** remain in force on **every route** —
+static and non-static alike. No route bypasses, weakens, or multiplies them;
+routing changes which pipeline runs, never the human-cognition gates around it.
+
+**Runtime scope — Claude Code only.** The non-static routes require the **Claude
+Code** runtime. On a tree without it — Copilot CLI or any agent lacking the
+workflow runtime — or whenever the flag is off, the classifier **falls back** to
+the **static pipeline** and **never errors**.
+
+**Boundary (INV-1).** Every route is **propose**-only: any workflow a route spawns
+reports findings and never writes a **durable** curated artefact — **HARNESS.md**,
+**AGENTS.md**, **CLAUDE.md**, or **MODEL_ROUTING.md**. The orchestrator's existing
+tools and the curation gates are unchanged.
+
 ## Pipeline
 
 Run the agents in this order. Steps marked PARALLEL may be dispatched in a single

--- a/ai-literacy-superpowers/commands/superpowers-status.md
+++ b/ai-literacy-superpowers/commands/superpowers-status.md
@@ -54,6 +54,22 @@ Check that the agent team is present and consistent:
 Report any agents that are present in `.claude/agents/` but not referenced
 in MODEL_ROUTING.md (potential routing gap).
 
+### Section 3a: Workflow routing
+
+Surface the orchestrator's task-routing posture (the opt-in classify-and-act
+routing):
+
+- **Posture.** Read the optional `orchestrator-routing` field in HARNESS.md.
+  Report `routing: enabled` when it is set to `enabled`, otherwise
+  `routing: opt-in, off by default` (the conservative default when the field is
+  absent). This is descriptive only — off-by-default is the intended posture, not
+  a warning.
+- **Last route taken.** When a durable trace of the most recent orchestrator run
+  exists, report which of the four routes it selected — `static`, `tournament`,
+  `root-cause`, or `triage`. When no such trace exists (the dashboard is a file
+  snapshot, not a live event stream), report the last route as `unavailable`
+  rather than inventing one.
+
 ### Section 4: Compound learning
 
 Evaluate the state of AGENTS.md:

--- a/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md
@@ -90,6 +90,13 @@ tiers, and the INV-1 boundary it respects. The deterministic firewall
 time, so keep durable artefacts out of executable code and quarantine any
 untrusted-content reader.
 
+The `orchestrator` also dogfoods these patterns through opt-in **task
+routing**: enable the optional `orchestrator-routing` field in HARNESS.md and it
+classifies a task to a tournament, root-cause, or triage route (else the static
+pipeline). Routing is off by default — the static pipeline stays the sole
+default for ordinary coding — and the Plan Approval GATE and `MAX_REVIEW_CYCLES`
+guardrail hold on every route.
+
 ---
 
 ## 5. Respect the invariants

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -41,6 +41,13 @@ sequence, passing context between them. Reads `CLAUDE.md`,
 The only agent with the Agent tool, which it uses to dispatch
 the other four pipeline agents and, when needed, harness agents.
 
+Before the pipeline it runs a **task-classification** step. By default the
+static pipeline is the sole path; non-static routes (tournament,
+root-cause, triage) are **opt-in** via the optional `orchestrator-routing`
+field in HARNESS.md (off by default) and require the Claude Code runtime,
+falling back to static where it is absent. The Plan Approval GATE and
+`MAX_REVIEW_CYCLES=3` GUARDRAIL hold on every route.
+
 ### carpaccio
 
 - **Tools**: Read, Glob, Grep

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -242,6 +242,9 @@ Literacy habitat and reports status per section:
 - **Agent team** — agent definitions and availability
 - **Compound learning** — reflection entries and curation state
 - **Model routing** — routing table and cost data
+- **Workflow routing** — orchestrator routing posture (opt-in / off by
+  default vs enabled) and the last route taken when traceable, else
+  unavailable
 - **CI status** — workflow presence and recent run health
 
 Each section reports **OK**, **WARNING**, or **MISSING**.

--- a/docs/superpowers/specs/2026-06-23-dynamic-workflows-s5-orchestrator-routing-design.md
+++ b/docs/superpowers/specs/2026-06-23-dynamic-workflows-s5-orchestrator-routing-design.md
@@ -1,0 +1,659 @@
+# Specification — Dynamic Workflows S5: Orchestrator Classify-and-Act Routing
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S5 of the Dynamic Workflows Alignment epic (D4 — the largest behavioural change)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S5)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/442>
+**Depends on:** S1 (#438, merged) — the `dynamic-workflows` skill + election rubric; S2 (#439, merged) — the workflow templates + the INV-1/INV-2 firewall; S3 (#440, merged) and S4 (#441, merged) — the proven workflow-mode pattern and the deterministic structural-test shape S5 reuses
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s5-orchestrator-routing`
+
+> **Implementer note (read first).** This slice adds a **classification step before the
+> existing pipeline** in the `orchestrator` agent and surfaces the selected route in the
+> `superpowers-status` dashboard. It ships **no new component** — it modifies one agent file
+> and one command file (plus version/docs surfaces). It does **not** rewrite any
+> `*.workflow.js` template; where a non-static route spawns a workflow, the orchestrator
+> **ADAPTs** the relevant S2-shipped template per run. The *exact* runtime function names for
+> spawning subagents and coordinating panels are **not authoritative in this spec** — consult
+> <https://code.claude.com/docs/en/workflows> as the source of truth and treat any call shape
+> here as ADAPTABLE pseudocode, not a frozen API.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code runtime
+> capability, **not transferable** to GitHub Copilot CLI or any other coding agent — those
+> trees have no workflow runtime. The plugin ships to both trees, so the **non-static routes**
+> this slice adds are **Claude-Code-gated**: where the runtime exists and the opt-in flag is
+> set, the orchestrator may route to a workflow; where it does not (Copilot CLI, other
+> agents), or where the flag is off, the classifier **selects the existing static pipeline and
+> never errors or pretends to route** — there is no degraded behaviour because the static path
+> is the universal fallback. The classification step must restate this boundary explicitly
+> (umbrella §5.5 / slicing-record runtime-scope note). The precise Copilot degradation
+> *contract* (guidance-only vs omit) is open-question 4, resolved in S7, and is **not** decided
+> here.
+
+---
+
+## 1. Context and motivation
+
+The `orchestrator` runs a **fixed static pipeline** for every task:
+`carpaccio → GATE → spec-writer → diaboli → cartographer → Plan Approval GATE → tdd-agent →
+implementer(s) → code-reviewer → MAX_REVIEW_CYCLES=3 GUARDRAIL → diaboli (code) → Integration
+Approval GATE → integration-agent`. Umbrella **D4** observes that not every task needs this
+chain, and that some task *types* are better served by a dynamic workflow shape:
+
+| Task type | Better-fit route | Why |
+| --- | --- | --- |
+| ordinary coding | **the existing static pipeline** | The default; works for all edge cases; nothing about it changes |
+| design / naming (taste-based) | **tournament** (rubric-bearing judge) | Taste questions resolve by comparing candidates against an explicit rubric, not by a single linear pass |
+| debugging / flaky-test / incident | **root-cause investigation** | ≥3 independent hypotheses from **disjoint evidence** + a panel of verifiers/refuters defeats premature single-hypothesis fixation |
+| large backlog | **triage-at-scale under quarantine (INV-2)** | Untrusted external content (issues, third-party PRs) is read by low-privilege agents; only trusted agents act |
+
+**The load-bearing decision (resolved, open-question 2).** For the first release the
+tournament / root-cause / triage routes are **opt-in behind an explicit flag**, and the
+**static pipeline is the SOLE default**. A routine task — *and ANY task when the flag is not
+set* — takes the existing static path with **zero extra compute and zero behaviour change**.
+The §7 over-orchestration risk names drift toward "everything is a workflow" as a **regression**
+to guard against. With the flag off, the classifier is a **no-op that selects static**: it
+costs nothing, decides nothing, and the pipeline runs exactly as it does today. This
+conservatism is the whole point of S5 — it introduces a *route* without changing the *default*.
+
+The slicing record records the `independence` lens: S5 is the largest behavioural change but
+lands without blocking S6 or S7, and is deliberately sequenced *after* S3/S4 proved the
+workflow-mode pattern so the blast radius is contained.
+
+S5 wires the orchestrator to ADAPT the relevant S2 templates where a non-static route spawns a
+workflow; it invents no new template and edits no template (per the AGENTS.md "a consumer never
+mutates the contract it consumes" decision). On every route — static or otherwise — the
+**Plan Approval GATE and the `MAX_REVIEW_CYCLES=3` GUARDRAIL remain in force** (umbrella D4
+acceptance), as do INV-1 (routes propose; never write durable artefacts) and INV-2 (triage
+quarantine).
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+1. **`orchestrator.agent.md` gains a "Task classification" step** placed **before** the
+   existing pipeline dispatches, integrating cleanly with **"Your first action on every task"**
+   and the carpaccio step 0 (it runs as a pre-pipeline classification that *selects which
+   pipeline runs*, not a new agent dispatch in the chain). The step declares:
+   - **The explicit opt-in flag / mechanism** (see §6 decision 1) — how routing is enabled.
+     **When the flag is absent or off, routing is a no-op: the classifier selects the static
+     pipeline.**
+   - **The four route types and their triggers**:
+     - **ordinary coding → the existing static pipeline (the DEFAULT branch — unchanged
+       behaviour).**
+     - **design / naming (taste-based) → a tournament with a rubric-bearing judge.**
+     - **debugging / flaky-test / incident → root-cause investigation** (≥3 independent
+       hypotheses from **disjoint evidence** + a panel of verifiers/refuters).
+     - **large backlog → triage-at-scale under quarantine (INV-2)** (untrusted external content
+       read by low-privilege agents; trusted agents act).
+   - **The static-default supremacy rule, stated three ways**: the **default**, the **flag-off**
+     case, and the **ambiguous-classification** case **all select the static pipeline**. There
+     is no route a routine task can fall into by accident.
+   - **The GATE/GUARDRAIL invariant** — the **Plan Approval GATE** and the
+     **`MAX_REVIEW_CYCLES=3` GUARDRAIL** remain in force **on every route** (umbrella D4
+     acceptance). No route may bypass, weaken, or multiply them.
+   - **The Claude-Code-only runtime scope + the non-erroring fallback** — the non-static routes
+     require the Claude Code runtime; on a tree without it (or with the flag off) the classifier
+     **selects the static pipeline and never errors**. The static path is the universal
+     fallback.
+   - **INV-1** — every route is **propose-only**: a workflow a route spawns **never writes a
+     durable curated artefact** (`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`);
+     keep-worthy discovery flows through the existing human-curation gate. **INV-2** — the
+     triage route reads untrusted/public content only with **low-privilege agents**, and only
+     **separate trusted agents act** on it.
+2. **`commands/superpowers-status.md` surfaces the route taken** in the dashboard (see §6
+   decision 3) — a new sub-section reporting which route the most-recent orchestrator run
+   selected, or that routing is **off by default** when no opt-in signal is present.
+3. **The INV-1 boundary preserved.** The orchestrator's `tools` list is **unchanged**; the
+   classification step adds no write capability. Any workflow a non-static route spawns is
+   propose-only, exactly as S3/S4 established for their workflow modes.
+4. **Supporting CI / version / docs surfaces** (see §7): the minor bump **`0.61.0 → 0.62.0`**
+   across the five CI-enforced locations + the README table cell, and reference/how-to
+   touch-ups now that the orchestrator carries a routing step.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred concern | Owning slice | Why not here |
+| --- | --- | --- |
+| `harness-enforcer` / `code-reviewer` / `assessor` / `harness-auditor` workflow modes | **S3 (#440)**, **S4 (#441)**, both merged | S5 reuses their proven pattern; it does not re-touch those agents |
+| `reflect --mine` mode + staging artefact | **S6 (#443)** | Riding open-question 3 |
+| README "Dynamic Workflows" prose section, advisory Stop hook, **Copilot degradation contract** | **S7 (#444)** | Per umbrella D9; open-question 4. S5 restates the Claude-Code-only boundary for its own behaviour but does **not** fix the degradation contract |
+| Skill-count / component-count badges | **unchanged** | S5 adds **no** new skill, agent, or command — only modifies two existing files. The component-count badges do not move |
+| Editing/rewriting any `*.workflow.js` template | **S2 (#439, merged)** | S5 *adapts and points at* templates where a non-static route spawns one; per the AGENTS.md "consumer never mutates the contract it consumes" decision, S5 edits no template |
+| Building the tournament / root-cause / triage routes *on by default* | **out of scope by disposition** | Open-question 2 is resolved **opt-in, static-default**. Default-on is explicitly the regression S5 guards against |
+
+**Boundary rule.** S5 modifies exactly **two files** —
+`ai-literacy-superpowers/agents/orchestrator.agent.md` and
+`ai-literacy-superpowers/commands/superpowers-status.md` — plus the version/docs surfaces in
+§7. It ships **no new component**, **no new CI workflow** (it *wires a new test file into the
+existing* `tdad-tests-fast.yml`), and **no edit to any S2 template**.
+
+---
+
+## 3. User story
+
+> **As an** engineer dispatching the orchestrator on a task that is **not** ordinary coding —
+> a taste-based naming decision, a flaky-test investigation, or a large untrusted backlog — **I
+> want** the orchestrator, **when I have explicitly opted in**, to route the task to the
+> workflow shape that fits it (tournament / root-cause / triage), **so that** the work gets the
+> structure it needs; **and as the same engineer on a routine task, or with the flag off, I
+> want** the orchestrator to run the existing static pipeline with **zero extra compute and
+> zero behaviour change**, **so that** introducing routing never makes my everyday work slower
+> or more expensive — the static pipeline stays the sole default and the GATE and
+> `MAX_REVIEW_CYCLES=3` GUARDRAIL hold on every route.
+
+This is the umbrella's **over-orchestration risk** held at bay by design: routing is a
+deliberately conservative, opt-in v1, and the static path is the universal fallback that any
+task lands on by default, by flag-off, or by ambiguity.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy:
+*deterministic* (CI-checkable / Layer-0–1 structural), *agent-backed* (a runtime / Layer-2–3
+behavioural property), or *unverified* (declared intent). Scenarios trace to umbrella **D4**
+acceptance. The tdd-agent turns the deterministic and structurally-assertable agent-backed
+scenarios into failing checks first.
+
+### From D4 — the live routing behaviour (agent-backed)
+
+**AC-1 *(agent-backed; structural shadow AC-5/AC-6)* — routine coding task selects the static pipeline.**
+**Given** a routine single-file coding task (and any flag state),
+**When** the orchestrator classifies it,
+**Then** it **selects the existing static pipeline** — **no workflow is spawned, no extra
+compute is spent**, and the pipeline runs exactly as today.
+*(Slot note: live classification of a given task is a runtime/behavioural property — not
+assertable from a static file read. Its structural shadow is AC-5 (the static-default rule is
+declared) and AC-6 (the four routes + triggers are declared). The behavioural assertion stands
+as a Layer-2/3 scenario the tdd-agent may add.)*
+
+**AC-2 *(agent-backed; structural shadow AC-6)* — taste-based task routes to a tournament.**
+**Given** the opt-in flag is set, the Claude Code runtime is present, and a **taste-based task**
+(naming / design),
+**When** the orchestrator classifies it,
+**Then** it routes to a **tournament with a rubric-bearing judge** agent.
+*(Slot note: runtime/behavioural; structural shadow is AC-6 declaring the tournament route and
+its trigger.)*
+
+**AC-3 *(agent-backed; structural shadow AC-6)* — flaky-test / incident task routes to root-cause investigation.**
+**Given** the opt-in flag is set, the runtime is present, and a **flaky-test or incident** task,
+**When** the orchestrator classifies it,
+**Then** it routes to **root-cause investigation** with **≥3 independent hypotheses from
+disjoint evidence** and a panel of verifiers/refuters.
+*(Slot note: runtime/behavioural; structural shadow is AC-6 declaring the root-cause route, its
+trigger, and the ≥3-disjoint-evidence-hypotheses + verifier/refuter-panel shape.)*
+
+**AC-4 *(unverified, declared)* — the Plan Approval GATE and MAX_REVIEW_CYCLES=3 GUARDRAIL hold on every route.**
+**Given** any route the orchestrator selects (static, tournament, root-cause, triage),
+**When** the route runs,
+**Then** the **Plan Approval GATE** and the **`MAX_REVIEW_CYCLES=3` GUARDRAIL** remain in force
+— no route bypasses, weakens, or multiplies them.
+*(Slot note: declared intent — the live enforcement of the gate/guardrail across a real
+non-static route is a pipeline-level behavioural property, not provable from the agent doc
+alone. Its structural shadow is AC-7 declaring that every route holds the GATE and GUARDRAIL.
+Must **not** be over-promised as deterministic.)*
+
+### Structural declarations on the orchestrator doc (the deterministic shadows of D4)
+
+**AC-5 *(deterministic, structural)* — the classification step exists, opt-in flag declared, static-is-default declared.**
+**Given** `orchestrator.agent.md`,
+**When** it is read,
+**Then** it contains a **task-classification step placed before the pipeline dispatches** that
+declares the **explicit opt-in flag mechanism** (the §6 decision-1 mechanism, named explicitly
+— not "somehow enabled") and states that the **static pipeline is the sole default**, selected
+when the **flag is absent/off**, when the task is **ordinary coding**, and when **classification
+is ambiguous**.
+
+**AC-6 *(deterministic, structural)* — the four routes and their triggers are declared.**
+**Given** the classification step,
+**When** it is read,
+**Then** it declares **all four** routes and their triggers: ordinary coding → **static
+pipeline (default)**; taste-based (naming/design) → **tournament with a rubric-bearing judge**;
+debugging/flaky-test/incident → **root-cause investigation (≥3 independent hypotheses from
+disjoint evidence + a verifier/refuter panel)**; large backlog → **triage-at-scale under INV-2
+quarantine**, and that any non-static route **adapts the relevant `*.workflow.js` template by
+relative path** (ADAPT, not run verbatim).
+
+**AC-7 *(deterministic, structural)* — the GATE/GUARDRAIL-hold invariant is declared on every route.**
+**Given** the classification step,
+**When** it is read,
+**Then** it states explicitly that the **Plan Approval GATE** and the **`MAX_REVIEW_CYCLES=3`
+GUARDRAIL** remain in force **on every route** (static and non-static alike) — no route bypasses
+or weakens them (umbrella D4 acceptance).
+
+**AC-8 *(deterministic, structural)* — the Claude-Code-only scope + non-erroring static fallback are declared.**
+**Given** the classification step,
+**When** it is read,
+**Then** it states that the **non-static routes require the Claude Code runtime** and that on a
+tree without it — **or whenever the opt-in flag is off** — the classifier **selects the static
+pipeline and never errors** (the static path is the universal fallback; umbrella §5.5 /
+runtime-scope note).
+
+### Cross-cutting — INV-1 and INV-2
+
+**AC-9 *(deterministic, structural)* — every route is propose-only; the orchestrator's tool set is unchanged; triage quarantines untrusted content.**
+**Given** `orchestrator.agent.md` frontmatter and the classification step,
+**When** they are read,
+**Then**:
+- the orchestrator's **`tools` list is unchanged** (the classification step adds no new write
+  capability) and the step states every route is **propose-only** — any workflow a route spawns
+  **never writes a durable curated artefact** (`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`,
+  `MODEL_ROUTING.md`); keep-worthy discovery flows through the human-curation gate (**INV-1**);
+- the **triage-at-scale route** states that untrusted/public content is read **only by
+  low-privilege agents** and that **only separate trusted agents act** on it (**INV-2**
+  quarantine).
+
+### From D4 — the status surface
+
+**AC-10 *(deterministic, structural)* — superpowers-status surfaces the route taken (or that routing is off by default).**
+**Given** `commands/superpowers-status.md`,
+**When** it is read,
+**Then** it documents a section/check that surfaces **which route the most-recent orchestrator
+run selected** (static / tournament / root-cause / triage), or reports that **routing is opt-in
+and off by default** when no opt-in signal is present (the §6 decision-3 shape).
+
+---
+
+## 5. Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios in §8.
+
+- **FR-1.** `orchestrator.agent.md` contains a **task-classification step placed before the
+  pipeline dispatches**, integrating with "Your first action on every task" / the carpaccio
+  step 0. *(AC-5)*
+- **FR-2.** The step declares the **explicit opt-in flag mechanism** (§6 decision 1, named) and
+  states that with the **flag absent/off the classifier is a no-op selecting the static
+  pipeline**. *(AC-5, AC-8)*
+- **FR-3.** The step states the **static pipeline is the sole default**, selected for **ordinary
+  coding**, **flag-off**, and **ambiguous classification** alike. *(AC-5; structural shadow of
+  AC-1)*
+- **FR-4.** The step declares the **four routes and triggers** — static (default) / tournament
+  (rubric-bearing judge) / root-cause (≥3 independent hypotheses from disjoint evidence + a
+  verifier/refuter panel) / triage-at-scale under INV-2 — and that any non-static route
+  **adapts the relevant `*.workflow.js` template by relative path** (ADAPT, not verbatim).
+  *(AC-6; structural shadow of AC-2, AC-3)*
+- **FR-5.** The step states the **Plan Approval GATE** and the **`MAX_REVIEW_CYCLES=3`
+  GUARDRAIL** remain in force **on every route** (umbrella D4 acceptance). *(AC-7; structural
+  shadow of AC-4)*
+- **FR-6.** The step states the **Claude-Code-only runtime scope** and the **non-erroring static
+  fallback** (runtime absent or flag off → static, never error). *(AC-8)*
+- **FR-7.** The orchestrator's `tools` list is **unchanged** and the step states every route is
+  **propose-only** — no workflow writes a durable curated artefact (INV-1). *(AC-9)*
+- **FR-8.** The **triage route** declares **INV-2 quarantine** — untrusted content read by
+  low-privilege agents, trusted agents act. *(AC-9)*
+- **FR-9.** `commands/superpowers-status.md` documents a section/check that **surfaces the route
+  the most-recent orchestrator run selected**, or reports **routing off by default** when no
+  opt-in signal is present (§6 decision 3). *(AC-10)*
+- **FR-10.** The plugin version is bumped **`0.61.0 → 0.62.0`** across all five CI-enforced
+  locations (§7.1), and the human-facing README plugin-table cell is updated. *(CI: Version
+  Check)*
+- **FR-11.** The how-to guide(s) and the agents/commands reference entries for the orchestrator
+  and `superpowers-status` are checked and updated for the new routing step (§7.3).
+  *(docs-impact)*
+
+---
+
+## 6. Decisions surfaced at the GATE
+
+Per the AGENTS.md STYLE note, a recommendation is a **hypothesis for the spec-mode diaboli to
+stress**, not a default to confirm — most acutely where the slice touches a **closed contract**
+(here: the static-default supremacy rule and the GATE/GUARDRAIL invariant the orchestrator must
+not weaken). The three decisions below are surfaced for the human; the spec-writer recommends
+but does not silently choose.
+
+**Pre-listed contract surfaces a recommendation could break** (so the diaboli's scrutiny is
+scoped): (1) the orchestrator's existing GATE/GUARDRAIL steps (Slice Adjudication, Plan
+Approval, Integration Approval, `MAX_REVIEW_CYCLES=3`) — no route may bypass them; (2) the
+`superpowers-status` Section/summary-line contract (Sections 1–8 + the `[OK/WARNING/MISSING]`
+output block) — a new surface must not collide with the existing disposition-counting algorithm;
+(3) the INV-1 four-artefact denylist and the INV-2 quarantine rule — a route must not relax
+either; (4) the static-default supremacy rule — the flag-off and ambiguous cases must both fall
+to static.
+
+### Decision 1 — The explicit opt-in flag mechanism
+
+The disposition is settled: routing is **opt-in behind an explicit flag**, static is the sole
+default. What is **not** yet decided is **how the flag is expressed**. Mirroring the resolved
+S3/S4 pattern (the threshold knobs both chose an optional `HARNESS.md` field), three options:
+
+- **Option M1 — a documented optional `HARNESS.md` field the orchestrator reads (RECOMMENDED),
+  e.g. `orchestrator-routing: enabled`** in a `Workflow mode` block (or the existing
+  Constraints/Status preamble), defaulting to **off** (static-only) when absent.
+  *Strength:* this is the **established epic precedent** — S3's `Workflow fan-out threshold` and
+  S4's `Deep-research threshold` both chose an optional `HARNESS.md` field read by the agent,
+  matching how every per-project knob in this plugin works (cf. the `fan-out-threshold`
+  precedent). `HARNESS.md` is **durable and human-curated**, so opting in is a curated act
+  consistent with INV-1 (the human sets it; the orchestrator only reads it). A missing/garbled
+  field **safe-defaults to off** — the conservative static path — rather than erroring, which is
+  exactly the v1 conservatism the disposition demands. No new file, no new schema, one
+  consistent knob style across the whole epic. *Diaboli should stress:* is a missing/garbled
+  field guaranteed to read as off (it must — default-off is the conservative direction)? Does
+  the orchestrator's read of `HARNESS.md` risk the firewall (no — the orchestrator *reads* a
+  durable artefact; it is not a *workflow* spelling a durable filename in executable code, so
+  the INV-1 firewall does not apply to the agent's own read).
+- **Option M2 — a value in `MODEL_ROUTING.md`'s workflow-election section.** S1 placed token
+  budgets and tiering there, so "is routing on?" is arguably workflow-election policy too.
+  *Weakness:* it diverges from the S3/S4 `HARNESS.md`-field precedent the epic has now set twice,
+  splitting the orchestrator's opt-in across a different durable file from where S3/S4 put their
+  knobs. *Tenable* if the human prefers **all** workflow-election policy (budgets, tiers,
+  routing-on) in one place — but that is a cross-epic consolidation, larger than S5.
+- **Option M3 — a command flag / env var (e.g. `--route` on the dispatch).** *Weakness:* an
+  ephemeral per-invocation flag is **not curated** and leaves no durable record of the project's
+  stance; it also has no natural home in this plugin's agent-dispatch model (the orchestrator is
+  dispatched by description, not a CLI with flags). Inconsistent with every other per-project
+  knob. *Rejected as the resolution* unless the human wants per-run rather than per-project
+  opt-in (then state it honestly as a per-invocation toggle with no persisted default).
+
+**Recommendation: M1** — a documented optional `HARNESS.md` field (e.g.
+`orchestrator-routing: enabled`), **default off** when absent. It matches the S3/S4 epic
+precedent exactly, keeps the opt-in curated and durable, and safe-defaults to the conservative
+static-only path. The diaboli should confirm the missing-field default is **off**, that this
+does not smuggle the flag into the firewall's scope, and that the field name does not collide
+with the existing S3/S4 `HARNESS.md` workflow-mode fields.
+
+### Decision 2 — The verification split (deterministic structural vs agent-backed behavioural)
+
+Mirroring S3 decision 2 / S4 decision 2: this repo's deterministic layer **reads files and
+matches structure**; it does **not** dispatch the orchestrator or classify a live task. So:
+
+- **Deterministically assertable (structural, Layer-0/1) — the declarations.** That the
+  orchestrator doc **declares**: the classification step exists before the pipeline (AC-5); the
+  opt-in flag mechanism + static-is-default (flag-off / ordinary / ambiguous) (AC-5); the four
+  routes + triggers + adapt-by-relative-path (AC-6); the GATE/GUARDRAIL-hold-on-every-route
+  invariant (AC-7); the Claude-Code-only scope + non-erroring static fallback (AC-8); the
+  propose-only/INV-1 boundary + tools-unchanged + INV-2 triage quarantine (AC-9); and that
+  `superpowers-status` **documents** the route surface (AC-10). These are file-read assertions a
+  structural test checks mechanically — the **honest deterministic shadow** of D4.
+- **Agent-backed / behavioural only (not deterministic) — the live classification.** That a real
+  run **classifies a routine task to static** (AC-1), a **taste task to a tournament** (AC-2),
+  and a **flaky-test/incident task to root-cause** (AC-3) are runtime properties of an actual
+  orchestrator dispatch. They are **agent-backed**, observed at runtime, and must **not** be
+  promised as deterministic.
+- **Unverified / declared (AC-4)** — the **GATE/GUARDRAIL holding across a real non-static
+  route** is a pipeline-level guarantee declared in the agent doc; its structural shadow is AC-7
+  (the section *states* it holds), but the live enforcement itself is pipeline-level behaviour,
+  not provable from the doc alone.
+
+**Recommendation:** the tdad-scenario set is **predominantly structural** (AC-5, AC-6, AC-7,
+AC-8, AC-9, AC-10 as Layer-0/1 file-read assertions), with AC-1, AC-2, AC-3 standing as
+**declared agent-backed** behavioural scenarios and AC-4 as **unverified/declared**. This is the
+same realistic split S3 and S4 landed. The diaboli should stress whether any property currently
+tagged structural actually requires a live dispatch (it should not — each is a file-read), and
+whether AC-1's "selects the static pipeline" risks being over-promised as deterministic (it must
+not — the *declaration* of static-default is structural; the *live selection* is agent-backed).
+
+### Decision 3 — How superpowers-status surfaces the route
+
+D4 says "surface which route was taken in the dashboard" but fixes neither the data nor the
+shape. The dashboard is a **read-only health snapshot** of files on disk — it does not have a
+live event stream of orchestrator dispatches — so the surface must be realistic about what it
+can actually read. Options:
+
+- **Option S1 — "routing posture" line + last-route, read from durable signals (RECOMMENDED).**
+  A short sub-section (folded into Section 3 *Agent team*, or a new compact "Workflow routing"
+  line in the output block) that reports two things: (a) the **routing posture** — read from the
+  `orchestrator-routing` `HARNESS.md` field (decision 1): **`opt-in, off by default`** when
+  absent/off, **`enabled`** when set; and (b) **the most-recent route taken**, *if* a durable
+  trace exists (e.g. the latest entry in a routing-trace the orchestrator already writes, or the
+  most recent spec/objection record's context) — otherwise **`last route: unavailable (no
+  recent run)`**. *Strength:* honest about the dashboard's read-only nature; degrades gracefully
+  to "off by default / unavailable" with no fabrication; reuses the same `HARNESS.md` field
+  decision 1 introduces, so no new state surface. *Diaboli should stress:* does a durable
+  last-route trace actually exist for the dashboard to read, or is "most-recent route" a value
+  no file carries (in which case the surface honestly reports posture only, not last-route)?
+- **Option S2 — a per-route counter (tournament: N, root-cause: N, triage: N, static: N).**
+  *Weakness:* requires a **persisted per-route tally** the orchestrator must maintain — new
+  durable state with its own GC/staleness surface, and the §289 disposition-counting machinery
+  shows how a naive count drifts. **Premature** for a deliberately conservative v1 where the
+  routes are opt-in and may rarely fire; no data yet exists on what a healthy distribution looks
+  like (cf. the AGENTS.md "no threshold before data" diaboli decision). *Tenable later* once
+  routing has run enough to make counts meaningful.
+- **Option S3 — "routing: opt-in, off by default" posture line only (no last-route).**
+  *Acceptable minimal form* — just report the posture from the `HARNESS.md` field with no
+  attempt at last-route. *Weakness:* it answers "is routing on?" but not D4's "which route was
+  taken", so it under-delivers the deliverable unless decision-1's field is the only honest
+  durable signal available (in which case S3 *is* S1 minus the last-route half).
+
+**Recommendation: S1** — a compact "Workflow routing" surface reporting **posture** (read from
+the decision-1 `HARNESS.md` field: `opt-in, off by default` vs `enabled`) **plus** the
+**most-recent route taken when a durable trace exists**, degrading to `unavailable (no recent
+run)` otherwise. It honours D4's "surface which route was taken" without inventing a persisted
+counter, and reuses decision-1's field rather than adding state. The diaboli should stress
+whether a last-route trace genuinely exists for the dashboard to read — and if it does not,
+whether S5 should **fall back to S3** (posture-only) honestly rather than promise a last-route
+the snapshot cannot compute. **Keep this surface descriptive — no threshold, no
+`WARNING` state** (consistent with the AGENTS.md "no threshold before data" decision and the
+Diaboli-panel precedent).
+
+### 6.1 Decision summary for the GATE
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| Opt-in flag mechanism | M1 optional `HARNESS.md` field `orchestrator-routing: enabled` (default off) / M2 `MODEL_ROUTING.md` workflow-election value / M3 command flag / env var | **M1** — optional `HARNESS.md` field, **default off** — matches the S3/S4 epic precedent and safe-defaults to static |
+| Verification split | all-deterministic / **structural declarations + agent-backed live classification + unverified GATE/GUARDRAIL-hold** | **structural declarations are the deterministic shadow; live route selection stays agent-backed; GATE/GUARDRAIL-hold stays unverified/declared** |
+| superpowers-status route surface | **S1 posture + last-route-when-traceable** / S2 per-route counter / S3 posture-only | **S1** — posture (from the decision-1 field) + most-recent route when a durable trace exists, else `unavailable`; descriptive, no threshold/WARNING; fall back to S3 honestly if no last-route trace exists |
+
+---
+
+## 7. CI, version, and docs checklist
+
+### 7.1 Version bump — a behavioural change to an existing agent + command (minor)
+
+Adding a classification/routing step to the `orchestrator` and a route surface to
+`superpowers-status` is a **behavioural addition to existing components** → **minor bump
+`0.61.0 → 0.62.0`** (current version confirmed **`0.61.0`** in `plugin.json`, the `README.md`
+badge + table cell, the `CHANGELOG.md` top heading, and both `marketplace.json` `plugin_version`
+and the `ai-literacy-superpowers` `plugins[].version` entry). The `Version Check` CI enforces
+**five** locations (per CLAUDE.md / the live `version-check.yml`). Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical; `0.61.0` →
+   `0.62.0`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.62.0` (line 6; currently
+   `v0.61.0`)
+3. `CHANGELOG.md` — new top heading `## 0.62.0 — 2026-06-23`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (currently `0.61.0`; owned by
+   ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers` `plugins[].version` entry
+   (currently `0.61.0`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md` plugin-table
+row cell (`| v0.61.0 |` → `| v0.62.0 |`, line 31).
+
+> The marketplace listing `version` (`0.4.0`) does **not** change — S5 alters no listing
+> contract (no description/keyword/permission/plugins-array/source change). The component-count
+> badges (`Skills-36`, `Agents-16`, `Commands-28`) do **not** change — S5 adds no new component,
+> only modifies two existing files.
+
+If a rebase surfaces a `plugin_version` conflict from a non-`ai-literacy-superpowers` PR, take
+main's value verbatim (CLAUDE.md Marketplace-versioning rule) — this PR owns the top-level
+pointer only because it bumps this plugin.
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.61\.0\|0\.61\.0' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+### 7.2 CI gates
+
+- **`spec-first-check`** — satisfied by **this spec being the first commit** on branch
+  `dynamic-workflows-s5-orchestrator-routing`. No exemption label; this is feature work.
+- **`tdad-scenario-check`** — S5 **modifies** an existing agent and command rather than adding
+  new components. The gate fires on *added* components, so it does **not strictly force** new
+  scenarios for a modification. **However**, this is a behavioural addition and warrants
+  scenarios. The `orchestrator` has **no scenario directory yet** —
+  `tdad_tests/scenarios/agents/orchestrator/` **does not exist** (confirmed; the agent file
+  carries an explicit comment recording the §A2.6 exemption). The **tdd-agent will create it**
+  and author the structural scenarios (AC-5 through AC-10), mirroring the S3/S4 scenario sets
+  under `tdad_tests/scenarios/agents/<agent>/`. Spec-writer **names** this so the tdd-agent has
+  an unambiguous home and assertion set; spec-writer does **not** create the directory or any
+  test file (spec-first discipline — no test files in this commit).
+- **The deterministic content test** — the tdd-agent authors a new
+  `tdad_tests/tests/test_s5_orchestrator_routing_structural.py`, mirroring
+  `test_s3_enforcer_fanout_structural.py` and `test_s4_adversarial_deepresearch_structural.py`
+  (a section-slicing helper that isolates the classification step in `orchestrator.agent.md`
+  and the route surface in `superpowers-status.md`; phrase assertions per AC), and **wires it
+  into the existing `.github/workflows/tdad-tests-fast.yml`** as a new step (a sibling of the
+  existing `Run Layer 1 (dynamic-workflows S4 adversarial review + deep research)` step at
+  lines 68–70). Spec-writer **notes** this; the tdd-agent authors and wires it. **Do not author
+  tests in this commit.**
+  - **Line-wrap caution (bit S3 twice and S4 twice).** Several assertions are **two-word
+    phrases** the structural test will match literally — e.g. `static pipeline`, `rubric-bearing
+    judge`, `disjoint evidence`, `Plan Approval`, `MAX_REVIEW_CYCLES`, `opt-in`,
+    `Claude Code`, `low-privilege`. When the tdd-agent and implementer author the agent-doc
+    prose, **keep these phrases unwrapped** (not split across a line break), or the literal
+    match fails. This is a tdd/impl concern, not a spec-writer one — noted here so it is not
+    rediscovered a fifth time.
+- **`INV-1 firewall` (S2, existing)** — S5 modifies **no `*.workflow.js` template**, so the
+  firewall is **not triggered by new template content**. The orchestrator's own *read* of
+  `HARNESS.md` (the opt-in flag) is an agent behaviour, not a workflow spelling a durable
+  filename in executable code, so it is outside the firewall's scope. (If the tdd-agent adds any
+  fixture that is a `.workflow.js`, it must itself pass the firewall — but the recommended
+  fixtures are structural scenarios, not workflows.)
+- **`lint-markdown`** — the modified `orchestrator.agent.md`, `superpowers-status.md`, this spec,
+  and any touched docs page must pass markdownlint (PreToolUse hook + CI).
+- **`Choice cartographer` / objection gates** — this feature PR proceeds through the plugin's
+  own pipeline (spec → diaboli → adjudicate → plan → implement → diaboli code-mode → adjudicate).
+  Dispositions on any objection record must be resolved before the plan-approval GATE.
+
+### 7.3 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Reference (`docs-reference-parity-check`) — no NEW component, so no new entry forced.** S5
+  adds no new skill/agent/command, so the parity gate is satisfied with no new heading. **But**
+  the existing `### orchestrator` entry in
+  `docs/plugins/ai-literacy-superpowers/reference/agents.md` should be **updated** to mention the
+  new **task-classification / routing step** (opt-in, static-default), and the
+  `### superpowers-status` entry in
+  `docs/plugins/ai-literacy-superpowers/reference/commands.md` should be **updated** to mention
+  the new **workflow-routing surface**, so the reference does not describe only the pre-routing
+  behaviour. These are *consistency* updates, not parity requirements. (Per the S3/S4 lesson:
+  do the declared touch-ups in the same PR.)
+- **How-to (touch-up).** `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` (the
+  orientation guide) should gain a short note that the `orchestrator` now elects a **routing
+  step** above its opt-in flag (tournament / root-cause / triage), extending the S3/S4
+  dogfooding line ("templates the plugin's own agents already adapt"). If a how-to for running
+  the pipeline / orchestrator exists, add a short "routing is opt-in and off by default; the
+  static pipeline is the default" note. Consistency touch-ups, not new pages.
+- **Explanation / tutorials.** None required — no existing explanation page describes the
+  orchestrator's pipeline as having *no* classification front-end in a way S5 would contradict;
+  the classify-and-act concept already lives in the skill's `references/patterns.md` (S1). If an
+  explanation page asserts "the orchestrator always runs the full static pipeline" as a fixed
+  property, soften it to "the static pipeline is the default; routing is an opt-in front-end."
+
+---
+
+## 8. FR → acceptance-scenario mapping
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-5 | deterministic (structural) |
+| FR-2 | AC-5, AC-8 | deterministic (structural) |
+| FR-3 | AC-5 (structural shadow of AC-1) | deterministic (structural) / agent-backed (AC-1) |
+| FR-4 | AC-6 (structural shadow of AC-2, AC-3) | deterministic (structural) / agent-backed (AC-2, AC-3) |
+| FR-5 | AC-7 (structural shadow of AC-4) | deterministic (structural) / unverified (AC-4) |
+| FR-6 | AC-8 | deterministic (structural) |
+| FR-7 | AC-9 | deterministic (structural) |
+| FR-8 | AC-9 | deterministic (structural) |
+| FR-9 | AC-10 | deterministic (structural) |
+| FR-10 | (CI: Version Check) | deterministic |
+| FR-11 | (docs-impact; reference + how-to touch-up) | deterministic (presence) |
+
+**Agent-backed runtime scenarios** (not deterministic; see §6 decision 2):
+
+- **AC-1** — routine task selects the static pipeline — runtime/behavioural; structural shadow
+  is AC-5/AC-6 (FR-3/FR-4).
+- **AC-2** — taste task routes to a tournament — runtime/behavioural; structural shadow is AC-6
+  (FR-4).
+- **AC-3** — flaky-test/incident task routes to root-cause — runtime/behavioural; structural
+  shadow is AC-6 (FR-4).
+
+**Unverified / declared:**
+
+- **AC-4** — Plan Approval GATE + `MAX_REVIEW_CYCLES=3` GUARDRAIL hold on every route — declared;
+  structural shadow is AC-7's section statement (FR-5). Must **not** be over-promised as
+  deterministic.
+
+---
+
+## 9. Risks and open questions
+
+**Risks.**
+
+- *Over-orchestration (umbrella §7 — the critical risk for this slice).* The temptation is to
+  let the classifier route routine work into a workflow. Mitigation: the **opt-in flag (default
+  off)** makes the static pipeline the **sole default**, and the **static-default supremacy
+  rule** routes flag-off, ordinary-coding, and ambiguous cases all to static. With the flag off
+  the classifier is a no-op — zero extra compute, zero behaviour change. This is the §6
+  decision-1 conservatism made load-bearing. The diaboli should reject any wording that lets a
+  routine task fall into a non-static route, or that makes the flag default to on.
+- *GATE/GUARDRAIL erosion.* A non-static route could be (mis)written to bypass the Plan Approval
+  GATE or multiply `MAX_REVIEW_CYCLES`. Mitigation: AC-7/FR-5 declare the invariant explicitly
+  on **every** route; the diaboli should stress any route description that omits or weakens it.
+- *Over-promising determinism.* Live classification (AC-1/2/3) and the GATE/GUARDRAIL-hold
+  (AC-4) are agent-backed/declared; tagging them deterministic would overclaim. Mitigation: §6
+  decision 2 fixes the honest split, as in S3/S4.
+- *Status surface promising data it cannot read.* The dashboard is a read-only file snapshot; a
+  "last route taken" line risks promising state no file carries. Mitigation: §6 decision 3's S1
+  reports **posture** from the decision-1 `HARNESS.md` field and degrades last-route to
+  `unavailable` (or falls back to posture-only, S3) when no durable trace exists — no
+  fabrication, no premature per-route counter.
+- *Firewall scope confusion.* The opt-in mechanism (M1) has the orchestrator **read**
+  `HARNESS.md`; a careless reading could think this trips the INV-1 firewall. Mitigation: the
+  firewall scopes to **`*.workflow.js` templates spelling a durable filename in executable
+  code**, not to an agent reading its own configuration. S5 edits no template.
+- *Scenario-home omission.* `orchestrator` has no scenario directory; a behavioural addition
+  without one leaves the new step unverified. Mitigation: §7.2 names the directory the tdd-agent
+  must create, the structural assertion set, the new content test file, and its
+  `tdad-tests-fast.yml` wiring — plus the two-word-phrase line-wrap caution.
+- *Field-name collision.* The decision-1 `HARNESS.md` field must not collide with the S3/S4
+  workflow-mode fields (`Workflow fan-out threshold`, `Deep-research threshold`). Mitigation: a
+  distinct name (`orchestrator-routing`) and the diaboli confirming no collision.
+
+**Open questions.** None block S5. The umbrella open questions ride later slices (Q3 staging →
+S6, Q4 Copilot → S7) and are out of scope (§2.2). **Open-question 2 (route default) is resolved
+opt-in, static-default**; the only S5-internal decisions are **how** the opt-in flag is
+expressed (§6 decision 1), the verification split (§6 decision 2), and the status surface (§6
+decision 3) — all **surfaced for the GATE, not left open**: the spec recommends and the human
+disposes.
+
+---
+
+## 10. References
+
+- Umbrella spec:
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+  (read-first runtime-scope note; §2 INV-1/INV-2; **D4**; §5; §6; §7 over-orchestration risk +
+  open-question 2).
+- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md`
+  (Runtime-scope section; **S5** entry — routes are opt-in behind an explicit flag, static
+  pipeline the sole default).
+- Proven precedents (merged):
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s3-enforcer-fanout-design.md` and
+  `docs/superpowers/specs/2026-06-22-dynamic-workflows-s4-adversarial-deepresearch-design.md`
+  (the "Workflow mode" / opt-in-knob pattern; the `HARNESS.md`-field threshold precedent);
+  `ai-literacy-superpowers/agents/harness-enforcer.agent.md` (the section pattern);
+  `tdad_tests/tests/test_s3_enforcer_fanout_structural.py` and
+  `tdad_tests/tests/test_s4_adversarial_deepresearch_structural.py` (the deterministic
+  structural-content test pattern); `.github/workflows/tdad-tests-fast.yml` (the test-wiring
+  pattern, lines 60–70).
+- Shipped templates S5 ADAPTs where a non-static route spawns a workflow:
+  `ai-literacy-superpowers/skills/dynamic-workflows/workflows/*.workflow.js` (the tournament /
+  root-cause / triage shapes; consult `SKILL.md`'s template table for the authoritative names);
+  `ai-literacy-superpowers/scripts/inv-firewall.sh` (the INV-1/INV-2 firewall; untouched by S5).
+- Target files S5 modifies:
+  - `ai-literacy-superpowers/agents/orchestrator.agent.md` (the task-classification step before
+    the pipeline; "Your first action on every task" / carpaccio step 0 integration; the existing
+    Plan Approval GATE and `MAX_REVIEW_CYCLES=3` GUARDRAIL the invariant must preserve).
+  - `ai-literacy-superpowers/commands/superpowers-status.md` (the new workflow-routing surface).
+- Runtime API (authoritative): <https://code.claude.com/docs/en/workflows>.
+- AGENTS.md decisions consulted: the "recommended option is a hypothesis for the diaboli" STYLE
+  note (closed-contract pre-listing, applied in §6); "a consumer never mutates the contract it
+  consumes" (S5 adapts but does not edit the S2 templates); "no threshold before data" (the
+  status surface stays descriptive, no WARNING state).

--- a/tdad_tests/scenarios/agents/orchestrator/declares-classification-step-opt-in-flag-static-default.md
+++ b/tdad_tests/scenarios/agents/orchestrator/declares-classification-step-opt-in-flag-static-default.md
@@ -1,0 +1,72 @@
+---
+component: orchestrator
+component_type: agent
+tier: structural
+---
+
+# Scenario: the orchestrator declares a classification step, the opt-in flag, and static-is-default (AC-5 / FR-1, FR-2, FR-3)
+
+## Given
+
+The file
+`ai-literacy-superpowers/agents/orchestrator.agent.md`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- A **task-classification section** is present — a level-2/3/4 heading
+  containing "Task classification" or "Workflow routing". The content test
+  slices from that heading; everything below is the routing contract.
+- The section declares the classification runs **before the pipeline
+  dispatches / as the first action** — it is a pre-pipeline step that
+  *selects which pipeline runs*, not a new agent in the chain. Keep "first
+  action" **unwrapped** on one line (the content test asserts "before" with
+  "pipeline", and "first action" as a single phrase).
+- The section names the **explicit opt-in flag mechanism**: routing is
+  enabled only via the optional **`orchestrator-routing`** field in
+  **`HARNESS.md`**, and **default off / absent → off** (static-only). The
+  tokens `orchestrator-routing` and `harness.md` are single unwrappable
+  tokens; "default off" / "absent" are asserted as co-occurring with the
+  flag. This name is **distinct** from the S3/S4 `fan-out-threshold` /
+  deep-research fields — no collision.
+- The section states the **static pipeline is the sole default**, stated
+  three ways — the **flag-off** case, **ordinary coding**, and **ambiguous**
+  classification **all select static**, with **no workflow and no extra
+  compute**. Keep "static pipeline", "no extra compute", and "ambiguous"
+  each **unwrapped**; the content test asserts "static" + "default",
+  "flag-off"/"flag off", "ambiguous", and "no extra compute" as co-occurring
+  tokens on the lowercased section.
+
+## Rubric
+
+Deterministic structural shadow of umbrella D4 / AC-1. What a static file
+read can verify is that the orchestrator doc *declares* the classification
+step, the `orchestrator-routing` opt-in flag (default off), and the
+static-default supremacy rule — not that a live dispatch actually classifies
+a routine task to static (that is the agent-backed AC-1, declared in
+`runtime-routes-routine-task-to-static.md`, not wired here).
+
+The load-bearing specifics:
+
+- the flag is **named** (`orchestrator-routing` in `HARNESS.md`), matching
+  the S3/S4 epic precedent of an optional `HARNESS.md` field, and the
+  missing/absent case is **off** — the conservative direction;
+- the static-default supremacy rule covers **all three** fall-through cases
+  (flag-off, ordinary coding, ambiguous) so no routine task can drift into a
+  non-static route by accident — this is the over-orchestration guard made
+  load-bearing.
+
+The scenario must **not** be read as asserting any live classification
+occurs — only that the contract is declared in checkable language.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s5_orchestrator_routing_structural.py`
+(`TestS5OrchestratorClassificationStep`). RED now because the agent doc
+contains no "Task classification" / "Workflow routing" section (`grep -n
+"Task classification\|Workflow routing"` returns nothing), so none of the
+flag / static-default phrases exist yet.

--- a/tdad_tests/scenarios/agents/orchestrator/declares-claude-code-scope-fallback-and-inv-boundaries.md
+++ b/tdad_tests/scenarios/agents/orchestrator/declares-claude-code-scope-fallback-and-inv-boundaries.md
@@ -1,0 +1,73 @@
+---
+component: orchestrator
+component_type: agent
+tier: structural
+---
+
+# Scenario: the classification step declares Claude-Code-only scope, non-erroring static fallback, INV-1 propose-only + tools-unchanged, and INV-2 triage quarantine (AC-8, AC-9 / FR-6, FR-7, FR-8)
+
+## Given
+
+The task-classification section of
+`ai-literacy-superpowers/agents/orchestrator.agent.md` and its frontmatter
+`tools`.
+
+## When
+
+The agent doc is read.
+
+## Then
+
+- The section states the **non-static routes require the Claude Code
+  runtime**, and that on a tree without it — **or whenever the opt-in flag
+  is off** — the classifier **selects the static pipeline and never errors**
+  (the static path is the universal fallback). "Claude Code" is two words —
+  keep it **unwrapped** on one line; the content test asserts "claude" +
+  "code", "fall back"/"falls back"/"fallback", and "never error".
+- The section states every route is **propose-only** — any workflow a route
+  spawns **never writes a durable curated artefact** (`HARNESS.md`,
+  `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`); keep-worthy discovery flows
+  through the human-curation gate (**INV-1**). Keep "durable artefact"
+  **unwrapped**; the content test asserts "durable" + "propose" co-occurring
+  with at least two of the four named artefact tokens.
+- The **triage route** states untrusted/public content is read **only by
+  low-privilege agents** and that **only separate trusted agents act** on it
+  (**INV-2** quarantine). Keep "low-privilege" **unwrapped**; the content
+  test asserts "low-privilege" + "trusted" co-occurring with "inv-2"/
+  "quarantine".
+- The frontmatter `tools` list is **unchanged** — it stays
+  `[Read, Write, Edit, Glob, Grep, Bash, Agent, WebFetch]`. The
+  classification step adds **no new write capability**. The content test
+  reads the current set and asserts it is unchanged (it does **not** assert a
+  specific new tool).
+
+## Rubric
+
+Deterministic structural assertion (AC-8 runtime scope + AC-9 INV-1/INV-2),
+grounded in the umbrella §5.5 runtime-scope note and the slicing-record
+"Runtime scope — Claude Code only" section. Dynamic workflows are a Claude
+Code runtime capability, not transferable to Copilot CLI or other agents;
+the non-static routes are therefore Claude-Code-gated, and the static path
+is the universal fallback (runtime absent **or** flag off → static, never
+error). S5 restates the Claude-Code-only nature for the orchestrator's *own*
+behaviour; it does **not** decide the precise Copilot degradation contract
+(open-question 4, owned by S7).
+
+INV-1: the orchestrator *reads* `HARNESS.md` for the flag — that is an agent
+read, not a workflow spelling a durable filename in executable code, so the
+firewall does not apply to the agent's own read. The propose-only boundary
+binds any *workflow* a route spawns: it never writes one of the four durable
+curated artefacts. The tool-set check is GREEN today (the list is unchanged)
+and must STAY green through S5 — it is the agent-level INV-1 enforcement.
+
+INV-2: the triage route quarantines untrusted-content readers (low-privilege
+agents) from the high-privilege agents that act.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s5_orchestrator_routing_structural.py`
+(`TestS5OrchestratorClaudeCodeScopeAndInvariants` for the section
+declarations; `TestS5OrchestratorToolsUnchanged` for the tool boundary). The
+section declarations are RED now (no classification section); the
+tools-unchanged assertion is GREEN now and stays green.

--- a/tdad_tests/scenarios/agents/orchestrator/declares-four-routes-and-triggers.md
+++ b/tdad_tests/scenarios/agents/orchestrator/declares-four-routes-and-triggers.md
@@ -1,0 +1,65 @@
+---
+component: orchestrator
+component_type: agent
+tier: structural
+---
+
+# Scenario: the classification step declares all four routes and their triggers (AC-6 / FR-4)
+
+## Given
+
+The task-classification section of
+`ai-literacy-superpowers/agents/orchestrator.agent.md`.
+
+## When
+
+The section is read.
+
+## Then
+
+The section declares **all four** routes and their triggers:
+
+- **static** — ordinary coding → the existing static pipeline (the default
+  branch, unchanged behaviour). Keep "static pipeline" **unwrapped**.
+- **tournament** — design / naming / taste-based decisions → a **tournament
+  with a rubric-bearing judge**. Keep "rubric-bearing judge" **unwrapped**
+  (the content test asserts "tournament" with "rubric-bearing judge").
+- **root-cause** — debugging / flaky-test / incident → **root-cause
+  investigation** with **≥3 independent hypotheses from disjoint evidence**
+  and a verifier/refuter panel. Keep "root-cause", "disjoint evidence", and
+  "hypotheses" each **unwrapped**; the content test asserts "root-cause",
+  "hypotheses" (with "3"/"≥3"), "disjoint" + "evidence", and "verif"/
+  "refut" as co-occurring tokens.
+- **triage** — large backlogs → **triage-at-scale under INV-2 quarantine**.
+  Keep "triage" and "low-privilege" **unwrapped**; the content test asserts
+  "triage" with "inv-2"/"quarantine".
+
+The section also states any **non-static route adapts the relevant
+`*.workflow.js` template by relative path** (ADAPT, not run verbatim).
+
+## Rubric
+
+Deterministic structural shadow of AC-2 / AC-3 (the live route selections,
+which are agent-backed and declared in
+`runtime-routes-taste-task-to-tournament.md` and
+`runtime-routes-incident-to-root-cause.md`). What a file read verifies is
+that the doc *declares* the four routes, their triggers, and the
+adapt-by-relative-path rule — not that any live dispatch picks them.
+
+The load-bearing specifics, each asserted as wrap-safe co-occurring tokens
+so a reasonable line break cannot redden the gate:
+
+- the four route names co-occur with their triggers;
+- the root-cause route names the **≥3-disjoint-evidence-hypotheses** +
+  **verifier/refuter-panel** shape (the discipline that defeats premature
+  single-hypothesis fixation);
+- the triage route names **INV-2 quarantine**;
+- any non-static route **ADAPTs** an S2 template, never edits or runs it
+  verbatim (the "consumer never mutates the contract it consumes" rule).
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s5_orchestrator_routing_structural.py`
+(`TestS5OrchestratorFourRoutes`). RED now: the classification section does
+not exist, so none of the four route names / triggers appear.

--- a/tdad_tests/scenarios/agents/orchestrator/declares-gate-guardrail-hold-on-every-route.md
+++ b/tdad_tests/scenarios/agents/orchestrator/declares-gate-guardrail-hold-on-every-route.md
@@ -1,0 +1,51 @@
+---
+component: orchestrator
+component_type: agent
+tier: structural
+---
+
+# Scenario: the classification step declares the GATE/GUARDRAIL-hold invariant on every route (AC-7, AC-4 structural shadow / FR-5)
+
+## Given
+
+The task-classification section of
+`ai-literacy-superpowers/agents/orchestrator.agent.md`.
+
+## When
+
+The section is read.
+
+## Then
+
+- The section states explicitly that the **Plan Approval GATE** remains in
+  force **on every route** (static and non-static alike). Keep "Plan
+  Approval" **unwrapped**; the content test asserts "plan approval" with
+  "gate".
+- The section states the **`MAX_REVIEW_CYCLES=3` GUARDRAIL** remains in
+  force on every route. `MAX_REVIEW_CYCLES` is a single unwrappable token;
+  the content test asserts "max_review_cycles" with "3".
+- The section states that **no route bypasses, weakens, or multiplies**
+  these — they hold on **every** route. The content test asserts "every
+  route" co-occurs with "gate"/"guardrail".
+
+## Rubric
+
+Deterministic structural shadow of AC-4 (umbrella D4 acceptance). AC-4 — the
+live enforcement of the gate/guardrail across a real non-static route — is a
+**pipeline-level behavioural property, unverified/declared**, NOT provable
+from the agent doc alone, and must **not** be over-promised as
+deterministic. What a file read *can* verify is that the section **declares**
+the invariant: the GATE and the `MAX_REVIEW_CYCLES=3` GUARDRAIL hold on
+every route, with no route permitted to bypass or weaken them.
+
+This is the load-bearing GATE/GUARDRAIL-erosion guard: a non-static route
+could be (mis)written to skip Plan Approval or multiply the review cap, so
+the declaration must be explicit and route-universal.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s5_orchestrator_routing_structural.py`
+(`TestS5OrchestratorGateGuardrailInvariant`). RED now: no classification
+section exists, so the GATE/GUARDRAIL-hold-on-every-route statement is
+absent.

--- a/tdad_tests/scenarios/agents/orchestrator/runtime-routes-incident-to-root-cause.md
+++ b/tdad_tests/scenarios/agents/orchestrator/runtime-routes-incident-to-root-cause.md
@@ -1,0 +1,45 @@
+---
+component: orchestrator
+component_type: agent
+tier: behavioural
+fixture: flaky-test-incident-task
+---
+
+# Scenario: a flaky-test / incident task routes to root-cause investigation (AC-3, agent-backed)
+
+## Given
+
+The **opt-in flag is set** (`orchestrator-routing: enabled` in `HARNESS.md`),
+the **Claude Code runtime is present**, and a **flaky-test or incident**
+task.
+
+## When
+
+The orchestrator classifies it.
+
+## Then
+
+- It routes to **root-cause investigation** with **≥3 independent hypotheses
+  from disjoint evidence** and a panel of verifiers/refuters.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-four-routes-and-triggers.md` (AC-6), which asserts the agent doc
+*declares* the root-cause route, its debugging/flaky-test/incident trigger,
+and the ≥3-disjoint-evidence-hypotheses + verifier/refuter-panel shape.
+
+A judge evaluating a live run confirms an incident/flaky-test task is routed
+to a root-cause investigation that generates at least three independent
+hypotheses from disjoint evidence and runs a verifier/refuter panel — the
+discipline that defeats premature single-hypothesis fixation. This requires
+the Claude Code workflow runtime and the opt-in flag set.
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadow declares. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/agents/orchestrator/runtime-routes-routine-task-to-static.md
+++ b/tdad_tests/scenarios/agents/orchestrator/runtime-routes-routine-task-to-static.md
@@ -1,0 +1,43 @@
+---
+component: orchestrator
+component_type: agent
+tier: behavioural
+fixture: routine-single-file-task
+---
+
+# Scenario: a routine coding task selects the static pipeline with no extra compute (AC-1, agent-backed)
+
+## Given
+
+A **routine single-file coding task** (and any flag state).
+
+## When
+
+The orchestrator classifies it.
+
+## Then
+
+- It **selects the existing static pipeline** — **no workflow is spawned and
+  no extra compute is spent** — and the pipeline runs exactly as today.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-classification-step-opt-in-flag-static-default.md` (AC-5, the
+static-default supremacy rule) and `declares-four-routes-and-triggers.md`
+(AC-6, the routes + triggers), which assert the agent doc *declares*
+static-is-default and the route set.
+
+A judge evaluating a live run confirms a routine task lands on the static
+pipeline with no workflow spawned. This is the over-orchestration guard
+observed at runtime: routing must never make everyday work slower or more
+expensive.
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadows declare. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/agents/orchestrator/runtime-routes-taste-task-to-tournament.md
+++ b/tdad_tests/scenarios/agents/orchestrator/runtime-routes-taste-task-to-tournament.md
@@ -1,0 +1,44 @@
+---
+component: orchestrator
+component_type: agent
+tier: behavioural
+fixture: taste-based-naming-task
+---
+
+# Scenario: a taste-based task routes to a tournament (AC-2, agent-backed)
+
+## Given
+
+The **opt-in flag is set** (`orchestrator-routing: enabled` in `HARNESS.md`),
+the **Claude Code runtime is present**, and a **taste-based task** (naming /
+design).
+
+## When
+
+The orchestrator classifies it.
+
+## Then
+
+- It routes to a **tournament with a rubric-bearing judge** agent.
+
+## Rubric
+
+This is a **runtime / behavioural** property — *not* deterministically
+assertable from a static file read, and explicitly tagged agent-backed in
+the spec (§6 decision 2). Its **structural shadow** is
+`declares-four-routes-and-triggers.md` (AC-6), which asserts the agent doc
+*declares* the tournament route and its taste/design trigger.
+
+A judge evaluating a live run confirms a taste/naming task is routed to a
+tournament with a rubric-bearing judge (taste resolves by comparing
+candidates against an explicit rubric, not a single linear pass). This
+requires the Claude Code workflow runtime and the opt-in flag set; it cannot
+run on a tree without the runtime or with the flag off (where the classifier
+falls back to the static pipeline).
+
+## Status
+
+This scenario is **declared, not wired** as a deterministic check. It is
+**not** part of the Layer-0/1 RED set the GATE confirms — it is a
+Layer-2/3 agent-backed scenario standing as the runtime promise the
+structural shadow declares. It must **not** be promised as CI-checkable.

--- a/tdad_tests/scenarios/commands/superpowers-status/surfaces-routing-posture-and-last-route.md
+++ b/tdad_tests/scenarios/commands/superpowers-status/surfaces-routing-posture-and-last-route.md
@@ -1,0 +1,52 @@
+---
+component: superpowers-status
+component_type: command
+tier: structural
+---
+
+# Scenario: superpowers-status surfaces routing posture and the last route taken (AC-10 / FR-9)
+
+## Given
+
+The file
+`ai-literacy-superpowers/commands/superpowers-status.md`.
+
+## When
+
+The command doc is read.
+
+## Then
+
+- The dashboard documents a **workflow-routing** surface (a section or check)
+  that reports the routing **posture** — read from the `orchestrator-routing`
+  `HARNESS.md` field: **`opt-in, off by default`** when absent/off, vs
+  **`enabled`** when set. Keep "opt-in" and "off by default" each
+  **unwrapped**; the content test asserts "routing" co-occurring with
+  "opt-in" and ("off by default" via "off" + "default") and "enabled".
+- The surface also reports the **most-recent route taken** when a durable
+  trace exists (static / tournament / root-cause / triage), degrading to
+  **`unavailable`** when no durable trace exists. Keep "last route" and
+  "unavailable" each **unwrapped**; the content test asserts "route"
+  co-occurring with "unavailable" (the honest degrade) and the four route
+  names.
+
+## Rubric
+
+Deterministic structural assertion (AC-10, §6 decision 3 / option S1). The
+dashboard is a **read-only health snapshot** of files on disk — it has no
+live event stream of orchestrator dispatches — so the surface must be honest
+about what it can read. It reports **posture** from the decision-1
+`orchestrator-routing` `HARNESS.md` field (reusing that field rather than
+inventing a persisted counter) **plus** the most-recent route when a durable
+trace exists, degrading to `unavailable` otherwise. The surface stays
+**descriptive — no threshold, no `WARNING` state** (the AGENTS.md "no
+threshold before data" decision). This is a file-read declaration check, not
+a live-dispatch property.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s5_orchestrator_routing_structural.py`
+(`TestS5SuperpowersStatusRouteSurface`). RED now: `superpowers-status.md`
+does not yet document any workflow-routing posture / last-route surface
+(`grep -n "orchestrator-routing\|workflow routing"` returns nothing).

--- a/tdad_tests/tests/test_s5_orchestrator_routing_structural.py
+++ b/tdad_tests/tests/test_s5_orchestrator_routing_structural.py
@@ -1,0 +1,439 @@
+"""Layer 1 structural content checks for dynamic-workflows S5.
+
+These tests are the *deterministic mechanism* behind the structural
+scenarios authored at ``scenarios/agents/orchestrator/`` and
+``scenarios/commands/superpowers-status/`` for slice S5 (the
+orchestrator classify-and-act routing step + the superpowers-status
+routing surface).
+
+Per the spec's §6 decision 2 (the verification split), this repo's
+deterministic layer reads files and matches structure — it does **not**
+dispatch the orchestrator or classify a live task. So what is
+deterministically asserted here is that the orchestrator doc **declares**
+the routing contract (classification step before the pipeline; the
+``orchestrator-routing`` opt-in flag, default off; static-is-the-sole-
+default stated three ways; the four routes + triggers + adapt-by-relative-
+path; the GATE/GUARDRAIL-hold-on-every-route invariant; the
+Claude-Code-only scope + non-erroring static fallback; the INV-1
+propose-only boundary + tools-unchanged; the INV-2 triage quarantine) and
+that ``superpowers-status`` **documents** the routing posture + last-route
+surface. The live properties (AC-1 routine→static, AC-2 taste→tournament,
+AC-3 incident→root-cause) are agent-backed and live as ``behavioural``
+scenarios, not wired here. AC-4 (GATE/GUARDRAIL hold across a real
+non-static route) is unverified/declared; its structural shadow (the doc
+*states* the invariant) is asserted here.
+
+RED state (before S5 implements): ``orchestrator.agent.md`` has no
+"Task classification" / "Workflow routing" section and
+``superpowers-status.md`` documents no routing posture / last-route
+surface, so every declaration assertion below fails on missing content —
+RED for the right reason (missing content, not a malformed scenario or an
+unresolvable component; both components already exist). The
+tools-unchanged check is GREEN today and stays green.
+
+Line-wrap note (the trap that bit S3 twice and S4 twice): a required
+two-word phrase that an implementer might wrap across a line is NOT
+asserted as a single substring. Where a guarantee needs two terms to
+co-occur, they are asserted as two independent ``in`` checks on the
+lowercased section so a wrapped phrase still passes. Single load-bearing
+tokens (filenames, ``orchestrator-routing``, ``harness.md``,
+``max_review_cycles``) are wrap-safe and asserted directly; ``claude
+code`` is two words and is split.
+
+Spec: docs/superpowers/specs/2026-06-23-dynamic-workflows-s5-orchestrator-routing-design.md
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+def _component_text(
+    plugin_path: Path, name: str, component_type: str
+) -> str:
+    component = plugin_runner.find_component(
+        plugin_path, name=name, component_type=component_type
+    )
+    return component.path.read_text(encoding="utf-8")
+
+
+def _routing_section(plugin_path: Path, name: str, component_type: str) -> str:
+    """Return the text from the 'Task classification' / 'Workflow routing'
+    heading to the next same-or-higher-level heading, lowercased. Empty
+    string if absent."""
+    text = _component_text(plugin_path, name, component_type)
+    m = re.search(
+        r"^(#{2,4})\s+.*(task classification|workflow routing).*$",
+        text,
+        re.IGNORECASE | re.MULTILINE,
+    )
+    if not m:
+        return ""
+    level = len(m.group(1))
+    start = m.end()
+    rest = text[start:]
+    nxt = re.search(rf"^#{{1,{level}}}\s+\S", rest, re.MULTILINE)
+    end = nxt.start() if nxt else len(rest)
+    return rest[:end].lower()
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — classification step before the pipeline; opt-in flag; static-default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS5OrchestratorClassificationStep:
+    """Structural shadow of AC-5 (and AC-1) — orchestrator.agent.md must
+    *declare* a classification step before the pipeline, the
+    ``orchestrator-routing`` opt-in flag (default off), and the
+    static-default supremacy rule (scenarios under
+    ``scenarios/agents/orchestrator/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _routing_section(plugin_path, "orchestrator", "agent")
+
+    def test_classification_section_exists(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert section, (
+            "orchestrator.agent.md must contain a 'Task classification' or "
+            "'Workflow routing' section (AC-5 / FR-1). None found."
+        )
+
+    def test_declares_classification_runs_before_pipeline(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # Wrap-safe: assert the routing step runs before the pipeline / as
+        # the first action, asserting co-occurring tokens.
+        assert "pipeline" in section and (
+            "before" in section or "first action" in section
+        ), (
+            "Classification section must state it runs before the pipeline "
+            "dispatches / as the first action (AC-5 / FR-1). Keep 'first "
+            "action' unwrapped."
+        )
+
+    def test_declares_orchestrator_routing_flag_default_off(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # 'orchestrator-routing' and 'harness.md' are single unwrappable
+        # tokens; default-off is asserted via co-occurring tokens.
+        assert "orchestrator-routing" in section and "harness.md" in section, (
+            "Classification section must name the explicit opt-in flag — the "
+            "optional `orchestrator-routing` field in HARNESS.md (AC-5 / "
+            "FR-2, §6 decision 1 M1). Both tokens are single/unwrappable."
+        )
+        assert ("default" in section or "absent" in section) and (
+            "off" in section
+        ), (
+            "Classification section must state the flag defaults to off when "
+            "absent (AC-5 / FR-2 / §9 safe-default — the conservative "
+            "direction)."
+        )
+
+    def test_declares_static_is_sole_default_three_ways(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # Static-default supremacy: flag-off, ordinary coding, AND ambiguous
+        # all select static, with no extra compute. Wrap-safe co-occurrence.
+        assert "static" in section and "default" in section, (
+            "Classification section must state the static pipeline is the "
+            "sole default (AC-5 / FR-3). Keep 'static pipeline' unwrapped."
+        )
+        assert ("flag-off" in section or "flag off" in section) and (
+            "ambiguous" in section
+        ), (
+            "Classification section must state the static pipeline is "
+            "selected for flag-off, ordinary coding, AND ambiguous "
+            "classification alike (AC-5 / FR-3 — the static-default "
+            "supremacy rule, stated three ways). Keep 'ambiguous' unwrapped."
+        )
+        assert "no extra compute" in section or (
+            "no" in section and "extra compute" in section
+        ), (
+            "Classification section must state the flag-off / static no-op "
+            "spends no extra compute (AC-5 / FR-3, the over-orchestration "
+            "guard). Keep 'extra compute' unwrapped."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — the four routes and their triggers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS5OrchestratorFourRoutes:
+    """Structural shadow of AC-6 (and AC-2, AC-3) — the classification
+    section must declare all four routes + triggers + adapt-by-relative-path
+    (scenarios under ``scenarios/agents/orchestrator/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _routing_section(plugin_path, "orchestrator", "agent")
+
+    def test_declares_static_route(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert "static pipeline" in section or (
+            "static" in section and "ordinary coding" in section
+        ), (
+            "Classification section must declare the static route — ordinary "
+            "coding → the existing static pipeline (the default) (AC-6 / "
+            "FR-4). Keep 'static pipeline' unwrapped."
+        )
+
+    def test_declares_tournament_route(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert "tournament" in section and "rubric-bearing judge" in section, (
+            "Classification section must declare the tournament route — "
+            "design/naming/taste → a tournament with a rubric-bearing judge "
+            "(AC-6 / FR-4; structural shadow of AC-2). Keep 'rubric-bearing "
+            "judge' unwrapped."
+        )
+
+    def test_declares_root_cause_route(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert "root-cause" in section and "hypotheses" in section and (
+            "3" in section
+        ), (
+            "Classification section must declare the root-cause route — "
+            "debugging/flaky-test/incident → root-cause investigation with "
+            "≥3 independent hypotheses (AC-6 / FR-4; structural shadow of "
+            "AC-3). Keep 'root-cause' unwrapped."
+        )
+
+    def test_declares_root_cause_disjoint_evidence_and_panel(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "disjoint" in section and "evidence" in section, (
+            "Classification section must declare the root-cause hypotheses "
+            "come from disjoint evidence (AC-6 / FR-4). Keep 'disjoint "
+            "evidence' unwrapped."
+        )
+        assert "verif" in section or "refut" in section, (
+            "Classification section must declare the root-cause route runs a "
+            "verifier/refuter panel (AC-6 / FR-4)."
+        )
+
+    def test_declares_triage_route_under_inv2(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert "triage" in section and (
+            "inv-2" in section or "quarantine" in section
+        ), (
+            "Classification section must declare the triage route — large "
+            "backlogs → triage-at-scale under INV-2 quarantine (AC-6 / "
+            "FR-4). Keep 'triage' unwrapped."
+        )
+
+    def test_declares_adapts_template_by_relative_path(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert ".workflow.js" in section and "adapt" in section and (
+            "relative path" in section
+        ), (
+            "Classification section must state any non-static route ADAPTs "
+            "the relevant `*.workflow.js` template by relative path — ADAPT, "
+            "not verbatim (AC-6 / FR-4)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 (structural shadow of AC-4) — GATE/GUARDRAIL hold on every route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS5OrchestratorGateGuardrailInvariant:
+    """Structural shadow of AC-7 / AC-4 — the classification section must
+    state the Plan Approval GATE and MAX_REVIEW_CYCLES=3 GUARDRAIL hold on
+    every route (scenarios under ``scenarios/agents/orchestrator/``).
+
+    AC-4 (live enforcement across a real non-static route) is
+    unverified/declared and is NOT asserted here — only the doc's
+    declaration of the invariant is checkable from a file read."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _routing_section(plugin_path, "orchestrator", "agent")
+
+    def test_declares_plan_approval_gate_holds(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "plan approval" in section and "gate" in section, (
+            "Classification section must state the Plan Approval GATE remains "
+            "in force on every route (AC-7 / FR-5). Keep 'Plan Approval' "
+            "unwrapped."
+        )
+
+    def test_declares_max_review_cycles_guardrail_holds(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "max_review_cycles" in section and "3" in section, (
+            "Classification section must state the MAX_REVIEW_CYCLES=3 "
+            "GUARDRAIL remains in force on every route (AC-7 / FR-5). Keep "
+            "'MAX_REVIEW_CYCLES' unwrapped."
+        )
+
+    def test_declares_invariant_holds_on_every_route(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        assert "every route" in section and (
+            "gate" in section or "guardrail" in section
+        ), (
+            "Classification section must state the GATE/GUARDRAIL hold on "
+            "EVERY route (static and non-static alike) — no route bypasses, "
+            "weakens, or multiplies them (AC-7 / FR-5). Keep 'every route' "
+            "unwrapped."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 / AC-9 — Claude-Code scope + fallback; INV-1 propose-only; INV-2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS5OrchestratorClaudeCodeScopeAndInvariants:
+    """Structural shadow of AC-8 / AC-9 — the classification section must
+    declare the Claude-Code-only scope + non-erroring static fallback, the
+    INV-1 propose-only boundary, and the INV-2 triage quarantine
+    (scenarios under ``scenarios/agents/orchestrator/``)."""
+
+    def _section(self, plugin_path: Path) -> str:
+        return _routing_section(plugin_path, "orchestrator", "agent")
+
+    def test_declares_claude_code_scope_and_fallback(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # 'claude code' is two words — split it.
+        assert "claude" in section and "code" in section and (
+            "fall back" in section
+            or "falls back" in section
+            or "fallback" in section
+        ) and ("never error" in section), (
+            "Classification section must state the non-static routes require "
+            "the Claude Code runtime and that on a tree without it — or with "
+            "the flag off — the classifier selects the static pipeline and "
+            "never errors (AC-8 / FR-6). Keep 'Claude Code' unwrapped."
+        )
+
+    def test_declares_propose_only_never_writes_durable(
+        self, plugin_path: Path
+    ) -> None:
+        section = self._section(plugin_path)
+        # The prohibition is on the four durable curated artefacts; assert
+        # 'durable' + 'propose' co-occur with at least two named artefacts.
+        named = sum(
+            t in section
+            for t in (
+                "harness.md",
+                "agents.md",
+                "claude.md",
+                "model_routing.md",
+            )
+        )
+        assert "durable" in section and "propose" in section and named >= 2, (
+            "Classification section must state every route is propose-only — "
+            "any workflow a route spawns never writes a durable curated "
+            "artefact (HARNESS.md/AGENTS.md/CLAUDE.md/MODEL_ROUTING.md) "
+            "(AC-9 / FR-7 / INV-1). Keep 'durable artefact' unwrapped."
+        )
+
+    def test_declares_inv2_triage_quarantine(self, plugin_path: Path) -> None:
+        section = self._section(plugin_path)
+        assert "low-privilege" in section and "trusted" in section and (
+            "inv-2" in section or "quarantine" in section
+        ), (
+            "Classification section must state the triage route reads "
+            "untrusted/public content only with low-privilege agents and "
+            "that only separate trusted agents act on it (AC-9 / FR-8 / "
+            "INV-2). Keep 'low-privilege' unwrapped."
+        )
+
+
+@pytest.mark.structural
+class TestS5OrchestratorToolsUnchanged:
+    """AC-9 / FR-7: the orchestrator's `tools` list is unchanged — the
+    classification step adds no new write capability. GREEN today and must
+    STAY green through S5."""
+
+    # The current tool set, read from the live frontmatter. S5 must not
+    # alter it; this asserts the exact set stays put (it does NOT assert a
+    # specific new tool).
+    _EXPECTED = ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Agent", "WebFetch"]
+
+    def test_tools_unchanged(self, plugin_path: Path) -> None:
+        component = plugin_runner.find_component(
+            plugin_path, name="orchestrator", component_type="agent"
+        )
+        tools = component.frontmatter.get("tools") or []
+        assert tools == self._EXPECTED, (
+            f"orchestrator `tools` must stay unchanged through S5 — the "
+            f"classification step adds no new write capability (AC-9 / FR-7 / "
+            f"INV-1). Expected {self._EXPECTED!r}, got {tools!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — superpowers-status surfaces routing posture + last route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS5SuperpowersStatusRouteSurface:
+    """Structural shadow of AC-10 — commands/superpowers-status.md must
+    document a routing surface reporting posture (opt-in/off-by-default vs
+    enabled) and the last route taken (else unavailable) (scenario under
+    ``scenarios/commands/superpowers-status/``)."""
+
+    def _text(self, plugin_path: Path) -> str:
+        return _component_text(
+            plugin_path, "superpowers-status", "command"
+        ).lower()
+
+    def test_documents_routing_posture(self, plugin_path: Path) -> None:
+        text = self._text(plugin_path)
+        assert "routing" in text and "opt-in" in text and (
+            "enabled" in text
+        ) and ("off" in text and "default" in text), (
+            "superpowers-status.md must document the routing posture — "
+            "`opt-in, off by default` (absent/off) vs `enabled` (set), read "
+            "from the orchestrator-routing HARNESS.md field (AC-10 / FR-9). "
+            "Keep 'opt-in' and 'off by default' unwrapped."
+        )
+
+    def test_documents_last_route_or_unavailable(
+        self, plugin_path: Path
+    ) -> None:
+        text = self._text(plugin_path)
+        assert "route" in text and "unavailable" in text, (
+            "superpowers-status.md must document the most-recent route taken "
+            "when a durable trace exists, degrading to `unavailable` "
+            "otherwise (AC-10 / FR-9, §6 decision 3 / S1). Keep 'last route' "
+            "and 'unavailable' unwrapped."
+        )
+
+    def test_documents_four_route_names(self, plugin_path: Path) -> None:
+        text = self._text(plugin_path)
+        assert all(
+            r in text for r in ("static", "tournament", "root-cause", "triage")
+        ), (
+            "superpowers-status.md must name the four routes the last-route "
+            "surface can report (static / tournament / root-cause / triage) "
+            "(AC-10 / FR-9). Keep 'root-cause' unwrapped."
+        )


### PR DESCRIPTION
## Summary

- Adds a **Task classification** step to `orchestrator.agent.md` that runs before the pipeline. Non-static routing is **opt-in** via the optional `orchestrator-routing` HARNESS.md field (**default off**); the static pipeline stays the sole default for flag-off, ordinary coding, and ambiguous classification — no extra compute in the common case.
- Four routes (static / tournament / root-cause / triage under INV-2), each adapting a `*.workflow.js` template. The **Plan Approval GATE** and the `MAX_REVIEW_CYCLES=3` GUARDRAIL hold on **every** route. Claude-Code-only with a non-erroring static fallback; propose-only (INV-1).
- `commands/superpowers-status.md` surfaces routing posture and the last route taken (or reports it unavailable).
- Minor bump 0.61.0 → 0.62.0 across all five CI-enforced locations; `reference/agents.md`, `reference/commands.md`, and the dynamic-workflows how-to updated. Deterministic structural checks (`test_s5_orchestrator_routing_structural.py`) wired into fast CI.

## Test plan

- Confirm the new "Run Layer 1 (dynamic-workflows S5 ...)" step is green inside the TDAD-fast job.
- Verify `Version Check` / version-consistency passes (0.62.0 across all five locations).
- Verify `Spec-First Check` passes — spec is the first commit on the branch.
- Manually skim `superpowers-status` output: routing posture + last route appear when `orchestrator-routing` is on; "unavailable" when off.
- Sanity-check that flag-off behaviour is unchanged (static pipeline only).

## References

- Spec: `docs/superpowers/specs/2026-06-23-dynamic-workflows-s5-orchestrator-routing-design.md`
- Epic / slicing record: `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`

Closes #442
