### PR TITLE
Dynamic Workflows S7 — docs, Copilot contract, epic finale

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.63.0",
+  "plugin_version": "0.64.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.63.0"
+      "version": "0.64.0"
     },
     {
       "name": "model-cards",

--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -76,3 +76,7 @@ jobs:
       - name: Run Layer 1 (dynamic-workflows S6 reflection mining)
         working-directory: tdad_tests
         run: pytest tests/test_s6_reflection_mining_structural.py -v
+
+      - name: Run Layer 1 (dynamic-workflows S7 docs + Copilot contract)
+        working-directory: tdad_tests
+        run: pytest tests/test_s7_docs_hook_copilot_structural.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.64.0 — 2026-06-23
+
+### dynamic-workflows: docs, Copilot contract, epic finale (S7, #444)
+
+The final slice of the Dynamic Workflows Alignment epic (D1–D9 now all
+delivered across S1–S7).
+
+- **README gains a "Dynamic Workflows" section** — the new ephemeral substrate,
+  the six patterns, the opt-in election discipline, INV-1/INV-2, and the
+  Claude-Code-only/guidance-everywhere boundary. The `Skills-36` badge is
+  deliberately unchanged (the count was reconciled in S1).
+- **Copilot CLI degradation contract resolved (open question 4 → Option A):** the
+  `dynamic-workflows` skill **ships to both** the Claude Code and Copilot CLI
+  trees and is **never omitted**. Where the workflow runtime is absent it is
+  guidance-only — readable knowledge with each workflow-mode degrading to its
+  static fallback, never erroring. Documented in the README and the skill's
+  `governance.md`. This is documentation of already-shipped behaviour — no agent
+  behaviour changes.
+- **`CLAUDE.md` (root) and `templates/CLAUDE.md`** gain a pointer: when a task
+  looks long-running, massively parallel, highly structured, or adversarial,
+  consult the `dynamic-workflows` skill before reaching for a workflow.
+- The optional advisory `Stop` hook from D9 was **deliberately deferred** (a Stop
+  hook cannot reliably know a task's shape; the election discipline already lives
+  in the skill and the orchestrator's classifier).
+- All four §7 open questions are now resolved: Q1 fan-out threshold = 8 (S3); Q2
+  routing opt-in (S5); Q3 staging = `REFLECTION_STAGING.md` (S6); Q4 Copilot =
+  Option A (here). Deterministic structural checks
+  (`test_s7_docs_hook_copilot_structural.py`) gate the declared contract.
+
 ## 0.63.0 — 2026-06-23
 
 ### dynamic-workflows: reflection-mining curation workflow (S6, #443)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,16 @@ When adding a new command that writes structured markdown, add a
 validation step following this pattern. Reference the format spec
 rather than inlining field definitions.
 
+## Dynamic Workflows
+
+When a task looks **long-running**, massively parallel, highly structured,
+or **adversarial**, consult the `dynamic-workflows` skill _before_ reaching
+for a workflow — it carries the six patterns, the when-not-to-use election
+rubric, and the INV-1/INV-2 invariants. Workflows are opt-in: the static
+pipeline stays the default, and a workflow must never write a durable
+curated artefact directly (INV-1). Dynamic workflows are Claude-Code-only;
+elsewhere the skill is guidance.
+
 ## Docs Site Review
 
 The `docs/` directory is the project's documentation site, organised

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.63.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.63.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.64.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -554,6 +554,23 @@ orchestrator
 The spec objection adjudication gate raises premise-level challenges before any tests or code exist — the cheapest moment to change course. The plan approval gate catches bad plans before they become bad code. The loop guardrail prevents unbounded reviewer cycles. The code objection adjudication gate surfaces threat-model, failure-mode, and operational concerns visible in the implementation before merge.
 
 The plugin ships the orchestrator, spec-writer, tdd-agent, code-reviewer, and integration-agent. Language-specific implementers are not included — each project creates its own based on the stack. See [How to Extend](#how-to-extend) for instructions.
+
+---
+
+## Dynamic Workflows
+
+Beneath the static agent pipeline sits an **ephemeral execution substrate**: *dynamic workflows* — self-authored, single-task multi-agent harnesses an agent writes, runs once, and discards. Each subagent gets a clean context window and its own model tier, which is what defeats the three failure modes a single long context is prone to: **agentic laziness** (declaring a multi-part job done after partial progress), **self-preferential bias** (an agent judging its own output), and **goal drift**. The conceptual model lives in the [`dynamic-workflows`](ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md) skill and the [how-to guide](docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md).
+
+**Six composable patterns** — classify-and-act, **fan-out**-and-synthesize, **adversarial** verification, generate-and-filter, **tournament**, and loop-until-done — are the building blocks. The plugin dogfoods them: the `harness-enforcer` fans out one verifier per constraint; `code-reviewer` reviews in a separate context; `assessor`/`harness-auditor` run deep-research scans; `/reflect --mine` mines the reflection log; and the `orchestrator` can route a task to a tournament, root-cause, or triage workflow.
+
+**Elect deliberately.** Workflows cost more tokens and suit long-running, massively parallel, highly structured, or adversarial tasks — so they are **opt-in**, never reflexive. The four-question [when-not-to-use](ai-literacy-superpowers/skills/dynamic-workflows/references/when-not-to-use.md) rubric keeps the **static pipeline the default**; reaching for a workflow on a routine task is treated as over-orchestration.
+
+**Two governing invariants** protect the curated harness from ephemeral churn:
+
+- **INV-1 — ephemeral proposes, durable curates.** A workflow may *propose* changes but **never writes** the durable, human-curated artefacts (`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`) directly; discoveries flow through `REFLECTION_LOG.md → human curates → AGENTS.md`. A deterministic CI firewall (`scripts/inv-firewall.sh`) enforces this on every shipped template.
+- **INV-2 — quarantine.** A workflow agent that reads untrusted or public content is withheld high-privilege tools; only separate trusted agents act on what it found.
+
+**Runtime scope — Claude Code only.** Dynamic workflows are a **Claude Code** runtime capability and are **not transferable** to other coding agents. The plugin ships the skill to both the Claude Code and **Copilot** CLI trees: where the workflow runtime is present, the modes execute; where it is absent (Copilot CLI or any other agent), the skill is **guidance** only — readable knowledge with each workflow-mode degrading to its static fallback — never omitted and never erroring.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Beneath the static agent pipeline sits an **ephemeral execution substrate**: *dy
 
 **Two governing invariants** protect the curated harness from ephemeral churn:
 
-- **INV-1 — ephemeral proposes, durable curates.** A workflow may *propose* changes but **never writes** the durable, human-curated artefacts (`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`) directly; discoveries flow through `REFLECTION_LOG.md → human curates → AGENTS.md`. A deterministic CI firewall (`scripts/inv-firewall.sh`) enforces this on every shipped template.
+- **INV-1 — ephemeral proposes, durable curates.** A workflow may *propose* changes but **never writes** the durable, human-curated artefacts (`HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, `MODEL_ROUTING.md`) directly; discoveries flow through `REFLECTION_LOG.md → human curates → AGENTS.md`. A deterministic CI firewall (`ai-literacy-superpowers/scripts/inv-firewall.sh`) enforces this on every shipped template.
 - **INV-2 — quarantine.** A workflow agent that reads untrusted or public content is withheld high-privilege tools; only separate trusted agents act on what it found.
 
 **Runtime scope — Claude Code only.** Dynamic workflows are a **Claude Code** runtime capability and are **not transferable** to other coding agents. The plugin ships the skill to both the Claude Code and **Copilot** CLI trees: where the workflow runtime is present, the modes execute; where it is absent (Copilot CLI or any other agent), the skill is **guidance** only — readable knowledge with each workflow-mode degrading to its static fallback — never omitted and never erroring.

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md
+++ b/ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md
@@ -74,3 +74,21 @@ something worth keeping does both: the untrusted reader stays low-privilege
 to `REFLECTION_LOG.md` or a staging file for a human to curate (INV-1) —
 never straight into `HARNESS.md`, `AGENTS.md`, `CLAUDE.md`, or
 `MODEL_ROUTING.md`.
+
+## Runtime scope and the Copilot contract
+
+Dynamic workflows are a **Claude Code** runtime capability. This plugin
+**ships the `dynamic-workflows` skill to both trees** — Claude Code and
+**Copilot** CLI — and the skill is **never omitted** on either. The
+behaviour degrades by runtime, not by deletion:
+
+- **On Claude Code:** the workflows execute; the patterns, election rubric,
+  and templates are runnable.
+- **On Copilot CLI (or any agent without the workflow runtime):** the skill
+  is **guidance** only — readable knowledge — and every workflow-mode falls
+  back to its existing static behaviour. It never errors and it is never
+  omitted; the knowledge (patterns, election rubric, INV-1/INV-2) is worth
+  reading even where no workflow can be spawned.
+
+This is the resolved degradation contract (Option A): **ship to both
+trees**, guidance-only where the runtime is absent.

--- a/ai-literacy-superpowers/templates/CLAUDE.md
+++ b/ai-literacy-superpowers/templates/CLAUDE.md
@@ -37,6 +37,15 @@ The five properties in brief:
 4. **Idiomatic** — does it follow the grain of the language and project conventions?
 5. **Domain-based** — do its names come from the problem domain, not the technical implementation?
 
+## Dynamic Workflows
+
+When a task looks **long-running**, massively parallel, highly structured, or
+**adversarial**, consult the `dynamic-workflows` skill before reaching for a
+workflow — it carries the six patterns, the when-not-to-use election rubric, and
+the INV-1/INV-2 invariants. Workflows are opt-in: the static pipeline stays the
+default, and a workflow never writes a durable curated artefact directly (INV-1).
+Dynamic workflows are Claude-Code-only; elsewhere the skill is guidance.
+
 ## Workflow
 
 ### Spec-First Change Discipline

--- a/docs/superpowers/specs/2026-06-23-dynamic-workflows-s7-docs-hook-copilot-design.md
+++ b/docs/superpowers/specs/2026-06-23-dynamic-workflows-s7-docs-hook-copilot-design.md
@@ -1,0 +1,713 @@
+# Specification — Dynamic Workflows S7: Documentation, Advisory Hook, Copilot Degradation Contract (epic finalisation)
+
+**Plugin:** `ai-literacy-superpowers` (Habitat-Thinking)
+**Slice:** S7 of the Dynamic Workflows Alignment epic — the **FINAL** slice (D9 — documentation, the optional advisory Stop hook, the CLAUDE.md pointer, and the Copilot CLI degradation contract that the whole epic has carried toward)
+**Umbrella spec:** `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md`
+**Slicing record:** `docs/superpowers/slices/dynamic-workflows-alignment.md` (§ S7; Runtime scope — Claude Code only)
+**Issue:** <https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/444>
+**Depends on:** S1 (#438, merged) — the `dynamic-workflows` skill + election rubric + MODEL_ROUTING workflow-election section; S2 (#439, merged) — the four `*.workflow.js` templates + INV-1/INV-2 firewall; S3 (#440, merged) — enforcer fan-out; S4 (#441, merged) — adversarial review + deep-research assessor/auditor; S5 (#442, merged) — orchestrator classify-and-act routing; S6 (#443, merged) — `/reflect --mine`. S7 documents the now-complete substrate and depends on every prior slice for accurate counts and prose.
+**Spec status:** Draft for implementation
+**Spec version:** 0.1.0
+**Owner:** Russ Miles / Habitat Thinking
+**Branch:** `dynamic-workflows-s7-docs-hook-copilot`
+
+> **Implementer note (read first).** This slice is **documentation + one optional advisory hook**. It
+> ships **no new skill, agent, or command** and **no new behaviour inside any existing agent**. It
+> adds: (1) a new **"Dynamic Workflows" prose section to `README.md`** describing the substrate the
+> epic shipped; (2) — *if the GATE accepts it* — **one optional advisory `Stop` hook** in
+> `ai-literacy-superpowers/hooks/hooks.json` (warn, **never** block) backed by a new POSIX-portable
+> script under `ai-literacy-superpowers/hooks/scripts/`; (3) **one pointer line** to the
+> `dynamic-workflows` skill in `CLAUDE.md` (repo root) **and** `ai-literacy-superpowers/templates/CLAUDE.md`;
+> (4) a `CHANGELOG.md` entry under the new version. The **headline decision** this slice resolves is
+> umbrella **open-question 4** — the **Copilot CLI degradation contract** (guidance-only fallback vs
+> omit the skill on the Copilot tree). That contract is **documentation only**: it requires **no code
+> change beyond words**, because every S1–S6 slice already declares the guidance-only non-erroring
+> fallback as how the agents behave.
+>
+> **Runtime scope — Claude Code only.** Dynamic workflows are a Claude Code runtime capability,
+> **not transferable** to GitHub Copilot CLI or any other coding agent — those trees have no workflow
+> runtime. The plugin ships to **both** trees. Where the runtime exists (Claude Code) the workflow
+> modes and templates execute; where it does not (Copilot CLI, other agents) the `dynamic-workflows`
+> skill and every workflow-mode section **degrade to guidance only** — the knowledge stays readable,
+> no workflow is spawned, and workflow-mode agents fall back to their existing static behaviour and
+> never error. S7 is the slice that **fixes the precise contract** behind this settled boundary
+> (umbrella §5.5 / open-question 4) and **documents it** in the README and the skill/governance
+> reference. The skill-count badge is **already 36** (reconciled in S1) — S7 does **not** re-bump it.
+
+---
+
+## 1. Context and motivation
+
+The Dynamic Workflows Alignment epic introduced dynamic workflows as a new **ephemeral execution
+substrate** beneath the plugin's static agents, governed by **INV-1** (ephemeral proposes, durable
+curates) and **INV-2** (quarantine untrusted-content readers). Six slices shipped it:
+
+- **S1** — the `dynamic-workflows` skill (six patterns, election rubric, INV-1/INV-2) + the
+  MODEL_ROUTING workflow-election + token-budget section; the skill-count badge was reconciled to **36** here.
+- **S2** — four `*.workflow.js` templates (enforcer-fanout, adversarial-review, reflection-mining,
+  deep-assessment) + the deterministic INV-1/INV-2 firewall (`inv-firewall.sh`).
+- **S3** — `harness-enforcer` fan-out (one verifier subagent per HARNESS rule + skeptic; threshold **8**).
+- **S4** — adversarial verification for `code-reviewer` + `Advocatus Diaboli`, and deep-research mode
+  for `assessor` + `harness-auditor`.
+- **S5** — `orchestrator` classify-and-act routing (static default; tournament / root-cause /
+  triage-at-scale **opt-in behind a flag**).
+- **S6** — `/reflect --mine` (cluster → adversarially filter → shortlist into `REFLECTION_STAGING.md`).
+
+What remains is **D9 — finalisation**: tell users the substrate exists (README), point agents at the
+skill (CLAUDE.md), optionally add the advisory nudge (Stop hook), and — the load-bearing decision —
+**settle the Copilot CLI degradation contract** that every prior slice declared but none has yet fixed
+as the plugin's stated cross-CLI policy. The slicing record records the `independence` lens: S7 blocks
+nothing and is blocked only by the completeness of the surfaces it documents. The Copilot degradation
+decision folds into S7 rather than its own slice because it has **no implementation substrate of its
+own** — it is a documentation-and-fallback contract that lives where the docs live.
+
+**Why this is the slice the epic carried toward.** Every S1–S6 spec restated "Claude-Code-gated;
+degrades to guidance only; never errors" and explicitly deferred the *precise* cross-CLI contract
+(guidance-only vs omit) to S7. S7 is where that promise is honoured: a single, authoritative
+statement of the contract, placed in the README and the skill/governance reference, with confirmation
+that it needs **no code change** because the degradation is already how the agents behave.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope (this slice)
+
+1. **`README.md` — a new "Dynamic Workflows" prose section.** A section (sibling of the existing
+   `### Skills (36)` / `### Hooks (11)` material under `## ai-literacy-superpowers — what it ships`,
+   or a top-level `## Dynamic Workflows` under that umbrella) documenting:
+   - **What dynamic workflows are** — self-authored, ephemeral, per-task multi-agent harnesses; the
+     new execution substrate beneath the static pipeline.
+   - **The six patterns / election discipline at a glance** — classify-and-act, fan-out-and-synthesize,
+     adversarial verification, generate-and-filter, tournament, loop-until-done; elected via the
+     when-not-to-use rubric (long-running / massively parallel / highly structured / adversarial), not
+     reflexive — the static pipeline stays the default.
+   - **INV-1** (ephemeral proposes, durable curates) and **INV-2** (quarantine untrusted-content readers).
+   - **Claude-Code-only runtime scope** with the **§5.5-style degradation statement** — the contract
+     resolved in §5 of this spec (guidance-only fallback on Copilot CLI / other agents).
+   - **Cross-links** to the `dynamic-workflows` skill (`ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md`)
+     and the how-to guide (`docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md`).
+   - **The skill-count badge is NOT re-bumped** — it already reads **36** (reconciled in S1). S7 adds
+     prose only; it does not touch the `Skills-36` badge or the plugin-table "36 skills" cell.
+2. **The Copilot CLI degradation contract (the headline GATE decision — open-question 4).** A single
+   authoritative statement of **Option A — guidance-only fallback** (recommended; see §5), placed:
+   - as the **§5.5-style statement in the README** Dynamic Workflows section, and
+   - as a **note in the skill/governance reference** —
+     `ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md` (and/or the SKILL.md
+     "Runtime scope — Claude Code only" section, which already carries the boundary prose).
+   The contract is **documentation only** — it requires **no code change** beyond words, because every
+   S1–S6 workflow-mode already degrades to its static/guidance fallback and never errors.
+3. **`hooks/hooks.json` + a backing script — an OPTIONAL advisory `Stop` hook (D9 "optional"; GATE
+   decides whether it ships).** If shipped: a `Stop`-array entry mirroring the existing entries
+   (`matcher: "*"`, a `type: "command"` invoking
+   `bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/<name>.sh`, a short timeout), backed by a new
+   POSIX-portable script that, when a session tackled a long / massively-parallel / adversarial task
+   **without** electing a workflow, prints a **low-confidence, low-noise** advisory nudging
+   consideration of one. **Advisory only — warns via `systemMessage`, NEVER blocks; exits 0 always.**
+   The new `.sh` honours the Layer-0 macOS+Linux portability constraint that applies to every hook script.
+4. **`CLAUDE.md` (repo root) and `ai-literacy-superpowers/templates/CLAUDE.md` — one pointer line.** A
+   single line directing agents to the `dynamic-workflows` skill: *when a task looks long-running /
+   massively parallel / highly structured / adversarial, consult the `dynamic-workflows` skill before
+   reaching for a workflow.*
+5. **`CHANGELOG.md` — an entry under the new version** (§7), themed for the epic finalisation.
+6. **Supporting CI / version surfaces** (§7) and the **docs-impact** touch-ups (§7.3).
+7. **An "epic complete" confirmation** (§9) — D1–D9 delivered across S1–S7; §7 open questions Q1–Q4
+   all resolved.
+
+### 2.2 Out of scope (explicitly deferred — do not blur)
+
+| Deferred / forbidden concern | Why not here |
+| --- | --- |
+| Any new behaviour inside a workflow-mode agent, or any new workflow template | The substrate is complete (S1–S6); S7 documents it and adds at most an advisory nudge. No `*.agent.md` behaviour change, no `*.workflow.js` edit. |
+| Re-bumping the **skill-count** badge (36) or component-count badges | S1 already reconciled the skill count to 36. S7 adds **no** new skill/agent/command — only prose, one pointer line, and (optionally) one hook. |
+| A **blocking** hook, or any hook that exits non-zero / persists state | Forbidden by the AGENTS.md "hook scripts never block, only warn" decision. The new hook (if shipped) is advisory-only, `exit 0` always, no disk writes about the human's state. |
+| Making the Stop hook *truly* detect task shape (parsing transcripts, model calls) | A Stop hook cannot reliably know whether a session was long/parallel/adversarial. The hook (if shipped) is a **low-confidence heuristic nudge** by design — see §6 decision 2. Over-claiming detection is a non-goal. |
+| Auto-omitting the skill on the Copilot tree (Option B) | Recommended **against** (§5) — it would contradict shipped S1–S6 behaviour, which already declares a guidance-only non-erroring fallback. Surfaced for the human, not chosen. |
+| Changing the listing `version` (`0.4.0`) | S7 alters no listing contract (no description/keyword/permission/source change, no plugin entry added/removed). The listing `version` stays `0.4.0`; only `plugin_version` + the per-plugin entry version move with the bump. |
+
+**Boundary rule.** S7 modifies, at most: `README.md`, `CLAUDE.md`, `ai-literacy-superpowers/templates/CLAUDE.md`,
+`CHANGELOG.md`, the skill/governance reference (`.../skills/dynamic-workflows/references/governance.md`
+and/or `SKILL.md`), the five CI-enforced version locations, and — *if the GATE ships the hook* —
+`ai-literacy-superpowers/hooks/hooks.json` plus one new
+`ai-literacy-superpowers/hooks/scripts/<name>.sh`. It ships **no new component** and **no new CI
+workflow** (the tdd-agent wires any new test into the existing `tdad-tests-fast.yml`).
+
+---
+
+## 3. User story
+
+> **As a** developer or new contributor browsing the `ai-literacy-superpowers` README, **I want** a
+> clear "Dynamic Workflows" section that explains what the new ephemeral multi-agent substrate is, the
+> six patterns and the election discipline at a glance, the two governance invariants, and that it is
+> **Claude-Code-only — degrading to readable guidance everywhere else** — **so that** I understand
+> what the plugin now ships, know when (and when not) to reach for a workflow, and know exactly what
+> to expect on the Copilot CLI tree (the knowledge is readable; no workflow is spawned; nothing errors).
+
+Supporting story (advisory nudge, if the hook ships):
+
+> **As an** agent finishing a session that tackled a long / massively-parallel / adversarial task
+> **without** electing a workflow, **I want** a gentle, low-noise end-of-session nudge to consider
+> whether a dynamic workflow would have fit, **so that** the substrate is reached for deliberately —
+> **without** ever being blocked, and without false-positive noise on ordinary coding sessions.
+
+This honours **INV-1** at the documentation layer: the README and reference state the durable/ephemeral
+boundary; the advisory hook (if shipped) only *nudges* — it never writes a durable artefact, never
+blocks, and never claims certainty it does not have.
+
+---
+
+## 4. Acceptance scenarios (Given / When / Then)
+
+Each scenario carries its **verification-slot** tag from the umbrella taxonomy: *deterministic*
+(CI-checkable / Layer-0–1 structural) or *unverified / observational* (declared intent). Scenarios
+trace to umbrella **D9** acceptance and to §5.5 (Copilot degradation). The tdd-agent turns the
+deterministic scenarios into failing checks first.
+
+> **Slot tags** are shown as `[deterministic]`, `[deterministic — conditional on hook GATE]`, and
+> `[observational]`. Scenarios AC-6 and AC-7 are **conditional on the hook-ship GATE decision** (§6
+> decision 1): they apply **only if** the advisory Stop hook ships.
+
+### The README Dynamic Workflows section (deterministic, structural)
+
+**AC-1 `[deterministic]` — the README has a Dynamic Workflows section.**
+**Given** `README.md`,
+**When** it is read,
+**Then** it contains a **"Dynamic Workflows" section** (a heading whose text contains
+`Dynamic Workflows`) describing dynamic workflows as the ephemeral, self-authored, per-task
+multi-agent substrate beneath the static pipeline.
+
+**AC-2 `[deterministic]` — the section names the six patterns and the election discipline.**
+**Given** the Dynamic Workflows section,
+**When** it is read,
+**Then** it names the **six patterns** (classify-and-act, fan-out-and-synthesize, adversarial
+verification, generate-and-filter, tournament, loop-until-done) and states the **election discipline**
+— workflows are elected via the when-not-to-use rubric, not reflexive; the static pipeline stays the
+default.
+
+**AC-3 `[deterministic]` — the section states INV-1 and INV-2.**
+**Given** the Dynamic Workflows section,
+**When** it is read,
+**Then** it states **INV-1** (ephemeral proposes, durable curates — a workflow may propose but never
+write `HARNESS.md`/`AGENTS.md`/`CLAUDE.md`/`MODEL_ROUTING.md`) and **INV-2** (quarantine — an
+untrusted-content reader is withheld high-privilege tools).
+
+**AC-4 `[deterministic]` — the section states the Claude-Code-only scope + the guidance-only Copilot contract, and cross-links the skill + how-to.**
+**Given** the Dynamic Workflows section,
+**When** it is read,
+**Then** it states that dynamic workflows are **Claude-Code-only** and that on Copilot CLI / other
+agents the skill and workflow modes **degrade to guidance only** (knowledge readable, no workflow
+spawned, no error) — the **Option A** contract of §5 — and it **cross-links** the `dynamic-workflows`
+skill and the how-to guide.
+
+**AC-5 `[deterministic]` — the skill-count badge is unchanged at 36.**
+**Given** `README.md`,
+**When** the `Skills-` shields badge and the plugin-table "skills" cell are read,
+**Then** they **still read 36** — S7 does **not** re-bump the skill count (reconciled in S1).
+
+### The Copilot degradation contract in the skill/governance reference (deterministic, structural)
+
+**AC-6c `[deterministic]` — the skill/governance reference states the guidance-only contract.**
+**Given** `ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md` (and/or the
+SKILL.md "Runtime scope" section),
+**When** it is read,
+**Then** it states the resolved Copilot CLI degradation contract: the skill **ships to both trees**;
+on a tree without the workflow runtime it is **guidance only** — readable knowledge, **no workflow
+spawned, never errors** — i.e. **Option A** (guidance-only fallback), **not** omission.
+*(Slot note: this is a file-read structural assertion. The contract being "no code change beyond
+documentation" is itself witnessed by the absence of any `*.agent.md` / `*.workflow.js` edit in this
+slice — the degradation is already how the agents behave from S1–S6.)*
+
+### The CLAUDE.md skill pointer (deterministic, structural)
+
+**AC-7p `[deterministic]` — both CLAUDE.md surfaces point to the skill.**
+**Given** `CLAUDE.md` (repo root) **and** `ai-literacy-superpowers/templates/CLAUDE.md`,
+**When** each is read,
+**Then** each contains a line directing agents to the **`dynamic-workflows`** skill when a task looks
+**long-running / massively parallel / highly structured / adversarial**, to consult the skill before
+reaching for a workflow.
+
+### The advisory Stop hook — CONDITIONAL on the hook-ship GATE (§6 decision 1)
+
+**AC-6 `[deterministic — conditional on hook GATE]` — if shipped, the hook is registered under `Stop` and invokes a script.**
+**Given** the GATE decides the advisory hook ships, and `ai-literacy-superpowers/hooks/hooks.json`,
+**When** the `Stop` hook array is read,
+**Then** it contains a new entry invoking
+`bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/<name>.sh` (mirroring the existing Stop-hook entries — a
+`type: "command"` hook with a short timeout, under a `matcher: "*"` block), and the named script
+**exists** under `ai-literacy-superpowers/hooks/scripts/`.
+
+**AC-7 `[deterministic — conditional on hook GATE]` — if shipped, the script is non-blocking and exits 0.**
+**Given** the GATE ships the hook, and the new
+`ai-literacy-superpowers/hooks/scripts/<name>.sh`,
+**When** it runs (with or without a matching session signal, on macOS or Linux),
+**Then** it **exits 0 always**, **never blocks** (emits at most a `systemMessage` advisory, like every
+other hook script), and persists **no** state to disk — a Layer-0 plumbing assertion mirroring the
+existing advisory-hook scripts.
+
+### Observational — the nudge actually helps / does not add noise (if the hook ships)
+
+**AC-8 `[observational]` — if shipped, the nudge is low-noise (no false positives on ordinary sessions).**
+**Given** an ordinary single-file coding session that did **not** warrant a workflow,
+**When** the session ends and the advisory hook runs,
+**Then** it **stays silent** (no nudge) — the nudge fires only on a low-confidence heuristic signal of
+a long/parallel/adversarial session with no workflow elected.
+*(Slot note: a Stop hook cannot truly know the task shape, so whether the heuristic fires
+**appropriately** is an **observation to record in a first-run note / snapshot**, not a deterministic
+assertion. The deterministic guarantees are AC-6/AC-7 — registered, non-blocking, exits 0; the
+*quality* of the heuristic is observational. If the GATE defers the hook, AC-8 does not apply.)*
+
+### Epic-complete confirmation (deterministic, structural — this spec)
+
+**AC-9 `[deterministic]` — this spec confirms the epic complete.**
+**Given** this S7 spec,
+**When** §9 is read,
+**Then** it confirms **D1–D9 delivered** across S1–S7 and the **four umbrella open questions resolved**
+(Q1 threshold=8 → S3; Q2 routing opt-in → S5; Q3 staging=`REFLECTION_STAGING.md` → S6; Q4 Copilot
+degradation → resolved here as Option A).
+
+---
+
+## 5. The headline GATE decision — open-question 4: the Copilot CLI degradation contract
+
+The plugin ships to **both** the Claude Code and Copilot CLI trees. Dynamic workflows are a Claude
+Code runtime capability with **no** equivalent on the Copilot tree. Umbrella §5.5 settled that the
+boundary is **Claude-Code-gated with a guidance-only degradation**; what S7 must **fix** is the
+*precise contract* — does the skill **ship to Copilot and degrade to guidance**, or is it **omitted
+entirely** on the Copilot tree?
+
+**Pre-listed contract surfaces a recommendation could break** (so the spec-mode diaboli's scrutiny is
+scoped, per the AGENTS.md STYLE note): (1) the **already-shipped S1–S6 declarations** — every slice
+states a guidance-only non-erroring fallback; a contract that contradicts them is a regression, not a
+decision; (2) the **plugin's cross-tree shipping model** — the plugin is distributed identically to
+both trees via the marketplace, so "omit on Copilot" implies a build-time or load-time gating
+mechanism the plugin does not have; (3) the **skill's own SKILL.md "Runtime scope" prose** (S1) which
+already tells a Copilot reader the skill is "guidance only" there.
+
+### Option A — guidance-only fallback (RECOMMENDED)
+
+The skill **ships to the Copilot tree too**. Without the workflow runtime it is **readable knowledge
+only**: every workflow-mode degrades to its static/guidance fallback, no workflow is spawned, and
+nothing errors. This is **exactly what every S1–S6 slice already declared** and what the shipped
+SKILL.md "Runtime scope — Claude Code only" section already tells the reader.
+
+- **Strength:** it is the **consistent** resolution — it matches shipped behaviour across all six prior
+  slices and the shipped SKILL.md prose. It requires **no code change beyond documentation**: the
+  degradation is already how the agents behave (a workflow-mode agent on a tree without the runtime
+  falls back to its static behaviour; this slice changes no agent). The knowledge (patterns, election
+  rubric, INV-1/INV-2) stays valuable to a Copilot reader as a way of *thinking* about delegation even
+  where they cannot spawn a workflow.
+- **Where it is documented:** a **§5.5-style statement in the README** Dynamic Workflows section
+  (AC-4) **and** a **note in the skill/governance reference** —
+  `skills/dynamic-workflows/references/governance.md` and/or the SKILL.md "Runtime scope" section
+  (AC-6c). One authoritative statement, two surfaces (user-facing README + agent-facing reference).
+- **Diaboli should stress:** does "guidance only" overclaim usefulness on Copilot (no — it explicitly
+  says no workflow can be spawned; the value is conceptual, and the static pipeline behaviour is
+  unchanged)? Does it require any code (no — confirm by the absence of any `*.agent.md` /
+  `*.workflow.js` edit in this slice)?
+
+### Option B — omit the skill entirely on the Copilot tree
+
+The `dynamic-workflows` skill is **not shipped** to the Copilot CLI tree at all.
+
+- **Weakness — this contradicts shipped behaviour.** Every merged slice (S1–S6) already declares a
+  guidance-only non-erroring fallback, and the shipped SKILL.md "Runtime scope" section already tells
+  a Copilot reader the skill is guidance-only *there*. Choosing B would make six shipped slices and a
+  shipped skill file **wrong retroactively**, and would require a tree-conditional packaging mechanism
+  the plugin does not have (it ships identically to both trees via the marketplace). It also discards
+  the conceptual value of the knowledge to a Copilot reader. B is tenable only if the team decides the
+  knowledge is *actively misleading* without the runtime — which the explicit "no workflow can be
+  spawned here" framing already prevents.
+
+### Recommendation
+
+**Option A — guidance-only fallback.** It is the consistent, already-shipped resolution; it needs **no
+code change beyond documentation**; and it is the contract the SKILL.md already implies. Document it
+once, authoritatively, in the README §5.5-style statement (AC-4) and the skill/governance reference
+(AC-6c). **Surfaced as the human's decision at the GATE** — the spec recommends A and the human
+disposes; B is presented honestly as the alternative and its cost (contradicting shipped behaviour)
+named.
+
+**Confirmation of "no code change":** Option A is satisfiable entirely in prose. There is **no**
+`*.agent.md`, `*.workflow.js`, or command edit required — the degradation is already the agents'
+behaviour from S1–S6. The only files A touches are the README and the skill/governance reference.
+
+---
+
+## 6. Other GATE decisions to surface
+
+### Decision 1 — does the advisory Stop hook ship at all? (D9 "optional")
+
+D9 marks the Stop hook **optional**. The honest tension: a Stop hook **cannot reliably know** whether
+a session was long-running, massively parallel, or adversarial — it runs at session end with access to
+cheap, coarse signals (git activity, wall-clock span, file counts), not the task's semantic shape. So
+the choice is between a **low-confidence, low-noise nudge** and **deferring the hook** to avoid noise.
+
+- **Option H1 — ship a low-confidence, low-noise advisory hook (RECOMMENDED, with the low-noise
+  default).** A new `Stop`-array entry mirroring the existing entries (`matcher: "*"`,
+  `type: "command"`, short timeout), backed by a POSIX-portable script that:
+  - fires **only** on a deliberately conservative heuristic — e.g. a session with a **large** number
+    of commits / touched files over a long wall-clock span (a coarse proxy for "long/parallel work")
+    **and** no sign a workflow was elected — tuned to **stay silent on ordinary sessions** (favour
+    false negatives over false positives; a missed nudge is cheap, a noisy one erodes trust);
+  - prints, when it fires, a single short `systemMessage` advisory: *this session looked
+    long/parallel/structured — consider whether a `dynamic-workflows` workflow would fit next time*;
+  - **never blocks, exits 0 always, persists no state** (the AGENTS.md advisory-hook decision);
+  - is **macOS+Linux portable** (the Layer-0 BSD/GNU constraint — POSIX-only constructs, no GNU-only
+    flags).
+  *Strength:* it makes the substrate **reachable** at the moment of reflection without adding a CI
+  surface; it is the same advisory-loop pattern as `reflection-prompt.sh` / `curation-nudge.sh`.
+  *Diaboli should stress:* will the heuristic false-positive on ordinary multi-commit sessions (it
+  must not — tune to the conservative end; AC-8 is the observational guard)? Does it duplicate an
+  existing Stop nudge (no — none of the eleven existing Stop hooks nudges about workflow election)?
+- **Option H2 — defer the hook; ship docs + the CLAUDE.md pointer only.** If the heuristic cannot be
+  made low-noise enough to be worth its place in the Stop array, **do not ship it**. The CLAUDE.md
+  pointer (AC-7p) and the README section already make the substrate discoverable; a noisy hook would
+  erode the "every Stop hook earns its place" trust the existing eleven have built. Document the
+  deferral and why (the Stop hook cannot truly know task shape) so the absence is deliberate, not an
+  oversight — and so a future slice with real signal (e.g. an `ultracode`-invocation record) can add
+  it on firmer ground.
+
+**Recommendation: H1 with the low-noise default — *but* this is genuinely the human's call**, because
+the value/noise trade-off is a judgement the spec cannot settle alone. If the GATE is unsure, **H2
+(defer) is the safer default**: the pointer + README already deliver discoverability, and a deferred
+hook costs nothing, whereas a noisy hook costs trust across every session. The spec recommends shipping
+**only if** the heuristic can be tuned conservatively enough to satisfy AC-8; otherwise defer.
+
+**Version consequence of this decision** (see §7): **shipping the hook** is a behavioural change → a
+**minor** bump is unambiguous. **Deferring the hook** leaves a new README section + the behavioural
+CLAUDE.md/template pointer — still a **minor** (a new documented substrate surface + a behavioural
+agent pointer in plugin files), recommended over patch (§7.1 reasons).
+
+### Decision 2 — the advisory-hook heuristic (if H1): what signal fires the nudge?
+
+*Applies only if Decision 1 ships the hook.* The heuristic must be **coarse, conservative, and
+portable**. Candidate signals (the implementer picks, the diaboli stresses for noise):
+
+- **Commit/file volume over a long span** — many commits or touched files in a long wall-clock session
+  (proxy for long/parallel work). Conservative thresholds; favour silence.
+- **No workflow-election signal** — no evidence the session reached for a workflow (e.g. no
+  `ultracode` marker / no workflow artefact). Absence is the trigger condition, not the heuristic by
+  itself.
+
+**Recommendation:** fire **only** when *both* a strong volume/span signal **and** the no-workflow
+condition hold, and **default to silent** otherwise. The thresholds are tuning constants the
+implementer sets conservatively; **no threshold is asserted as precise** (cf. AGENTS.md "no threshold
+before data"). AC-8 records the heuristic's real-world appropriateness observationally — it is **not**
+promised as deterministic.
+
+### Decision 3 — the verification split (deterministic structural vs unverified/observational)
+
+Mirroring S3–S6 decision-N: this repo's deterministic layer **reads files and matches structure**; it
+does **not** run a session and judge whether the hook *should* have fired.
+
+- **Deterministically assertable (structural, Layer-0/1) — the declarations + plumbing.**
+  - README has a Dynamic Workflows section (AC-1) naming the six patterns + election discipline
+    (AC-2), INV-1/INV-2 (AC-3), the Claude-Code-only + guidance-only Copilot contract + skill/how-to
+    cross-links (AC-4); the skill-count badge is unchanged at 36 (AC-5).
+  - The skill/governance reference states the guidance-only contract (AC-6c).
+  - Both CLAUDE.md surfaces carry the skill pointer (AC-7p).
+  - **If the hook ships:** `hooks.json` registers it under `Stop` invoking the named script, which
+    exists (AC-6); the script **exits 0 / is non-blocking** on macOS+Linux (AC-7) — a **Layer-0
+    plumbing** assertion, mirroring how the existing hook scripts are exercised.
+- **Unverified / observational — the heuristic quality.** Whether the nudge fires **appropriately**
+  (AC-8) is an observation to record in a first-run note / snapshot, **not** a deterministic assertion
+  — a Stop hook cannot truly know task shape. It must **not** be over-promised as deterministic.
+
+**Recommendation:** the tdad-scenario set is **predominantly structural** (AC-1–AC-5, AC-6c, AC-7p as
+Layer-1 file-read assertions; AC-6/AC-7 as Layer-1 structural + Layer-0 plumbing **if** the hook
+ships), with **AC-8** standing as **observational/unverified**. The tdd-agent will author a new
+deterministic content test `tdad_tests/tests/test_s7_docs_hook_copilot_structural.py` (mirroring
+`test_s6_reflection_mining_structural.py` — a section-slicing helper isolating the README Dynamic
+Workflows section, the governance-reference contract statement, and the CLAUDE.md pointer lines; phrase
+assertions per AC) and **wire it into the existing `.github/workflows/tdad-tests-fast.yml`** as a new
+step (a sibling of the existing `Run Layer 1 (dynamic-workflows S6 reflection mining)` step at lines
+76–78). **If the hook ships**, the tdd-agent also adds a **Layer-0** assertion that the new
+`<name>.sh` exits 0 / is non-blocking (mirroring the Layer-0 plumbing tests for the existing advisory
+scripts). Spec-writer **names** these homes; spec-writer does **not** create the directories or any
+test file (spec-first discipline — no test files in this commit).
+
+The diaboli should stress whether any property tagged structural actually needs a live session (it
+should not — each is a file read or a `bash`-exit-code check), and whether AC-8 risks being
+over-promised as deterministic (it must not — the *registration + exit-0* are structural; the
+*heuristic-fires-appropriately* property is observational).
+
+### 6.1 Decision summary for the GATE
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| **Copilot CLI degradation contract (open-question 4 — the headline)** | **A guidance-only fallback** / B omit the skill on Copilot | **A** — guidance-only; consistent with shipped S1–S6 behaviour and the shipped SKILL.md; **no code change beyond documentation**; documented in the README §5.5-style statement + the skill/governance reference. B contradicts shipped behaviour. |
+| Does the advisory Stop hook ship? | **H1 ship low-confidence, low-noise hook** / H2 defer (docs + pointer only) | **H1 *only if* the heuristic tunes conservatively enough to satisfy AC-8; otherwise H2 (defer).** Genuinely the human's call; H2 is the safer default. Either way → **minor** bump (§7.1). |
+| The heuristic signal (if H1) | volume/span + no-workflow / other | Fire only on **both** a strong volume/span signal **and** the no-workflow condition; default silent; conservative thresholds (no threshold asserted as precise). |
+| Verification split | all-deterministic / **structural declarations + plumbing + observational heuristic** | **structural (AC-1–AC-5, AC-6c, AC-7p; AC-6/AC-7 if hook ships) + observational heuristic quality (AC-8)** — same realistic split as S3–S6. |
+
+---
+
+## 7. CI, version, and docs checklist
+
+### 7.1 Version bump — minor, **`0.63.0 → 0.64.0`**
+
+Current version confirmed **`0.63.0`** (`plugin.json`; the `README.md` badge line 6 + plugin-table
+cell line 31; the `CHANGELOG.md` top heading; both `marketplace.json` `plugin_version` and the
+`ai-literacy-superpowers` `plugins[].version` entry).
+
+**Bump rationale.** If the hook ships, S7 adds a **new advisory hook → behavioural change → minor**,
+unambiguously. **Even if the hook is deferred** (Decision 1 → H2), S7 still adds (a) a **new
+documented substrate surface** (the README Dynamic Workflows section) and (b) a **behavioural pointer
+in plugin files** (`templates/CLAUDE.md` directs agents to consult the skill). Per CLAUDE.md Semantic
+Versioning — *"adds … or changes plugin behaviour → minor"* — the template CLAUDE.md pointer is a
+behavioural change to a plugin file, so a **minor** is the honest call in **both** branches. (A
+README-only docs change would be a patch, but the `templates/CLAUDE.md` pointer is inside the plugin
+directory and changes agent guidance.) **Recommend minor `0.63.0 → 0.64.0` regardless of the hook
+decision.**
+
+The `Version Check` CI enforces **five** locations (per CLAUDE.md / the live `version-check.yml`).
+Update **every** one:
+
+1. `ai-literacy-superpowers/.claude-plugin/plugin.json` — `"version"` (canonical; `0.63.0` → `0.64.0`)
+2. `README.md` — shields.io **badge** `ai--literacy--superpowers-v0.64.0` (line 6; currently `v0.63.0`)
+3. `CHANGELOG.md` — new top heading `## 0.64.0 — 2026-06-23`
+4. `.claude-plugin/marketplace.json` — top-level `plugin_version` (`0.63.0` → `0.64.0`; owned by
+   ai-literacy-superpowers PRs)
+5. `.claude-plugin/marketplace.json` — the `ai-literacy-superpowers` `plugins[].version` entry
+   (`0.63.0` → `0.64.0`)
+
+Also update, for human-facing consistency (**not** CI-enforced): the `README.md` plugin-table row cell
+(`| v0.63.0 |` → `| v0.64.0 |`, line 31).
+
+> The marketplace listing `version` (`0.4.0`) does **not** change — S7 alters no listing contract.
+> The **skill-count** badge (`Skills-36`) and the plugin-table "36 skills" cell do **not** change —
+> S1 reconciled them; S7 adds no skill. **If the hook ships**, the human-facing `### Hooks (11)`
+> README section heading becomes **`### Hooks (12)`** and a twelfth bullet is added — this is a
+> human-facing count, **not** a CI-enforced badge (there is no `Hooks-` shields badge). If the hook is
+> deferred, the Hooks count stays **11**.
+
+If a rebase surfaces a `plugin_version` conflict from a non-`ai-literacy-superpowers` PR, take **main's
+value verbatim** (CLAUDE.md Marketplace-versioning rule) — this PR owns the top-level pointer only
+because it bumps this plugin.
+
+Before committing, grep for the **old** version to surface every spot at once:
+
+```text
+grep -rn 'v0\.63\.0\|0\.63\.0' README.md .claude-plugin/marketplace.json \
+  ai-literacy-superpowers/.claude-plugin/plugin.json CHANGELOG.md
+```
+
+### 7.2 CI gates
+
+- **`spec-first-check`** — satisfied by **this spec being the first commit** on branch
+  `dynamic-workflows-s7-docs-hook-copilot`. No exemption label; this is feature work.
+- **`tdad-scenario-check`** — **if the hook ships**, the new hook script is a new *script*, not a
+  skill/agent/command, so the component-scoped scenario gate is not strictly forced; nonetheless the
+  tdd-agent authors structural scenarios for the README/reference/CLAUDE.md declarations (AC-1–AC-5,
+  AC-6c, AC-7p) and, if the hook ships, the hook-registration + plumbing scenarios (AC-6, AC-7). The
+  tdd-agent creates `tdad_tests/scenarios/...` homes mirroring the S6 set; spec-writer **names** the
+  homes and assertion set but does **not** create directories or test files (spec-first discipline).
+- **The deterministic content test** — the tdd-agent authors
+  `tdad_tests/tests/test_s7_docs_hook_copilot_structural.py` (mirroring
+  `test_s6_reflection_mining_structural.py`) and **wires it into the existing
+  `.github/workflows/tdad-tests-fast.yml`** as a new step (sibling of the S6 step at lines 76–78).
+  **If the hook ships**, the tdd-agent adds a **Layer-0** exit-0/non-blocking assertion for the new
+  `<name>.sh` alongside the existing advisory-script plumbing tests. Spec-writer **notes** this; the
+  tdd-agent authors and wires it. **Do not author tests in this commit.**
+  - **Line-wrap caution (bit S3 twice, S4 twice, flagged for S5/S6).** Several assertions are
+    **two-word phrases** the structural test may match literally — e.g. `Dynamic Workflows`,
+    `Claude Code`, `guidance only`, `dynamic-workflows`, `long-running`, `massively parallel`,
+    `highly structured`, `static pipeline`, `ephemeral proposes`, `durable curates`. When the
+    tdd-agent and implementer author the prose, **keep these phrases unwrapped** (not split across a
+    line break), or assert them as co-occurring tokens per the S5/S6 split convention. Single
+    load-bearing tokens (`dynamic-workflows`, `INV-1`, `INV-2`, `36`) are wrap-safe. This is a
+    tdd/impl concern — noted so it is not rediscovered a sixth time.
+- **`shellcheck` / `bash -n` (if the hook ships)** — the new `<name>.sh` must pass ShellCheck and the
+  `bash -n` syntax check (the deterministic shell gates) and the **macOS+Linux portability** constraint
+  (no GNU-only flags; POSIX-portable constructs) — the Layer-0 BSD/GNU lesson the epic's reflection
+  recorded. Run ShellCheck against the new script before promoting (AGENTS.md GOTCHA — deterministic
+  tools catch what review misses).
+- **`INV-1 firewall` (S2, existing)** — S7 adds **no `*.workflow.js` template** and edits none, so the
+  firewall is not triggered by new template content. The advisory hook (if shipped) writes **no**
+  durable artefact — it emits at most a `systemMessage` and exits 0.
+- **`lint-markdown`** — the modified `README.md`, `CLAUDE.md`, `templates/CLAUDE.md`, the
+  skill/governance reference, this spec, and any touched docs page must pass markdownlint (PreToolUse
+  hook + CI).
+- **`Choice cartographer` / objection gates** — this feature PR proceeds through the plugin's own
+  pipeline (spec → diaboli → adjudicate → plan → implement → diaboli code-mode → adjudicate).
+  Dispositions on any objection record must be resolved before the plan-approval GATE.
+
+### 7.3 Docs-impact note (CLAUDE.md "Docs Site Review")
+
+- **Explanation / how-to (touch-up).** The orientation guide
+  `docs/plugins/ai-literacy-superpowers/how-to/dynamic-workflows.md` already exists (S1) and already
+  carries the "Runtime scope — Claude Code only / guidance only" note. S7 should **confirm it states
+  the resolved Option A contract** (guidance-only, never omit) so the how-to and the README §5.5-style
+  statement agree, and add a one-line cross-link to the new README Dynamic Workflows section.
+  Consistency touch-up, not a new page.
+- **Reference.** The skill/governance reference
+  (`skills/dynamic-workflows/references/governance.md`) is **edited in-scope** (AC-6c) to state the
+  Option A contract. If a docs-site reference page mirrors the skill's governance content, keep it
+  current — a one-line note that the Copilot fallback is guidance-only.
+- **Hooks reference (if the hook ships).** If a docs-site reference enumerates the hooks, add the new
+  advisory hook to that list (and the README `### Hooks (11)` → `(12)` count, §7.1). If the hook is
+  deferred, no hooks-reference change.
+- **Tutorials.** None required — no tutorial describes the substrate as *undocumented* in a way S7
+  would contradict.
+
+---
+
+## 8. FR → acceptance-scenario mapping
+
+### 8.1 Functional requirements
+
+Numbered and testable; each maps to one or more acceptance scenarios.
+
+- **FR-1.** `README.md` contains a **Dynamic Workflows section** describing the ephemeral multi-agent
+  substrate. *(AC-1)*
+- **FR-2.** The section names the **six patterns** and the **election discipline** (elected, not
+  reflexive; static pipeline stays default). *(AC-2)*
+- **FR-3.** The section states **INV-1** and **INV-2**. *(AC-3)*
+- **FR-4.** The section states the **Claude-Code-only scope** + the **guidance-only Copilot contract**
+  (Option A) and **cross-links** the skill + how-to. *(AC-4)*
+- **FR-5.** The **skill-count badge + plugin-table cell remain 36** (no re-bump). *(AC-5)*
+- **FR-6.** The **skill/governance reference** states the resolved **Option A** guidance-only Copilot
+  contract (ship to both trees; guidance-only where no runtime; never omit, never error). *(AC-6c)*
+- **FR-7.** **`CLAUDE.md` (root) and `templates/CLAUDE.md`** each carry a **pointer line** to the
+  `dynamic-workflows` skill for long-running / massively parallel / highly structured / adversarial
+  tasks. *(AC-7p)*
+- **FR-8 *(conditional — only if Decision 1 ships the hook)*.** `hooks/hooks.json` registers a **new
+  advisory `Stop` hook** invoking a new POSIX-portable `hooks/scripts/<name>.sh` that **exits 0,
+  never blocks, persists no state**, and fires a low-noise nudge only on a conservative
+  long/parallel/adversarial-without-workflow heuristic. *(AC-6, AC-7; AC-8 observational)*
+- **FR-9.** The plugin version is bumped **`0.63.0 → 0.64.0`** across all five CI-enforced locations
+  (§7.1), and the human-facing README plugin-table cell (and Hooks count, if the hook ships) is
+  updated. *(CI: Version Check)*
+- **FR-10.** The how-to / reference docs are checked and updated for the resolved Copilot contract
+  (and the new hook, if shipped) (§7.3). *(docs-impact)*
+- **FR-11.** This spec **confirms the epic complete** — D1–D9 across S1–S7; Q1–Q4 resolved. *(AC-9)*
+
+### 8.2 Mapping table
+
+| FR | Covered by | Slot |
+| --- | --- | --- |
+| FR-1 | AC-1 | deterministic (structural) |
+| FR-2 | AC-2 | deterministic (structural) |
+| FR-3 | AC-3 | deterministic (structural) |
+| FR-4 | AC-4 | deterministic (structural) |
+| FR-5 | AC-5 | deterministic (structural — no-change assertion) |
+| FR-6 | AC-6c | deterministic (structural) |
+| FR-7 | AC-7p | deterministic (structural) |
+| FR-8 *(conditional)* | AC-6, AC-7 (deterministic); AC-8 (observational) | deterministic (structural + Layer-0 plumbing) / observational |
+| FR-9 | (CI: Version Check) | deterministic |
+| FR-10 | (docs-impact) | deterministic (presence) |
+| FR-11 | AC-9 | deterministic (structural — this spec) |
+
+**Observational / unverified:**
+
+- **AC-8** — the advisory hook's heuristic fires appropriately (low-noise, no false positives on
+  ordinary sessions) — recorded in a first-run note / snapshot. Applies only if the hook ships. Must
+  **not** be over-promised as deterministic.
+
+---
+
+## 9. Epic-complete confirmation, risks, and open questions
+
+### 9.1 Epic complete — D1–D9 delivered across S1–S7
+
+This is the **final** slice. With S7 merged, the Dynamic Workflows Alignment epic is complete:
+
+| Deliverable | Slice | Status |
+| --- | --- | --- |
+| **D1** — `dynamic-workflows` skill | S1 (#438) | delivered |
+| **D8** — compute-discipline election gate | S1 (#438) | delivered |
+| **D2** — four `*.workflow.js` templates | S2 (#439) | delivered |
+| **§5.1** — INV-1/INV-2 firewall (`inv-firewall.sh`) | S2 (#439) | delivered |
+| **D3** — `harness-enforcer` fan-out | S3 (#440) | delivered |
+| **D5** — adversarial `code-reviewer` + `Advocatus Diaboli` | S4 (#441) | delivered |
+| **D7** — deep-research `assessor` + `harness-auditor` | S4 (#441) | delivered |
+| **D4** — `orchestrator` classify-and-act routing | S5 (#442) | delivered |
+| **D6** — reflection-mining (`/reflect --mine` → `REFLECTION_STAGING.md`) | S6 (#443) | delivered |
+| **D9** — README section, advisory hook (optional), CLAUDE.md pointer, CHANGELOG, **Copilot contract** | **S7 (#444 — this slice)** | **delivering** |
+
+### 9.2 The four umbrella open questions — all resolved
+
+| Q | Question | Resolution | Slice |
+| --- | --- | --- | --- |
+| **Q1** | D3 fan-out constraint-count threshold | **8** (spec default, configurable per project) | S3 |
+| **Q2** | D4 tournament/root-cause/triage routes default | **opt-in behind an explicit flag**; static pipeline remains the sole default | S5 |
+| **Q3** | D6 staging artefact location | **a new `REFLECTION_STAGING.md`** (clean separation from the append-only log) | S6 |
+| **Q4** | Copilot CLI degradation contract | **Option A — guidance-only fallback** (ship to both trees; guidance-only where no runtime; never omit, never error); documentation only, no code change | **S7 (this slice)** |
+
+With Q4 resolved, **all four open questions are closed** and the umbrella spec's §7 is fully
+dispositioned.
+
+### 9.3 Risks
+
+- *Over-claiming the advisory hook's intelligence.* A Stop hook cannot know task shape; framing the
+  nudge as a confident detector would mislead. Mitigation: §6 decision 1/2 frame it as a
+  **low-confidence, low-noise** heuristic; AC-8 keeps its real-world quality observational; H2 (defer)
+  is the safe default if it cannot be tuned conservatively.
+- *Hook noise eroding trust.* A false-positive nudge on ordinary sessions erodes the "every Stop hook
+  earns its place" trust the existing eleven have built. Mitigation: fire only on a conservative
+  both-signals heuristic; default silent; the diaboli should reject any heuristic that nudges on a
+  plain multi-commit session.
+- *Contradicting shipped behaviour on the Copilot contract.* Choosing Option B would make six merged
+  slices and the shipped SKILL.md retroactively wrong. Mitigation: §5 recommends A (the consistent
+  resolution) and names B's cost explicitly; the diaboli should reject any contract that diverges from
+  the shipped guidance-only fallback.
+- *Re-bumping the skill count.* The skill-count badge is **already 36** (S1). Mitigation: AC-5/FR-5
+  assert it stays 36; the diaboli should reject any change to the `Skills-36` badge or the
+  plugin-table "36 skills" cell.
+- *Version under-bump.* Treating S7 as docs-only (patch) would under-bump — the `templates/CLAUDE.md`
+  pointer is a behavioural change to a plugin file. Mitigation: §7.1 recommends **minor** in both hook
+  branches.
+
+### 9.4 Open questions
+
+**None block S7.** Q4 — the Copilot CLI degradation contract — is **resolved here** (Option A,
+recommended; surfaced for the human at the GATE). The only S7-internal decisions are the
+**hook-ship** decision (§6 decision 1), the **heuristic signal** (§6 decision 2, if H1), and the
+**verification split** (§6 decision 3) — all **surfaced for the GATE, not left open**: the spec
+recommends and the human disposes.
+
+**Flagged, not built (v1 restraint).** If the hook ships, **no threshold for the heuristic is asserted
+as precise** — the firing constants are conservative tuning values, not a measured gate (cf. AGENTS.md
+"no threshold before data"). A firmer signal (e.g. recording `ultracode` invocations, per the merged
+affordances epic's invocation recorder) could sharpen the heuristic in a future slice; flagged here so
+the coarseness is deliberate, not an oversight.
+
+---
+
+## 10. References
+
+- Umbrella spec: `docs/superpowers/specs/2026-06-22-dynamic-workflows-alignment-design.md` (read-first
+  runtime-scope note; §2 INV-1/INV-2; **D9**; §5 esp. **§5.5 Copilot degradation**; §6; **§7
+  open-question 4** — Copilot CLI degradation, dispositioned here).
+- Slicing record: `docs/superpowers/slices/dynamic-workflows-alignment.md` (Runtime scope — Claude
+  Code only; the **S7** entry — Copilot degradation contract + whether the advisory Stop hook ships;
+  the `independence` lens).
+- Merged precedents (S1–S6): `docs/superpowers/specs/2026-06-22-dynamic-workflows-s1-skill-design.md`;
+  `…-s2-templates-design.md`; `…-s3-enforcer-fanout-design.md`;
+  `…-s4-adversarial-deepresearch-design.md`;
+  `docs/superpowers/specs/2026-06-23-dynamic-workflows-s5-orchestrator-routing-design.md`;
+  `…-s6-reflection-mining-design.md` (the deterministic-vs-agent-backed/observational verification
+  split; the line-wrap caution; the test-wiring pattern).
+- Test pattern: `tdad_tests/tests/test_s6_reflection_mining_structural.py` (the section-slicing
+  structural-content test + two-word-phrase split convention); `.github/workflows/tdad-tests-fast.yml`
+  (the test-wiring pattern, lines 76–78 — the S6 step S7 mirrors).
+- Target files S7 modifies: `README.md` (the new Dynamic Workflows section + the version bump, badge,
+  table cell; the skill-count badge stays 36); `CLAUDE.md` (root — the skill pointer);
+  `ai-literacy-superpowers/templates/CLAUDE.md` (the skill pointer); `CHANGELOG.md` (the new
+  `## 0.64.0 — 2026-06-23` entry); `ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md`
+  and/or `…/SKILL.md` (the Option A contract statement); `.claude-plugin/marketplace.json` and
+  `ai-literacy-superpowers/.claude-plugin/plugin.json` (version locations); **if the hook ships:**
+  `ai-literacy-superpowers/hooks/hooks.json` + a new `ai-literacy-superpowers/hooks/scripts/<name>.sh`.
+- Existing advisory-hook precedents the new hook mirrors:
+  `ai-literacy-superpowers/hooks/scripts/reflection-prompt.sh` and `curation-nudge.sh` (the
+  `systemMessage`, `exit 0`, never-block, `set -euo pipefail` shape).
+- Shipped skill the contract documents: `ai-literacy-superpowers/skills/dynamic-workflows/SKILL.md`
+  (the "Runtime scope — Claude Code only" section already states guidance-only on Copilot — Option A
+  is the consistent resolution).
+- AGENTS.md decisions consulted: "hook scripts never block, only warn" (the advisory-hook contract);
+  the cognitive-reservoir advisory-only generalisation (advisory mechanisms never block / persist
+  human-state); "recommended option is a hypothesis for the diaboli to stress" STYLE note
+  (closed-contract pre-listing, applied in §5/§6); "no threshold before data" (no precise heuristic
+  threshold for the hook in v1); the BSD/GNU shell-portability lesson (the macOS+Linux constraint on
+  any new `.sh`).
+- Runtime API (authoritative): <https://code.claude.com/docs/en/workflows>.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/claude-md-skill-pointer.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/claude-md-skill-pointer.md
@@ -1,0 +1,47 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: both CLAUDE.md surfaces point to the dynamic-workflows skill (AC-7p / FR-7)
+
+## Given
+
+`CLAUDE.md` (repo root, read via `_repo_root(plugin_path) / "CLAUDE.md"`)
+**and** `ai-literacy-superpowers/templates/CLAUDE.md` (read via
+`plugin_path / "templates" / "CLAUDE.md"`). The repo-root `CLAUDE.md` is not
+a plugin component; this scenario is filed against the `dynamic-workflows`
+skill so the corpus can resolve a target.
+
+## When
+
+Each `CLAUDE.md` surface is read.
+
+## Then
+
+- **Each** file references `dynamic-workflows` (the skill name — a single
+  wrap-safe token, asserted directly) **AND** a **trigger cue** so the pointer
+  is meaningful, not a bare mention: one of `long-running` /
+  `massively parallel` / `adversarial` / `workflow`. Keep `dynamic-workflows`,
+  `long-running`, `massively parallel`, `highly structured` **unwrapped**; the
+  test asserts the trigger cue as co-occurring tokens within each file.
+
+## Rubric
+
+Deterministic structural shadow of AC-7p / FR-7. Both CLAUDE.md surfaces — the
+repo-root project conventions and the plugin's `templates/CLAUDE.md` (the
+behavioural agent pointer that justifies the minor bump) — must carry a single
+line directing agents to consult the `dynamic-workflows` skill when a task
+looks long-running / massively parallel / highly structured / adversarial,
+before reaching for a workflow. A bare mention of the skill name without a
+trigger cue is insufficient: the pointer must tell an agent *when* to consult
+the skill.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s7_docs_hook_copilot_structural.py`
+(`TestS7ClaudeMdSkillPointer`). RED now because neither `CLAUDE.md` (repo
+root) nor `ai-literacy-superpowers/templates/CLAUDE.md` references
+`dynamic-workflows` — the skill pointer is absent from both.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/governance-copilot-option-a-contract.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/governance-copilot-option-a-contract.md
@@ -1,0 +1,52 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: the skill/governance reference states the Option A Copilot contract (AC-6c / FR-6)
+
+## Given
+
+`ai-literacy-superpowers/skills/dynamic-workflows/references/governance.md`
+(read via `plugin_path / "skills" / "dynamic-workflows" / "references" /
+"governance.md"`).
+
+## When
+
+`governance.md` is read.
+
+## Then
+
+- The reference states the resolved **Copilot CLI degradation contract**:
+  `copilot` co-occurs with `guidance` — the skill is **guidance only** on a
+  tree without the workflow runtime. Keep `guidance only` / `guidance-only`
+  **unwrapped**; the test asserts `copilot` and `guidance` as co-occurring
+  tokens (NOT a joined substring).
+- The reference carries a **never-omit / never-error assurance** — one of
+  `never omit` / `not omitted` / `ship to both` / `both trees` — stating the
+  skill is guidance-only where the runtime is absent and is **not omitted**
+  (Option A, not Option B). Keep `both trees` / `ship to both` / `never omit`
+  **unwrapped**; the test asserts the assurance as a small set of
+  co-occurring tokens.
+
+## Rubric
+
+Deterministic structural shadow of AC-6c / FR-6. The skill/governance
+reference is the agent-facing authoritative home for the resolved
+open-question-4 contract: **Option A — guidance-only fallback**. The skill
+ships to **both** the Claude Code and Copilot CLI trees; without the workflow
+runtime it is **readable knowledge only** — no workflow is spawned, nothing
+errors, and the skill is **never omitted**. This is the consistent resolution
+with shipped S1–S6 behaviour and requires no code change beyond words. Option
+B (omit on Copilot) is recommended against and is NOT the contract stated
+here.
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s7_docs_hook_copilot_structural.py`
+(`TestS7GovernanceCopilotContract`). RED now because `governance.md` carries
+the INV-1/INV-2 invariants but no Copilot Option-A degradation statement, so
+the `copilot` + `guidance` co-occurrence and the never-omit/both-trees
+assurance are absent.

--- a/tdad_tests/scenarios/skills/dynamic-workflows/readme-dynamic-workflows-section.md
+++ b/tdad_tests/scenarios/skills/dynamic-workflows/readme-dynamic-workflows-section.md
@@ -1,0 +1,74 @@
+---
+component: dynamic-workflows
+component_type: skill
+tier: structural
+---
+
+# Scenario: README ships a Dynamic Workflows section (AC-1–AC-5 / FR-1–FR-5)
+
+## Given
+
+The repo-root `README.md` (read via `_repo_root(plugin_path) / "README.md"`
+— `README.md` is at the **repo root**, not a plugin component; this scenario
+is filed against the `dynamic-workflows` skill only so the corpus can resolve
+a target, mirroring how S6's `.gitignore` check lives under
+`commands/reflect` but asserts a repo-root file).
+
+## When
+
+`README.md` is read and the Dynamic Workflows section is isolated (from a
+heading whose text contains `dynamic workflows`, case-insensitive, to the
+next same-or-higher-level heading).
+
+## Then
+
+- A **heading containing `dynamic workflows`** exists (case-insensitive).
+  `dynamic workflows` is two words — the content test isolates the section by
+  matching a heading that contains both, but assertions on the section body
+  use co-occurring single tokens. Keep the heading phrase **unwrapped**.
+- The section references the **six patterns**: the content test asserts a few
+  load-bearing tokens co-occur — `fan-out` (single token, keep unwrapped) and
+  `adversarial` and `tournament` — and/or the phrase concept "six patterns".
+  Keep `fan-out`, `classify-and-act`, `loop-until-done` **unwrapped** (each is
+  a single hyphenated token).
+- The section references the **election discipline** — that workflows are
+  elected (opt-in), not reflexive: the test asserts one of `elect` /
+  `opt-in` / `when not to use`. Keep `opt-in` and `when not to use`
+  **unwrapped**.
+- The section names **INV-1** AND **INV-2** — both are single wrap-safe
+  tokens, asserted directly.
+- The section states the **Claude Code-only** scope: `claude code` is **two
+  words** — keep it **unwrapped**; the test asserts `claude` and `code` as two
+  independent co-occurring tokens (NOT a joined substring).
+- The section states the **Option A Copilot guidance contract**: `copilot`
+  co-occurs with `guidance` — i.e. the README states the skill ships to
+  Copilot CLI as **guidance only** (the guidance-only fallback), not omitted.
+  Keep `guidance only` / `guidance-only` **unwrapped**; the test asserts
+  `copilot` and `guidance` as co-occurring tokens.
+- The README **Skills badge still reads 36** — the test asserts `Skills-36`
+  is present and `Skills-37` is **absent** (a guard against an accidental
+  re-bump; S1 already reconciled the count). `Skills-36` and `Skills-37` are
+  single wrap-safe tokens. **This is a guard that must STAY green now, not a
+  RED-now assertion.**
+
+## Rubric
+
+Deterministic structural shadow of AC-1 through AC-5. The README must gain a
+prose Dynamic Workflows section documenting the ephemeral, self-authored,
+per-task multi-agent substrate beneath the static pipeline: the six patterns
+at a glance, the election discipline (elected via the when-not-to-use rubric,
+not reflexive — the static pipeline stays the default), the two governance
+invariants INV-1 (ephemeral proposes, durable curates) and INV-2 (quarantine
+untrusted-content readers), and the Claude-Code-only runtime scope with the
+resolved **Option A** Copilot degradation contract (guidance-only fallback,
+never omitted). S7 adds prose only: it does **not** re-bump the `Skills-36`
+badge (reconciled in S1).
+
+## Evaluation
+
+Evaluated deterministically by
+`tests/test_s7_docs_hook_copilot_structural.py`
+(`TestS7ReadmeDynamicWorkflowsSection`). RED now because `README.md` has no
+Dynamic Workflows section — only a one-line skill-table row — so the section,
+the patterns/election/INV/scope/Copilot phrases are absent. The
+`Skills-36`-present / `Skills-37`-absent guard is GREEN now and must stay so.

--- a/tdad_tests/tests/test_s7_docs_hook_copilot_structural.py
+++ b/tdad_tests/tests/test_s7_docs_hook_copilot_structural.py
@@ -1,0 +1,340 @@
+"""Layer 1 structural content checks for dynamic-workflows S7 (epic final).
+
+These tests are the *deterministic mechanism* behind the structural
+scenarios authored at ``scenarios/skills/dynamic-workflows/`` for slice S7
+(the README Dynamic Workflows section, the skill/governance reference's
+Copilot Option-A contract, and the two CLAUDE.md skill pointers).
+
+Per the spec's §6 decision 3 (the verification split), this repo's
+deterministic layer reads files and matches structure — it does **not** run
+a session, dispatch a workflow, or judge whether the (deferred) advisory hook
+*should* have fired. So what is deterministically asserted here is that:
+
+- the repo-root ``README.md`` gains a **Dynamic Workflows** section naming the
+  six patterns + election discipline (AC-2), INV-1/INV-2 (AC-3), the
+  Claude-Code-only scope + the guidance-only Copilot **Option A** contract
+  (AC-4), and that the ``Skills-36`` badge is **unchanged** (AC-5);
+- ``skills/dynamic-workflows/references/governance.md`` states the resolved
+  **Option A** Copilot degradation contract — ships to both trees, guidance
+  only where no runtime, never omitted (AC-6c / FR-6);
+- both ``CLAUDE.md`` surfaces (repo root + ``templates/CLAUDE.md``) carry the
+  ``dynamic-workflows`` skill pointer with a trigger cue (AC-7p / FR-7).
+
+The README/CLAUDE.md targets are **repo-root** files (read via
+``_repo_root(plugin_path)``, like the S6 ``.gitignore`` check), not plugin
+components — the scenarios are filed under the ``dynamic-workflows`` skill so
+the corpus can resolve a target, and the real assertions live here.
+
+GATE decisions this slice builds to:
+
+- **Copilot contract = Option A.** The skill ships to BOTH the Claude Code
+  and Copilot CLI trees; without the workflow runtime it is guidance-only
+  (readable knowledge), every workflow-mode degrades to its static/guidance
+  fallback, and it **never** omits the skill or errors.
+- **Advisory Stop hook = DEFERRED** (not shipping in S7). So this file
+  authors **no** hook test and **no** ``hooks.json`` / hook-script assertion.
+  AC-6/AC-7/AC-8 (hook registration, exit-0/non-blocking, heuristic quality)
+  do not apply in S7.
+
+RED state (before S7 implements): ``README.md`` has no Dynamic Workflows
+section, ``governance.md`` has no Copilot Option-A statement, and neither
+``CLAUDE.md`` carries the skill pointer — so every declaration assertion below
+fails on missing content (RED for the right reason: missing content, not a
+malformed scenario or an unresolvable component; the ``dynamic-workflows``
+skill and both ``CLAUDE.md`` files already exist). The corpus/parse/tier
+checks in ``test_layer1_structural.py`` stay GREEN.
+
+**Guard that must STAY green now:** the ``Skills-36``-present /
+``Skills-37``-absent assertion is **not** a RED-now assertion — S1 already
+reconciled the count to 36. It guards against an accidental re-bump and must
+pass both before and after S7 implements.
+
+Line-wrap note (the trap that bit S3 twice, S4 twice, S5 once, S6 once): a
+required two-word phrase an implementer might wrap across a line is NOT
+asserted as a single substring. Where a guarantee needs two terms to
+co-occur, they are asserted as two independent ``in`` checks on the
+lowercased section so a wrapped phrase still passes. Single load-bearing
+tokens (``skills-36``, ``skills-37``, ``inv-1``, ``inv-2``,
+``dynamic-workflows``, ``fan-out``, ``opt-in``, ``long-running``) are
+wrap-safe and asserted directly; ``claude code`` and ``massively parallel``
+are two words and are split.
+
+Spec: docs/superpowers/specs/2026-06-23-dynamic-workflows-s7-docs-hook-copilot-design.md
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from runner import plugin as plugin_runner  # noqa: E402
+
+
+def _repo_root(plugin_path: Path) -> Path:
+    """The repo root — parent of the ``ai-literacy-superpowers`` plugin
+    directory (``plugin_path`` points at the plugin dir)."""
+    return plugin_path.parent
+
+
+def _readme_text(plugin_path: Path) -> str:
+    """Full text of the repo-root README.md (NOT lowercased — the badge
+    assertions are case-sensitive)."""
+    return (_repo_root(plugin_path) / "README.md").read_text(encoding="utf-8")
+
+
+def _dynamic_workflows_section(plugin_path: Path) -> str:
+    """Return the text of the README Dynamic Workflows section — from a
+    heading whose text contains "dynamic workflows" to the next
+    same-or-higher-level heading, lowercased. Empty string if absent.
+
+    Matches a level-2/3/4 heading so either a top-level ``## Dynamic
+    Workflows`` or a ``### Dynamic Workflows`` subsection is found."""
+    text = _readme_text(plugin_path)
+    m = re.search(
+        r"^(#{2,4})\s+.*dynamic workflows.*$",
+        text,
+        re.IGNORECASE | re.MULTILINE,
+    )
+    if not m:
+        return ""
+    level = len(m.group(1))
+    start = m.end()
+    rest = text[start:]
+    nxt = re.search(rf"^#{{1,{level}}}\s+\S", rest, re.MULTILINE)
+    end = nxt.start() if nxt else len(rest)
+    return rest[:end].lower()
+
+
+def _governance_text(plugin_path: Path) -> str:
+    """Lowercased text of the skill/governance reference."""
+    path = (
+        plugin_path
+        / "skills"
+        / "dynamic-workflows"
+        / "references"
+        / "governance.md"
+    )
+    return path.read_text(encoding="utf-8").lower()
+
+
+def _claude_md_root(plugin_path: Path) -> str:
+    """Lowercased text of the repo-root CLAUDE.md."""
+    return (_repo_root(plugin_path) / "CLAUDE.md").read_text(
+        encoding="utf-8"
+    ).lower()
+
+
+def _claude_md_template(plugin_path: Path) -> str:
+    """Lowercased text of the plugin's templates/CLAUDE.md."""
+    return (
+        plugin_path / "templates" / "CLAUDE.md"
+    ).read_text(encoding="utf-8").lower()
+
+
+# ---------------------------------------------------------------------------
+# AC-1 – AC-5 / FR-1 – FR-5 — the README Dynamic Workflows section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS7ReadmeDynamicWorkflowsSection:
+    """Structural shadow of AC-1–AC-5 — README.md must gain a Dynamic
+    Workflows section naming the six patterns + election discipline,
+    INV-1/INV-2, the Claude-Code-only scope + the guidance-only Copilot
+    Option-A contract, while leaving the Skills-36 badge unchanged
+    (scenario ``scenarios/skills/dynamic-workflows/readme-dynamic-workflows-section.md``)."""
+
+    def test_section_exists(self, plugin_path: Path) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        assert section, (
+            "README.md must contain a 'Dynamic Workflows' section — a heading "
+            "whose text contains 'Dynamic Workflows' (AC-1 / FR-1). None "
+            "found. Keep 'Dynamic Workflows' unwrapped in the heading."
+        )
+
+    def test_names_the_six_patterns(self, plugin_path: Path) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        # A few load-bearing pattern tokens co-occurring — 'fan-out' is a
+        # single hyphenated token; 'adversarial' and 'tournament' single
+        # words. Keep each unwrapped.
+        assert "fan-out" in section and "adversarial" in section and (
+            "tournament" in section
+        ), (
+            "Dynamic Workflows section must reference the six patterns — the "
+            "test asserts 'fan-out', 'adversarial', and 'tournament' co-occur "
+            "(AC-2 / FR-2). Keep 'fan-out', 'classify-and-act', "
+            "'loop-until-done' unwrapped (each a single hyphenated token)."
+        )
+
+    def test_states_election_discipline(self, plugin_path: Path) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        # Workflows are elected (opt-in), not reflexive. Any of these single
+        # markers satisfies the discipline. Keep 'opt-in' / 'when not to use'
+        # unwrapped.
+        assert (
+            "elect" in section
+            or "opt-in" in section
+            or "opt in" in section
+            or "when not to use" in section
+        ), (
+            "Dynamic Workflows section must state the election discipline — "
+            "workflows are elected (opt-in) via the when-not-to-use rubric, "
+            "not reflexive; the static pipeline stays the default (AC-2 / "
+            "FR-2). Keep 'opt-in' and 'when not to use' unwrapped."
+        )
+
+    def test_states_inv1_and_inv2(self, plugin_path: Path) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        # 'inv-1' and 'inv-2' are single wrap-safe tokens (lowercased).
+        assert "inv-1" in section and "inv-2" in section, (
+            "Dynamic Workflows section must name both INV-1 (ephemeral "
+            "proposes, durable curates) and INV-2 (quarantine "
+            "untrusted-content readers) (AC-3 / FR-3). 'INV-1'/'INV-2' are "
+            "single unwrappable tokens."
+        )
+
+    def test_states_claude_code_only_scope(self, plugin_path: Path) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        # 'claude code' is two words — split it.
+        assert "claude" in section and "code" in section, (
+            "Dynamic Workflows section must state the Claude-Code-only runtime "
+            "scope (AC-4 / FR-4). Keep 'Claude Code' unwrapped — asserted as "
+            "two co-occurring tokens, NOT a joined substring."
+        )
+
+    def test_states_copilot_guidance_only_contract(
+        self, plugin_path: Path
+    ) -> None:
+        section = _dynamic_workflows_section(plugin_path)
+        # Option A: ships to Copilot as guidance only (not omitted).
+        # 'copilot' + 'guidance' co-occurring, NOT a joined substring.
+        assert "copilot" in section and "guidance" in section, (
+            "Dynamic Workflows section must state the Option A Copilot "
+            "contract — on the Copilot CLI tree the skill degrades to "
+            "guidance only (readable knowledge, no workflow spawned, no "
+            "error), NOT omitted (AC-4 / FR-4). Keep 'guidance only' / "
+            "'guidance-only' unwrapped; 'copilot' and 'guidance' asserted as "
+            "two co-occurring tokens."
+        )
+
+    def test_skill_count_badge_unchanged_at_36(
+        self, plugin_path: Path
+    ) -> None:
+        # GUARD (must STAY green): S7 must NOT re-bump the skill count. The
+        # badge reads 'Skills-36' (reconciled in S1); 'Skills-37' must be
+        # absent. Read the full README (case-sensitive) — the badge text is
+        # 'Skills-36', a single unwrappable token.
+        text = _readme_text(plugin_path)
+        assert "Skills-36" in text, (
+            "README skills shields badge must still read 'Skills-36' — S7 adds "
+            "prose only and does NOT re-bump the skill count (AC-5 / FR-5; "
+            "reconciled in S1). 'Skills-36' is a single unwrappable token. "
+            "This guard must stay GREEN before and after S7 implements."
+        )
+        assert "Skills-37" not in text, (
+            "README must NOT contain 'Skills-37' — S7 ships no new skill; "
+            "re-bumping the skill-count badge is forbidden (AC-5 / FR-5). "
+            "This guard must stay GREEN before and after S7 implements."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-6c / FR-6 — the skill/governance reference states the Option A contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS7GovernanceCopilotContract:
+    """Structural shadow of AC-6c — governance.md must state the resolved
+    Option A Copilot degradation contract: ships to both trees, guidance
+    only where no runtime, never omitted (scenario
+    ``scenarios/skills/dynamic-workflows/governance-copilot-option-a-contract.md``)."""
+
+    def test_states_copilot_guidance_only(self, plugin_path: Path) -> None:
+        text = _governance_text(plugin_path)
+        # 'copilot' + 'guidance' co-occurring, NOT a joined substring.
+        assert "copilot" in text and "guidance" in text, (
+            "governance.md must state the Copilot CLI degradation contract — "
+            "on a tree without the workflow runtime the skill is guidance "
+            "only (AC-6c / FR-6). Keep 'guidance only' / 'guidance-only' "
+            "unwrapped; 'copilot' and 'guidance' asserted as two co-occurring "
+            "tokens."
+        )
+
+    def test_states_never_omit_ships_to_both(
+        self, plugin_path: Path
+    ) -> None:
+        text = _governance_text(plugin_path)
+        # Option A is the NEVER-OMIT contract: the skill ships to BOTH trees
+        # and is not omitted. Any of these assurances satisfies it; keep
+        # 'both trees' / 'ship to both' / 'never omit' unwrapped.
+        assert (
+            "never omit" in text
+            or "not omitted" in text
+            or "ship to both" in text
+            or "ships to both" in text
+            or "both trees" in text
+        ), (
+            "governance.md must state the never-omit assurance — the skill "
+            "ships to BOTH trees and is guidance-only where the runtime is "
+            "absent, NOT omitted (Option A, not Option B) (AC-6c / FR-6). "
+            "Keep 'both trees' / 'ship to both' / 'never omit' unwrapped — "
+            "asserted as co-occurring tokens."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-7p / FR-7 — both CLAUDE.md surfaces point to the dynamic-workflows skill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.structural
+class TestS7ClaudeMdSkillPointer:
+    """Structural shadow of AC-7p — both CLAUDE.md (repo root) and
+    templates/CLAUDE.md must reference the `dynamic-workflows` skill with a
+    trigger cue, so the pointer is meaningful, not a bare mention (scenario
+    ``scenarios/skills/dynamic-workflows/claude-md-skill-pointer.md``)."""
+
+    @staticmethod
+    def _assert_pointer(text: str, where: str) -> None:
+        # 'dynamic-workflows' is a single wrap-safe token. The trigger cue is
+        # any of these; 'long-running' is a single hyphenated token,
+        # 'massively parallel' is two words (the test matches either word).
+        assert "dynamic-workflows" in text, (
+            f"{where} must reference the `dynamic-workflows` skill name "
+            "(AC-7p / FR-7). 'dynamic-workflows' is a single unwrappable "
+            "token."
+        )
+        assert (
+            "long-running" in text
+            or "massively parallel" in text
+            or "massively-parallel" in text
+            or "adversarial" in text
+            or "workflow" in text
+        ), (
+            f"{where} must carry a trigger cue alongside the skill name — one "
+            "of 'long-running' / 'massively parallel' / 'adversarial' / "
+            "'workflow' — so the pointer tells an agent WHEN to consult the "
+            "skill, not a bare mention (AC-7p / FR-7). Keep 'long-running', "
+            "'massively parallel', 'highly structured' unwrapped."
+        )
+
+    def test_root_claude_md_points_to_skill(
+        self, plugin_path: Path
+    ) -> None:
+        self._assert_pointer(
+            _claude_md_root(plugin_path), "CLAUDE.md (repo root)"
+        )
+
+    def test_template_claude_md_points_to_skill(
+        self, plugin_path: Path
+    ) -> None:
+        self._assert_pointer(
+            _claude_md_template(plugin_path),
+            "ai-literacy-superpowers/templates/CLAUDE.md",
+        )


### PR DESCRIPTION
## Summary

- **README gains a "Dynamic Workflows" section** documenting the substrate, the six patterns, the opt-in election discipline, INV-1/INV-2, and the Claude-Code-only / guidance-everywhere posture. The `Skills-36` badge is unchanged (reconciled in S1).
- **Copilot CLI degradation contract resolved (open question 4 → Option A):** the `dynamic-workflows` skill ships to BOTH the Claude Code and Copilot CLI trees and is never omitted — guidance-only where the runtime is absent, never errors. Documented in the README and the skill's `governance.md`.
- **`CLAUDE.md` (root) and `templates/CLAUDE.md`** gain a pointer to the skill for long-running, massively parallel, highly structured, and adversarial tasks.
- The optional advisory `Stop` hook from D9 was **deliberately deferred**, with rationale recorded in the CHANGELOG. Minor bump 0.63.0 → 0.64.0.

## Test plan

- `test_s7_docs_hook_copilot_structural.py` deterministic structural checks pass (56/56 locally) and are wired into the fast CI as a new "Run Layer 1 (dynamic-workflows S7 ...)" step inside the TDAD-fast job — confirm it runs green.
- markdownlint is clean on the changed docs files.
- Version-consistency CI passes (0.64.0 across all five enforced locations; no re-bump in this PR).
- Spec is the first commit on the branch → spec-first-check satisfied.

## Spec & slicing record

- Design spec: `docs/superpowers/specs/2026-06-23-dynamic-workflows-s7-docs-hook-copilot-design.md`

## Epic complete

This completes the Dynamic Workflows Alignment epic: **D1–D9 delivered across S1–S7 (#438–#444), all merged**, and all four §7 open questions resolved.

Closes #444