### PR TITLE
Docs: ground the sentinel category in Storey's triple-debt model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.66.0",
+  "plugin_version": "0.66.1",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.66.0"
+      "version": "0.66.1"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.66.1 — 2026-07-20
+
+### Docs: ground the sentinel category in Storey's triple-debt model
+
+- Grounded the sentinel category in Margaret-Anne Storey's *From
+  Technical Debt to Cognitive and Intent Debt* (2026, arXiv:2603.22106):
+  where the pipeline and harness agents fight **technical** debt in the
+  code, sentinels service the human side of the ledger, holding back the
+  **cognitive** debt (erosion of shared understanding) and **intent**
+  debt (absence of externalised rationale, goals, and constraints) that
+  accrue when AI generates code faster than a team can absorb it.
+- Framed sentinels as the agent pattern that establishes and protects the
+  human's **understanding, judgement, and discernment** — three edges of
+  one commitment, each mapped to a debt and to the sentinels that hold it
+  back. Discernment (telling a sound AI output from a plausible-but-wrong
+  one) is named as the sharpest edge and the one AI erodes most quietly.
+- Added the grounding to `explanation/sentinels.md`, the `sentinel-design`
+  skill, the `design-a-sentinel` how-to, the README Sentinels intro, and
+  the reference entry; kept the crisp one-line definition and layered the
+  triple-debt framing on top. Patch bump — plugin doc-only change.
+
 ## 0.66.0 — 2026-07-20
 
 ### Feature: the sentinel agent category

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.66.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.66.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -212,6 +212,13 @@ whose object of care is an artefact, the pipeline, or the harness.
 > support the understanding and judgement of the human in the workflow.
 > It informs, challenges, surfaces, or warns — it never fixes, writes,
 > merges, or decides.
+
+Sentinels are the answer to the human side of Margaret-Anne Storey's
+[triple-debt model](docs/plugins/ai-literacy-superpowers/explanation/sentinels.md#why-the-category-exists-the-debts-ai-moves-upstream):
+where the pipeline and harness agents fight *technical* debt in the code,
+sentinels establish and protect the human's **understanding, judgement,
+and discernment** — holding back the *cognitive* and *intent* debt that
+accrue when AI produces output faster than a person can absorb it.
 
 Every sentinel satisfies the three-part **sentinel signature**: **S1**
 read-only trust boundary (no Write/Edit; `Bash` only for read-only

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
+++ b/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
@@ -26,6 +26,54 @@ triad (`carpaccio`, `advocatus-diaboli`, `choice-cartographer`) plus the
 the same shape without anyone naming the shape. This skill names it, so
 that the next one can be built deliberately rather than rediscovered.
 
+## Why sentinels exist: the debts AI moves upstream
+
+The category has a reason to exist, and it comes from Margaret-Anne
+Storey's **triple-debt model** (*From Technical Debt to Cognitive and
+Intent Debt: Rethinking Software Health in the Age of AI*, 2026;
+arXiv:2603.22106, expanded in ACM Queue). Storey argues that generative
+AI produces code faster than a team can comprehend it, which shifts where
+the real risk to software health lives. Three debts interact:
+
+- **Technical debt** lives in the **code** — the debt the pipeline and
+  harness agents already fight.
+- **Cognitive debt** lives in the **people** — the erosion of shared
+  understanding, leaving inadequate mental models for safely changing the
+  system.
+- **Intent debt** lives in the **artefacts** — the absence of the
+  explicit rationale, goals, and constraints humans and agents need to
+  evolve the system safely.
+
+In AI-assisted development, cognitive and intent debt may matter *more*
+than technical debt — and neither is paid down by cleaner code. They are
+paid down by protecting the human's grip on the system. **A sentinel is
+the agent pattern that services the human side of that ledger.** It works
+to establish and protect the human's **understanding, judgement, and
+discernment** so those two debts do not silently accrue.
+
+These are three edges of one commitment, each holding back a debt:
+
+- **Understanding** — the shared mental model of what the system does and
+  why (holds back cognitive debt). Guarded by `carpaccio` (keeps each
+  decision holdable) and `choice-cartographer` (surfaces implicit
+  decisions).
+- **Judgement** — the quality of the human's *yes* at the gate (cognitive
+  debt). Guarded by `reservoir-warden` (watches the decider) and
+  `advocatus-diaboli` (steel-mans the objections).
+- **Discernment** — the ability to tell a *good* AI output from a
+  *plausible-but-wrong* one (cognitive + intent debt). This is the
+  sharpest edge and the one AI erodes most quietly: a plausible spec, a
+  confident estimate, and a clean-looking diff all *read* as correct.
+  Guarded by `advocatus-diaboli` (names what could be wrong) and
+  `cost-estimator` (refuses an ungroundable estimate rather than
+  fabricating a confident one).
+
+A sentinel's advisory record also pays down intent debt directly: a
+choice-story or objection record *is* externalised rationale — the very
+artefact whose absence Storey names as intent debt. Keep this in view
+when authoring: prefer emitting a durable "why" the next human or agent
+can read over a verdict that evaporates once the gate closes.
+
 ## The sentinel signature
 
 An agent is a sentinel if and only if it satisfies all three criteria.

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -21,6 +21,66 @@ The category emerged organically before it was named. The
 the shape. Naming it lets the next one be built deliberately, and lets
 the shape be enforced rather than merely hoped for.
 
