### PR TITLE
Resolve plugin-script references in cache installs via bin/ shims (#475)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.64.0",
+  "plugin_version": "0.65.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.64.0"
+      "version": "0.65.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.65.0 — 2026-07-04
+
+### Fix: GC-rule Tool paths resolve in cache installs via bin/ shims (#475)
+
+HARNESS.md GC-rule `Tool:` fields pointed at
+`ai-literacy-superpowers/scripts/<name>.sh`, a path that only exists when
+the plugin is vendored in-repo. In the default (non-vendored) install the
+plugin runs from the versioned marketplace cache, so those rules silently
+failed to resolve — most importantly the **active, deterministic**
+"Reflection log archival of promoted entries" rule, which shipped enabled
+with no caveat.
+
+The root cause: a GC-rule `Tool:` field is executed by the **harness-gc
+subagent**, and `${CLAUDE_PLUGIN_ROOT}` is only defined for hooks — it is
+UNSET in the subagent's Bash context (verified empirically on Claude Code
+2.1.200, in both `--plugin-dir` and real marketplace-cache installs). The
+one thing that IS on PATH in every context, including subagents, is the
+plugin's `bin/` directory.
+
+- **New `ai-literacy-superpowers/bin/` shims** — `archive-promoted-reflections`,
+  `harness-affordance-check`, `harness-affordance-staleness`, and
+  `harness-affordance-invocations`. Each resolves the plugin root from its
+  own location and `exec`s the corresponding `scripts/<name>.sh`,
+  preserving the caller's working directory.
+- **`templates/HARNESS.md`** — the reflection-archival and affordance
+  `Tool:` fields are now **bare commands** (e.g. `archive-promoted-reflections`)
+  that resolve via `bin/` on PATH regardless of vendored-vs-cache install
+  and survive plugin upgrades. Added a Garbage Collection section note
+  explaining the mechanism, and reworded the affordance caveat (no more
+  "adjust to your install location").
+- **`agents/harness-gc.agent.md`** — Path 1 now invokes the bare
+  `archive-promoted-reflections` command with an explanatory note.
+- The `sync-to-global-cache` hook example now shows `${CLAUDE_PLUGIN_ROOT}`
+  (hooks resolve it; GC-rule Tool fields do not).
+
 ## 0.64.0 — 2026-06-23
 
 ### Docs: curated agentic-engineering video library (#456)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,38 +2,51 @@
 
 ## 0.65.0 — 2026-07-04
 
-### Fix: GC-rule Tool paths resolve in cache installs via bin/ shims (#475)
+### Fix: plugin-script references resolve in cache installs via bin/ shims (#475)
 
-HARNESS.md GC-rule `Tool:` fields pointed at
-`ai-literacy-superpowers/scripts/<name>.sh`, a path that only exists when
-the plugin is vendored in-repo. In the default (non-vendored) install the
-plugin runs from the versioned marketplace cache, so those rules silently
-failed to resolve — most importantly the **active, deterministic**
-"Reflection log archival of promoted entries" rule, which shipped enabled
-with no caveat.
+Commands, agents, and GC-rule `Tool:` fields referenced plugin scripts by
+path — either `ai-literacy-superpowers/scripts/<name>.sh` (only valid when
+the plugin is vendored in-repo) or `${CLAUDE_PLUGIN_ROOT}/scripts/<name>.sh`.
+In the default (non-vendored) install the plugin runs from the versioned
+marketplace cache, and **`${CLAUDE_PLUGIN_ROOT}` is defined only for hooks**
+— it is UNSET in slash-command, main-agent, and subagent Bash contexts
+(verified empirically on Claude Code 2.1.200, in both `--plugin-dir` and
+real marketplace-cache installs). So every such reference silently failed
+to resolve outside a vendored checkout — most importantly the **active,
+deterministic** "Reflection log archival of promoted entries" GC rule,
+which ships enabled with no caveat.
 
