### PR TITLE
Add Convention parity constraint (deterministic PR gate)

### DIFF
--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -216,3 +216,10 @@ alwaysApply: true
 - **Enforcement**: deterministic
 - **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`
 - **Scope**: pr
+
+## Convention parity
+
+- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule.
+- **Enforcement**: deterministic
+- **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
+- **Scope**: pr

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,3 +162,7 @@ Every non-example, non-hook affordance declared in the `## Affordances` section 
 ### Permissions have declared affordances
 
 Every entry in the permissions allowlist should have a matching affordance in the `## Affordances` section. An ungoverned permission is paperwork debt, not a safety violation — flag it, do not block. Enforcement: deterministic (`bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`). Scope: pr.
+
+### Convention parity
+
+Every active constraint heading in HARNESS.md's Constraints section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Enforcement: deterministic (`python3 scripts/check-convention-parity.py`, CI `.github/workflows/convention-parity-check.yml`). Scope: pr.

--- a/.github/workflows/convention-parity-check.yml
+++ b/.github/workflows/convention-parity-check.yml
@@ -1,0 +1,47 @@
+# Convention-parity check for pull requests.
+#
+# The Cursor / Copilot / Windsurf convention files are generated from
+# HARNESS.md by /convention-sync. They can silently fall behind by whole
+# constraints (content drift, not just a stale mtime) — the weekly
+# "Convention file sync" GC rule only runs on cadence, so drift can
+# accumulate across many PRs unnoticed. This deterministic PR-time gate
+# fails when any active HARNESS.md constraint is missing from a convention
+# file. Surfaced by the 2026-06-23 audit (REFLECTION_LOG signal=failure),
+# which found two constraints missing from the convention files since
+# 2026-06-01.
+#
+# It is a whole-repo invariant (checked on HEAD, not a diff) because a
+# constraint can be added to HARNESS.md in one PR while the convention
+# files are updated — or forgotten — in another.
+
+name: Convention Parity Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "HARNESS.md"
+      - ".cursor/rules/constraints.mdc"
+      - ".github/copilot-instructions.md"
+      - ".windsurf/rules/constraints.md"
+      - "scripts/check-convention-parity.py"
+      - ".github/workflows/convention-parity-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check convention files mirror HARNESS.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify convention files mirror HARNESS.md constraints
+        run: python3 scripts/check-convention-parity.py

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -210,3 +210,10 @@
 - **Enforcement**: deterministic
 - **Tool**: `bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory`
 - **Scope**: pr
