### PR TITLE
Fix gc-rotate strict-mode check false positives (#362)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.64.0",
+  "plugin_version": "0.64.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.64.0"
+      "version": "0.64.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.64.1 — 2026-07-03
+
+### Fix: gc-rotate strict-mode check false positives (#362)
+
+- **`hooks/scripts/gc-rotate.sh` rule 3 (shell strict mode)** now scans
+  the whole file for any start-of-line `set` that enables
+  errexit/nounset/pipefail, instead of matching the exact literal
+  `set -euo pipefail` in the first 15 lines only. The old check produced
+  false positives on two legitimate patterns: strict-mode lines that sit
+  below a documented header comment block (past line 15), and deliberate
+  fail-open subsets such as `set -uo pipefail` (hooks that must not abort
+  mid-run) and `set -u` (telemetry/CI scripts). The `[euo]` anchor still
+  rejects `set -- "$@"` and still flags scripts with no strict mode at
+  all. (Defect 1 from the issue — whole-tree `*.sh` scan — was already
+  fixed by the `git ls-files` scoping in `list_owned_shell_scripts`.)
+
 ## 0.64.0 — 2026-06-23
 
 ### Docs: curated agentic-engineering video library (#456)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.64.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.64.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
+++ b/ai-literacy-superpowers/hooks/scripts/gc-rotate.sh
@@ -101,14 +101,24 @@ case $rule_index in
     ;;
   3)
     # Shell scripts strict mode
+    #
+    # Detect any start-of-line `set` that enables errexit/nounset/pipefail,
+    # anywhere in the file. Scanning the whole file (not just head -15)
+    # sees `set` lines that sit below a documented header comment block,
+    # and matching the strict-mode family rather than the exact literal
+    # `set -euo pipefail` accepts deliberate fail-open subsets — e.g.
+    # `set -uo pipefail` (hooks that must not abort mid-run) and `set -u`
+    # (telemetry/CI scripts that must never fail the run). The `[euo]`
+    # anchor still rejects `set -- "$@"` (positional-params reset) and a
+    # script with no strict mode at all is still flagged.
     missing_files=""
     while IFS= read -r -d '' f; do
-      if ! head -15 "$f" | grep -q "set -euo pipefail"; then
+      if ! grep -qE '^[[:space:]]*set -[a-z]*[euo]' "$f"; then
         missing_files="${missing_files}\n- $f"
       fi
     done < <(list_owned_shell_scripts)
     if [ -n "$missing_files" ]; then
-      printf '{"systemMessage": "GC check (strict mode): missing set -euo pipefail in:%s"}' "$missing_files"
+      printf '{"systemMessage": "GC check (strict mode): missing strict mode (set -e/-u/-o pipefail) in:%s"}' "$missing_files"
     fi
     ;;
 esac


### PR DESCRIPTION
Fixes #362 (Defect 2). Requested by @russmiles in the issue thread.

## What

Rule 3 of `hooks/scripts/gc-rotate.sh` (the rotating Stop-hook GC check for shell strict mode) decided a script was missing strict mode with:

```sh
head -15 "$f" | grep -q "set -euo pipefail"
```

That produced false positives on scripts that **do** set strict mode, for two reasons:

1. **15-line window** — scripts opening with a documented header comment block have their `set` line below line 15, so it's never seen.
2. **Exact-literal match** — deliberate fail-open subsets never match: `set -uo pipefail` (hooks, which must not abort mid-run and block the session) and `set -u` (telemetry/CI scripts that must never fail the run).

In the reporter's repo this flagged 27 of 34 first-party scripts, all of which had strict mode present — a 100% false-positive rate on rotation days. Because the rule is advisory-only, the banner became pure noise, which erodes trust in the GC mechanism.

## Change

Scan the whole file for any start-of-line `set` that enables errexit/nounset/pipefail:

```sh
grep -qE '^[[:space:]]*set -[a-z]*[euo]' "$f"
```

This accepts the whole strict-mode family (`set -e`, `set -u`, `set -eu`, `set -uo pipefail`, `set -euo pipefail`, `set -o pipefail`, …) wherever it appears, while still firing on a script with no strict mode. The `[euo]` anchor does **not** mistake `set -- "$@"` (positional-params reset) for strict mode. The advisory message is updated to name the family rather than the single literal.

Verified against the family and against `set -- "$@"`, comments, and a bare script — 0 false positives, bare script still correctly flagged.

## Note on Defect 1

The issue also reported Defect 1 (whole-tree `*.sh` scan picking up `node_modules`, worktrees, and zsh snapshots). That is **already fixed** on `main` — `list_owned_shell_scripts` now scopes to `git ls-files`. This PR addresses only the remaining Defect 2.

## Versioning

Patch bump 0.64.0 → 0.64.1 (bug fix to plugin script). Updated plugin.json, README badge + table row, both marketplace.json version fields, and CHANGELOG. `fix/` branch prefix exempts the spec-first check.

> Note: if another plugin PR merges first and takes 0.64.1, this needs a trivial rebase to the next patch.