-The root cause: a GC-rule `Tool:` field is executed by the **harness-gc
-subagent**, and `${CLAUDE_PLUGIN_ROOT}` is only defined for hooks — it is
-UNSET in the subagent's Bash context (verified empirically on Claude Code
-2.1.200, in both `--plugin-dir` and real marketplace-cache installs). The
-one thing that IS on PATH in every context, including subagents, is the
-plugin's `bin/` directory.
+The one thing that IS on PATH in every context, including the harness-gc
+subagent, is the plugin's `bin/` directory.
 
 - **New `ai-literacy-superpowers/bin/` shims** — `archive-promoted-reflections`,
-  `harness-affordance-check`, `harness-affordance-staleness`, and
-  `harness-affordance-invocations`. Each resolves the plugin root from its
-  own location and `exec`s the corresponding `scripts/<name>.sh`,
-  preserving the caller's working directory.
+  `harness-affordance-check`, `harness-affordance-staleness`,
+  `harness-affordance-invocations`, `harness-affordance-discover`,
+  `update-badge`, `update-health-badge`, and `regenerate-reflection-log`.
+  Each resolves the plugin root from its own location and `exec`s the
+  corresponding `scripts/<name>.sh`, preserving the caller's working
+  directory.
 - **`templates/HARNESS.md`** — the reflection-archival and affordance
   `Tool:` fields are now **bare commands** (e.g. `archive-promoted-reflections`)
   that resolve via `bin/` on PATH regardless of vendored-vs-cache install
   and survive plugin upgrades. Added a Garbage Collection section note
   explaining the mechanism, and reworded the affordance caveat (no more
-  "adjust to your install location").
-- **`agents/harness-gc.agent.md`** — Path 1 now invokes the bare
-  `archive-promoted-reflections` command with an explanatory note.
-- The `sync-to-global-cache` hook example now shows `${CLAUDE_PLUGIN_ROOT}`
-  (hooks resolve it; GC-rule Tool fields do not).
+  "adjust to your install location"). The `sync-to-global-cache` hook
+  example now shows `${CLAUDE_PLUGIN_ROOT}` (hooks resolve it; GC-rule
+  Tool fields do not).
+- **Commands / agents / skills** — badge, discovery, and reflection-log
+  regeneration instructions now invoke the bare `bin/` commands instead of
+  `${CLAUDE_PLUGIN_ROOT}` or vendored paths: `commands/harness-health.md`,
+  `commands/harness-init.md`, `commands/harness-affordance.md`,
+  `commands/reflect.md`, `agents/harness-gc.agent.md`,
+  `agents/harness-auditor.agent.md`, `agents/integration-agent.agent.md`,
+  and `skills/ai-literacy-assessment/SKILL.md`.
+
+Known remaining edge (not addressed here): the read-side-filtering
+instruction in `agents/harness-auditor.agent.md` sources the
+`reflection-log-helpers.sh` function library rather than executing a
+top-level script, so a `bin/` shim does not map to it cleanly — it needs
+its own treatment.
 
 ## 0.64.0 — 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ instruction in `agents/harness-auditor.agent.md` sources the
 `reflection-log-helpers.sh` function library rather than executing a
 top-level script, so a `bin/` shim does not map to it cleanly — it needs
 its own treatment.
+
 ## 0.64.1 — 2026-07-03
 
 ### Fix: gc-rotate strict-mode check false positives (#362)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.65.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.64.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.65.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/harness-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/harness-auditor.agent.md
@@ -82,8 +82,8 @@ matches what the project actually has.
 
 8. **Update README badge**: If a README.md exists and contains a
    harness badge, update the badge URL to reflect the current
-   enforcement ratio and colour. Use the script at
-   `${CLAUDE_PLUGIN_ROOT}/scripts/update-badge.sh` if available.
+   enforcement ratio and colour. Run the `update-badge` command
+   (a plugin `bin/` shim, on PATH) if available.
 
 9. **Report results**:
 

