### PR TITLE
Formalise the gh-cli affordance grant

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh *)"
+    ]
+  }
+}

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -884,14 +884,15 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   token scopes `gist`, `read:org`, `repo`, `workflow`)
 - **Audit trail**: github-audit (org audit log, 90-day retention,
   admin-only access)
-- **Permission**: `Bash(gh *)`
+- **Permission**: `Bash(gh *)` (allowlist in `.claude/settings.json`)
 - **Last reviewed**: 2026-06-23
 - **Notes**: On this machine `$GITHUB_TOKEN` is unset, so `gh` resolves to
   the keychain identity above (chain: `$GITHUB_TOKEN` → keychain → fail).
-  No static allowlist currently grants `Bash(gh *)` — it runs via
-  session-level permission, not a declared grant. To formalise (and to
-  satisfy the affordance↔permission constraints once they are
-  uncommented), add `Bash(gh *)` to `.claude/settings.local.json`.
+  The grant is declared in the committed `.claude/settings.json`
+  permissions allowlist (`Bash(gh *)`), so the affordance↔permission
+  constraints will pass in CI once they are uncommented. Committed (not
+  per-machine) because the constraints are deterministic PR-scope checks
+  that can only read tracked files.
 
 ### honeycomb-mcp
 <!-- affordance-example -->


### PR DESCRIPTION
Formalises the `gh-cli` affordance (declared in #462) by giving it a real, CI-visible permission grant.

## What changed

- **New `.claude/settings.json`** (committed) with a `permissions.allow` entry for `Bash(gh *)`.
- **HARNESS.md** — the gh-cli affordance's `Permission` annotation and `Notes` now point at the committed grant instead of the placeholder note.

## Why committed `settings.json`, not `settings.local.json`

The affordance↔permission constraints (`harness-affordance-check.sh`, currently commented-out in HARNESS.md) are **deterministic, PR-scope** checks. CI can only read tracked files, so a per-machine `.claude/settings.local.json` grant would be invisible to CI and the blocking check would fail once uncommented. A committed `settings.json` makes the grant team-wide and CI-verifiable. (`.claude/settings.local.json` is also not gitignored in this repo, which would have made the "per-machine" framing misleading.)

## Verification

Both directions of the affordance check now pass against the working tree:

- `--direction=blocking` → `OK: every declared affordance has a matching permission.` (exit 0)
- `--direction=advisory` → `OK: every permission has a declared affordance.` (exit 0)

(Previously both self-gated to `unverified: no real affordances declared`.) `settings.json` is valid JSON; `markdownlint` clean on HARNESS.md.

## Scope

`.claude/settings.json` + HARNESS.md — both repo root, outside `ai-literacy-superpowers/`. No plugin version bump; CHANGELOG untouched. The affordance↔permission constraints remain commented-out — this PR makes them *passable*, it does not activate them. Labelled `chore` for the spec-first exemption.