### PR TITLE
Add macOS Layer 0 CI leg; promote cross-OS constraint

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -149,9 +149,9 @@ alwaysApply: true
 
 ## Layer 0 bash tests run on macOS and Linux
 
-- **Rule**: The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner. The plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine. Declared unverified until `tdad-tests-fast.yml` adds a `macos-latest` leg to its runner matrix (currently Ubuntu-only).
-- **Enforcement**: unverified
-- **Tool**: `.github/workflows/tdad-tests-fast.yml` (add `macos-latest` to the runner matrix)
+- **Rule**: The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner. The plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/tdad-tests-fast.yml` (the `layer0-macos` job runs Layer 0 on `macos-latest`; `fast-suite` runs it on `ubuntu-latest`)
 - **Scope**: pr
 
 ## New plugin components must ship with a TDAD scenario

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,7 +125,7 @@ Layer 0 (deterministic bash plumbing tests) and Layer 1 (structural tests for pl
 
 ### Layer 0 bash tests run on macOS and Linux
 
-The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner — the plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine. Declared unverified until `tdad-tests-fast.yml` adds a `macos-latest` leg to its runner matrix (currently Ubuntu-only). Enforcement: unverified (`.github/workflows/tdad-tests-fast.yml`). Scope: pr.
+The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner — the plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine. Enforcement: deterministic (`.github/workflows/tdad-tests-fast.yml` — the `layer0-macos` job runs Layer 0 on macOS, the `fast-suite` job on Ubuntu). Scope: pr.
 
 ### New plugin components must ship with a TDAD scenario
 

--- a/.github/workflows/tdad-tests-fast.yml
+++ b/.github/workflows/tdad-tests-fast.yml
@@ -80,3 +80,29 @@ jobs:
       - name: Run Layer 1 (dynamic-workflows S7 docs + Copilot contract)
         working-directory: tdad_tests
         run: pytest tests/test_s7_docs_hook_copilot_structural.py -v
+
+  # Cross-OS coverage for Layer 0: the deterministic bash scripts use
+  # grep/date/sort/stat, which diverge between BSD (macOS) and GNU
+  # (Ubuntu). A dedicated macOS leg verifies the scripts are portable —
+  # the bugs are masked on a GNU-only runner. Layer 0 only (Layer 1 is
+  # OS-independent structural Python and already runs on Ubuntu above).
+  layer0-macos:
+    name: Layer 0 on macOS (BSD coreutils)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: tdad_tests/pyproject.toml
+
+      - name: Install tdad_tests
+        working-directory: tdad_tests
+        run: pip install -e .
+
+      - name: Run Layer 0 (deterministic plumbing) on BSD coreutils
+        working-directory: tdad_tests
+        run: pytest tests/test_layer0_deterministic.py -v

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -143,9 +143,9 @@
 
 ## Layer 0 bash tests run on macOS and Linux
 
-- **Rule**: The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner. The plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine. Declared unverified until `tdad-tests-fast.yml` adds a `macos-latest` leg to its runner matrix (currently Ubuntu-only).
-- **Enforcement**: unverified
-- **Tool**: `.github/workflows/tdad-tests-fast.yml` (add `macos-latest` to the runner matrix)
+- **Rule**: The Layer 0 deterministic bash tests must pass on both a macOS (BSD coreutils) and an Ubuntu (GNU coreutils) CI runner. The plugin's deterministic check scripts use `grep`, `date`, `sort`, and `stat`, which diverge between BSD and GNU and are masked on a macOS dev machine.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/tdad-tests-fast.yml` (the `layer0-macos` job runs Layer 0 on `macos-latest`; `fast-suite` runs it on `ubuntu-latest`)
 - **Scope**: pr
 
 ## New plugin components must ship with a TDAD scenario

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -323,12 +323,11 @@
   diverge between BSD and GNU — and the bugs are masked on a macOS dev machine
   (the Claude Code harness even aliases `grep` to `ugrep`, so a GNU-only
   `grep '\|'` passes locally while bare BSD grep treats it as a literal). A