--- a/ai-literacy-superpowers/agents/harness-gc.agent.md
+++ b/ai-literacy-superpowers/agents/harness-gc.agent.md
@@ -151,13 +151,17 @@ flagging, not full analysis.
 
 ### Path 1 — Auto-archive of promoted entries (weekly, deterministic)
 
-When this rule fires, run:
+When this rule fires, run the bare command (do NOT prefix a path — it
+resolves via the plugin's `bin/` directory, which is on PATH even in
+this subagent context, where `${CLAUDE_PLUGIN_ROOT}` is not set):
 
 ```bash
-bash ai-literacy-superpowers/scripts/archive-promoted-reflections.sh
+archive-promoted-reflections
 ```
 
-The script identifies active fragments (`reflections/active/*.md`) with a
+The command dispatches to the plugin's
+`scripts/archive-promoted-reflections.sh`, which identifies active
+fragments (`reflections/active/*.md`) with a
 `Promoted` line, verifies the right-hand side resolves to actual
 AGENTS.md / HARNESS.md content (or is a closure form), moves verified
 fragments to `reflections/archive/<YYYY>.md`, deletes them, and

--- a/ai-literacy-superpowers/agents/integration-agent.agent.md
+++ b/ai-literacy-superpowers/agents/integration-agent.agent.md
@@ -157,7 +157,7 @@ Derive a kebab-case slug from the Task (≤6 words) and write the body to
 collisions). Regenerate the aggregate and commit both:
 
 ```bash
-bash ai-literacy-superpowers/scripts/regenerate-reflection-log.sh
+regenerate-reflection-log
 git add reflections/active/ REFLECTION_LOG.md
 git commit -m "Add reflection for: [task summary]"
 ```

--- a/ai-literacy-superpowers/bin/archive-promoted-reflections
+++ b/ai-literacy-superpowers/bin/archive-promoted-reflections
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/archive-promoted-reflections.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context, INCLUDING the harness-gc subagent that runs HARNESS.md
+# GC-rule "Tool:" fields — the one context where ${CLAUDE_PLUGIN_ROOT}
+# is NOT set (it is defined only for hooks). Pointing a Tool: field at
+# a bare command name therefore resolves via PATH regardless of whether
+# the plugin is vendored in-repo or installed in the versioned
+# marketplace cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/archive-promoted-reflections.sh" "$@"

--- a/ai-literacy-superpowers/bin/harness-affordance-check
+++ b/ai-literacy-superpowers/bin/harness-affordance-check
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/harness-affordance-check.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context, INCLUDING the harness-gc subagent that runs HARNESS.md
+# GC-rule "Tool:" fields — the one context where ${CLAUDE_PLUGIN_ROOT}
+# is NOT set (it is defined only for hooks). Pointing a Tool: field at
+# a bare command name therefore resolves via PATH regardless of whether
+# the plugin is vendored in-repo or installed in the versioned
+# marketplace cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/harness-affordance-check.sh" "$@"

--- a/ai-literacy-superpowers/bin/harness-affordance-discover
+++ b/ai-literacy-superpowers/bin/harness-affordance-discover
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/harness-affordance-discover.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context — hooks, slash commands, and subagents — but ${CLAUDE_PLUGIN_ROOT}
+# is defined ONLY for hooks. A command/agent instruction that runs this
+# script therefore cannot rely on ${CLAUDE_PLUGIN_ROOT} or on a vendored
+# path; a bare command name resolves via PATH regardless of whether the
+# plugin is vendored in-repo or installed in the versioned marketplace
+# cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/harness-affordance-discover.sh" "$@"

