### PR TITLE
Enable and tune the cognitive-reservoir watch

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,17 @@
     "allow": [
       "Bash(gh *)"
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/ai-literacy-superpowers/hooks/scripts/reservoir-check.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -992,12 +992,11 @@ honour the values declared here when reading.
 
 ---
 
-<!-- ## Cognitive reservoir  (OPTIONAL — to opt in, remove this `<!--` line and the closing `-->` below)
+## Cognitive reservoir
 
-Advisory watch on the human verifier the harness cannot verify. Opt in
-by uncommenting this block so the `## Cognitive reservoir` heading
-becomes active — the reservoir-check Stop hook and the /reservoir agent
-only run when the heading is uncommented.
+Advisory watch on the human verifier the harness cannot verify — **active**.
+The reservoir-check Stop hook and the `/reservoir` agent read the
+thresholds declared below.
 
 NOT a Constraint. This is advisory-only: it never gates CI, never blocks
 a commit/merge/session, and never records a claim about your cognitive
@@ -1012,19 +1011,26 @@ in `skills/cognitive-reservoir/SKILL.md`.
 
 Thresholds are disjunctive — any one crossing fires a single session-end
 advisory. Tune to taste; a cluster of advisories you routinely ignore is
-a signal to raise a threshold, not to distrust the honesty rule.
+a signal to raise a threshold, not to distrust the honesty rule. Keep
+each value on its own clean `key: value` line — the Stop hook's parser
+reads everything after the colon, so a trailing inline `# comment` would
+corrupt the value (and silently degrade a tuned number back to default).
 
-- window_hours: 8       # how far back the proxies look
-- span_minutes: 180     # continuous session span (min) before the span proxy fires
-- decision_volume: 8    # approval-like events (commits/merges) in the window
-- context_switches: 4   # distinct work streams touched in the window
-- chronotype:           # optional: early | late | intermediate. Only when
-                        #   declared is the late-hour circadian band labelled
-                        #   (optimal / dip / suboptimal); otherwise the hour is
-                        #   reported as asked/unverified.
+- window_hours: 8
+- span_minutes: 180
+- decision_volume: 8
+- context_switches: 4
+- chronotype: intermediate
+
+Field notes (kept out of the value lines on purpose): `window_hours` is
+how far back the proxies look; `span_minutes` is continuous session span
+before the span proxy fires; `decision_volume` is approval-like events
+(commits/merges) in the window; `context_switches` is distinct work
+streams touched; `chronotype` (`early` | `late` | `intermediate`) labels
+the late-hour circadian band (optimal / dip / suboptimal) — without it
+the hour stays asked/unverified.
 
 Run /reservoir for an on-demand read, or /reservoir tune to edit this block.
--->
 
 ---
 


### PR DESCRIPTION
Activates the advisory human-verifier watch (the "depletable-capacity" nudge) — previously added commented-out in #460 — and tunes it per the maintainer's choices.

## What changed

- **HARNESS.md**: uncommented the `## Cognitive reservoir` block so the heading is active (the Stop hook and `/reservoir` agent self-gate on it).
- **Tuning**: `chronotype: intermediate`; thresholds kept at defaults (`window_hours 8` / `span_minutes 180` / `decision_volume 8` / `context_switches 4`).
- **`.claude/settings.json`**: wired the reservoir-check **Stop hook** (committed) for an automatic session-end advisory.

## Parser fix worth flagging

The hook's `read_key` (in `reservoir-check.sh`) strips whitespace but **not** trailing `# comments` — so the template's `decision_volume: 8  # ...` format only "works" because a polluted value fails the numeric guard and degrades to the *same* default. Any **tuned** non-default value would be silently dropped, and `chronotype: ...  # ...` would parse as a corrupted string. So this block uses **clean `key: value` lines** with the field notes moved to a separate paragraph. (Potential upstream template improvement — noted for a future reflection.)

## Verified live

Ran the Stop hook against the repo with the active heading:
- Self-gate passes; parser reads `chronotype=intermediate` and thresholds `8/180/8/4` correctly.
- It fired a single advisory on this session — **span 310 min, decision volume 15, context switches 50** (all past threshold), exit 0. Exactly the nudge it's designed to give.

## Not a constraint

Advisory-only: never gates CI, never blocks a commit/merge/session, persists no record of cognitive state. Not added to the Constraints section, so no convention-parity / Status / badge impact.

## Scope

HARNESS.md + `.claude/settings.json` — repo root, outside `ai-literacy-superpowers/`. No plugin version bump. Labelled `chore`.