-  single-runner suite cannot catch this class; only a cross-OS matrix can.
-  Declared `unverified` until `tdad-tests-fast.yml` adds a `macos-latest` leg
-  to its runner matrix (the current implementation runs on Ubuntu only).
-- **Enforcement**: unverified
-- **Tool**: `.github/workflows/tdad-tests-fast.yml` (add `macos-latest` to the
-  runner matrix)
+  single-runner suite cannot catch this class; only cross-OS coverage can.
+- **Enforcement**: deterministic
+- **Tool**: `.github/workflows/tdad-tests-fast.yml` (the `layer0-macos` job
+  runs Layer 0 on `macos-latest`; the `fast-suite` job runs it on
+  `ubuntu-latest`)
 - **Scope**: pr
 
 ### New plugin components must ship with a TDAD scenario
@@ -1018,6 +1017,6 @@ Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
 Last audit: 2026-06-23
-Constraints enforced: 28/30
+Constraints enforced: 29/30
 Garbage collection active: 19/19
-Drift detected: no (convention files + ONBOARDING.md synced to template-v0.64.0 on 2026-06-23; template currency in sync at 0.64.0. The two affordance↔permission constraints are now active — gh-cli is a real affordance with a matching Bash(gh *) grant in committed .claude/settings.json, both check directions pass. Affordance GC rules remain commented-out and excluded from totals.)
+Drift detected: no (convention files + ONBOARDING.md synced to template-v0.64.0 on 2026-06-23; template currency in sync at 0.64.0. Affordance↔permission constraints active (gh-cli affordance + committed Bash(gh *) grant, both directions pass). "Layer 0 bash tests run on macOS and Linux" promoted unverified→deterministic — tdad-tests-fast.yml now runs Layer 0 on a dedicated macos-latest job (verified passing on BSD coreutils). Only "Tests must pass" remains unverified, by design (no suite). Affordance GC rules remain commented-out.)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
-[![Harness](https://img.shields.io/badge/Harness-28%2F30_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-29%2F30_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)


### PR DESCRIPTION
Closes the verification gap documented by the **Layer 0 bash tests run on macOS and Linux** constraint (the last closeable `unverified` one), and promotes it to `deterministic`.

## What changed

- **`.github/workflows/tdad-tests-fast.yml`**: new `layer0-macos` job runs Layer 0 on `macos-latest` (BSD coreutils). The existing `fast-suite` job (Ubuntu/GNU) is unchanged, so Layer 0 now runs on **both** OSes.
- **HARNESS.md**: constraint promoted `unverified → deterministic`; Status `28/30 → 29/30`.
- **README badge**: `28/30 → 29/30`.
- **Convention files** (Cursor/Copilot/Windsurf): Enforcement updated to `deterministic` + Tool wording. 30/30 parity maintained.

## Why a dedicated job, not a matrix

The constraint's Tool wording said "add `macos-latest` to the runner matrix," but converting `fast-suite` to a matrix would rename the `Run TDAD Layers 0 + 1` check (GitHub appends the matrix value). Branch protection isn't readable from here, so renaming a possibly-required check risks stranding PRs. A separate job **preserves the existing check name**, covers Layer 0 on both OSes, and avoids redundantly re-running the OS-independent Layer 1 on the pricier macOS runner.

## Verified before pushing

Ran all **11 Layer 0 tests locally on this macOS machine** — they pass under real `/usr/bin/grep` (BSD grep 2.6.0-FreeBSD), confirmed *not* the session's `ugrep` alias (pytest subprocesses spawn non-interactive bash that doesn't load the alias). So the scripts are genuinely BSD-portable; the new CI leg is expected green. This PR modifies `tdad-tests-fast.yml`, so the `layer0-macos` job runs on the PR itself.

## Result

Enforcement now **29/30** — the only remaining `unverified` is *Tests must pass*, which has no suite to back it (unverified by design).

## Scope

CI workflow + HARNESS.md + README + convention files — all outside `ai-literacy-superpowers/`. No plugin version bump; CHANGELOG untouched. Labelled `chore`.