--- a/ai-literacy-superpowers/bin/harness-affordance-invocations
+++ b/ai-literacy-superpowers/bin/harness-affordance-invocations
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/harness-affordance-invocations.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context, INCLUDING the harness-gc subagent that runs HARNESS.md
+# GC-rule "Tool:" fields — the one context where ${CLAUDE_PLUGIN_ROOT}
+# is NOT set (it is defined only for hooks). Pointing a Tool: field at
+# a bare command name therefore resolves via PATH regardless of whether
+# the plugin is vendored in-repo or installed in the versioned
+# marketplace cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/harness-affordance-invocations.sh" "$@"

--- a/ai-literacy-superpowers/bin/harness-affordance-staleness
+++ b/ai-literacy-superpowers/bin/harness-affordance-staleness
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/harness-affordance-staleness.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context, INCLUDING the harness-gc subagent that runs HARNESS.md
+# GC-rule "Tool:" fields — the one context where ${CLAUDE_PLUGIN_ROOT}
+# is NOT set (it is defined only for hooks). Pointing a Tool: field at
+# a bare command name therefore resolves via PATH regardless of whether
+# the plugin is vendored in-repo or installed in the versioned
+# marketplace cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/harness-affordance-staleness.sh" "$@"

--- a/ai-literacy-superpowers/bin/regenerate-reflection-log
+++ b/ai-literacy-superpowers/bin/regenerate-reflection-log
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/regenerate-reflection-log.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context — hooks, slash commands, and subagents — but ${CLAUDE_PLUGIN_ROOT}
+# is defined ONLY for hooks. A command/agent instruction that runs this
+# script therefore cannot rely on ${CLAUDE_PLUGIN_ROOT} or on a vendored
+# path; a bare command name resolves via PATH regardless of whether the
+# plugin is vendored in-repo or installed in the versioned marketplace
+# cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/regenerate-reflection-log.sh" "$@"

--- a/ai-literacy-superpowers/bin/update-badge
+++ b/ai-literacy-superpowers/bin/update-badge
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/update-badge.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context — hooks, slash commands, and subagents — but ${CLAUDE_PLUGIN_ROOT}
+# is defined ONLY for hooks. A command/agent instruction that runs this
+# script therefore cannot rely on ${CLAUDE_PLUGIN_ROOT} or on a vendored
+# path; a bare command name resolves via PATH regardless of whether the
+# plugin is vendored in-repo or installed in the versioned marketplace
+# cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/update-badge.sh" "$@"

--- a/ai-literacy-superpowers/bin/update-health-badge
+++ b/ai-literacy-superpowers/bin/update-health-badge
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bin shim → scripts/update-health-badge.sh
+#
+# A plugin's bin/ directory is on PATH in every Claude Code execution
+# context — hooks, slash commands, and subagents — but ${CLAUDE_PLUGIN_ROOT}
+# is defined ONLY for hooks. A command/agent instruction that runs this
+# script therefore cannot rely on ${CLAUDE_PLUGIN_ROOT} or on a vendored
+# path; a bare command name resolves via PATH regardless of whether the
+# plugin is vendored in-repo or installed in the versioned marketplace
+# cache, and survives plugin upgrades. See issue #475.
+#
+# This shim resolves the plugin root from its own location and execs the
+# real implementation, preserving the caller's working directory (the
+# scripts expect to run from the consumer repo root).
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$here/../scripts/update-health-badge.sh" "$@"

--- a/ai-literacy-superpowers/commands/harness-affordance.md
+++ b/ai-literacy-superpowers/commands/harness-affordance.md
@@ -37,8 +37,8 @@ server.
    `.claude/settings.local.json`, or `.mcp.json`. If none exist,
    tell the user: "No project config found to scan — nothing to
    discover."
-2. **Invoke the scanner.** Run
-   `bash ${CLAUDE_PLUGIN_ROOT}/scripts/harness-affordance-discover.sh`
+2. **Invoke the scanner.** Run the bare command
+   `harness-affordance-discover` (a plugin `bin/` shim, on PATH)
    from the project root. The script is responsible for reading
    sources, deriving entries, and writing the output file.
 3. **Report.** Print to the user:

