### PR TITLE
Harness audit 2026-06-23: refresh Status and badge

### DIFF
--- a/HARNESS.md
+++ b/HARNESS.md
@@ -1025,7 +1025,7 @@ Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
 
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
-Last audit: 2026-06-01
-Constraints enforced: 25/26
+Last audit: 2026-06-23
+Constraints enforced: 26/28
 Garbage collection active: 19/19
-Drift detected: yes (ONBOARDING.md stale vs the new marketplace-docs-coverage constraint — run /harness-onboarding; convention files + Status block synced via /harness-sync 2026-06-01)
+Drift detected: yes (ONBOARDING.md + convention files (.cursor/rules, .github/copilot-instructions.md, .windsurf/rules) last synced 2026-06-01, now stale vs the 2026-06-23 template-v0.64.0 upgrade — run /harness-sync then /harness-onboarding. Template currency now in sync at 0.64.0. Affordances section holds example entries only (no project config found); affordance constraints + GC rules remain commented-out and excluded from totals.)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
-[![Harness](https://img.shields.io/badge/Harness-25%2F26_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-26%2F28_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-10-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)


### PR DESCRIPTION
Full harness meta-verification (`/harness-audit`) following the template-v0.64.0 upgrade (#460).

## Results

- **Constraints: 26/28 enforced (92.9%)** — 18 deterministic, 8 agent, 2 unverified (`Tests must pass`, `Layer 0 bash tests on macOS+Linux`). The 4 affordance/spec/governance example constraints are inside HTML-comment blocks and correctly excluded.
- **Garbage collection: 19/19 active.**
- **Template currency: resolved** — HARNESS.md `template-version: 0.64.0` now equals `plugin.json`.
- **Affordances: example entries only** — `/harness-affordance discover` found no project config, so `harness-affordance-check.sh` self-gates to `skipped (unverified)` for both directions. Affordance constraints + GC rules remain commented-out and excluded from totals.

## Drift detected

- **ONBOARDING.md + convention files** (`.cursor/rules`, `.github/copilot-instructions.md`, `.windsurf/rules`) last synced 2026-06-01 — stale vs the 2026-06-23 upgrade. Remediate with `/harness-sync` then `/harness-onboarding` (follow-up, not in this PR).
- Snapshot is 25 days old (within the 30-day monthly threshold; `/harness-health` due ~2026-06-28).

## Reflection-log archival

- Active: 51 entries; archive: empty. Path 1 (deterministic auto-archive) and Path 2 (aged-out review) GC rules both declared and operating. Two `Promoted` lines (2026-06-14/15) did not verify against current AGENTS.md text, so Path 1 conservatively archived nothing — designed behaviour. No aged-out curation debt (oldest active entry 78 days < 180-day threshold).

## Changed

- `HARNESS.md` `## Status` block (audit auto-update).
- `README.md` harness badge `25/26 → 26/28` (colour unchanged, steel blue).

## Scope

Status auto-update + badge only — both at repo root, outside `ai-literacy-superpowers/`. No plugin version bump; CHANGELOG untouched. Labelled `chore` for the spec-first exemption.