### PR TITLE
Docs: complete the affordance lifecycle loop

### DIFF
--- a/docs/plugins/ai-literacy-superpowers/explanation/garbage-collection.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/garbage-collection.md
@@ -119,6 +119,44 @@ This is a learning-driven GC rule. Most GC rules scan code for entropy. This rul
 
 ---
 
+## Affordance GC Rules
+
+The harness template also ships three GC rules that fight entropy in the affordance inventory — the `## Affordances` section of `HARNESS.md` that declares each tool the agent can invoke, its identity, and its audit trail (see [Harness Affordances](harness-affordances.md) for the concept). Unlike the built-ins above, these three rules ship **commented out** in the template's Garbage Collection section: they are opt-in, activated by uncommenting the block once a project has a populated affordances inventory. Each is report-only — the fix is always a human action, never an auto-fix.
+
+Two of the three rely on **local, per-machine** observability data (`observability/affordance-invocations.json`, written by a `PostToolUse` recorder hook). That file is gitignored, so those two rules describe what each developer can run on their own machine via `/harness-gc`; they are **not** CI gates. The first rule is deterministic against committed content and runs anywhere.
+
+### Affordance review staleness
+
+- **What it checks**: Whether any affordance in the `## Affordances` section has a `Last reviewed` date older than the configured threshold, or no valid date at all.
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: `harness-affordance-staleness.sh`
+- **Auto-fix**: false
+
+Governance judgments rot. A credential rotates, an audit endpoint is decommissioned, a permission pattern is removed — and the affordance entry keeps asserting the old answer until someone re-checks it. This rule flags entries whose `Last reviewed` date has aged past the threshold (default 180 days / ~6 months, tunable via the `affordance-review-threshold-days` marker in the `## Affordances` section header). Because `Last reviewed` is bumped **only** by `/harness-affordance review` after all three of its re-validation checks pass — not by editing other fields and not by a `git` mtime — the date is a trustworthy attestation, and this rule stays meaningful. The fix it reports is a human running `/harness-affordance review <name>`. This rule reads committed content, so it works the same on any machine and in CI.
+
+### Affordance recorder freshness (LOCAL — per-machine only)
+
+- **What it checks**: Whether the gitignored `observability/affordance-invocations.json` exists and its newest invocation is within the threshold (default 7 days) — a proxy for whether the `PostToolUse` recorder hook is actually operating.
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: `harness-affordance-invocations.sh --check=freshness`
+- **Auto-fix**: false
+
+This is a meta-check on the recorder itself: if the invocation log has gone stale, the local observability the next rule depends on is no longer being collected. Because the invocation file is gitignored and machine-specific, this is **local observability** a developer runs via `/harness-gc` on their own machine, not a control enforced in CI.
+
+### Affordance dead inventory (LOCAL — per-machine only)
+
+- **What it checks**: Each declared, non-example, non-hook affordance that has had no observed invocation in the last 30 days, according to the local recorder. Bash program matching is coarse and deliberately conservative.
+- **Frequency**: weekly
+- **Enforcement**: deterministic
+- **Tool**: `harness-affordance-invocations.sh --check=dead-inventory`
+- **Auto-fix**: false
+
+An affordance the agent never actually invokes is a candidate for retirement: a grant and a governance burden carried for a tool no longer in use. This rule surfaces those candidates so a human can decide whether to keep, narrow, or remove the entry and its permission. Like recorder freshness, it reads gitignored per-machine data, so it is **local observability** rather than a CI gate.
+
+---
+
 ## Cadence Matching
 
 Different types of entropy operate at different speeds. Matching inspection frequency to entropy rate is a design decision that affects both signal quality and noise levels.

--- a/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/harness-affordances.md
@@ -105,6 +105,8 @@ scattered config.
 
 - [Discover affordances](../how-to/discover-affordances.md) — produce a
   draft inventory and promote entries with `add`.