+
+## Convention parity
+
+- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints` section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule.
+- **Enforcement**: deterministic
+- **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
+- **Scope**: pr

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -476,6 +476,22 @@
 - **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory
 - **Scope**: pr
 
+### Convention parity
+
+- **Rule**: Every active constraint heading in HARNESS.md's `## Constraints`
+  section must appear verbatim in all three generated convention files
+  (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`,
+  `.windsurf/rules/constraints.md`). Those files are generated from HARNESS.md
+  by `/convention-sync` and can drift by whole constraints — content drift, not
+  just a stale mtime — without any single PR touching them. This PR-time gate
+  complements the weekly "Convention file sync" GC rule, which only runs on
+  cadence. Surfaced by the 2026-06-23 audit, which found two constraints
+  missing from the convention files since 2026-06-01 (`/reflect` signal=failure).
+- **Enforcement**: deterministic
+- **Tool**: `python3 scripts/check-convention-parity.py`
+  (CI: `.github/workflows/convention-parity-check.yml`)
+- **Scope**: pr
+
 <!-- Uncomment if using spec-first development:
 
 ### Spec conformance
@@ -1017,6 +1033,6 @@ Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
 <!-- Auto-updated by /harness-audit — do not edit manually -->
 
 Last audit: 2026-06-23
-Constraints enforced: 29/30
+Constraints enforced: 30/31
 Garbage collection active: 19/19
-Drift detected: no (independently recounted: 30 active constraints — 20 deterministic + 9 agent + 1 unverified; only "Tests must pass" is unverified, by design (no suite). All referenced CI workflows and scripts exist on HEAD. Affordance↔permission constraints active: gh-cli affordance + committed Bash(gh *) grant in .claude/settings.json; harness-affordance-check.sh passes both --direction=blocking and --direction=advisory. "Layer 0 bash tests run on macOS and Linux" is deterministic — tdad-tests-fast.yml carries a layer0-macos job on macos-latest plus the ubuntu-latest fast-suite. Convention files (.cursor/rules, .github/copilot-instructions.md, .windsurf/rules) + ONBOARDING.md synced 2026-06-23, all mirror the 30 constraints incl. the activated affordance + promoted layer0 constraints. Template currency in sync at 0.64.0; latest snapshot 2026-06-23 (current). Reflection log: 52 active fragments, 0 archived, 0 entries older than 180 days (no curation debt); Path 1 (deterministic auto-archive) and Path 2 (agent aged-out review) GC rules declared and operating — Path 1 correctly held 2 Promoted entries whose RHS did not verify. Affordance GC rules remain commented-out by design.)
+Drift detected: no (31 active constraints — 21 deterministic + 9 agent + 1 unverified; only "Tests must pass" is unverified, by design (no suite). New "Convention parity" deterministic constraint (scripts/check-convention-parity.py + convention-parity-check.yml) gates that every active HARNESS.md constraint appears in all three convention files — passing at 31/31. All referenced CI workflows and scripts exist on HEAD. Affordance↔permission constraints active: gh-cli affordance + committed Bash(gh *) grant in .claude/settings.json; harness-affordance-check.sh passes both --direction=blocking and --direction=advisory. "Layer 0 bash tests run on macOS and Linux" is deterministic — tdad-tests-fast.yml carries a layer0-macos job on macos-latest plus the ubuntu-latest fast-suite. Convention files (.cursor/rules, .github/copilot-instructions.md, .windsurf/rules) + ONBOARDING.md synced 2026-06-23, all mirror the 30 constraints incl. the activated affordance + promoted layer0 constraints. Template currency in sync at 0.64.0; latest snapshot 2026-06-23 (current). Reflection log: 52 active fragments, 0 archived, 0 entries older than 180 days (no curation debt); Path 1 (deterministic auto-archive) and Path 2 (agent aged-out review) GC rules declared and operating — Path 1 correctly held 2 Promoted entries whose RHS did not verify. Affordance GC rules remain commented-out by design.)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
-[![Harness](https://img.shields.io/badge/Harness-29%2F30_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-30%2F31_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)

--- a/scripts/check-convention-parity.py
+++ b/scripts/check-convention-parity.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Convention-parity check — fail when a convention file is missing a constraint.
+
+The Cursor / Copilot / Windsurf convention files are generated from
+HARNESS.md by /convention-sync. They can silently fall behind by whole
+constraints (content drift, not just a stale mtime) — the weekly
+"Convention file sync" GC rule only runs on cadence, so drift can
+accumulate across many PRs unnoticed. This deterministic PR-time gate
+catches it the moment it happens: every *active* constraint heading in
+HARNESS.md must appear in all three convention constraint files.
+
+"Active" excludes the HTML-commented `<!-- Uncomment ... -->` template
+blocks in the Constraints section (those are not in force). Matching is a
+case-sensitive substring test of the constraint heading against the file
+body — the same notion of "appears" the project's audit uses.
+
+Exit 0 when every active constraint is present in every file; exit 1 with
+a per-file list of the missing headings otherwise. Pure standard library,
+no shell-tool calls — immune to the BSD/GNU coreutils divergence that
+motivated the sibling "Layer 0 bash tests run on macOS and Linux"
+constraint.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CONVENTION_FILES = [
+    ".cursor/rules/constraints.mdc",
+    ".github/copilot-instructions.md",
+    ".windsurf/rules/constraints.md",
+]
+
+
+def active_constraint_headings(harness_text: str) -> list[str]:
+    """Return the `### ` headings inside ## Constraints, excluding commented blocks."""
+    start = harness_text.index("\n## Constraints")
+    end = harness_text.index("\n## Garbage Collection", start)
+    section = harness_text[start:end]
+    # Strip HTML comment blocks so commented-out example constraints
+    # (Spec conformance, governance template, the affordance examples)
+    # are not counted as active.
+    section = re.sub(r"<!--.*?-->", "", section, flags=re.DOTALL)
+    return re.findall(r"^### (.+)$", section, flags=re.M)
+
+
+def main() -> int:
+    harness = (REPO_ROOT / "HARNESS.md").read_text(encoding="utf-8")
+    headings = active_constraint_headings(harness)
+    if not headings:
+        print("FAIL: no active constraints parsed from HARNESS.md", file=sys.stderr)
+        return 1
+
+    missing_any = False
+    for rel in CONVENTION_FILES:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            print(f"FAIL: convention file missing: {rel}", file=sys.stderr)
+            missing_any = True
+            continue
+        body = path.read_text(encoding="utf-8")
+        missing = [h for h in headings if h not in body]
+        if missing:
+            missing_any = True
+            print(f"FAIL: {rel} is missing {len(missing)} constraint(s):", file=sys.stderr)
+            for h in missing:
+                print(f"  - {h}", file=sys.stderr)
+
+    if missing_any:
+        print(
+            "\nRun /convention-sync (or add the missing headings by hand) so the "
+            "convention files mirror HARNESS.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: all {len(headings)} active constraints present in all "
+          f"{len(CONVENTION_FILES)} convention files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the constraint accepted during `/reflect` (signal=failure): the convention files had drifted from HARNESS.md by **two whole constraints** since 2026-06-01, and nothing caught it at PR time — only a manual audit did. This adds a deterministic PR-time gate so content drift fails fast, complementing the weekly (cadence-only) "Convention file sync" GC rule.

## What's added

- **`scripts/check-convention-parity.py`** — every active HARNESS.md constraint heading must appear in all three convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). Pure standard library — deliberately no `grep`/`sed`/`awk`, so it is immune to the BSD/GNU divergence that motivated the sibling "Layer 0 bash tests" constraint. Exits 1 with a per-file list of missing headings.
- **`.github/workflows/convention-parity-check.yml`** — runs the check on PRs touching HARNESS.md, any convention file, the script, or the workflow. Whole-repo invariant (checked on HEAD), since a constraint can be added in one PR and the convention files updated in another.
- **Constraint declared in HARNESS.md** and propagated to all three convention files (the gate requires the new constraint itself to be present — verified the check passes at 31/31).

## Counts

Active constraints **30 → 31**; enforced **29/30 → 30/31** (the new constraint is deterministic and passing). Status block + README badge updated.

## Why this catches what the GC rule didn't

The existing "Convention file sync" GC rule is weekly and agent-enforced with no auto-fix — it only surfaces drift if someone runs `/harness-gc`. This gate runs on every relevant PR and blocks merge, so drift cannot accumulate silently across PRs.

## Verification

- `python3 scripts/check-convention-parity.py` → `OK: all 31 active constraints present in all 3 convention files.` (exit 0). Self-tested that it detects a missing heading.
- Workflow YAML valid; markdownlint clean. The new `Convention Parity Check` runs on this PR itself.

## Scope / classification

New script lives at repo-root `scripts/` (outside `ai-literacy-superpowers/`), so no plugin version bump; CHANGELOG untouched. Labelled `chore`: this is harness-governance infrastructure closing a reflection-surfaced gap via the standard constraint-authoring path, not a plugin feature.