+## Why the category exists: the debts AI moves upstream
+
+Margaret-Anne Storey's **triple-debt model** gives the sentinel category
+its reason to exist.[^storey] Storey argues that generative AI generates
+code faster than a team can comprehend it, and that this shifts *where*
+the most significant risk to software health lives. Three debts interact:
+
+- **Technical debt** lives in the **code** — the quality shortcuts in the
+  codebase itself. This is the debt the plugin's pipeline and harness
+  agents already fight (TDD, CUPID review, garbage collection).
+- **Cognitive debt** lives in the **people** — "the erosion of shared
+  understanding across a team", leaving increasingly inadequate mental
+  models for reasoning about and safely changing the system.
+- **Intent debt** lives in the **artefacts** — the absence or erosion of
+  the explicit rationale, goals, and constraints that both humans and
+  agents need in order to evolve the system safely.
+
+Storey's claim is that in AI-assisted development, cognitive and intent
+debt may matter *more* than technical debt — and neither is paid down by
+making the code cleaner. They are paid down by protecting the human's
+grip on the system. **Sentinels are the agent pattern that services the
+human side of that ledger.** A sentinel does not touch the code; it works
+to establish and protect the human's **understanding, judgement, and
+discernment** so that cognitive and intent debt do not silently accrue as
+the AI produces output faster than a person can absorb it.
+
+### Three edges of one commitment
+
+*Understanding, judgement,* and *discernment* are not three separate
+goals — they are three edges of the same commitment to keep the human in
+genuine command of an AI-accelerated workflow. Each maps to a debt a
+sentinel holds back:
+
+| Edge | What it protects | Debt it holds back | Sentinels |
+| --- | --- | --- | --- |
+| **Understanding** | The human's shared mental model of what the system does and why | Cognitive debt | `carpaccio` keeps each decision small enough to hold; `choice-cartographer` surfaces the implicit decisions a spec has made |
+| **Judgement** | The quality of the human's *yes* at the gate | Cognitive debt | `reservoir-warden` watches the state of the decider; `advocatus-diaboli` steel-mans the objections before the human commits |
+| **Discernment** | The human's ability to tell a *good* AI output from a *plausible-but-wrong* one | Cognitive + intent debt | `advocatus-diaboli` names what could be wrong; `cost-estimator` refuses an ungroundable estimate rather than fabricating a confident one |
+
+Discernment is the sharpest edge — and the one AI erodes most quietly. A
+plausible spec, a confident estimate, a clean-looking diff all *read* as
+correct; discernment is what lets a human tell the genuinely-sound from
+the merely-fluent. The `advocatus-diaboli` exists to make that
+distinction visible, and the `cost-estimator`'s refusal-over-fabrication
+rule exists so a fluent-but-baseless number never passes for a grounded
+one.
+
+Several sentinels also pay down **intent debt directly**: the
+`choice-cartographer`'s choice-story records and the `advocatus-diaboli`'s
+objection records are *externalised rationale* — exactly the artefacts
+whose absence Storey names as intent debt. A sentinel's advisory output
+is not only consumed by the human at the gate; once written it becomes
+the durable "why" that a later human or agent needs.
+
+[^storey]: Margaret-Anne Storey, *From Technical Debt to Cognitive and
+    Intent Debt: Rethinking Software Health in the Age of AI*, 2026 —
+    [arXiv:2603.22106](https://arxiv.org/abs/2603.22106), with an
+    expanded version in [ACM Queue](https://queue.acm.org/detail.cfm?id=3807966).
+    See also [margaretstorey.com](https://margaretstorey.com/).
+
 ## The sentinel signature
 
 An agent is a sentinel if and only if it satisfies all three criteria.

--- a/docs/plugins/ai-literacy-superpowers/how-to/design-a-sentinel.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/design-a-sentinel.md
@@ -44,7 +44,11 @@ If your candidate fails any one of these, it is not a sentinel — see
 The category turns on *what the agent cares about*, not its trust
 boundary. Ask: does the agent's output describe **what the human can or
 should hold in mind**, or the **state of an artefact** that merely gets
-reported to a human?
+reported to a human? A sentinel exists to hold back the *cognitive* and
+*intent* debt of Storey's
+[triple-debt model](../explanation/sentinels.md#why-the-category-exists-the-debts-ai-moves-upstream)
+— it establishes and protects the human's understanding, judgement, and
+discernment, not the health of the code.
 
 - "You are about to approve a spec whose cost you have not seen" →
   sentinel (guards the decider).

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -228,7 +228,11 @@ the diaboli challenges them. Added in v0.37.0 (issue #313, PR #314).
 
 Authoring guidance for the **sentinel** agent category — agents whose
 object of care is the human's understanding and judgement rather than an
-artefact. Defines the three-part **sentinel signature**: S1 (read-only
+artefact. Grounds the category in Margaret-Anne Storey's triple-debt
+model (technical / cognitive / intent debt): sentinels service the human
+side of the ledger, holding back the cognitive and intent debt AI accrues
+by establishing and protecting the human's understanding, judgement, and
+discernment. Defines the three-part **sentinel signature**: S1 (read-only
 trust boundary — denies Write/Edit, Bash permitted for read-only
 inspection), S2 (advisory output a human disposes, no automated action),
 and S3 (an explicit epistemic honesty rule declaring the status of its

--- a/tdad_tests/scenarios/skills/sentinel-design/defines-signature-and-anti-patterns.md
+++ b/tdad_tests/scenarios/skills/sentinel-design/defines-signature-and-anti-patterns.md
@@ -32,6 +32,10 @@ the filesystem.
 
 - States the **definition** of a sentinel: an agent whose primary purpose is to
   protect and support the understanding and judgement of the human.
+- **Grounds the category in Storey's triple-debt model**: names technical,
+  cognitive, and intent debt, and frames sentinels as the pattern that services
+  the human side of that ledger by establishing and protecting the human's
+  understanding, judgement, and **discernment**.
 - Defines all three signature criteria: **S1** (read-only trust boundary —
   denies Write/Edit, Bash permitted for read-only inspection), **S2** (advisory
   output a human disposes, no automated action), and **S3** (explicit epistemic


### PR DESCRIPTION
Gives the sentinel category a stated reason to exist, grounded in Margaret-Anne Storey's *From Technical Debt to Cognitive and Intent Debt: Rethinking Software Health in the Age of AI* (2026, [arXiv:2603.22106](https://arxiv.org/abs/2603.22106), expanded in [ACM Queue](https://queue.acm.org/detail.cfm?id=3807966)).

## The framing

Storey's triple-debt model: **technical debt** lives in the code, **cognitive debt** in the people (erosion of shared understanding), **intent debt** in the artefacts (absence of externalised rationale, goals, constraints). As AI generates code faster than teams can comprehend it, cognitive and intent debt may matter more than technical debt — and neither is paid down by cleaner code.

Sentinels are the agent pattern that services the human side of that ledger: they establish and protect the human's **understanding, judgement, and discernment**, three edges of one commitment, each mapped to a debt and to the sentinels that hold it back. Discernment — telling a sound AI output from a plausible-but-wrong one — is named as the sharpest edge and the one AI erodes most quietly.

## What changed

- **`explanation/sentinels.md`** — new *Why the category exists* section with the triple-debt grounding, the three-edges table, and a cited footnote.
- **`sentinel-design` skill** — same grounding woven into the pattern's canonical description (plugin file → patch bump).
- **How-to, README intro, reference entry** — the framing threaded through and cross-linked.
- **TDAD scenario** — updated so the skill's structural spec names the triple-debt grounding.
- **Version** — 0.66.0 → 0.66.1 (plugin doc-only change).

Per the reviewer's steer: the crisp one-line definition is kept; the trio is layered on as enrichment, not a redefinition.

## Verification

- `mkdocs build --strict` exits 0; no warnings reference the changed files; the footnote and all cross-page anchors resolve.
- markdownlint clean; TDAD Layers 0/1 + S7 (39 passed); version consistency + convention parity green.

Exempt from spec-first via the `chore` prefix/label (plugin doc-only change, no behaviour change).