+- [Maintain your affordance inventory](../how-to/maintain-affordance-inventory.md)
+  — the complete loop: add, review, respond to staleness, retire.
 - [Affordance schema](../reference/affordance-schema.md) — field-by-field
   reference.
 - [Harness Affordances — Design Spec](../../../superpowers/specs/2026-04-26-harness-affordances-design.md)

--- a/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/discover-affordances.md
@@ -160,10 +160,15 @@ changed.
   spurious warning when you promote it.
 - The scanner does not infer `Identity`, `Audit trail`, or `Last
   reviewed` — these are governance judgments that humans must make.
-- The `review` subcommand (re-validation + the staleness GC rule) lands
-  in a later sequencing step of the affordances design.
+- Discovery is only the first stage. Once entries are in `HARNESS.md`
+  they need promoting, re-validating, and eventually retiring — see
+  [Maintain Your Affordance Inventory](maintain-affordance-inventory.md)
+  for the complete loop, including the `review` subcommand and the
+  affordance GC rules.
 
 ## Related
 
+- [Maintain Your Affordance Inventory](maintain-affordance-inventory.md) — the full lifecycle after discovery.
+- [Affordance schema reference](../reference/affordance-schema.md) — field-by-field definitions.
 - [Harness Affordances — Design Spec](../../../superpowers/specs/2026-04-26-harness-affordances-design.md)
 - [`/harness-affordance discover` — Implementation Spec](../../../superpowers/specs/2026-04-27-harness-affordance-discover.md)

