### PR TITLE
Add harness health snapshot 2026-07-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
 [![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
-[![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/)
+[![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
 [![Copilot CLI](https://img.shields.io/badge/Copilot_CLI-Plugin-000000?style=flat-square&logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Harness Enabled](https://img.shields.io/badge/Agent_Harness-Enabled-000000?style=flat-square)](HARNESS.md)

--- a/observability/snapshots/2026-07-21-snapshot.md
+++ b/observability/snapshots/2026-07-21-snapshot.md
@@ -1,0 +1,252 @@
+# Harness Health Snapshot — 2026-07-21
+
+## Enforcement
+
+- Constraints: 31/32 enforced (97%)
+- Deterministic: 22 | Agent: 9 | Unverified: 1
+- Drift detected: minor — the HARNESS.md Status section is one constraint
+  behind reality. It was last written by `/harness-audit` on 2026-06-23
+  (30/31) and predates the **Sentinel integrity** constraint that landed
+  in #482. Actual current state is 32 active / 31 enforced. A
+  `/harness-audit` will reconcile the Status section; no functional gap
+  (the constraint is live in CI).
+
+The only unverified constraint is "Tests must pass" (by design — this
+plugin has no application test suite; the TDAD suite covers the plugin's
+own components and is CI-gated separately). Two template/example
+constraint blocks (`Spec conformance`, `[Governance constraint name]`)
+live inside HTML comments in HARNESS.md and are excluded from the totals.
+
+## Enforcement Loop History
+
+- Advisory (edit-time): active since 2026-04-06
+- Strict (merge-time): active since 2026-04-10
+- Investigative (scheduled): active since 2026-04-06
+
+## Garbage Collection
+
+- Rules active: 19/19
+- Last run: 2026-06-23 (Status regen via /harness-audit); the weekly
+  `gc.yml` sweep runs on schedule and now also carries the Sentinel
+  integrity check (#482)
+- Cadence compliance: on schedule (28 days since last audit, threshold 90)
+- Findings since last snapshot: 0 (no drift surfaced; the window's work
+  was feature + docs + bug-fix PRs, all green through the PR gates)
+
+The four affordance GC rules remain commented-out and are excluded from
+the 19/19 active total, consistent with the HARNESS.md Status note.
+
+## Mutation Testing
+
+- Not applicable — this project has no application code or mutation-tested
+  suite. The TDAD test suite under `tdad_tests/` covers the plugin's own
+  components (Layer 0 deterministic, Layer 1 structural, Layer 2 trigger,
+  Layer 3 behavioural). Layers 0 and 1 are CI-gated on every PR via
+  `tdad-tests-fast.yml`.
+
+## Compound Learning
+
+- REFLECTION_LOG entries: 54 (2 new since 2026-06-23, both dated
+  2026-06-23 and added after the prior snapshot was generated). No
+  reflections were captured for the 2026-07-16 → 2026-07-20 work window
+  (7 PRs, including the sentinel-category feature epic) — a mild
+  learning-flow gap, though /reflect remains within its monthly cadence.
+- AGENTS.md entries: 26 (last modified 2026-06-16 — unchanged this window)
+- Promotions since last snapshot: 0 (no new AGENTS.md promotions; the
+  prior window's promotion backlog was already paid down)
+
+### Reflection log + archive
+
+- Active log entry count: 54
+- Archive entry count: 0 (no `reflections/archive/` yet)
+- Curation debt (unpromoted entries older than 180 days): 0
+
+## Session Quality
+
+- Reflections with signal: 50/54 (93%)
+- Quality trend: stable (92% → 93%, within ±2% threshold; the four
+  signal-less entries all predate the Signal field on 2026-04-08 and
+  count as "none")
+
+## Diaboli
+
+Overall:
+
+- In-scope specs: 50 (specs dated ≥ 2026-04-19; +1 since 2026-06-23 —
+  the sentinel-agent-category design spec)
+- Objection records present: 38 (spec-mode: 25 | code-mode: 13) —
+  unchanged this window
+- In-scope specs without any record: the sentinel-category spec ran a
+  lighter ceremony — its open questions were dispositioned inline by the
+  human (recorded in the spec's disposition notes) rather than through a
+  formal objection record, consistent with the "concentrate objection
+  runs on contract-bearing slices" pattern
+- Objections total: ~347 (across all records)
+- Mean objections per record: ~9.1
+
+Spec-mode:
+
+- Records present: 25 (unchanged)
+- Fully-resolved rate: ~96% (24 of 25; `choice-cartographer.md` retains
+  the long-standing pending dispositions from earlier)
+
+Code-mode:
+
+- Records present: 13 (unchanged)
+- Fully-resolved rate: ~100%
+
+## Cartographer
+
+- In-scope specs: 45 (specs dated ≥ 2026-04-27; +1 since 2026-06-23)
+- Choice-story records present: 11 (unchanged this window — the sentinel
+  spec's decisions were captured inline rather than as a cartographer
+  record)
+- Stories total: 95
+- Mean stories per record: 8.6
+- cartograph_pending_count: 0
+- Fully-resolved rate: 100% (11 of 11 records fully resolved)
+
+## Operational Cadence
+
+- Last /harness-audit: 2026-06-23 (28 days ago — on schedule, target 90)
+- Last /assess: 2026-05-11 (71 days ago — on schedule, target 90)
+- Last /reflect: 2026-06-23 (28 days ago — on schedule, target 30;
+  approaching the monthly threshold)
+- Last /cost-capture: 2026-06-13 (38 days ago — on schedule, target 90)
+- Last /governance-audit: 2026-06-13 (38 days ago — on schedule, target 90)
+- Outer loop overdue: no
+
+## Cost Indicators
+
+- Model routing configured: yes (MODEL_ROUTING.md present)
+- Tier distribution: documented (most-capable, standard, capable tiers)
+- Last cost capture: 2026-06-13 (single-session sample in
+  `observability/costs/`)
+- Monthly average: not tracked (single-session sample only — $287.64 for
+  one multi-day local session; not a full billing-period aggregate)
+- Budget status: not set
+- Cost trend: unknown (still a single capture — no second snapshot to
+  compare against)
+
+## Sustainable Pace
+
+- This month's pace: sustainable
+- Note: a lighter, well-controlled window versus the prior three-epic
+  sprint — one feature epic (the sentinel agent category), two docs PRs,
+  and four maintenance/bug-fix PRs, every one merged green with all gates
+  passing. Cadences held; the only slack is reflection capture for the
+  feature work.
+- Trend: holding (sustainable → sustainable vs 2026-06-23)
+
+## Portfolio Adoption
+
+- Plugin installs (cumulative): not tracked
+- /assess invocations from other projects: not tracked
+- Upstream PRs into ai-literacy-for-software-engineers: not tracked this
+  window
+- agent-harness-enabled tagged repos discovered: not tracked
+- Trend: stable (telemetry still not wired; sister plugins remain
+  project-internal at this stage)
+
+## Regression Indicators
+
+- Snapshot stale: no (today's snapshot; previous was 28 days ago, under
+  the 30-day monthly threshold)
+- Snapshot age: 28 days (since 2026-06-23)
+- Cadence non-compliance: 0 of 5 activities overdue (audit, assess,
+  reflect, cost-capture, governance-audit)
+- Consecutive weeks without reflections: ~4 (most recent reflection dated
+  2026-06-23; no new capture in the July work window)
+- Regression flag: no
+
+## Meta
+
+- Snapshot cadence: on schedule (28-day gap from 2026-06-23, under the
+  30-day monthly threshold)
+- Cadence compliance: 5/5 on schedule (audit, assess, reflect,
+  cost-capture, governance-audit)
+- Learning flow: mostly active — reflections and promotions are current
+  through 2026-06-23, but the 2026-07 feature work shipped without a
+  /reflect run. Worth a reflection pass on the sentinel epic before the
+  monthly cadence lapses.
+- GC effectiveness: quiet (no findings this window; no drift to catch —
+  the Status-section staleness below is the one open item, and it is a
+  known post-audit lag, not slow drift)
+- Trend alerts: none
+- Health: **Healthy**
+
+## Changes Since Last Snapshot
+
+- Constraints added: 1 (Sentinel integrity — deterministic,
+  `sentinel-integrity-check.sh`; #482) — net active count grew 31 → 32,
+  enforced 30 → 31
+- Constraints promoted: none this window (Convention parity add and
+  Layer-0 promotion were already reconciled in the 2026-06-23 post-audit
+  Status)
+- Constraints removed: none
+- GC rules added: none (net 19 active; the Sentinel integrity check runs
+  in `gc.yml` as a workflow step, not as a new HARNESS.md GC rule)
+- Skills added: sentinel-design (#482)
+- Agents added: none — but the five roster agents (reservoir-warden,
+  advocatus-diaboli, choice-cartographer, carpaccio, cost-estimator) were
+  tagged `role: sentinel` (#482)
+- Commands added: none
+- New category introduced: **sentinels** — agents whose object of care is
+  the human's understanding, judgement, and discernment; grounded in
+  Storey's triple-debt model (#484)
+- Docs added: `explanation/sentinels.md`, `how-to/design-a-sentinel.md`,
+  reference entries; `/superpowers-status` now reports sentinel coverage
+- Bug fixes: harness-auditor bounded read-side filtering (#479);
+  plugin-script cache references via bin/ shims (#477); gc-rotate
+  strict-mode false positives (#476); Node.js 20 GitHub Actions bump
+  (#346)
+- Features: curated agentic-engineering video library (#474)
+- Plugin versions shipped: ai-literacy-superpowers 0.64.0 → 0.66.1
+- Assessments completed: none since 2026-05-11
+- Governance audits completed: none since 2026-06-13
+
+## Trends (vs 2026-06-23)
+
+| Metric | Previous | Current | Change |
+| --- | --- | --- | --- |
+| Enforcement ratio | 93% (28/30) | 97% (31/32) | +4% (Sentinel integrity added; the +1 active/+1 enforced also reflects the 2026-06-23 post-audit reconciliation the prior snapshot predated) |
+| Mutation (Go/Kotlin/Python) | n/a | n/a | n/a |
+| Reflections | 52 | 54 | +2 |
+| Promotions | 7+ | 0 | -7 (backlog already cleared; nothing new to promote) |
+| Reflections with signal | 92% (48/52) | 93% (50/54) | +1% |
+| GC findings | 2 | 0 | -2 (no drift this window) |
+| Cadence status | on schedule | on schedule | unchanged |
+| In-scope specs (cartographer) | 44 | 45 | +1 |
+| Choice-story records | 11 | 11 | unchanged |
+| Objection records | 38 | 38 | unchanged |
+| Plugin count | 3 | 3 | unchanged |
+
+Direction: steady and healthy, at a calmer cadence than the prior
+three-epic window. The headline change is the **sentinel agent category**
+(#482–#484) — a new agent taxonomy with a deterministic integrity
+constraint, a backing skill, full Diataxis docs, and a triple-debt
+conceptual grounding — shipped alongside four maintenance/bug-fix PRs and
+the video-library feature. The plugin moved 0.64.0 → 0.66.1. Enforcement
+rose to 31/32 (the highest ratio to date) with the one unverified
+constraint unchanged and by-design. The single soft spot is compound
+learning: capture and promotion are current only through 2026-06-23, and
+the July feature work has not yet been reflected on.
+
+## Notes
+
+- **The HARNESS.md Status section is one constraint behind.** It reads
+  30/31 (last audit 2026-06-23) but actual state is 31/32 — the Sentinel
+  integrity constraint (#482) landed after the audit. This is a benign
+  post-audit lag, not drift in the harness itself; the constraint is live
+  in CI and the weekly GC sweep. Running `/harness-audit` will refresh the
+  Status section to match.
+- **Reflection capture lagged the July feature work.** Seven PRs merged
+  2026-07-16 → 2026-07-20 (including the sentinel-category epic) without a
+  /reflect run. The monthly cadence is still met (28 days), but a
+  reflection on the sentinel epic — e.g. the "disposition-via-question
+  instead of a formal diaboli record for a small feature spec" call, or
+  the triple-debt grounding as a reusable framing — would keep learning
+  flow ahead of the cadence rather than at its edge.
+- **Cost data remains a single-session sample.** No new capture since
+  2026-06-13; monthly average and trend stay "not tracked" until a full
+  provider-dashboard capture replaces the session sample.


### PR DESCRIPTION
Lands the 2026-07-21 harness health snapshot generated by `/harness-health` (quick mode).

## Health: Healthy ✅

| Metric | 2026-06-23 | 2026-07-21 |
| --- | --- | --- |
| Enforcement | 30/31 | **31/32 (97%, all-time high)** |
| Reflections | 52 | 54 (+2) |
| Reflections w/ signal | 92% | 93% |
| GC findings | 2 | 0 |
| Cadence | 5/5 on schedule | 5/5 on schedule |

Window covered the **sentinel agent category** epic (#482–#484), the video-library feature (#474), and four maintenance/bug-fix PRs. Plugin moved 0.64.0 → 0.66.1.

## Two soft items noted (neither a degradation)

- **HARNESS.md Status section is one constraint behind reality.** It reads 30/31 (last audit 2026-06-23); the Sentinel integrity constraint landed after that audit, so actual state is 31/32. Benign post-audit lag — a `/harness-audit` will reconcile it.
- **Reflection capture lagged the July work** — 7 PRs merged without a `/reflect` run (~4 weeks since the last reflection, still inside the 30-day cadence).

## Known tooling bug (not fixed here)

`update-health-badge.sh` returned "Attention" because its `grep -iE "alert|declining"` matches the substring "alert" inside the standard Meta line "Trend alerts: none" — a false positive (the prior Healthy snapshot uses identical wording). The badge is set to the assessed status (Healthy) manually. A word-boundary guard in the script is a good follow-up.

## Scope

Snapshot lives under `observability/` (outside the plugin dir) plus a one-line README badge retarget — no plugin files, no version bump. Snapshot validated against the 16-section format; markdownlint clean. Exempt from spec-first via the `chore` prefix/label.