### PR TITLE
Fix health badge to mirror the authoritative Health line

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.66.1",
+  "plugin_version": "0.66.2",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.66.1"
+      "version": "0.66.2"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.66.2 — 2026-07-22
+
+### Fix: health badge mirrors the authoritative Health line
+
+- `update-health-badge.sh` re-derived the harness health status by
+  keyword-sniffing the snapshot's Meta section, so the standard line
+  `Trend alerts: none` false-positived on the substring "alert" and
+  flagged **Attention** on a genuinely Healthy snapshot; a `head -20`
+  window could also miss the Health line in a longer Meta section. The
+  script now reads the explicit `- Health: **X**` line the
+  `/harness-health` skill already computes (Healthy / Attention /
+  Degraded) as the source of truth, keeping the `<70%` enforcement ratio
+  as a Degraded safety-net override and a word-boundaried keyword
+  heuristic only as a fallback for snapshots with no Health line.
+- Added a Layer-0 regression test (`test-update-health-badge.sh`)
+  covering the `Trend alerts: none` case, all three Health statuses, the
+  enforcement override, a Health line past 20 lines of Meta, and the
+  badge link target.
+
 ## 0.66.1 — 2026-07-20
 
 ### Docs: ground the sentinel category in Storey's triple-debt model

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.1-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.66.1 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.66.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/scripts/update-health-badge.sh
+++ b/ai-literacy-superpowers/scripts/update-health-badge.sh
@@ -23,32 +23,47 @@ health_status="Healthy"
 health_colour="2E8B57"  # green
 
 if [ -n "$SNAPSHOT_FILE" ] && [ -f "$SNAPSHOT_FILE" ]; then
-  # Check for overdue/stalled/silent/alert signals in Meta section
-  meta_section=$(sed -n '/^## Meta$/,/^## /p' "$SNAPSHOT_FILE" | head -20)
+  # The /harness-health skill already computes the aggregate health status
+  # (its step 5) and writes it as an explicit `- Health: **X**` line in the
+  # Meta section. That line is the source of truth — mirror it, do not
+  # re-derive it. Re-deriving by keyword-sniffing the whole Meta section was
+  # fragile: the standard line "Trend alerts: none" contains the substring
+  # "alert", so the old heuristic flagged Attention on a Healthy snapshot,
+  # and a `head -20` window could miss the Health line entirely once the
+  # Meta section ran past twenty lines.
+  meta_section=$(sed -n '/^## Meta$/,/^## /p' "$SNAPSHOT_FILE")
+  health_line=$(echo "$meta_section" | grep -iE '^- Health:' | head -1)
 
-  attention_signals=0
-  if echo "$meta_section" | grep -qi "overdue"; then
-    attention_signals=$((attention_signals + 1))
-  fi
-  if echo "$meta_section" | grep -qi "stalled"; then
-    attention_signals=$((attention_signals + 1))
-  fi
-  if echo "$meta_section" | grep -qi "silent"; then
-    attention_signals=$((attention_signals + 1))
-  fi
-  if echo "$meta_section" | grep -qiE "alert|declining"; then
-    attention_signals=$((attention_signals + 1))
-  fi
+  case "$health_line" in
+    *[Dd]egraded*) health_status="Degraded";  health_colour="DC143C" ;;  # crimson
+    *[Aa]ttention*) health_status="Attention"; health_colour="DAA520" ;;  # amber
+    *[Hh]ealthy*)  health_status="Healthy";   health_colour="2E8B57" ;;  # green
+    *)
+      # No explicit Health line (older or malformed snapshot) — fall back to
+      # the signal heuristic. Word boundaries keep "alerts" in the standard
+      # "Trend alerts:" label from counting as an "alert" signal.
+      attention_signals=0
+      for signal in overdue stalled silent; do
+        if echo "$meta_section" | grep -qiw "$signal"; then
+          attention_signals=$((attention_signals + 1))
+        fi
+      done
+      if echo "$meta_section" | grep -qiwE 'alert|declining'; then
+        attention_signals=$((attention_signals + 1))
+      fi
+      if [ "$attention_signals" -ge 2 ]; then
+        health_status="Degraded"
+        health_colour="DC143C"
+      elif [ "$attention_signals" -ge 1 ]; then
+        health_status="Attention"
+        health_colour="DAA520"
+      fi
+      ;;
+  esac
 