--- a/docs/plugins/ai-literacy-superpowers/how-to/maintain-affordance-inventory.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/maintain-affordance-inventory.md
@@ -1,0 +1,179 @@
+---
+title: Maintain Your Affordance Inventory
+---
+# Maintain Your Affordance Inventory
+
+Declaring an affordance is not a one-off act. A tool grant is a governance
+claim — *this tool runs under that identity, and a record of what it did
+lives there* — and claims rot. Credentials rotate, audit endpoints are
+decommissioned, permissions are removed, and tools fall out of use. This
+guide walks the **complete loop** an affordance travels through, from first
+discovery to eventual retirement, and the commands and checks that move it
+between stages.
+
+If you only want to produce a first draft inventory, see
+[Discover Affordances](discover-affordances.md). If you want the concept and
+the *why*, see [Harness Affordances](../explanation/harness-affordances.md).
+This page is about what happens **after** an entry is in `HARNESS.md`.
+
+## When to use this
+
+- **You have run `discover` and now need to promote drafts** into the
+  `## Affordances` section as governed entries.
+- **An affordance has aged** and the `Affordance review staleness` check is
+  flagging it.
+- **You are wiring the affordance constraints into CI** and want to
+  understand what they will and will not block.
+- **You suspect a declared tool is no longer used** and want to retire it
+  cleanly rather than carry an ungoverned grant.
+
+## The loop at a glance
+
+| Stage | What moves it | Where it lives |
+| --- | --- | --- |
+| 1. Discover | `/harness-affordance discover` | draft scratch file |
+| 2. Add | `/harness-affordance add <name>` | `## Affordances` in `HARNESS.md` |
+| 3. Live | the two affordance constraints | every PR |
+| 4. Re-validate | `/harness-affordance review <name>` | `Last reviewed` date |
+| 5. Staleness | `Affordance review staleness` GC rule | weekly sweep |
+| 6. Retire | `Affordance dead inventory` GC rule + a human | removed entry + permission |
+
+The loop is not a straight line: stages 3–5 cycle for as long as the tool is
+in use. An affordance leaves the loop only when a human retires it at stage 6.
+
+## 1. Discover the tools already in play
+
+Run the scanner to turn your existing config into a draft inventory:
+
+```text
+/harness-affordance discover
+```
+
+It reads `.claude/settings.json`, `.claude/settings.local.json`, and
+`.mcp.json` and writes one draft entry per permission, hook, and MCP server
+to a gitignored scratch file. It fills the machine-derivable fields and
+leaves the governance fields as `TODO`. This is the backfill path — run it
+once on an existing project and you have a starting point for every grant.
+Full walkthrough: [Discover Affordances](discover-affordances.md).
+
+## 2. Add an affordance with its governance fields
+
+Promote a draft (or declare a brand-new tool) into `HARNESS.md`:
+
+```text
+/harness-affordance add <name>
+```
+
+`add` seeds from the matching discovery draft, then prompts only for the
+fields a human must decide:
+
+- **Identity** — whose credentials authorise the action: one of `user-sso`,
+  `service-account`, `current-user`, `runtime-resolved`, or `none`. This is
+  the load-bearing field; for `runtime-resolved`, record the resolution
+  chain in Notes.
+- **Audit trail** — where a record of the action would be found. `none` is a
+  valid and useful answer: it tells reviewers exactly where the gap is.
+- **Constraint references** and **Notes** — optional.
+
+It sets `Last reviewed` to today (an `add` *is* a genuine first review), and
+**warns without blocking** if the permission pattern is not present in any
+readable settings allowlist — a tool you have declared but not yet granted.
+Idempotency keys on the permission pattern, so re-running `add` for the same
+pattern edits the entry in place rather than duplicating it. The field
+definitions live in the
+[affordance schema reference](../reference/affordance-schema.md).
+
+## 3. Live: the two constraints gate every PR
+
+Once the `## Affordances` section is populated and the constraints are
+uncommented, two deterministic checks run on every pull request:
+
+- **Affordances have matching permissions** (*blocking*) — every
+  non-example, non-hook affordance must have a `Permission` pattern that
+  appears verbatim in a settings allowlist. An affordance with no matching
+  grant is a declared-but-unusable tool — the PR fails.
+- **Permissions have declared affordances** (*advisory*) — every allowlist
+  entry should have a matching affordance. An ungoverned permission is
+  paperwork debt, not a safety hole, so this one flags without blocking.
+
+Both self-gate to `unverified` (a passing no-op) until the project has at
+least one real, non-example affordance and a readable allowlist, so they are
+safe to enable early. The matching rule is string equality on the permission
+pattern — see the
+[matching algorithm](../reference/affordance-schema.md#matching-algorithm).
+
+## 4. Re-validate with `review`
+
+A governance claim is only as trustworthy as its last check. Re-validate an
+entry with:
+
+```text
+/harness-affordance review <name>
+```
+
+`review` walks the **three checks** — Identity, Audit trail, and Permission
+— each with an explicit `yes / no / needs-edit` prompt; there is no implicit
+"looks fine" pass. The disposition is deliberate:
+
+- **All three `yes`** → `Last reviewed` is bumped to today, and any stale
+  `[review-gap: <check>]` Notes lines are cleared.
+- **A `needs-edit`** → you dictate the new value; an edit alone does **not**
+  bump the date — a bump requires re-answering all three checks `yes`.
+- **An unresolved `no`** → the date is left unchanged and a single
+  `[review-gap: <check>]` Notes line records the gap, so the staleness rule
+  keeps firing until it is genuinely resolved.
+
+Because the date is bumped *only* by a passing `review` — never by editing
+another field, never by a `git` mtime — `Last reviewed` is a real
+attestation rather than a timestamp.
+
+## 5. Respond to staleness
+
+The `Affordance review staleness` GC rule sweeps weekly and flags any entry
+whose `Last reviewed` has aged past the threshold (default 180 days, tunable
+via the `affordance-review-threshold-days` marker in the `## Affordances`
+header) or has no valid date. It reads committed content, so it runs the same
+on any machine and in CI. It is report-only — the fix it reports is running
+`review` on the named entry, which loops you back to stage 4. See the
+[Garbage Collection](../explanation/garbage-collection.md#affordance-gc-rules)
+explanation for how these rules fit the wider entropy-fighting model.
+
+## 6. Retire dead affordances
+
+Two **local, per-machine** GC rules watch for tools that have fallen out of
+use, reading the gitignored `observability/affordance-invocations.json`
+written by a `PostToolUse` recorder hook:
+
+- **Affordance recorder freshness** — a meta-check that the recorder is still
+  running, so the next rule's data can be trusted.
+- **Affordance dead inventory** — surfaces each declared affordance with no
+  observed invocation in the last 30 days.
+
+A dead affordance is a grant and a governance burden carried for nothing. When
+one is surfaced, decide deliberately: keep it (the recorder may simply have
+missed it — matching is conservative), narrow it, or remove the entry **and**
+its permission together. Removing the entry without removing the permission
+re-creates the advisory finding from stage 3; removing the permission without
+the entry re-creates the blocking one. Retire both, and the affordance leaves
+the loop.
+
+## The loop, restated
+
+`discover` produces candidates; `add` turns a candidate into a governed
+claim; the constraints keep the claim honest on every PR; `review` refreshes
+the claim before it goes stale; the staleness rule makes sure `review`
+actually happens; and the dead-inventory rule asks, periodically, whether the
+claim is still worth carrying at all. Nothing in the loop writes a governance
+judgment for you — every stage either transcribes a decision you made or
+surfaces a question for you to answer.
+
+## Related
+
+- [Discover Affordances](discover-affordances.md) — produce the first draft.
+- [Harness Affordances](../explanation/harness-affordances.md) — the concept
+  and the contractor scenario.
+- [Affordance schema reference](../reference/affordance-schema.md) — every
+  field, value by value.
+- [Garbage Collection](../explanation/garbage-collection.md#affordance-gc-rules)
+  — the affordance GC rules in context.
+- The command itself: `ai-literacy-superpowers/commands/harness-affordance.md`.

--- a/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/affordance-schema.md
@@ -107,6 +107,13 @@ in the `## Affordances` section header) or has no valid date. Hook entries
 are included (their Identity/Audit trail can go stale too); example entries
 are skipped. The rule is report-only — the fix is running `review`.
 
+### `Constraint references`
+
+*Optional.* The constraint heading(s) that depend on this affordance — for
+example a chained constraint that consumes the grant. Human-owned and
+free-form: `add` and `review` only transcribe what you dictate, never infer
+it. Omit the field entirely when no constraint references the entry.
+
 ## Matching algorithm
 
 When a chained constraint compares affordances against permissions,

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -137,15 +137,19 @@ does not re-prompt until the next plugin update.
 
 - **Skills read**: none
 - **Agents dispatched**: none
-- **Subcommands**: `discover` (implemented), `add` and `review`
-  (planned)
+- **Subcommands**: `discover`, `add <name>`, `review <name>` (all
+  implemented)
 
 Manage the project's affordance inventory — the declared tools the
 agent can invoke, with the identity each tool runs under, the audit
 trail each tool produces, and the permission allowlist that
 authorises it. See the
 [harness-affordances design spec](../../../superpowers/specs/2026-04-26-harness-affordances-design.md)
-for the full schema.
+for the full schema, the
+[affordance schema reference](affordance-schema.md) for the
+field-by-field definitions, and
+[Maintain Your Affordance Inventory](../how-to/maintain-affordance-inventory.md)
+for the end-to-end lifecycle.
 
 `/harness-affordance discover` reads `.claude/settings.json`,
 `.claude/settings.local.json`, and `.mcp.json`, and writes a draft
@@ -160,14 +164,39 @@ existing permission. See
 [Discover Affordances](../how-to/discover-affordances.md) for the
 full how-to.
 
-`/harness-affordance add <name>` (planned, sequencing step 3 of the
-affordances design) will guide annotation of a draft entry —
-prompts for Identity, Audit trail, optional Notes, then appends the
-completed entry to `HARNESS.md`.
+`/harness-affordance add <name>` promotes one draft entry into the
+`## Affordances` section of `HARNESS.md`. Use it after `discover` (or
+when declaring a new tool by hand). It seeds from the newest discovery
+draft when one matches the permission, then prompts only for the
+governance fields the human must decide — `Identity` (one of
+`user-sso`, `service-account`, `current-user`, `runtime-resolved`,
+`none`), `Audit trail` (where a record of the action would be found;
+`none` is a valid, useful answer), and optional `Constraint references`
+and `Notes`. It sets `Last reviewed` to today (an `add` is a genuine
+first review), validates the required fields and the `Mode`/`Trigger`
+pairing, and **warns without blocking** if the permission pattern is
+absent from every readable settings allowlist. Idempotency keys on the
+**permission pattern**, not the heading: re-running `add` for the same
+pattern edits the existing entry in place rather than appending a
+duplicate, even under a different name. The command only transcribes
+the human's answers, so `HARNESS.md` stays human-authored in spirit.
 
-`/harness-affordance review <name>` (planned, sequencing step 6)
-will walk through the three re-validation checks (Identity, Audit
-trail, Permission) and bump `Last reviewed` if all pass.
+`/harness-affordance review <name>` re-validates one existing
+affordance and bumps its `Last reviewed` date to today **only if all
+three checks pass** — so the date attests to a real human
+re-validation, not a file mtime. It walks the three checks, each with
+an explicit `yes / no / needs-edit` prompt: **Identity** (the named
+credential still exists and belongs to the named principal; for
+`runtime-resolved`, the resolution chain in `Notes` still holds),
+**Audit trail** (the endpoint still exists with the stated retention
+and access scope), and **Permission** (the pattern is still present in
+a settings allowlist). If all three pass, the date bumps and any
+`[review-gap: …]` Notes lines are cleared. A `needs-edit` opens the
+field for an inline edit but does **not** bump the date on its own — a
+bump after any edit requires re-answering all three checks. An
+unresolved `no` leaves the date unchanged and records a single
+`[review-gap: <check>]` Notes line for the failing check. Use `review`
+to clear what the **Affordance review staleness** GC rule reports.
 
 ---
 


### PR DESCRIPTION
Closes #472. Fills the affordance documentation gaps surfaced by the docs audit — so the site now explains the **complete loop**: how the feature works *and* how an affordance evolves over time.

## Changes

| File | Change |
| --- | --- |
| `reference/commands.md` | **Fix factual bug** — `/harness-affordance add` and `review` were mislabelled "(planned)"; both are implemented. Now documented accurately. |
| `explanation/garbage-collection.md` | Add the **three affordance GC rules** (review staleness; recorder freshness LOCAL; dead inventory LOCAL) — what each checks, the LOCAL/per-machine distinction, and that they ship commented-out/opt-in. |
| `how-to/maintain-affordance-inventory.md` | **NEW — the centrepiece.** Walks the full lifecycle: discover → add → live (the two constraints gate PRs) → review (the three checks) → respond to staleness → retire dead inventory. "The loop at a glance" table + per-stage steps. |
| `reference/affordance-schema.md` | Document the optional `Constraint references` field. (The `review` three-check + `[review-gap]` syntax were already covered under `Last reviewed`.) |
| `how-to/discover-affordances.md` | Fix the stale "`review` lands in a later step" claim; cross-link to the new loop page. |
| `explanation/harness-affordances.md` | Cross-link to the new loop page so the lifecycle is discoverable from the concept page. |

## Coverage now

All 8 loop stages are documented and cross-linked: concept ✅, discover ✅, **add ✅**, **review ✅**, enforcement ✅, **GC rules ✅**, schema ✅, **lifecycle narrative ✅** (the new how-to).

## Verification

- `mkdocs build --strict` passes locally — **0 warnings** (all links/anchors resolve; the new page is picked up by the awesome-pages nav). Ran in a clean venv against `requirements.txt`.
- `markdownlint-cli2` clean on all six files.
- No "(planned)" labels remain for `add`/`review`.

## Scope

Docs-only, under `docs/plugins/` (outside `ai-literacy-superpowers/`). No plugin version bump; CHANGELOG untouched. Labelled `chore`.