--- a/ai-literacy-superpowers/commands/harness-health.md
+++ b/ai-literacy-superpowers/commands/harness-health.md
@@ -129,7 +129,9 @@ Do not regenerate the snapshot. Fix the output directly.
 
 ### 8. Update README
 
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/update-health-badge.sh` to update:
+Run the `update-health-badge` command (a plugin `bin/` shim, on PATH; do
+not use a `${CLAUDE_PLUGIN_ROOT}` path — that variable is unset outside
+hooks) to update:
 
 - The health badge colour and text
 - The health icon link target (point to the new snapshot)

--- a/ai-literacy-superpowers/commands/harness-init.md
+++ b/ai-literacy-superpowers/commands/harness-init.md
@@ -277,8 +277,8 @@ first." Then skip to the next step.
 
 If HARNESS.md has content, proceed with badge generation as before:
 
-Add the harness badge to the project's README.md. Use the badge update
-script at `${CLAUDE_PLUGIN_ROOT}/scripts/update-badge.sh` or insert
+Add the harness badge to the project's README.md. Run the `update-badge`
+command (a plugin `bin/` shim, on PATH) or insert
 manually:
 
 ```text

--- a/ai-literacy-superpowers/commands/reflect.md
+++ b/ai-literacy-superpowers/commands/reflect.md
@@ -109,10 +109,11 @@ never edit it by hand.
    If a file with that name already exists (another reflection the same
    day), append a numeric suffix: `<date>-<slug>-2.md`, `-3.md`, etc.
 
-   Then regenerate the aggregate so readers see the new entry:
+   Then regenerate the aggregate so readers see the new entry (bare
+   command — a plugin `bin/` shim on PATH):
 
    ```bash
-   bash ai-literacy-superpowers/scripts/regenerate-reflection-log.sh
+   regenerate-reflection-log
    ```
 
    If that script is not present in the project, regenerate by hand:

--- a/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
+++ b/ai-literacy-superpowers/skills/ai-literacy-assessment/SKILL.md
@@ -208,7 +208,8 @@ Capture a reflection on the assessment itself:
 
 Write this as a per-entry fragment under `reflections/active/` (one
 file per reflection, body only, no leading `---`), then regenerate the
-aggregate with `scripts/regenerate-reflection-log.sh`. Never append to
+aggregate with the `regenerate-reflection-log` command (a plugin `bin/`
+shim on PATH). Never append to
 `REFLECTION_LOG.md` directly — it is a generated view.
 
 ### Phase 7: README Badge

--- a/ai-literacy-superpowers/templates/HARNESS.md
+++ b/ai-literacy-superpowers/templates/HARNESS.md
@@ -112,9 +112,11 @@
      least one real (non-example) affordance AND a readable project
      permissions allowlist, so it is safe to leave active. Matching is
      string equality on the permission pattern; hook-mode affordances are
-     skipped. The Tool path assumes the plugin is vendored at
-     `ai-literacy-superpowers/` (as in this repo) — adjust it to your
-     plugin install location otherwise.
+     skipped. The Tool field is a bare command
+     (`harness-affordance-check`) that resolves via the plugin's `bin/`
+     directory on PATH, so it works whether the plugin is vendored
+     in-repo or installed in the versioned marketplace cache — no path
+     adjustment needed.
 
 ### Affordances have matching permissions
 
@@ -125,7 +127,7 @@
   without a matching permission is a tool the agent has declared but cannot
   invoke — a safety gap.
 - **Enforcement**: deterministic
-- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=blocking
+- **Tool**: harness-affordance-check --direction=blocking
 - **Scope**: pr
 
 ### Permissions have declared affordances
@@ -134,7 +136,7 @@
   affordance in the `## Affordances` section. An ungoverned permission is
   paperwork debt, not a safety violation — flag it, do not block.
 - **Enforcement**: deterministic
-- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-check.sh --direction=advisory
+- **Tool**: harness-affordance-check --direction=advisory
 - **Scope**: pr
 -->
 
@@ -173,6 +175,15 @@ Use /governance-constrain for guided authoring of governance constraints.
 
 <!-- Periodic checks that fight entropy — the slow drift that neither
      real-time hooks nor PR gates catch. -->
+
+<!-- Tool fields that name a plugin-shipped deterministic check (e.g.
+     `archive-promoted-reflections`) are BARE COMMANDS, not paths. They
+     resolve via the plugin's bin/ directory, which Claude Code puts on
+     PATH in every execution context — including the harness-gc subagent
+     that runs these rules, where ${CLAUDE_PLUGIN_ROOT} is NOT set. This
+     is what lets a deterministic GC rule run identically whether the
+     plugin is vendored in-repo or installed in the versioned marketplace
+     cache. Do not rewrite these back to script paths. -->
 
 ### Documentation freshness
 
@@ -301,7 +312,7 @@ Use /governance-constrain for guided authoring of governance constraints.
   AGENTS.md or HARNESS.md content, or matches a closure form).
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: `ai-literacy-superpowers/scripts/archive-promoted-reflections.sh`
+- **Tool**: archive-promoted-reflections
 - **Auto-fix**: true (moves the fragment to `reflections/archive/<YYYY>.md`,
   deletes it, and regenerates the aggregate `REFLECTION_LOG.md`)
 
@@ -408,7 +419,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   days / ~6 months), or no valid date at all
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-staleness.sh
+- **Tool**: harness-affordance-staleness
 - **Auto-fix**: false (the fix is a human running /harness-affordance review <name>)
 
 ### Affordance recorder freshness (LOCAL — per-machine only)
@@ -421,7 +432,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   your machine), not a CI control.
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-invocations.sh --check=freshness
+- **Tool**: harness-affordance-invocations --check=freshness
 - **Auto-fix**: false
 
 ### Affordance dead inventory (LOCAL — per-machine only)
@@ -432,7 +443,7 @@ Run /governance-audit quarterly to keep governance constraints fresh.
   data).
 - **Frequency**: weekly
 - **Enforcement**: deterministic
-- **Tool**: bash ai-literacy-superpowers/scripts/harness-affordance-invocations.sh --check=dead-inventory
+- **Tool**: harness-affordance-invocations --check=dead-inventory
 - **Auto-fix**: false
 -->
 ---
@@ -466,7 +477,6 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 <!-- affordance-review-threshold-days: 180 -->
 <!-- ^ Tune the review-staleness threshold here (the staleness GC rule reads
      this value). This line is human-owned and survives /harness-upgrade. -->
-
 
 ### gh-cli
 <!-- affordance-example -->
@@ -513,7 +523,9 @@ Run /governance-audit quarterly to keep governance constraints fresh.
 - **Identity**: current-user
 - **Audit trail**: none (hook stderr, lost at session end)
 - **Permission**: `hooks.Stop` entry in `.claude/settings.local.json`
-  invoking `ai-literacy-superpowers/scripts/sync-to-global-cache.sh`
+  invoking `${CLAUDE_PLUGIN_ROOT}/scripts/sync-to-global-cache.sh`
+  (hooks resolve `${CLAUDE_PLUGIN_ROOT}`; GC-rule Tool fields do not —
+  see the note under Garbage Collection)
 - **Last reviewed**: 2026-04-26
 - **Notes**: invokes `rsync` under the current user after every session
 


### PR DESCRIPTION
Fixes #475.

## Problem

Plugin scripts were referenced **by path** across three surfaces — GC-rule `Tool:` fields, and command/agent/skill bodies — using either `ai-literacy-superpowers/scripts/<name>.sh` (only valid when the plugin is **vendored** in-repo) or `${CLAUDE_PLUGIN_ROOT}/scripts/<name>.sh`. In the default (non-vendored) install the plugin runs from the versioned marketplace cache, so every one of these silently failed to resolve.

