### PR TITLE
Promote 'derive from the source of truth' pattern to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,29 @@
   `docs/superpowers/objections/dl-s2b-challenge-protocol-design.md` and
   `docs/superpowers/objections/choice-cartographer.md` (O7). Promoted per #348.
 
+- Decision: harness artefacts (checks, scripts, badges, structural tests)
+  **derive from the source of truth — they do not pin a copy of it or
+  re-derive it heuristically.** When an artefact needs a value the harness
+  already determines — a count on disk, a status a skill computes, a version
+  in `plugin.json` — it reads that source rather than hard-coding a literal or
+  re-computing it. Two failures in the 0.66 line proved the anti-pattern's two
+  shapes. **(1) A pinned literal goes stale on a legitimate change:** the S7
+  structural test asserted `Skills-36` to stop a *prior* PR re-bumping the
+  badge, so adding the legitimate 37th skill (`sentinel-design`) turned the
+  guard red for the *right* change (#482); the fix asserts against
+  `len(glob("skills/*/SKILL.md"))`. **(2) A re-derivation heuristic invites
+  false positives:** `update-health-badge.sh` re-derived health by
+  keyword-sniffing the snapshot Meta, so the standard line `Trend alerts: none`
+  matched the substring "alert" and flagged Attention on a Healthy snapshot
+  (#486); the fix reads the explicit `- Health: **X**` line the
+  `/harness-health` skill already computes. Guidance: prefer reading the
+  source; if a literal pin is genuinely unavoidable (no on-disk source exists),
+  the guard must carry a comment stating what makes the literal change and why
+  it was not derived. This applies equally to test guards (assert against
+  reality, not a frozen count) and to scripts that mirror a computed value
+  (mirror the authoritative line, don't sniff prose). Promoted from the
+  2026-07-22 reflection (#488).
+
 ## TEST_STRATEGY
 
 <!-- How tests are structured in this project. Helps agents write consistent

--- a/REFLECTION_LOG.md
+++ b/REFLECTION_LOG.md
@@ -870,6 +870,7 @@
 - **Improvement**: Two process notes. (a) The sentinel spec was a feature with a committed spec, but its open questions were dispositioned inline via AskUserQuestion rather than through formal advocatus-diaboli / choice-cartographer records — consistent with the "concentrate ceremony on contract-bearing slices" pattern, but the snapshot's Diaboli/Cartographer counts show it as a spec-without-record; worth a one-line note in such specs pointing to where the dispositions live. (b) Reflection capture lagged the feature work by ~4 weeks (this entry is the catch-up) — capturing a reflection at epic-merge time, not only at snapshot time, would keep learning flow ahead of the monthly cadence.
 - **Signal**: failure
 - **Constraint**: none (the two fixes are the durable guard; the general pattern is a proposal for AGENTS.md, not a mechanically-enforceable rule)
+- **Promoted**: 2026-07-22 → AGENTS.md ARCH_DECISIONS: "harness artefacts derive from the source of truth — they do not pin a copy of it or re-derive it heuristically (a count on disk, a status a skill computes, a version in plugin.json); pinned literals go stale on legitimate changes (S7 Skills-36 guard, #482) and re-derivation heuristics invite false positives (badge substring 'alert', #486); prefer reading the source, and comment any unavoidable literal pin"
 - **Session metadata**:
   - Duration: multi-session (PRs #482–#487, spanning 2026-07-20 → 2026-07-22)
   - Model tiers used: capable (Opus 4.8) throughout


### PR DESCRIPTION
Promotes the central learning from the 2026-07-22 reflection (#488) into durable memory.

## The pattern (→ AGENTS.md ARCH_DECISIONS)

**Harness artefacts derive from the source of truth — they don't pin a copy of it or re-derive it heuristically.** When a check, script, badge, or structural test needs a value the harness already determines (a count on disk, a status a skill computes, a version in `plugin.json`), it reads that source rather than hard-coding a literal or re-computing it.

Two failures in the 0.66 line proved the anti-pattern's two shapes:

1. **Pinned literal goes stale** — the S7 test asserted `Skills-36` to stop a *prior* PR re-bumping the badge; adding the legitimate 37th skill turned the guard red for the *right* change (#482). Fix: assert against `len(glob("skills/*/SKILL.md"))`.
2. **Re-derivation heuristic false-positives** — `update-health-badge.sh` keyword-sniffed the Meta section, so `Trend alerts: none` matched the substring "alert" and flagged Attention on a Healthy snapshot (#486). Fix: read the explicit `- Health: **X**` line the skill computes.

Guidance captured: prefer reading the source; if a literal pin is genuinely unavoidable, the guard must comment what makes the literal change and why it wasn't derived.

## Also

Marks the #488 reflection entry with a `Promoted` line (which the Path-1 archival GC rule keys on).

## Scope

AGENTS.md + REFLECTION_LOG.md (repo root) — no version bump. Reflection change goes via PR per the "Reflections via PR workflow" constraint. markdownlint clean. Exempt from spec-first via the `chore` label.