-  if [ "$attention_signals" -ge 2 ]; then
-    health_status="Degraded"
-    health_colour="DC143C"  # crimson red
-  elif [ "$attention_signals" -ge 1 ]; then
-    health_status="Attention"
-    health_colour="DAA520"  # goldenrod/amber
-  fi
-
-  # Also check enforcement ratio
+  # Safety net: a collapsed enforcement ratio forces Degraded regardless of
+  # what the Health line claims — belt-and-suspenders against a snapshot that
+  # under-reports its own health.
   enforced_line=$(grep -E '^- Constraints:' "$SNAPSHOT_FILE" || echo "")
   if [ -n "$enforced_line" ]; then
     pct=$(echo "$enforced_line" | grep -oE '[0-9]+%' | tr -d '%')

--- a/tdad_tests/layer0_deterministic/test-update-health-badge.sh
+++ b/tdad_tests/layer0_deterministic/test-update-health-badge.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for update-health-badge.sh — the /harness-health badge writer.
+#
+# Contract under test:
+#   The badge status mirrors the authoritative `- Health: **X**` line the
+#   /harness-health skill writes in the snapshot's Meta section (Healthy /
+#   Attention / Degraded), NOT a re-derivation by keyword-sniffing.
+#
+# Regression guard (the bug this test was born from): a Healthy snapshot whose
+# Meta contains the standard line "Trend alerts: none" must stay Healthy. The
+# old heuristic matched the substring "alert" inside "alerts" and flagged
+# Attention on a clean snapshot.
+#
+# Also covered:
+#   - Attention and Degraded Health lines map to their statuses/colours.
+#   - The <70% enforcement safety net forces Degraded even when the Health
+#     line says Healthy.
+#   - The Health line is honoured even when it sits past line 20 of Meta
+#     (the old `head -20` window could miss it).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BADGE="$SCRIPT_DIR/../../ai-literacy-superpowers/scripts/update-health-badge.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$BADGE" ] || fail "badge script not found at $BADGE"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Seed a README carrying a Harness Health badge (starting colour is irrelevant;
+# the script rewrites it).
+seed_readme() {
+  printf '# Project\n[![Harness Health](https://img.shields.io/badge/Harness_Health-Unknown-000000?style=flat-square)](old)\n' \
+    > "$WORK/README.md"
+}
+
+# run <snapshot-file> -> sets STATUS to the badge status token in the README
+run() {
+  seed_readme
+  bash "$BADGE" "$WORK" "$1" >/dev/null 2>&1 || fail "badge script exited non-zero on $1"
+  STATUS=$(grep -oE 'Harness_Health-[A-Za-z]+' "$WORK/README.md" | head -1 | sed 's/Harness_Health-//')
+  [ -n "$STATUS" ] || fail "no Harness Health badge found in README after running on $1"
+  LINK=$(grep -oE '\]\([^)]*\)$' "$WORK/README.md" | tail -1)
+}
+
+# --- Regression: Healthy snapshot with "Trend alerts: none" stays Healthy ----
+cat > "$WORK/healthy.md" <<'EOF'
+# Harness Health Snapshot — test
+
+## Meta
+
+- Snapshot cadence: on schedule
+- Trend alerts: none
+- Health: **Healthy**
+
+## Changes Since Last Snapshot
+EOF
+run "$WORK/healthy.md"
+[ "$STATUS" = "Healthy" ] || fail "Healthy snapshot with 'Trend alerts: none' must map to Healthy, got '$STATUS' (the 'alert' substring regression)"
+
+# --- Attention Health line ---------------------------------------------------
+cat > "$WORK/attention.md" <<'EOF'
+## Meta
+
+- Trend alerts: none
+- Health: **Attention**
+
+## Changes Since Last Snapshot
+EOF
+run "$WORK/attention.md"
+[ "$STATUS" = "Attention" ] || fail "Health: **Attention** must map to Attention, got '$STATUS'"
+
+# --- Degraded Health line ----------------------------------------------------
+cat > "$WORK/degraded.md" <<'EOF'
+## Meta
+
+- Health: **Degraded**
+
+## Changes Since Last Snapshot
+EOF
+run "$WORK/degraded.md"
+[ "$STATUS" = "Degraded" ] || fail "Health: **Degraded** must map to Degraded, got '$STATUS'"
+
+# --- Enforcement <70% safety net overrides a Healthy line --------------------
+cat > "$WORK/collapsed.md" <<'EOF'
+# Snapshot
+
+- Constraints: 5/10 enforced (50%)
+
+## Meta
+
+- Health: **Healthy**
+
+## Changes Since Last Snapshot
+EOF
+run "$WORK/collapsed.md"
+[ "$STATUS" = "Degraded" ] || fail "50% enforcement must force Degraded regardless of the Health line, got '$STATUS'"
+
+# --- Health line past line 20 of Meta is still honoured ----------------------
+{
+  printf '## Meta\n\n'
+  for i in $(seq 1 25); do printf -- '- filler line %s with the word alerts in it\n' "$i"; done
+  printf -- '- Health: **Attention**\n\n## Changes Since Last Snapshot\n'
+} > "$WORK/deep.md"
+run "$WORK/deep.md"
+[ "$STATUS" = "Attention" ] || fail "Health line beyond 20 lines of Meta must still be read, got '$STATUS'"
+
+# --- Link target points at the snapshot file ---------------------------------
+run "$WORK/healthy.md"
+case "$LINK" in
+  *healthy.md*) : ;;
+  *) fail "badge link must target the snapshot file, got '$LINK'" ;;
+esac
+
+echo "PASS: update-health-badge mirrors the authoritative Health line; 'Trend alerts: none' no longer false-positives"

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -60,6 +60,9 @@ BASH_TEST_SCRIPTS = [
     # sentinel agent category — the read-only integrity matcher for
     # role: sentinel agents (§5.4).
     "test-sentinel-integrity",
+    # harness-health badge writer — mirrors the authoritative Health line
+    # rather than re-deriving it (regression: "Trend alerts: none").
+    "test-update-health-badge",
 ]
 
 