The most severe case is the **active, deterministic** "Reflection log archival of promoted entries" GC rule (ships enabled, no caveat) — but the same breakage hit `/harness-health`, `/harness-init`, `/harness-affordance`, `/reflect`, and several agents/skills.

## Root cause — established empirically, not assumed

`${CLAUDE_PLUGIN_ROOT}` is documented only for **hooks**. I built a throwaway probe plugin (hook + slash-command + subagent surfaces) and ran it on Claude Code 2.1.200 in **both** `--plugin-dir` and a **real marketplace-cache install**:

| Context | `CLAUDE_PLUGIN_ROOT` | `${CLAUDE_PLUGIN_ROOT}/scripts/…` resolves? | plugin `bin/` on `PATH`? |
|---|---|---|---|
| Hook (control) | set | ✅ yes | ✅ |
| Slash-command `!`-injection | **UNSET** | ❌ no | ✅ |
| Main-agent Bash tool (in a plugin command) | **UNSET** | ❌ no | ✅ |
| Plugin subagent Bash tool (the GC-rule context) | **UNSET** | ❌ no | ✅ **yes** |

So `${CLAUDE_PLUGIN_ROOT}` is a dead end outside hooks — but the plugin's **`bin/` directory is on `PATH` in every context**, and a bare-name executable there resolves and runs (verified by the executable printing its own absolute `$0`). That's the mechanism this PR uses.

## Fix

- **8 new `bin/` shims** — `archive-promoted-reflections`, `harness-affordance-check`, `harness-affordance-staleness`, `harness-affordance-invocations`, `harness-affordance-discover`, `update-badge`, `update-health-badge`, `regenerate-reflection-log`. Each resolves the plugin root from its own location and `exec`s `scripts/<name>.sh`, preserving the caller's CWD.
- **`templates/HARNESS.md`** — GC-rule/affordance `Tool:` fields become **bare commands**; added a Garbage Collection note explaining the mechanism; reworded the affordance caveat; the `sync-to-global-cache` hook example now shows `${CLAUDE_PLUGIN_ROOT}` (hooks resolve it — highlighting the distinction).
- **Commands / agents / skills** — badge, discovery, and reflection-log regeneration instructions now invoke bare `bin/` commands: `harness-health`, `harness-init`, `harness-affordance`, `reflect`, `harness-gc.agent`, `harness-auditor.agent`, `integration-agent.agent`, and the `ai-literacy-assessment` skill.

Version-agnostic (no cache-version segment to break on upgrade), **no consumer-side wrapper** and no `/harness-init` / `/harness-upgrade` changes.

## Verification

- The `archive-promoted-reflections` shim runs end-to-end from a mock repo root — resolves `../scripts/`, sources its lib, honors CWD, exits cleanly — both by path and as a bare `PATH` command.
- All 8 `bin/` executables committed with the exec bit (`100755`); each carries `set -euo pipefail`.
- `claude plugin validate` passes; changed markdown adds no new lint errors.

## Scope notes

- This repo's **own** root `HARNESS.md` instance keeps its (working, vendored) paths — the one place a vendored path is legitimately correct. It picks up the bare-command form on the next `/harness-upgrade`, the designed propagation path.
- **One known edge, deliberately not fixed here:** the read-side-filtering instruction in `agents/harness-auditor.agent.md` *sources* the `reflection-log-helpers.sh` function library (rather than executing a top-level script), so a `bin/` shim doesn't map to it cleanly — and the instruction is already broken-as-written (functions don't survive a separate `bash` invocation). It needs its own treatment; flagged for a follow-up.

> Draft for maintainer review. Version-bump files are included; if another plugin PR merges first, this needs a trivial version rebase.