### PR TITLE
Fix harness-auditor bounded read-side filtering (#478)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.64.0",
+  "plugin_version": "0.64.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.64.0"
+      "version": "0.64.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.64.1 — 2026-07-04
+
+### Fix: harness-auditor bounded read-side filtering (#478)
+
+The harness-auditor's "Read-side filtering policy" told the agent to
+`bash …/scripts/lib/reflection-log-helpers.sh` and then call
+`bounded_entries` — broken two ways: the vendored path does not exist in
+a marketplace-cache install (the #475 class of failure), and
+`reflection-log-helpers.sh` is a *sourced* function library, so running
+it with `bash` in a subshell never defines the function for the caller.
+
+Fixing the invocation surfaced a third, latent defect: `bounded_entries`
+itself returned empty entry bodies. It wrote each multi-line entry into a
+tmpfile with real newlines, so the line-based `sort`/`awk` that follow
+shattered every record — only the first physical line kept its tab, and
+the rest read back blank. The existing tests missed it because they
+counted `---ENTRY---` markers only, never the bodies.
+
+- **`scripts/lib/reflection-log-helpers.sh`** — `bounded_entries` now
+  encodes each entry body as a single physical line (newlines → literal
+  `\n`) before the sort, which the downstream `awk` already decodes.
+  Entry bodies are preserved.
+- **New `bin/reflection-log-bounded` shim** — sources the helper library
+  (resolved from its own location) and calls `bounded_entries` with the
+  caller's arguments, so it works vendored or cache-installed and via
+  PATH as a bare command.
+- **`agents/harness-auditor.agent.md`** — the read-side-filtering
+  instruction now runs `reflection-log-bounded REFLECTION_LOG.md 50 90`.
+- **Test** — added `test_bounded_entries_preserves_entry_bodies`
+  (asserts bodies == markers); it fails against the pre-fix function.
+
 ## 0.64.0 — 2026-06-23
 
 ### Docs: curated agentic-engineering video library (#456)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.64.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.64.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.64.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/harness-auditor.agent.md
+++ b/ai-literacy-superpowers/agents/harness-auditor.agent.md
@@ -161,11 +161,13 @@ Include a Meta section in the audit results:
 
 When reading `REFLECTION_LOG.md` for routine audits, default to the
 bounded read: the more inclusive of the last 50 entries OR entries
-within the last 90 days. Use:
+within the last 90 days. Run the bare command (a plugin `bin/` shim on
+PATH — it sources the reflection-log helper library and calls its
+`bounded_entries` function, resolving whether the plugin is vendored or
+cache-installed):
 
 ```bash
-bash ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
-# then call: bounded_entries REFLECTION_LOG.md 50 90
+reflection-log-bounded REFLECTION_LOG.md 50 90
 ```
 
 For audits that require historical claims (e.g., "verify the harness

--- a/ai-literacy-superpowers/bin/reflection-log-bounded
+++ b/ai-literacy-superpowers/bin/reflection-log-bounded
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Bin shim → sources scripts/lib/reflection-log-helpers.sh and runs its
+# bounded_entries function.
+#
+# Unlike the other bin/ shims (which exec a top-level script),
+# reflection-log-helpers.sh is a FUNCTION LIBRARY meant to be sourced —
+# so it cannot be dispatched with `exec bash <lib>` (that runs it in a
+# subshell that exits without exposing the function). This wrapper sources
+# the library in its own shell and invokes bounded_entries with the
+# caller's arguments.
+#
+# As with every bin/ entry, the plugin's bin/ directory is on PATH in all
+# execution contexts (hooks, commands, subagents), while ${CLAUDE_PLUGIN_ROOT}
+# is set only for hooks — so referencing this as a bare command resolves
+# whether the plugin is vendored in-repo or installed in the versioned
+# marketplace cache. See issues #475 and #478.
+#
+# Usage: reflection-log-bounded <log-path> <max-count> <max-days>
+#   e.g. reflection-log-bounded REFLECTION_LOG.md 50 90
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$here/../scripts/lib/reflection-log-helpers.sh"
+bounded_entries "$@"

--- a/ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
+++ b/ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
@@ -115,7 +115,14 @@ bounded_entries() {
       entry_date=$(extract_field "$entry" "Date")
       entry_epoch=$(date -j -f '%Y-%m-%d' "$entry_date" '+%s' 2>/dev/null \
                     || date -d "$entry_date" '+%s')
-      printf '%s\t%s\n' "$entry_epoch" "$entry" >> "$tmpfile"
+      # Encode the multi-line entry body as a single physical line
+      # (real newlines → literal \n) so each tmpfile record survives the
+      # line-based sort and awk below — which decode it again with
+      # gsub(/\\n/, "\n"). Without this the record spans several lines,
+      # sort shuffles them, and awk sees a tab only on the first line, so
+      # every body reads back empty.
+      local entry_encoded="${entry//$'\n'/\\n}"
+      printf '%s\t%s\n' "$entry_epoch" "$entry_encoded" >> "$tmpfile"
       entry=""
     else
       entry+="${line}"$'\n'

--- a/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
+++ b/tdad_tests/layer0_deterministic/test-reflection-log-helpers.sh
@@ -108,6 +108,19 @@ test_bounded_entries_day_window_clips() {
           | grep -c "^---ENTRY---$" || true)
   assert_eq "$count" "50"
 }
+test_bounded_entries_preserves_entry_bodies() {
+  # Regression (#478): the multi-line entry body must survive the tmpfile
+  # round-trip through sort/awk, not collapse to empty. The count tests
+  # above only assert the number of ---ENTRY--- markers, which stayed
+  # correct even while every body read back blank. Assert every returned
+  # entry still carries its own Date line (bodies == markers).
+  local out markers dates
+  out=$(bounded_entries "$FIXTURES_DIR/reflection-log-many-entries.md" 50 1000)
+  markers=$(printf '%s\n' "$out" | grep -c "^---ENTRY---$" || true)
+  dates=$(printf '%s\n' "$out" | grep -c "^- \*\*Date\*\*:" || true)
+  assert_eq "$markers" "60"
+  assert_eq "$dates" "60"
+}
 
 # --- verify_rhs promotion-target coverage (#319, #320) ---
 # verify_rhs greps targets relative to cwd; a ( cd … ) subshell inherits the
@@ -178,6 +191,7 @@ test_extract_field_signal
 test_resolve_year
 test_bounded_entries_count_is_inclusive_of_max
 test_bounded_entries_day_window_clips
+test_bounded_entries_preserves_entry_bodies
 test_verify_rhs_agents_form
 test_verify_rhs_claude_root_form
 test_verify_rhs_claude_subcomponent_form


### PR DESCRIPTION
Fixes #478. Follow-up to #475 (deliberately split out there).

## Problem

The harness-auditor's "Read-side filtering policy" instruction:

```bash
bash ai-literacy-superpowers/scripts/lib/reflection-log-helpers.sh
# then call: bounded_entries REFLECTION_LOG.md 50 90
```

was broken **three** ways:

1. **Cache-install path** — `ai-literacy-superpowers/scripts/lib/...` only exists when the plugin is vendored in-repo (the #475 class of failure).
2. **Sourced lib run as a script** — `reflection-log-helpers.sh` is a function library meant to be *sourced*. `bash <lib>` runs it in a subshell that exits, so `bounded_entries` is never defined for the caller — the "then call …" step can't work.
3. **`bounded_entries` returns empty bodies** (surfaced while fixing 1–2). It wrote each multi-line entry into a tmpfile with **real newlines**, so the line-based `sort` and `awk -F '\t'` that follow shattered every record: only the first physical line kept its tab+epoch, the rest read back blank. Against the real `REFLECTION_LOG.md` (54 entries) it returned 54 `---ENTRY---` markers with **0** entry bodies. This function is referenced only by this instruction, so it was executed successfully nowhere — and the existing tests only counted markers, never bodies, so the bug survived.

## Fix

- **`scripts/lib/reflection-log-helpers.sh`** — `bounded_entries` encodes each entry body as a single physical line (real newlines → literal `\n`) before the sort; the downstream `awk` already decodes with `gsub(/\\n/, "\n")`. Bodies are preserved.
- **New `bin/reflection-log-bounded` shim** — sources the helper library (resolved from its own location) and calls `bounded_entries "$@"`. Works vendored or cache-installed, on PATH as a bare command — consistent with the `bin/` mechanism from #475. (A plain `exec`-style shim doesn't fit here because the target is a sourced lib, not a top-level script — which is why this was split out of #475.)
- **`agents/harness-auditor.agent.md`** — the instruction now runs `reflection-log-bounded REFLECTION_LOG.md 50 90`.
- **Regression test** — `test_bounded_entries_preserves_entry_bodies` asserts returned bodies == markers (60/60). Verified it **fails against the pre-fix function** (`expected '60' got '0'`) and passes after.

## Verification

- Full `test-reflection-log-helpers.sh` green (incl. the new test); sibling `test-archive-promoted-reflections.sh` and `test-migrate-reflection-log.sh` still green (shared lib).
- Against the real 54-entry `REFLECTION_LOG.md`, the bare command now returns 54 entries **with** their Date/body lines.
- `bin/reflection-log-bounded` committed `100755` with `set -euo pipefail`; `claude plugin validate` passes; markdown lint clean.

> Draft for review. This is the third of three open fix PRs (#476, #477, this) that each touch the version files, so a **trivial version reconciliation** is needed on merge — I used the next patch off `main` (0.64.1); the maintainer should set the final number by merge order.