### PR TITLE
Activate affordance↔permission constraints

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -202,3 +202,17 @@ alwaysApply: true
 - **Enforcement**: agent
 - **Tool**: harness-enforcer
 - **Scope**: pr
+
+## Affordances have matching permissions
+
+- **Rule**: Every non-example, non-hook affordance declared in the `## Affordances` section must have a `Permission` pattern that appears verbatim (string equality) in the permissions allowlist (`.claude/settings.json` or `.claude/settings.local.json`). An affordance without a matching permission is a tool the agent has declared but cannot invoke — a safety gap.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking`
+- **Scope**: pr
+
+## Permissions have declared affordances
+
+- **Rule**: Every entry in the permissions allowlist should have a matching affordance in the `## Affordances` section. An ungoverned permission is paperwork debt, not a safety violation — flag it, do not block.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`
+- **Scope**: pr

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -154,3 +154,11 @@ When creating a PR with `gh pr create` that requires a label (`chore`, `fix`, `c
 ### Docs propagation when shipping new commands
 
 When a PR adds a new command, skill, or agent in `ai-literacy-superpowers/` that consolidates or replaces existing functionality, the same PR must update every reference in `docs/plugins/<plugin>/` to the commands or skills the new one composes or replaces. A `See also` callout pattern is insufficient when the new artefact is meant to be the canonical entry point — the older pages must explicitly frame the existing artefacts as primitives or alternatives, not as first-class equivalents. Effective from 2026-05-07. Enforcement: agent (harness-enforcer). Scope: pr.
+
+### Affordances have matching permissions
+
+Every non-example, non-hook affordance declared in the `## Affordances` section must have a `Permission` pattern that appears verbatim (string equality) in the permissions allowlist (`.claude/settings.json` or `.claude/settings.local.json`). An affordance without a matching permission is a tool the agent has declared but cannot invoke — a safety gap. Enforcement: deterministic (`bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking`). Scope: pr.
+
+### Permissions have declared affordances
+
+Every entry in the permissions allowlist should have a matching affordance in the `## Affordances` section. An ungoverned permission is paperwork debt, not a safety violation — flag it, do not block. Enforcement: deterministic (`bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`). Scope: pr.

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -196,3 +196,17 @@
 - **Enforcement**: agent
 - **Tool**: harness-enforcer
 - **Scope**: pr
+
+## Affordances have matching permissions
+
+- **Rule**: Every non-example, non-hook affordance declared in the `## Affordances` section must have a `Permission` pattern that appears verbatim (string equality) in the permissions allowlist (`.claude/settings.json` or `.claude/settings.local.json`). An affordance without a matching permission is a tool the agent has declared but cannot invoke — a safety gap.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking`
+- **Scope**: pr
+
+## Permissions have declared affordances
+
+- **Rule**: Every entry in the permissions allowlist should have a matching affordance in the `## Affordances` section. An ungoverned permission is paperwork debt, not a safety violation — flag it, do not block.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`
+- **Scope**: pr

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -456,16 +456,6 @@
   those references)
 - **Scope**: pr
 
-<!-- Uncomment if using the Affordances feature (the chained-constraint
-     pair from the harness-affordances design, steps 4-5). The check
-     self-gates to "unverified" (passes, no-op) until the project has at
-     least one real (non-example) affordance AND a readable project
-     permissions allowlist, so it is safe to leave active. Matching is
-     string equality on the permission pattern; hook-mode affordances are
-     skipped. The Tool path assumes the plugin is vendored at
-     `ai-literacy-superpowers/` (as in this repo) — adjust it to your
-     plugin install location otherwise.
-
 ### Affordances have matching permissions
 
 - **Rule**: Every non-example, non-hook affordance declared in the
@@ -486,7 +476,6 @@
 - **Enforcement**: deterministic
 - **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory
 - **Scope**: pr
--->
 
 <!-- Uncomment if using spec-first development:
 
@@ -1029,6 +1018,6 @@ Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
 Last audit: 2026-06-23
-Constraints enforced: 26/28
+Constraints enforced: 28/30
 Garbage collection active: 19/19
-Drift detected: yes (ONBOARDING.md + convention files (.cursor/rules, .github/copilot-instructions.md, .windsurf/rules) last synced 2026-06-01, now stale vs the 2026-06-23 template-v0.64.0 upgrade — run /harness-sync then /harness-onboarding. Template currency now in sync at 0.64.0. Affordances section holds example entries only (no project config found); affordance constraints + GC rules remain commented-out and excluded from totals.)
+Drift detected: no (convention files + ONBOARDING.md synced to template-v0.64.0 on 2026-06-23; template currency in sync at 0.64.0. The two affordance↔permission constraints are now active — gh-cli is a real affordance with a matching Bash(gh *) grant in committed .claude/settings.json, both check directions pass. Affordance GC rules remain commented-out and excluded from totals.)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
-[![Harness](https://img.shields.io/badge/Harness-26%2F28_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-28%2F30_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-05-10-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)


### PR DESCRIPTION
Activates the two affordance↔permission constraints (made *passable* in #464) and propagates the change across every dependent surface.

## What changed

- **HARNESS.md**: uncommented `Affordances have matching permissions` (blocking) and `Permissions have declared affordances` (advisory). Both are `deterministic`, `pr`-scope, backed by `harness-affordance-check.sh`. Active constraints 28 → **30**.
- **Status block**: `26/28 → 28/30` enforced; drift line cleared.
- **README badge**: `26/28 → 28/30` (colour unchanged, steel blue / 93%).
- **Convention files** (Cursor/Copilot/Windsurf): added both constraints — all **30/30** active constraints now present in all three.

## Why these gates are green on this PR

`gh-cli` is a real affordance (#462) with a matching `Bash(gh *)` grant in committed `.claude/settings.json` (#464). Verified on this branch:

- `--direction=blocking` → `OK: every declared affordance has a matching permission.` (exit 0)
- `--direction=advisory` → `OK: every permission has a declared affordance.` (exit 0)

## Effect going forward

Every future PR now gets two new deterministic checks: a **blocking** one (an affordance without a matching permission fails the PR) and an **advisory** one (a permission without a declared affordance is flagged, not blocked). Adding a new tool grant to `.claude/settings.json` will now require declaring a matching affordance in HARNESS.md.

The affordance *GC rules* (review staleness, recorder freshness, dead inventory) remain commented-out — they depend on a per-machine recorder hook that isn't configured.

## Scope

HARNESS.md + README + convention files — all repo root / outside `ai-literacy-superpowers/`. No plugin version bump; CHANGELOG untouched. Labelled `chore`.