### PR TITLE
Introduce the sentinel agent category

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.65.1",
+  "plugin_version": "0.66.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.65.1"
+      "version": "0.66.0"
     },
     {
       "name": "model-cards",

--- a/.cursor/rules/constraints.mdc
+++ b/.cursor/rules/constraints.mdc
@@ -223,3 +223,10 @@ alwaysApply: true
 - **Enforcement**: deterministic
 - **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
+
+## Sentinel integrity
+
+- **Rule**: Any agent whose frontmatter declares `role: sentinel` MUST NOT be granted `Write` or `Edit` tools — a sentinel's object of care is the human's understanding and judgement, and criterion S1 of the sentinel signature is a read-only trust boundary (`Bash` is permitted for read-only inspection such as `git log`). The same check also rejects any `role:` value outside the enum `{sentinel}`, so a typo fails loudly rather than silently exempting the agent.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents` (CI: `.github/workflows/harness.yml`; also runs weekly in `.github/workflows/gc.yml`)
+- **Scope**: pr

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,3 +166,7 @@ Every entry in the permissions allowlist should have a matching affordance in th
 ### Convention parity
 
 Every active constraint heading in HARNESS.md's Constraints section must appear verbatim in all three generated convention files (`.cursor/rules/constraints.mdc`, `.github/copilot-instructions.md`, `.windsurf/rules/constraints.md`). These files are generated from HARNESS.md by `/convention-sync` and can drift by whole constraints (content drift, not a stale mtime). This PR-time gate complements the weekly "Convention file sync" GC rule. Enforcement: deterministic (`python3 scripts/check-convention-parity.py`, CI `.github/workflows/convention-parity-check.yml`). Scope: pr.
+
+### Sentinel integrity
+
+Any agent whose frontmatter declares `role: sentinel` MUST NOT be granted `Write` or `Edit` tools — a sentinel's object of care is the human's understanding and judgement, and criterion S1 of the sentinel signature is a read-only trust boundary (`Bash` is permitted for read-only inspection such as `git log`). The same check also rejects any `role:` value outside the enum `{sentinel}`, so a typo fails loudly rather than silently exempting the agent. Enforcement: deterministic (`bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents`, CI `.github/workflows/harness.yml`; also weekly in `.github/workflows/gc.yml`). Scope: pr.

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -80,6 +80,10 @@ jobs:
 
           echo "Snapshot is within 30-day freshness window"
 
+      - name: "GC: Sentinel integrity"
+        run: |
+          bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents
+
       - name: "GC: Shell scripts pass syntax check"
         run: |
           failed=0

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -64,6 +64,10 @@ jobs:
           sudo apt-get -qq install -y shellcheck
           find . -name "*.sh" -not -path "./.git/*" -exec shellcheck {} +
 
+      - name: "Constraint: Sentinel integrity"
+        run: |
+          bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents
+
       - name: Summary
         if: always()
         run: echo "Harness constraint check complete. See HARNESS.md for constraint details."

--- a/.windsurf/rules/constraints.md
+++ b/.windsurf/rules/constraints.md
@@ -217,3 +217,10 @@
 - **Enforcement**: deterministic
 - **Tool**: `python3 scripts/check-convention-parity.py` (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
+
+## Sentinel integrity
+
+- **Rule**: Any agent whose frontmatter declares `role: sentinel` MUST NOT be granted `Write` or `Edit` tools — a sentinel's object of care is the human's understanding and judgement, and criterion S1 of the sentinel signature is a read-only trust boundary (`Bash` is permitted for read-only inspection such as `git log`). The same check also rejects any `role:` value outside the enum `{sentinel}`, so a typo fails loudly rather than silently exempting the agent.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents` (CI: `.github/workflows/harness.yml`; also runs weekly in `.github/workflows/gc.yml`)
+- **Scope**: pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.66.0 — 2026-07-20
+
+### Feature: the sentinel agent category
+
+Names the sub-family of agents whose object of care is the human's
+understanding and judgement rather than an artefact, the pipeline, or
+the harness. Categorisation, documentation, and one new enforceable
+constraint — no agent renames, no behavioural changes, no new gates.
+
+- **`role: sentinel` frontmatter tag** — added to the five roster agents
+  (`reservoir-warden`, `advocatus-diaboli`, `choice-cartographer`,
+  `carpaccio`, `cost-estimator`). An enum with a single permitted value;
+  absence means "pipeline/harness agent" and changes nothing.
+- **Sentinel integrity constraint** — `sentinel-integrity-check.sh`
+  fails CI if a `role: sentinel` agent is granted Write/Edit (criterion
+  S1), or if any `role:` value falls outside the enum. Runs at PR time
+  (`harness.yml`) and weekly (`gc.yml`), and as a Layer-0 test with
+  red/green fixtures. This makes the category load-bearing, not
+  decorative — mislabel an agent and the build goes red.
+- **`sentinel-design` skill** — documents the three-part signature (S1
+  read-only, S2 advisory-to-human, S3 explicit honesty rule), the
+  near-miss gallery (why code-reviewer and harness-auditor don't
+  qualify), the honesty-rule-before-detection-logic discipline, and the
+  three anti-patterns.
+- **README Sentinels section** — the *Agents (16)* table splits into
+  Sentinels (5) and Pipeline & harness agents (11).
+- **Docs** — new `explanation/sentinels.md` page; `/superpowers-status`
+  now reports sentinel coverage and integrity-constraint state.
+
 ## 0.65.1 — 2026-07-16
 
 ### Fix: harness-auditor bounded read-side filtering (#478)

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -492,6 +492,23 @@
   (CI: `.github/workflows/convention-parity-check.yml`)
 - **Scope**: pr
 
+### Sentinel integrity
+
+- **Rule**: Any agent whose frontmatter declares `role: sentinel` MUST
+  NOT be granted `Write` or `Edit` tools — a sentinel's object of care is
+  the human's understanding and judgement, and criterion S1 of the
+  sentinel signature is a read-only trust boundary (`Bash` is permitted
+  for read-only inspection such as `git log`). The same check also
+  rejects any `role:` value outside the enum `{sentinel}`, so a typo
+  fails loudly rather than silently exempting the agent. See the
+  `sentinel-design` skill and the spec at
+  `docs/superpowers/specs/2026-07-20-sentinel-agent-category-design.md`.
+- **Enforcement**: deterministic
+- **Tool**: `bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh ai-literacy-superpowers/agents`
+  (CI: `.github/workflows/harness.yml`; also runs weekly in
+  `.github/workflows/gc.yml`)
+- **Scope**: pr
+
 <!-- Uncomment if using spec-first development:
 
 ### Spec conformance

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.65.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-36-2E8B57?style=flat-square)](#skills-36)
+[![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
-[![Harness](https://img.shields.io/badge/Harness-30%2F31_enforced-4682B4?style=flat-square)](HARNESS.md)
+[![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.65.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **36 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.66.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (36)
+### Skills (37)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -197,10 +197,45 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | choice-cartographer | Decision archaeology — six-lens map of implicit choices a spec has made (forces, alternatives, defaults, patterns, consequences, coherence); routing rule partitions findings between the Cartographer and the diaboli |
 | component-design-with-tdad | Design-time methodology for new plugin components — names the five design questions implied by the four-layer TDAD architecture (component type, layer targeting, scenario shape, new-vs-modification, scenario-vs-finding); loadable by spec-writer, tdd-agent, or human brainstorming |
 | cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
+| sentinel-design | Defines the sentinel agent category — the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery (why code-reviewer and harness-auditor don't qualify), the honesty-rule-before-detection-logic discipline, and the three anti-patterns (scoring the human, persisting human-state records, gating automatically) |
 
 ### Agents (16)
 
-A coordinated team that handles the full development lifecycle.
+A coordinated team that handles the full development lifecycle. It
+splits into two families: **sentinels**, whose object of care is the
+human's understanding and judgement, and **pipeline & harness agents**,
+whose object of care is an artefact, the pipeline, or the harness.
+
+#### Sentinels (5)
+
+> **Sentinel** — any agent whose primary purpose is to protect and
+> support the understanding and judgement of the human in the workflow.
+> It informs, challenges, surfaces, or warns — it never fixes, writes,
+> merges, or decides.
+
+Every sentinel satisfies the three-part **sentinel signature**: **S1**
+read-only trust boundary (no Write/Edit; `Bash` only for read-only
+inspection), **S2** advisory output a human disposes (no automated
+action), and **S3** an explicit epistemic honesty rule (it declares the
+status of its claims). S1 is enforced deterministically — the
+[Sentinel integrity](HARNESS.md) constraint fails CI if a
+`role: sentinel` agent is granted Write/Edit. See the `sentinel-design`
+skill for the near-miss gallery and authoring guidance.
+
+The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation/decision-discipline-triad.md)
+(`carpaccio`, `advocatus-diaboli`, `choice-cartographer`) guards
+*decisions*; the `reservoir-warden` guards *the decider*; the
+`cost-estimator` guards *the decision's inputs*.
+
+| Agent | Guards | Role | Trust boundary |
+| ----- | ------ | ---- | -------------- |
+| carpaccio | Judgement scale | Cadence governor — runs at orchestrator step 0 before spec-writer; slices the raw task description into thin, end-to-end-complete pieces; hard gate on slice dispositions | Read only |
+| advocatus-diaboli | Decisions at both gates | Adversarial reviewer — spec-time (premise/design focus, before plan approval) and code-time (risk/implementation focus, before integration); six-category objection record, human-cognition gate on dispositions at both gates | Read only |
+| choice-cartographer | Understanding of implicit decisions | Decision-archaeology mapper — runs after spec-mode diaboli dispositions are resolved; emits choice stories (Henney pattern stories) for each material implicit decision; soft gate at plan approval, merge-time HARNESS constraint enforces resolution | Read only |
+| reservoir-warden | The decider | Verifier-watch — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and offers the single decide-your-stop-first recommendation when a threshold is crossed; persists no record of the human's state | Read only (no Write/Edit) |
+| cost-estimator | The decision's inputs | Prospective-cost emitter — reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns an estimate-record string (token + time ranges, dollar cost only when grounded) for a dispatcher to persist after a human disposes; refuses rather than fabricating an ungroundable estimate | Read only |
+
+#### Pipeline & harness agents (11)
 
 | Agent | Role | Trust boundary |
 | ----- | ---- | -------------- |
@@ -215,11 +250,6 @@ A coordinated team that handles the full development lifecycle.
 | harness-auditor | Meta-agent — checks whether the harness matches reality | Write to Status only |
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
-| advocatus-diaboli | Adversarial reviewer — spec-time (premise/design focus, before plan approval) and code-time (risk/implementation focus, before integration); six-category objection record, read-only trust boundary, human-cognition gate on dispositions at both gates | Read only |
-| choice-cartographer | Decision-archaeology mapper — runs after spec-mode diaboli dispositions are resolved; emits choice stories (Henney pattern stories) for each material implicit decision; soft gate at plan approval, merge-time HARNESS constraint enforces resolution | Read only |
-| carpaccio | Cadence governor — runs at orchestrator step 0 before spec-writer; slices the raw task description into thin, end-to-end-complete pieces; hard gate on slice dispositions; the third member of the decision-discipline triad alongside diaboli and choice-cartographer | Read only |
-| cost-estimator | Prospective-cost emitter — reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns an estimate-record string (token + time ranges, dollar cost only when grounded) for a dispatcher to persist after a human disposes; refuses rather than fabricating an ungroundable estimate | Read only |
-| reservoir-warden | Verifier-watch — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and offers the single decide-your-stop-first recommendation when a threshold is crossed; persists no record of the human's state | Read only (no Write/Edit) |
 
 ### Commands (28)
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.65.1",
+  "version": "0.66.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
+++ b/ai-literacy-superpowers/agents/advocatus-diaboli.agent.md
@@ -2,6 +2,7 @@
 name: advocatus-diaboli
 description: Use after spec-writer completes (spec mode) or after the final code-reviewer PASS (code mode) — reads the spec or implementation and produces a structured objection record; read-only trust boundary enforces the human-cognition gate on dispositions at both gates
 tools: [Read, Glob, Grep]
+role: sentinel
 ---
 
 # Advocatus Diaboli Agent

--- a/ai-literacy-superpowers/agents/carpaccio.agent.md
+++ b/ai-literacy-superpowers/agents/carpaccio.agent.md
@@ -2,6 +2,7 @@
 name: carpaccio
 description: Use when starting any new task via the orchestrator — reads the raw task description, slices it into end-to-end-complete pieces, and produces a structured slicing record; read-only trust boundary enforces the human-cognition gate on dispositions; runs at orchestrator step 0 before spec-writer
 tools: [Read, Glob, Grep]
+role: sentinel
 ---
 
 # Carpaccio Agent

--- a/ai-literacy-superpowers/agents/choice-cartographer.agent.md
+++ b/ai-literacy-superpowers/agents/choice-cartographer.agent.md
@@ -2,6 +2,7 @@
 name: choice-cartographer
 description: Use after spec-mode advocatus-diaboli dispositions are resolved and before plan approval — reads the spec, reconstructs the decisions it implies (including the silent ones), and produces a structured choice-story record; read-only trust boundary enforces the human-cognition gate on dispositions
 tools: [Read, Glob, Grep]
+role: sentinel
 ---
 
 # Choice Cartographer Agent

--- a/ai-literacy-superpowers/agents/cost-estimator.agent.md
+++ b/ai-literacy-superpowers/agents/cost-estimator.agent.md
@@ -3,6 +3,7 @@ name: cost-estimator
 description: Use to estimate the token usage, agent-compute time, and (only when a cost snapshot grounds it) the dollar cost of a task BEFORE it runs — given a target (raw task text, a slicing record, a single slice, or a spec), reads MODEL_ROUTING.md and the latest observability/costs/ snapshot, applies the cost-estimation methodology, and returns the estimate-record content as a string for a dispatcher to persist after a human disposes. Read-only trust boundary; refuses rather than fabricating an ungroundable estimate; never decides go/no-go.
 tools: [Read, Glob, Grep]
 model: inherit
+role: sentinel
 ---
 
 # Cost Estimator Agent

--- a/ai-literacy-superpowers/agents/reservoir-warden.agent.md
+++ b/ai-literacy-superpowers/agents/reservoir-warden.agent.md
@@ -2,6 +2,7 @@
 name: reservoir-warden
 description: Use on demand via /reservoir to watch the human verifier the harness cannot verify — counts observable proxies (session span, decision volume, context switches, wall-clock hour) over the recent git window, reports each with an observed/inferred/asked flag, and if a threshold is crossed offers the single decide-your-stop-first recommendation; read-only by design, never writes a record of the human's state
 tools: [Read, Glob, Grep, Bash]
+role: sentinel
 ---
 
 # Reservoir Warden Agent

--- a/ai-literacy-superpowers/commands/superpowers-status.md
+++ b/ai-literacy-superpowers/commands/superpowers-status.md
@@ -70,6 +70,29 @@ routing):
   snapshot, not a live event stream), report the last route as `unavailable`
   rather than inventing one.
 
+### Section 3b: Sentinel coverage
+
+Surface the health of the [sentinel](../skills/sentinel-design/SKILL.md)
+agent family — the agents whose object of care is the human's understanding
+and judgement (`carpaccio`, `advocatus-diaboli`, `choice-cartographer`,
+`reservoir-warden`, `cost-estimator` in the flagship, plus any downstream
+additions):
+
+- **Count.** Count `.claude/agents/*.md` files whose frontmatter declares
+  `role: sentinel`. Report `N sentinels active`. A count of zero is **not a
+  warning** — a downstream project may legitimately ship none; report it as
+  descriptive (`0 sentinels active`).
+- **Integrity constraint.** Report the state of the Sentinel integrity
+  constraint. When the plugin's `sentinel-integrity-check.sh` script is
+  available, run it against the agents directory:
+  `bash ai-literacy-superpowers/scripts/sentinel-integrity-check.sh <agents-dir>`.
+  Report `integrity constraint green` on exit 0, or `integrity constraint
+  WARNING` naming the offending agent(s) on a non-zero exit. When the script
+  is not available (e.g. a bare-harness install without the plugin cache),
+  report `integrity constraint unavailable` rather than inventing a verdict.
+
+Combined line, e.g. `Sentinels: 5 active, integrity constraint green`.
+
 ### Section 4: Compound learning
 
 Evaluate the state of AGENTS.md:
@@ -278,6 +301,7 @@ AI Literacy Habitat Status
 Habitat files    [OK / WARNING / MISSING]
 Harness          [OK / WARNING / MISSING]
 Agent team       [OK / WARNING / MISSING]
+Sentinels        [N active, integrity constraint green / WARNING / unavailable]
 Compound learning [OK / WARNING / MISSING]
 Model routing    [OK / WARNING / MISSING]
 CI               [OK / WARNING / MISSING]

--- a/ai-literacy-superpowers/scripts/sentinel-integrity-check.sh
+++ b/ai-literacy-superpowers/scripts/sentinel-integrity-check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# sentinel-integrity-check.sh — the deterministic teeth of the sentinel
+# integrity constraint (spec 2026-07-20-sentinel-agent-category-design.md, §5.4).
+#
+# Why this exists. A "sentinel" is an agent whose object of care is the human's
+# understanding and judgement, not an artefact (README §Sentinels; the
+# sentinel-design skill). Criterion S1 of the sentinel signature is a read-only
+# trust boundary: a sentinel informs, challenges, surfaces, or warns — it never
+# fixes, writes, merges, or decides. The `role: sentinel` frontmatter tag is a
+# promise; this script is what makes breaking that promise fail CI rather than
+# merely contradict the docs. Mislabel an agent — grant it Write while calling
+# it a sentinel — and the category stops being decorative and starts being
+# load-bearing.
+#
+# The check, per agent frontmatter block:
+#   1. If `role:` is present and its value is outside the enum {sentinel},
+#      FAIL — a typo (`role: sentinal`) must be loud, never a silent exemption.
+#   2. If `role: sentinel`, the `tools:` list must NOT contain Write or Edit
+#      (case-insensitive). Bash is permitted — read-only inspection (git log,
+#      date) is within the boundary. FAIL on a Write/Edit grant, naming the
+#      agent and the S1 criterion.
+#
+# Runs two ways from one script (mirroring inv-firewall.sh): a PR-time gate in
+# .github/workflows/harness.yml and the weekly GC sweep, plus Layer-0 tests
+# against red/green fixtures. One matcher, so every caller enforces the same
+# rule.
+#
+# Known limit (by design). This is a deterministic backstop to human PR review,
+# not a sandbox. It reads the declared `tools:` line; an agent that reaches a
+# write capability through an undeclared channel is out of scope here and is the
+# harness-enforcer's S2/S3 agent-review territory.
+#
+# Usage: sentinel-integrity-check.sh [agents-dir ...]
+#   Defaults to the plugin's agents directory relative to this script.
+
+# The single permitted role value. Widen only when a second category earns a
+# name (spec §5.1: enum, not free-form).
+ALLOWED_ROLES="sentinel"
+
+# Resolve default agents dir relative to this script when no argument is given.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$#" -gt 0 ]; then
+  DIRS=("$@")
+else
+  DIRS=("$SCRIPT_DIR/../agents")
+fi
+
+# Extract the value of a frontmatter key from the leading `---` block of a file.
+# Prints the trimmed value, or nothing if the key is absent. Only the first
+# frontmatter block (lines between the first two `---` fences) is considered.
+frontmatter_value() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    NR == 1 && $0 != "---" { exit }        # no frontmatter at all
+    NR == 1 { infm = 1; next }
+    infm && $0 == "---" { exit }            # end of frontmatter
+    infm {
+      # match "key:" allowing leading spaces
+      if ($0 ~ "^[[:space:]]*" key "[[:space:]]*:") {
+        sub("^[[:space:]]*" key "[[:space:]]*:[[:space:]]*", "")
+        print
+        exit
+      }
+    }
+  ' "$file"
+}
+
+failed=0
+checked=0
+
+for dir in "${DIRS[@]}"; do
+  [ -d "$dir" ] || { echo "::warning::not a directory, skipping: $dir" >&2; continue; }
+  while IFS= read -r -d '' file; do
+    role="$(frontmatter_value "$file" role)"
+    [ -n "$role" ] || continue   # untagged agent — pipeline/harness, not our concern
+
+    checked=$((checked + 1))
+    name="$(frontmatter_value "$file" name)"
+    [ -n "$name" ] || name="$(basename "$file")"
+
+    # Criterion: role value must be in the enum.
+    is_allowed=0
+    for allowed in $ALLOWED_ROLES; do
+      [ "$role" = "$allowed" ] && { is_allowed=1; break; }
+    done
+    if [ "$is_allowed" -eq 0 ]; then
+      echo "FAIL: agent '$name' declares unknown role '$role' (allowed: $ALLOWED_ROLES) — $file"
+      failed=1
+      continue
+    fi
+
+    # role: sentinel — enforce S1 read-only trust boundary.
+    tools="$(frontmatter_value "$file" tools)"
+    if printf '%s' "$tools" | grep -qiE '\b(Write|Edit)\b'; then
+      echo "FAIL: sentinel '$name' is granted Write/Edit — violates criterion S1 (read-only trust boundary) — $file"
+      failed=1
+    fi
+  done < <(find "$dir" -maxdepth 1 -name '*.agent.md' -print0 2>/dev/null)
+done
+
+if [ "$failed" -eq 0 ]; then
+  echo "sentinel integrity: OK ($checked role-tagged agent(s) checked)"
+fi
+exit "$failed"

--- a/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
+++ b/ai-literacy-superpowers/skills/cognitive-reservoir/SKILL.md
@@ -208,3 +208,12 @@ mechanism is the same at every level; what changes is how it is used.
 - **A second nudge.** One advisory, then silence.
 - **Manufactured concern on a quiet session.** Below all thresholds →
   say nothing.
+
+## Related
+
+The `reservoir-warden` is a **sentinel** — an agent whose object of care
+is the human's understanding and judgement, not an artefact. The
+honesty-rule-before-detection-logic discipline described above is the
+model for every sentinel; the `sentinel-design` skill generalises it,
+along with the three-part sentinel signature and the anti-patterns that
+eject an agent from the category.

--- a/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
+++ b/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: sentinel-design
+description: Use when designing, reviewing, or classifying an agent that guards the human — defines the sentinel category, the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery that explains why read-only-plus-advisory is not sufficient, the honesty-rule-before-detection-logic discipline, and the three anti-patterns that eject an agent from the category
+---
+
+# Sentinel Design
+
+Most agents in this plugin act on an artefact. The spec-writer edits a
+spec, the tdd-agent writes tests, the integration-agent commits and
+merges, the harness-gc rewrites stale documentation. Their object of
+care is a thing in the repository, and you judge them by what they did
+to that thing.
+
+A **sentinel** is different. Its object of care is not the codebase, the
+pipeline, or the harness — it is **the human**. A sentinel protects and
+supports the understanding and judgement of the person in the workflow.
+It informs, challenges, surfaces, or warns. It never fixes, writes,
+merges, or decides.
+
+> **Sentinel** — any agent whose primary purpose is to protect and
+> support the understanding and judgement of the human in the workflow.
+
+The category emerged organically. Four agents — the decision-discipline
+triad (`carpaccio`, `advocatus-diaboli`, `choice-cartographer`) plus the
+`reservoir-warden` — and later the `cost-estimator` were all built to
+the same shape without anyone naming the shape. This skill names it, so
+that the next one can be built deliberately rather than rediscovered.
+
+## The sentinel signature
+
+An agent is a sentinel if and only if it satisfies all three criteria.
+
+### S1 — Read-only trust boundary
+
+The agent's frontmatter denies `Write` and `Edit`. It may hold `Read`,
+`Glob`, `Grep`, and `Bash` — `Bash` is permitted for read-only
+inspection (`git log`, `date`), not for mutation. A sentinel that can
+write can change the thing it is supposed to be watching from the
+outside, and the boundary that keeps it honest is gone.
+
+S1 is the one criterion a machine can check. The
+`sentinel-integrity-check.sh` script parses every agent's `role:` tag
+and `tools:` list; a `role: sentinel` agent granted `Write` or `Edit`
+fails CI. This is what makes the category load-bearing rather than
+decorative: mislabel an agent and the build goes red.
+
+### S2 — Advisory output for a human
+
+The agent's output is a record, an objection, a story, an estimate, or a
+recommendation that a **human** disposes. It triggers no automated
+action. Nothing downstream reads the sentinel's output and *acts* on it
+without a person in between. The reservoir-warden's stop recommendation,
+the diaboli's objection record, the cartographer's choice stories, the
+carpaccio's slice dispositions, the cost-estimator's estimate record —
+each is deposited in front of a human who decides what to do with it.
+
+### S3 — Explicit epistemic honesty rule
+
+The agent declares the *status* of its claims. It does not launder
+inference as observation. Concretely, each existing sentinel carries
+its own honesty discipline:
+
+- **reservoir-warden** — `observed` / `inferred` / `asked` flags on
+  every proxy; every `inferred` claim must sit on an `observed` one;
+  never a combined fatigue score.
+- **advocatus-diaboli** — six objection categories, each with an
+  evidence requirement; discloses what it did *not* challenge.
+- **choice-cartographer** — a six-lens map that declares what was found
+  in the spec versus what was inferred.
+- **cost-estimator** — ranges with a disclosed confidence label;
+  refuses rather than fabricating an ungroundable estimate.
+
+The common thread: a sentinel would rather say "I don't know" than
+invent a number, and always tells the human which of its claims are
+solid and which are precaution under uncertainty.
+
+## The roster
+
+| Agent | Guards |
+| ----- | ------ |
+| `reservoir-warden` | The decider — the verifier's cognitive reservoir |
+| `advocatus-diaboli` | Decisions at both gates — spec-time premises, code-time risks |
+| `choice-cartographer` | Understanding of the implicit decisions a spec has made |
+| `carpaccio` | Judgement scale — keeps each decision small enough to hold |
+| `cost-estimator` | The decision's inputs — what a choice will cost before it is made |
+
+Narrative: the decision-discipline triad guards *decisions*; the
+reservoir-warden guards *the decider*; the cost-estimator guards *the
+decision's inputs*.
+
+## The near-miss gallery
+
+The signature has a trap. **Read-only plus advisory is not sufficient.**
+Two agents in this plugin satisfy S1 and S2 and are still not sentinels,
+because the category turns on the *object of care*, not the trust
+boundary.
+
+- **code-reviewer** — read-only (S1 ✓), reports findings to a human
+  (S2 ✓). Not a sentinel: its object of care is **the code**. Its
+  finding is "this function violates the joinability property", not
+  "you, the human, are about to approve something you do not
+  understand".
+- **harness-auditor** — read-only on everything but the Status section
+  (S1 ✓ in spirit), reports to a human (S2 ✓). Not a sentinel: its
+  object of care is **the harness** — whether declared enforcement
+  matches reality. Its finding is about an artefact that happens to be
+  reported to a person.
+
+The test: does the finding describe *what the human can or should hold
+in mind* (sentinel), or *the state of an artefact* that is merely
+reported to a human (near-miss)? If you catch yourself justifying a new
+agent's sentinel status with "well, it's read-only and a human reads its
+output", you have found a near-miss, not a sentinel.
+
+## Design discipline: honesty rule before detection logic
+
+When you author a new sentinel, **write S3 before you write what it
+detects.** This mirrors the `cognitive-reservoir` skill's
+contested-versus-robust science discipline: the reservoir-warden's
+honesty rule (which findings are precaution, which claims are never
+asserted as fact) was fixed *before* its proxy-counting logic, so the
+counting could never quietly outrun what the evidence supports.
+
+A sentinel that grows its detection logic first, and bolts on an honesty
+rule afterwards, will always be tempted to over-claim — the detection
+found something, so surely it can be stated plainly. Fixing the honesty
+rule first bounds what the detection is *allowed* to say. Decide what
+you will refuse to assert, then build only what you can honestly report.
+
+## Anti-patterns
+
+An agent that does any of these has left the category, whatever its
+`role:` tag says:
+
+1. **Scores the human.** A sentinel reports proxies and precautions; it
+   never emits a single number that grades the person (a "fatigue score",
+   a "judgement quality index"). Composite scores invite the human to
+   argue with the number instead of attending to their own state.
+2. **Persists a record of the human's state.** The reservoir-warden has
+   no `Write` *by design* — it never writes down that the human was
+   tired at 21:00. A sentinel that files human-state records has built a
+   surveillance artefact, not a guardrail. (This is also why S1 is
+   enforced, not merely recommended.)
+3. **Gates automatically.** A sentinel feeds an existing human gate; it
+   does not become one. The moment its output blocks or advances the
+   pipeline without a person disposing it, S2 is violated and the human
+   has been removed from their own decision.
+
+## When you have a candidate
+
+1. Check S1, S2, S3 against the candidate. All three, or it is not a
+   sentinel.
+2. Run it past the near-miss test: object of care is the human's
+   understanding, not an artefact.
+3. Write the honesty rule first.
+4. Add `role: sentinel` to the frontmatter, confirm no `Write`/`Edit`,
+   and let `sentinel-integrity-check.sh` enforce it.
+5. Add it to the roster in the README Sentinels section and the
+   `explanation/sentinels.md` docs page.

--- a/docs/plugins/ai-literacy-superpowers/explanation/decision-discipline-triad.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/decision-discipline-triad.md
@@ -87,6 +87,8 @@ implementers   Step 3 — make tests green
 
 ## See also
 
+- [Sentinels](sentinels.md) — the wider category the triad belongs to:
+  agents whose object of care is the human's understanding and judgement.
 - `/carpaccio` — manual invocation
 - `/diaboli` — manual invocation
 - `/choice-cartograph` — manual invocation

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -1,0 +1,105 @@
+# Sentinels — the agents that guard the human
+
+Most agents in the plugin act on an artefact. The `spec-writer` edits a
+spec, the `tdd-agent` writes tests, the `integration-agent` commits and
+merges, the `harness-gc` rewrites stale documentation. You judge each by
+what it did to the thing it touched.
+
+A **sentinel** is different. Its object of care is not the codebase, the
+pipeline, or the harness — it is the human.
+
+> **Sentinel** — any agent whose primary purpose is to protect and
+> support the understanding and judgement of the human in the workflow.
+> It informs, challenges, surfaces, or warns — it never fixes, writes,
+> merges, or decides.
+
+The category emerged organically before it was named. The
+[decision-discipline triad](decision-discipline-triad.md) — `carpaccio`,
+`advocatus-diaboli`, `choice-cartographer` — plus the `reservoir-warden`
+(see [Watching the verifier](watching-the-verifier.md)) and later the
+`cost-estimator` were all built to the same shape without anyone naming
+the shape. Naming it lets the next one be built deliberately, and lets
+the shape be enforced rather than merely hoped for.
+
+## The sentinel signature
+
+An agent is a sentinel if and only if it satisfies all three criteria.
+
+| # | Criterion | Testable form |
+| --- | --- | --- |
+| S1 | **Read-only trust boundary** | Frontmatter denies Write/Edit (Bash may be permitted for read-only inspection, e.g. `git log`) |
+| S2 | **Advisory output for a human** | The output is a record, objection, story, estimate, or recommendation a *human* disposes; it triggers no automated action |
+| S3 | **Explicit epistemic honesty rule** | The agent declares the status of its claims (observed/inferred/asked flags, objection categories with evidence requirements, refusal over fabrication) |
+
+**S1 is machine-checkable.** The
+`sentinel-integrity-check.sh` script parses every agent's `role:` tag and
+`tools:` list; a `role: sentinel` agent granted Write or Edit fails CI,
+and so does any `role:` value outside the enum `{sentinel}`. The check
+runs at PR time (`harness.yml`), weekly in the GC sweep (`gc.yml`), and
+as a Layer-0 test with red/green fixtures. This is what makes the
+category *load-bearing* rather than decorative: mislabel an agent and the
+build goes red. S2 and S3 are agent-verifiable via the harness-enforcer.
+
+## The roster
+
+| Agent | Guards | Signature evidence |
+| ----- | ------ | ------------------ |
+| `carpaccio` | Judgement scale — keeps each decision small enough to hold | Read-only; slice dispositions are a hard human gate |
+| `advocatus-diaboli` | Decisions at both gates — spec-time premises, code-time risks | Read-only; six-category objection record disposed by human; evidence requirements per objection |
+| `choice-cartographer` | Understanding of implicit decisions | Read-only; choice stories disposed at a soft gate; six-lens map declares what was found vs. inferred |
+| `reservoir-warden` | The decider — the verifier's cognitive reservoir | Read-only (no Write/Edit); single decide-your-stop-first recommendation; observed/inferred/asked flags; persists no record of human state |
+| `cost-estimator` | The decision's inputs — what a choice will cost before it is made | Read-only; human disposes the estimate record; refuses rather than fabricating an ungroundable estimate |
+
+The narrative: the decision-discipline triad guards *decisions*; the
+`reservoir-warden` guards *the decider*; the `cost-estimator` guards
+*the decision's inputs*.
+
+## The near-miss gallery
+
+The signature has a trap. **Read-only plus advisory is not sufficient.**
+Two agents satisfy S1 and S2 and are still not sentinels, because the
+category turns on the *object of care*, not the trust boundary.
+
+- **`code-reviewer`** — read-only (S1 ✓), reports findings to a human
+  (S2 ✓). Not a sentinel: its object of care is the *code*. Its finding
+  is "this function violates the joinability property", not "you are
+  about to approve something you do not understand".
+- **`harness-auditor`** — read-only but for the Status section (S1 ✓ in
+  spirit), reports to a human (S2 ✓). Not a sentinel: its object of care
+  is the *harness* — whether declared enforcement matches reality.
+
+The test: does the finding describe *what the human can or should hold
+in mind* (sentinel), or *the state of an artefact* that happens to be
+reported to a person (near-miss)?
+
+## Extending the category
+
+When you author a new sentinel:
+
+1. Check S1, S2, S3. All three, or it is not a sentinel.
+2. Run the near-miss test — object of care is the human's understanding,
+   not an artefact.
+3. **Write the honesty rule (S3) first**, before the detection logic.
+   This mirrors the `cognitive-reservoir` skill's contested-vs-robust
+   science discipline: fixing what you refuse to assert *first* bounds
+   what the detection is allowed to say, so the logic can never quietly
+   outrun the evidence.
+4. Add `role: sentinel` to the frontmatter, confirm no Write/Edit, and
+   let `sentinel-integrity-check.sh` enforce it.
+5. Add the agent to the README Sentinels section and this page.
+
+Avoid the three anti-patterns — an agent that **scores the human**,
+**persists a record of the human's state**, or **gates automatically**
+has left the category, whatever its `role:` tag says.
+
+The full authoring guidance lives in the `sentinel-design` skill.
+
+## What this is not
+
+- **Not a new gate.** Sentinels feed existing gates; the category adds
+  none.
+- **Not a behavioural change.** The five roster agents behave exactly as
+  before; the `role: sentinel` tag is additive.
+- **Not cross-plugin (yet).** The `diagnostic-legibility` plugin's
+  charter ("maintaining human understanding") makes it a natural future
+  sentinel host, but that migration is deferred to a separate spec.

--- a/docs/plugins/ai-literacy-superpowers/explanation/watching-the-verifier.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/watching-the-verifier.md
@@ -116,3 +116,6 @@ not to take the decision out of human hands.
   carpaccio / diaboli / cartographer agents that protect the human's
   decision budget at the *input* side, complementary to the warden's
   watch on the verifier at the *output* side.
+- [Sentinels](sentinels.md) — the reservoir-warden is one of five
+  sentinels: agents whose object of care is the human's understanding
+  and judgement rather than an artefact.

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -8,6 +8,17 @@ The plugin ships 16 agents organised into three groups: the
 the **harness agents** that verify and maintain infrastructure
 conventions, and the **assessor** that measures AI literacy.
 
+Cutting across those groups is a fourth, cross-cutting family — the
+**[sentinels](../explanation/sentinels.md)**. A sentinel is any agent
+whose object of care is the human's understanding and judgement rather
+than an artefact: `carpaccio`, `advocatus-diaboli`,
+`choice-cartographer`, `reservoir-warden`, and `cost-estimator`. Each
+declares `role: sentinel` in its frontmatter, is read-only (criterion
+S1, enforced deterministically by the Sentinel integrity constraint),
+emits advisory output a human disposes (S2), and carries an explicit
+epistemic honesty rule (S3). See the `sentinel-design` skill for the
+signature and the near-miss gallery.
+
 Every agent reads `CLAUDE.md` and `AGENTS.md` before acting.
 Agents that modify files are read-write; agents that only inspect
 are read-only. The trust boundary column in the summary table

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -223,3 +223,22 @@ or human brainstorming. Not a gate — the forcing functions are the
 deterministic CI workflows shipped in v0.36.0. Pairs with
 advocatus-diaboli (review-time): the skill names the design choices,
 the diaboli challenges them. Added in v0.37.0 (issue #313, PR #314).
+
+### sentinel-design
+
+Authoring guidance for the **sentinel** agent category — agents whose
+object of care is the human's understanding and judgement rather than an
+artefact. Defines the three-part **sentinel signature**: S1 (read-only
+trust boundary — denies Write/Edit, Bash permitted for read-only
+inspection), S2 (advisory output a human disposes, no automated action),
+and S3 (an explicit epistemic honesty rule declaring the status of its
+claims). Documents the **near-miss gallery** — why `code-reviewer` and
+`harness-auditor` satisfy S1 and S2 yet are not sentinels (their object
+of care is the code and the harness, not the human) — so authors do not
+read read-only-plus-advisory as sufficient. Names the design discipline
+(write the honesty rule S3 *before* the detection logic, mirroring the
+`cognitive-reservoir` skill's contested-vs-robust discipline) and the
+three anti-patterns that eject an agent from the category: scoring the
+human, persisting a record of the human's state, or gating
+automatically. S1 is enforced deterministically by
+`sentinel-integrity-check.sh`. Added in v0.66.0.

--- a/docs/superpowers/specs/2026-07-20-sentinel-agent-category-design.md
+++ b/docs/superpowers/specs/2026-07-20-sentinel-agent-category-design.md
@@ -1,0 +1,196 @@
+# Spec: Introduce the Sentinel Agent Category
+
+**Status:** Approved
+**Date:** 2026-07-20
+**Scope:** `ai-literacy-superpowers` plugin only
+**Explicitly out of scope:** the `diagnostic-legibility` plugin (no changes, no
+migration, no renaming — see Non-Goals)
+
+---
+
+## 1. Problem Statement
+
+The plugin ships sixteen agents, currently presented as a flat table
+differentiated only by role description and trust boundary. Hidden inside that
+table is a coherent sub-family that has emerged organically: agents whose object
+of care is not the codebase, the pipeline, or the harness, but **the human**.
+They protect and support the understanding and judgement of the human in the
+workflow.
+
+These agents already share a signature — read-only trust boundary, advisory
+output, positioning at or feeding a human gate, an explicit honesty rule — but
+the category is unnamed. Unnamed categories cannot be documented, enforced,
+taught, or extended deliberately. This spec names it.
+
+## 2. Definition
+
+> **Sentinel** — any agent whose primary purpose is to protect and support the
+> understanding and judgement of the human in the workflow.
+
+A sentinel acts on the human's epistemic state, not on artefacts. It informs,
+challenges, surfaces, or warns — it never fixes, writes, merges, or decides.
+
+## 3. Membership Criteria (the Sentinel Signature)
+
+An agent qualifies as a sentinel if and only if it satisfies all three:
+
+| # | Criterion | Testable form |
+|---|-----------|---------------|
+| S1 | **Read-only trust boundary** | Agent frontmatter denies Write/Edit (Bash may be permitted for read-only inspection, e.g. `git log`) |
+| S2 | **Advisory output for a human** | The agent's output is a record, objection, story, estimate, or recommendation that a *human* disposes; it triggers no automated action |
+| S3 | **Explicit epistemic honesty rule** | The agent declares the status of its claims (e.g. observed/inferred/asked flags, objection categories with evidence requirements, refusal-over-fabrication) |
+
+S1 is deterministically CI-checkable. S2 and S3 are agent-verifiable via the
+harness-enforcer.
+
+## 4. Sentinel Roster
+
+| Agent | Guards | Signature evidence |
+|-------|--------|--------------------|
+| `reservoir-warden` | The decider — the verifier's cognitive reservoir | Read-only (no Write/Edit); single decide-your-stop-first recommendation; observed/inferred/asked flags; persists no record of human state |
+| `advocatus-diaboli` | Decisions at both gates — spec-time premises, code-time risks | Read-only; six-category objection record disposed by human; evidence requirements per objection |
+| `choice-cartographer` | Understanding of implicit decisions | Read-only; choice stories disposed at soft gate; six-lens map declares what was found vs. inferred |
+| `carpaccio` | Judgement scale — keeps each decision small enough to hold | Read-only; slice dispositions are a hard human gate |
+| `cost-estimator` | The decision's inputs — what a choice will cost before it is made | Read-only; human disposes the estimate record; refuses rather than fabricating an ungroundable estimate |
+
+**Disposition of Open Question 1 (human-approved, 2026-07-20):**
+`cost-estimator` **joins the roster**. It satisfies S1–S3 without qualification.
+Its object of care is arguably the *decision's inputs* rather than the decider
+directly, but supplying a human with a grounded, refusable estimate before they
+commit is squarely "protecting and supporting judgement". The adjacent-tier
+alternative was rejected as a distinction without an enforceable difference.
+
+### Explicitly not sentinels
+
+`orchestrator`, `spec-writer`, `tdd-agent`, `code-reviewer`,
+`integration-agent`, `harness-discoverer`, `harness-enforcer`, `harness-gc`,
+`harness-auditor`, `assessor`, `governance-auditor` — each acts on artefacts,
+pipeline state, or the harness itself.
+
+`code-reviewer` and `harness-auditor` are near-misses. Both are read-only
+(S1 ✓) and both report to a human (S2 ✓). Neither is a sentinel, because the
+category turns on the *object of care*, not the trust boundary: the
+code-reviewer's object of care is the code, and the harness-auditor's is the
+harness. A sentinel's finding is about what the human can or should hold in
+mind; a near-miss's finding is about an artefact that happens to be reported to
+a human. This distinction is documented in the `sentinel-design` skill's
+near-miss gallery so future authors do not read "read-only + advisory" as
+sufficient.
+
+## 5. Changes
+
+### 5.1 Agent frontmatter: `role: sentinel`
+
+Add an optional `role` field to agent frontmatter. **Enum with a single
+permitted value, `sentinel`** (disposition of Open Question 2). Applied to the
+five roster agents in §4. Absence of the field means "pipeline/harness agent" —
+no change to existing agents' behaviour. The enum is widened only when a second
+category earns a name.
+
+### 5.2 README: Sentinels section
+
+Restructure the *Agents (16)* table into two tables:
+
+1. **Sentinels (5)** — with the definition (§2), the signature (§3), and a
+   one-line narrative: *the decision-discipline triad guards decisions; the
+   reservoir-warden guards the decider; the cost-estimator guards the decision's
+   inputs.*
+2. **Pipeline & harness agents (11)** — the existing table, unchanged rows.
+
+No agent is renamed. `carpaccio`, `advocatus-diaboli`, `choice-cartographer`,
+and `reservoir-warden` keep their names; "decision-discipline triad" remains
+valid vocabulary and is cross-referenced from the Sentinels section.
+
+### 5.3 New skill: `sentinel-design`
+
+A skill documenting the category for humans and agents authoring new sentinels:
+
+- The definition and the three-part signature
+- The near-miss gallery (why code-reviewer and harness-auditor don't qualify)
+- Design guidance: a sentinel's honesty rule must be written *before* its
+  detection logic (mirrors the cognitive-reservoir skill's contested-vs-robust
+  science discipline)
+- Anti-patterns: a sentinel that scores the human, persists human-state
+  records, or gates automatically has left the category
+
+### 5.4 HARNESS constraint: sentinel integrity
+
+New constraint in the plugin's own HARNESS.md:
+
+> Any agent whose frontmatter declares `role: sentinel` MUST NOT be granted
+> Write or Edit tools.
+
+- **Verification slot:** deterministic — `sentinel-integrity-check.sh` parses
+  agent frontmatter and tool grants.
+- **Scope:** pr, via `.github/workflows/harness.yml`.
+- **Also a GC rule:** the same script runs in the weekly GC sweep, catching a
+  violation introduced by a path that bypassed the PR gate.
+- The script additionally rejects a `role:` value outside the enum (§5.1), so a
+  typo like `role: sentinal` fails loudly rather than silently exempting the
+  agent from the check.
+
+This makes the category *load-bearing* rather than decorative: mislabel an agent
+and CI fails.
+
+### 5.5 Docs
+
+- New docs page:
+  `docs/plugins/ai-literacy-superpowers/explanation/sentinels.md` — definition,
+  signature, roster, narrative framing, extension guide.
+- Cross-links from the agent pipeline docs, the decision-discipline-triad page,
+  the watching-the-verifier page, and the cognitive-reservoir skill.
+- Reference-page entries for the new skill (`reference/skills.md`) and a
+  Sentinels grouping note in `reference/agents.md`.
+
+**Disposition of the spec's stated docs path (human-approved, 2026-07-20):**
+the spec originally named `docs/plugins/ai-literacy-superpowers/sentinels.md`.
+That path sits outside every Diataxis quadrant and conflicts with the
+`Docs Site Review` convention in CLAUDE.md, which the `mkdocs-awesome-pages`
+nav derivation depends on. The page is placed in `explanation/` instead,
+alongside its conceptual neighbours.
+
+### 5.6 `/superpowers-status`: sentinel coverage
+
+**Disposition of Open Question 3 (human-approved, 2026-07-20): yes.**
+`/superpowers-status` gains a `Sentinels` line reporting the count of agents
+declaring `role: sentinel` and the state of the integrity constraint, e.g.
+`5 sentinels active, integrity constraint green`. Reported descriptively; a
+sentinel count of zero is not a warning (a downstream project may legitimately
+ship none). The constraint state is WARNING only when a violation is detected.
+
+## 6. Non-Goals
+
+- **No changes to the `diagnostic-legibility` plugin.** Its charter
+  ("maintaining human understanding") makes it a natural future sentinel host,
+  but migration, renaming, or cross-plugin tagging is deferred to a separate
+  spec.
+- **No agent renames.**
+- **No behavioural changes** to any agent — this is categorisation,
+  documentation, and one new enforceable constraint.
+- **No new gates.** Sentinels feed existing gates; none are added.
+
+## 7. Acceptance Scenarios (TDAD)
+
+1. **Frontmatter tagging** — Given the five roster agents, when the plugin is
+   built, then each declares `role: sentinel` and passes schema validation.
+2. **Sentinel integrity constraint (green)** — Given all `role: sentinel`
+   agents deny Write/Edit, when the CI constraint check runs, then it passes.
+3. **Sentinel integrity constraint (red)** — Given a test fixture agent
+   declaring `role: sentinel` *and* a Write grant, when the check runs, then CI
+   fails with a message naming the agent and the violated criterion (S1).
+4. **Unknown role value rejected** — Given a fixture agent declaring a `role`
+   value outside the enum, when the check runs, then it fails naming the agent
+   and the invalid value.
+5. **README structure** — Given the README, then a *Sentinels* section exists
+   containing exactly the roster agents, and no agent appears in both tables.
+6. **Skill discovery** — Given a session in a project with the plugin
+   installed, when an agent is asked to design a new human-guarding agent, then
+   the `sentinel-design` skill is loadable and its anti-patterns section is
+   present.
+
+## 8. Migration & Rollout
+
+Single minor version bump (0.65.1 → 0.66.0). No breaking changes: the `role`
+field is additive, the constraint only binds agents that opt into the tag, and
+README restructuring is presentational. `/harness-upgrade` surfaces the new
+constraint and skill to downstream projects as optional template content.

--- a/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/clean/good-sentinel.agent.md
+++ b/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/clean/good-sentinel.agent.md
@@ -1,0 +1,7 @@
+---
+name: good-sentinel
+description: A valid sentinel with read-only Bash inspection.
+tools: [Read, Glob, Grep, Bash]
+role: sentinel
+---
+Body.

--- a/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/clean/pipeline-agent.agent.md
+++ b/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/clean/pipeline-agent.agent.md
@@ -1,0 +1,6 @@
+---
+name: pipeline-agent
+description: An untagged pipeline agent — Write is fine, the check must ignore it.
+tools: [Read, Write, Edit, Bash]
+---
+Body.

--- a/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/violation-role/typo-role.agent.md
+++ b/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/violation-role/typo-role.agent.md
@@ -1,0 +1,7 @@
+---
+name: typo-role
+description: A role typo — must fail the enum check.
+tools: [Read, Glob, Grep]
+role: sentinal
+---
+Body.

--- a/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/violation-write/bad-sentinel.agent.md
+++ b/tdad_tests/layer0_deterministic/fixtures/sentinel-integrity/violation-write/bad-sentinel.agent.md
@@ -1,0 +1,7 @@
+---
+name: bad-sentinel
+description: A sentinel wrongly granted Write — must fail S1.
+tools: [Read, Write, Glob, Grep]
+role: sentinel
+---
+Body.

--- a/tdad_tests/layer0_deterministic/test-sentinel-integrity.sh
+++ b/tdad_tests/layer0_deterministic/test-sentinel-integrity.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the sentinel integrity matcher
+# (spec 2026-07-20-sentinel-agent-category-design.md, §5.4; AC-2, AC-3, AC-4).
+#
+# The matcher is a single bash script invoked two ways: a PR-time GitHub gate
+# (.github/workflows/harness.yml) and this Layer-0 test, where the red/green
+# fixtures live and prove its precision. One matcher, so both callers enforce
+# the same rule.
+#
+# Contract under test (spec §5.4):
+#   sentinel-integrity-check.sh <agents-dir>
+#     - FAILS (exit non-zero) if any `role: sentinel` agent in the dir is
+#       granted Write or Edit, naming the agent and criterion S1 (AC-3);
+#     - FAILS if any agent declares a `role:` value outside the enum
+#       {sentinel}, naming the agent and the value (AC-4);
+#     - PASSES (exit 0) when every sentinel is read-only and untagged
+#       pipeline agents — even ones with Write — are ignored (AC-2).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MATCHER="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/sentinel-integrity-check.sh"
+FIX="$SCRIPT_DIR/fixtures/sentinel-integrity"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Guard: the matcher must exist and be executable.
+[ -f "$MATCHER" ] || fail "matcher script not found at $MATCHER"
+[ -x "$MATCHER" ] || fail "matcher script exists but is not executable: $MATCHER"
+
+# run <agents-dir> -> sets RC and OUT
+run() {
+  set +e
+  OUT=$("$MATCHER" "$1" 2>&1)
+  RC=$?
+  set -e
+}
+
+# --- AC-2: green — read-only sentinel + untagged Write agent both pass --------
+run "$FIX/clean"
+[ "$RC" -eq 0 ] || fail "clean fixtures must PASS (a read-only sentinel and an ignored untagged agent); got exit $RC: $OUT"
+
+# --- AC-3: red — sentinel granted Write must FAIL, naming agent + S1 ----------
+run "$FIX/violation-write"
+[ "$RC" -ne 0 ] || fail "a sentinel granted Write must FAIL (got exit 0): $OUT"
+echo "$OUT" | grep -q "bad-sentinel" || fail "S1 violation message must name the offending agent: $OUT"
+echo "$OUT" | grep -q "S1" || fail "S1 violation message must cite criterion S1: $OUT"
+
+# --- AC-4: red — unknown role value must FAIL, naming agent + value -----------
+run "$FIX/violation-role"
+[ "$RC" -ne 0 ] || fail "an unknown role value must FAIL (got exit 0): $OUT"
+echo "$OUT" | grep -q "typo-role" || fail "unknown-role message must name the offending agent: $OUT"
+echo "$OUT" | grep -q "sentinal" || fail "unknown-role message must name the invalid value: $OUT"
+
+echo "PASS: sentinel integrity matcher — green clean, red on Write grant, red on unknown role"

--- a/tdad_tests/scenarios/skills/sentinel-design/defines-signature-and-anti-patterns.md
+++ b/tdad_tests/scenarios/skills/sentinel-design/defines-signature-and-anti-patterns.md
@@ -1,0 +1,60 @@
+---
+component: sentinel-design
+component_type: skill
+tier: structural
+---
+
+# Scenario: sentinel-design defines the signature, the near-miss gallery, and the anti-patterns
+
+## Given
+
+The `sentinel-design` skill (spec
+`docs/superpowers/specs/2026-07-20-sentinel-agent-category-design.md`, §5.3) is
+the authoring guidance for the sentinel agent category — the reference a human
+or agent consults before designing a new agent that guards the human's
+understanding and judgement. It documents the category so the next sentinel is
+built deliberately rather than rediscovered.
+
+## When
+
+The skill file at
+`ai-literacy-superpowers/skills/sentinel-design/SKILL.md` is read directly from
+the filesystem.
+
+## Then
+
+**Frontmatter**:
+
+- YAML frontmatter present with `name: sentinel-design` and a non-empty
+  `description`.
+
+**Content — the definition and the three-part signature** (§2, §3):
+
+- States the **definition** of a sentinel: an agent whose primary purpose is to
+  protect and support the understanding and judgement of the human.
+- Defines all three signature criteria: **S1** (read-only trust boundary —
+  denies Write/Edit, Bash permitted for read-only inspection), **S2** (advisory
+  output a human disposes, no automated action), and **S3** (explicit epistemic
+  honesty rule declaring the status of its claims).
+
+**Content — the near-miss gallery** (§4):
+
+- Names **code-reviewer** and **harness-auditor** as near-misses and explains
+  that read-only-plus-advisory is *not sufficient* — the category turns on the
+  object of care (the human's understanding) not the trust boundary.
+
+**Content — design discipline and anti-patterns** (§5.3):
+
+- States the **honesty-rule-before-detection-logic** discipline, cross-
+  referencing the `cognitive-reservoir` skill's contested-vs-robust discipline.
+- Lists the three **anti-patterns**: a sentinel that **scores the human**, that
+  **persists a record of the human's state**, or that **gates automatically**
+  has left the category.
+
+## Rubric
+
+Layer 1 structural scenario: every assertion is mechanically checkable by
+reading the skill and matching against its section headings and key phrases.
+The scenario passes only when the definition, the three signature criteria
+(S1/S2/S3), the two near-miss agents, the honesty-rule-first discipline, and
+the three anti-patterns are all present.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -57,6 +57,9 @@ BASH_TEST_SCRIPTS = [
     # RED until S2 ships the matcher script and the four templates.
     "test-inv1-firewall",
     "test-workflow-templates",
+    # sentinel agent category — the read-only integrity matcher for
+    # role: sentinel agents (§5.4).
+    "test-sentinel-integrity",
 ]
 
 

--- a/tdad_tests/tests/test_s7_docs_hook_copilot_structural.py
+++ b/tdad_tests/tests/test_s7_docs_hook_copilot_structural.py
@@ -13,7 +13,7 @@ a session, dispatch a workflow, or judge whether the (deferred) advisory hook
 - the repo-root ``README.md`` gains a **Dynamic Workflows** section naming the
   six patterns + election discipline (AC-2), INV-1/INV-2 (AC-3), the
   Claude-Code-only scope + the guidance-only Copilot **Option A** contract
-  (AC-4), and that the ``Skills-36`` badge is **unchanged** (AC-5);
+  (AC-4), and that the ``Skills-N`` badge tracks the real skill count (AC-5);
 - ``skills/dynamic-workflows/references/governance.md`` states the resolved
   **Option A** Copilot degradation contract — ships to both trees, guidance
   only where no runtime, never omitted (AC-6c / FR-6);
@@ -44,17 +44,18 @@ malformed scenario or an unresolvable component; the ``dynamic-workflows``
 skill and both ``CLAUDE.md`` files already exist). The corpus/parse/tier
 checks in ``test_layer1_structural.py`` stay GREEN.
 
-**Guard that must STAY green now:** the ``Skills-36``-present /
-``Skills-37``-absent assertion is **not** a RED-now assertion — S1 already
-reconciled the count to 36. It guards against an accidental re-bump and must
-pass both before and after S7 implements.
+**Guard that must STAY green now:** the ``Skills-N`` badge assertion is
+**not** a RED-now assertion — it derives the expected count from the skill
+directories on disk and asserts the badge matches. It guards against both an
+accidental re-bump and a stale count, and must pass before and after S7
+implements (and after any legitimate skill addition).
 
 Line-wrap note (the trap that bit S3 twice, S4 twice, S5 once, S6 once): a
 required two-word phrase an implementer might wrap across a line is NOT
 asserted as a single substring. Where a guarantee needs two terms to
 co-occur, they are asserted as two independent ``in`` checks on the
 lowercased section so a wrapped phrase still passes. Single load-bearing
-tokens (``skills-36``, ``skills-37``, ``inv-1``, ``inv-2``,
+tokens (``skills-N``, ``inv-1``, ``inv-2``,
 ``dynamic-workflows``, ``fan-out``, ``opt-in``, ``long-running``) are
 wrap-safe and asserted directly; ``claude code`` and ``massively parallel``
 are two words and are split.
@@ -146,7 +147,7 @@ class TestS7ReadmeDynamicWorkflowsSection:
     """Structural shadow of AC-1–AC-5 — README.md must gain a Dynamic
     Workflows section naming the six patterns + election discipline,
     INV-1/INV-2, the Claude-Code-only scope + the guidance-only Copilot
-    Option-A contract, while leaving the Skills-36 badge unchanged
+    Option-A contract, while the Skills-N badge tracks the real skill count
     (scenario ``scenarios/skills/dynamic-workflows/readme-dynamic-workflows-section.md``)."""
 
     def test_section_exists(self, plugin_path: Path) -> None:
@@ -222,24 +223,24 @@ class TestS7ReadmeDynamicWorkflowsSection:
             "two co-occurring tokens."
         )
 
-    def test_skill_count_badge_unchanged_at_36(
+    def test_skill_count_badge_matches_actual_count(
         self, plugin_path: Path
     ) -> None:
-        # GUARD (must STAY green): S7 must NOT re-bump the skill count. The
-        # badge reads 'Skills-36' (reconciled in S1); 'Skills-37' must be
-        # absent. Read the full README (case-sensitive) — the badge text is
-        # 'Skills-36', a single unwrappable token.
+        # GUARD (must STAY green): the README skills shields badge must equal
+        # the ACTUAL number of skill directories — no spurious bump, no stale
+        # count. Originally this pinned the literal 'Skills-36' (S7 must not
+        # re-bump); it now derives the expected count from the filesystem so a
+        # legitimate new skill (e.g. sentinel-design, the 37th) updates the
+        # badge without the guard going stale. Read the full README
+        # (case-sensitive) — the badge text is 'Skills-N', a single
+        # unwrappable token.
         text = _readme_text(plugin_path)
-        assert "Skills-36" in text, (
-            "README skills shields badge must still read 'Skills-36' — S7 adds "
-            "prose only and does NOT re-bump the skill count (AC-5 / FR-5; "
-            "reconciled in S1). 'Skills-36' is a single unwrappable token. "
-            "This guard must stay GREEN before and after S7 implements."
-        )
-        assert "Skills-37" not in text, (
-            "README must NOT contain 'Skills-37' — S7 ships no new skill; "
-            "re-bumping the skill-count badge is forbidden (AC-5 / FR-5). "
-            "This guard must stay GREEN before and after S7 implements."
+        actual = len(list((plugin_path / "skills").glob("*/SKILL.md")))
+        assert f"Skills-{actual}" in text, (
+            f"README skills shields badge must read 'Skills-{actual}' to match "
+            f"the {actual} skill directories under ai-literacy-superpowers/"
+            "skills/ (AC-5 / FR-5). The badge count must track the real skill "
+            "count — bump it when adding a skill, and never spuriously."
         )
 
 


### PR DESCRIPTION
Closes #481.

Names the sub-family of agents whose object of care is the human's understanding and judgement rather than an artefact. Categorisation, documentation, and one new enforceable constraint — no agent renames, no behavioural changes, no new gates.

## What changed

- **`role: sentinel` frontmatter** on the five roster agents (`reservoir-warden`, `advocatus-diaboli`, `choice-cartographer`, `carpaccio`, `cost-estimator`). An enum with a single value; absence means pipeline/harness agent, changes nothing.
- **Sentinel integrity constraint** — `sentinel-integrity-check.sh` fails CI if a `role: sentinel` agent is granted Write/Edit (criterion S1), or if a `role:` value falls outside the enum. Runs at PR time (`harness.yml`), weekly (`gc.yml`), and as a Layer-0 test with red/green fixtures. Makes the category load-bearing, not decorative.
- **`sentinel-design` skill** — three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), near-miss gallery (why code-reviewer and harness-auditor don't qualify), honesty-rule-before-detection-logic discipline, three anti-patterns.
- **README** — Agents table split into Sentinels (5) and Pipeline & harness agents (11).
- **Docs** — new `explanation/sentinels.md`; `/superpowers-status` reports sentinel coverage; reference-page and cross-link updates.
- **Version** — 0.65.1 → 0.66.0 across all CI-checked locations.

## Open-question dispositions (human-approved)

- cost-estimator **joins** the roster (5 sentinels)
- `role` is an **enum** `{sentinel}`
- `/superpowers-status` **reports** coverage
- docs page under **explanation/** per the Diataxis convention

## Spec

First commit on the branch: `docs/superpowers/specs/2026-07-20-sentinel-agent-category-design.md`.

## Local verification

- Layer 0 + Layer 1 TDAD suites: 28 passed
- Sentinel integrity: green on real agents, red on Write grant + bad enum
- Convention parity: 32/32 across three files
- Version consistency + markdown lint clean