### PR DESCRIPTION
Fixes the badge-script false positive flagged in the 2026-07-21 snapshot PR (#485).

## The bug

`update-health-badge.sh` re-derived the harness health status by keyword-sniffing the snapshot's Meta section. The standard Meta line `Trend alerts: none` contains the substring **alert**, so `grep -iE 'alert|declining'` matched and flagged **Attention** on a genuinely Healthy snapshot. A `head -20` window on the Meta section could also miss the `Health` line entirely once Meta ran past twenty lines.

## The fix

The `/harness-health` skill already computes the aggregate health status (its step 5) and writes it as an explicit `- Health: **X**` line in Meta. The script now **mirrors that line** as the source of truth (Healthy / Attention / Degraded → green / amber / crimson), instead of re-deriving it. Retained:

- the `<70%` enforcement-ratio → **Degraded** safety-net override (belt-and-suspenders against a snapshot under-reporting itself), and
- a **word-boundaried** keyword heuristic (`grep -w`) as a fallback only for snapshots with no Health line — so `alerts` no longer counts as an `alert`.

## Test

New Layer-0 regression test `test-update-health-badge.sh` covers: the `Trend alerts: none` case (the regression), all three Health statuses, the enforcement override beating a Healthy line, a Health line past 20 lines of Meta, and the badge link target. Registered in the Layer-0 pytest list (13 pass).

## Scope

Plugin bug fix → patch bump 0.66.1 → 0.66.2 across all five CI-checked locations. Exempt from spec-first via the `fix` label. markdownlint clean; strict-mode + syntax verified locally.