### PR TITLE
Cadence Sentinels S1 — shared infrastructure: pact file, session registry, record contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.66.2",
+  "plugin_version": "0.67.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.66.2"
+      "version": "0.67.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.67.0 — 2026-08-08
+
+### Cadence Sentinels S1 — the shared substrate
+
+The plumbing the four cadence sentinels (Coda, Mast, WIP Warden, Convener)
+will consume, shipped once so none of them re-derives it. Nothing in this
+slice gates anything.
+
+- **The pact file (`~/.claude/pacts.md`).** A new, user-scoped declaration
+  surface carrying three optional blocks — `Session WIP`, `Budgets`, and a
+  reserved `Sync cadence`. Pacts belong to a person, not a repository: a stop
+  hour and a concurrency limit are properties of the human, so they live
+  outside every work tree and are never committed. `HARNESS.md` remains the
+  repo's declaration surface and is untouched.
+- **`Budgets` carries its governing clause.** *Unspent budget is not a debt.*
+  A block whose clause has been deleted reads as `malformed` and every
+  consumer drops back to observe-only, rather than holding its keeper to a
+  pact whose governing sentence is gone.
+- **A block reader that does not mangle its own vocabulary.**
+  `lib/pact-blocks.sh` splits on the first delimiter and trims at the ends
+  only. The inherited `read_key` is greedy on `:` and strips interior spaces,
+  which turns `hard_stop_hour: 18:30` into `30` — three of seven `Budgets`
+  keys would have parsed to garbage.
+- **The session registry is a lease, not a log.** `SessionStart` writes,
+  `Stop` renews, and only lease expiry retires an entry. `Stop` fires per
+  assistant turn rather than per session, so a delete-on-`Stop` registry would
+  have emptied itself after each session's first response — and the WIP Warden
+  would have reported one live session while four ran.
+- **The honesty flag belongs to the count, not the reader.** `registry_count`
+  is a pure read; pruning happens on the hook rail. A count following a
+  retirement stays `inferred` for every subsequent reader, not just the first.
+- **The registry library is split along the sentinel trust boundary.**
+  Sentinels may source the read surface; the mutation surface is reachable
+  only from hook scripts. The frontmatter check permits `Bash` and names this
+  as its own known limit, so the boundary is preserved by what an agent can
+  reach rather than by what it is trusted not to call.
+- **Records are append-only, and now actually are.** Parking and consultation
+  records carry their state in the filename; a transition writes a new file
+  rather than editing a `status` key in place. `records_open` answers "what is
+  still open" from the names.
+- **Record schemas ship as published reference pages.**
+  `reference/parking-record-format.md` and
+  `reference/consultation-record-format.md`, plus `reference/pacts-format.md`.
+  A schema homed in `docs/superpowers/` would be excluded from the site by
+  `mkdocs.yml` — the one format contract an adopter could not read.
+- **25 Layer-0 scenarios** across `test-pact-blocks.sh`,
+  `test-session-registry.sh`, and `test-record-contracts.sh`.
+
 ## 0.66.2 — 2026-07-22
 
 ### Fix: health badge mirrors the authoritative Health line

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.66.2-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.67.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.66.2 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.67.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.66.2",
+  "version": "0.67.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, and reservoir check (Stop) close all feedback loops at session end; template currency check (SessionStart) nudges on plugin upgrade",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry.",
   "hooks": {
     "PreToolUse": [
       {
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if HARNESS.md exists in the project root. If it does, read the Constraints section and identify any constraints with scope 'commit'. For each commit-scoped constraint, evaluate whether the file being written or edited would violate it. If violations are found, return a warning describing each violation with the constraint name. Do not block — only warn. If no HARNESS.md exists or no commit-scoped constraints apply, return nothing.",
+            "prompt": "Check if HARNESS.md exists in the project root. If it does, read the Constraints section and identify any constraints with scope 'commit'. For each commit-scoped constraint, evaluate whether the file being written or edited would violate it. If violations are found, return a warning describing each violation with the constraint name. Do not block \u2014 only warn. If no HARNESS.md exists or no commit-scoped constraints apply, return nothing.",
             "timeout": 30
           },
           {

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -78,6 +78,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/reservoir-check.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-registry-sweep.sh",
+            "timeout": 10
           }
         ]
       }
@@ -89,6 +94,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/template-currency-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-registry-start.sh",
             "timeout": 10
           }
         ]

--- a/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
@@ -45,27 +45,47 @@ pact_file() {
   printf '%s' "${CLAUDE_PACTS_FILE:-$HOME/.claude/pacts.md}"
 }
 
+# _KNOWN_BLOCKS — the block vocabulary. A span ends only at one of these.
+_KNOWN_BLOCKS='Session WIP|Budgets|Sync cadence'
+
 # _block_span <heading> — the lines belonging to a block: from its heading to
-# the next heading of equal-or-higher level, exclusive. Prints nothing when
-# the block or the file is absent.
+# the next KNOWN block heading, exclusive. Prints nothing when the block or the
+# file is absent.
 #
 # Scoping is the whole point of a purpose-built parser. A whole-file lookup
 # returns the first match in document order, so two blocks declaring the same
 # key would both answer with the first one's value (B8).
+#
+# It ends at a known heading rather than at "any heading of equal-or-higher
+# level" because this file is hand-edited. Under the general markdown rule an
+# ordinary standalone comment — `# revisit this in Q4` — parses as a level-1
+# heading, truncates the block, and drops every key below it INCLUDING the
+# mandatory clause, silently flipping a well-formed block to `malformed`. The
+# shipped guidance warns only against a trailing `#` on a value line, which
+# reads as permission for exactly that. Failing safe is not good enough here:
+# the human's symptom is that the pact they wrote stopped being read, with no
+# line telling them which sentence broke it.
+#
+# The trade this accepts: an unrelated `## Section` written BETWEEN two blocks
+# is absorbed into the preceding block's span rather than ending it. That is
+# the containable direction — a stray section would have to declare a key with
+# a name from the same vocabulary to affect anything.
 _block_span() {
   local heading="$1" file
   file="$(pact_file)"
   [ -f "$file" ] || return 0
-  awk -v want="$heading" '
-    # Heading line: capture its level and title.
+  awk -v want="$heading" -v known="$_KNOWN_BLOCKS" '
+    BEGIN { n = split(known, k, "|"); for (i = 1; i <= n; i++) isblock[k[i]] = 1 }
+    # Heading line: capture its title, and act only on the known vocabulary.
     /^#{1,6}[[:space:]]+/ {
       level = 0
       while (substr($0, level + 1, 1) == "#") level++
       title = substr($0, level + 1)
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
 
-      if (inblock && level <= want_level) { exit }   # equal-or-higher ends it
-      if (!inblock && title == want) { inblock = 1; want_level = level; next }
+      if (!(title in isblock)) { if (inblock) print; next }   # a comment, not a block
+      if (inblock) { exit }                                    # next block ends this one
+      if (title == want) { inblock = 1 }
       next
     }
     inblock { print }

--- a/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# pact-blocks.sh — the one reader for ~/.claude/pacts.md.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §3
+# Tests: tdad_tests/layer0_deterministic/test-pact-blocks.sh (B1–B9)
+#
+# Why this exists at all. Four cadence sentinels (S2–S5) need to read the same
+# three blocks. Left to themselves that becomes three near-identical parsers
+# and three subtly different answers to "is this block declared". This library
+# is the single answer, so none of them re-derives one.
+#
+# THE NULL OBJECT CONTRACT. A consumer never branches on absence. `block_key`
+# always returns something — the declared value or the caller's default — and
+# `block_absent_note` supplies the one sentence every sentinel says when a
+# block is missing. That is why absent and malformed collapse to the same
+# behaviour: it is the guarantee, not a coincidence. Sentinels run one code
+# path whether or not the human has authored a pact file.
+#
+# THE EXTRACTION RULE, and why this does not reuse read_key. The reservoir
+# hook's `read_key` does `sed -E "s/.*[:=][[:space:]]*//"` — greedy, so it
+# consumes through the LAST colon on the line — then `tr -d '[:space:]'`,
+# which deletes interior spaces. That is safe for the reservoir block, whose
+# every value is a bare integer or a single word. It is destructive here:
+#
+#     hard_stop_hour: 18:30                    -> 30
+#     focus_blocks: 09:00-12:00, 14:00-17:00   -> 00
+#     daily_cost_ceiling: not observable       -> notobservable
+#
+# So: split on the FIRST delimiter after the key, and trim at the ends only.
+# B7 is the test that forbids the greedy version from creeping back in.
+#
+# Everything here is read-only. A sentinel may source this file.
+
+# The pact file. $CLAUDE_PACTS_FILE overrides, so tests need no home directory.
+pact_file() {
+  printf '%s' "${CLAUDE_PACTS_FILE:-$HOME/.claude/pacts.md}"
+}
+
+# _block_span <heading> — the lines belonging to a block: from its heading to
+# the next heading of equal-or-higher level, exclusive. Prints nothing when
+# the block or the file is absent.
+#
+# Scoping is the whole point of a purpose-built parser. A whole-file lookup
+# returns the first match in document order, so two blocks declaring the same
+# key would both answer with the first one's value (B8).
+_block_span() {
+  local heading="$1" file
+  file="$(pact_file)"
+  [ -f "$file" ] || return 0
+  awk -v want="$heading" '
+    # Heading line: capture its level and title.
+    /^#{1,6}[[:space:]]+/ {
+      level = 0
+      while (substr($0, level + 1, 1) == "#") level++
+      title = substr($0, level + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+
+      if (inblock && level <= want_level) { exit }   # equal-or-higher ends it
+      if (!inblock && title == want) { inblock = 1; want_level = level; next }
+      next
+    }
+    inblock { print }
+  ' "$file"
+}
+
+# block_key <heading> <key> [default] — the value, first-delimiter split,
+# trimmed at the ends only. Returns the default when the block, the file, or
+# the key is absent. Never fails.
+block_key() {
+  local heading="$1" key="$2" def="${3-}" val
+  val="$(_block_span "$heading" | awk -v key="$key" '
+    {
+      line = $0
+      sub(/^[[:space:]]*[-*][[:space:]]*/, "", line)     # optional list bullet
+      if (substr(line, 1, length(key)) != key) next
+      rest = substr(line, length(key) + 1)
+      if (rest !~ /^[[:space:]]*[:=]/) next              # key must be followed by a delimiter
+      sub(/^[[:space:]]*[:=][[:space:]]*/, "", rest)     # FIRST delimiter only
+      print rest
+      exit
+    }
+  ')"
+  # Trim trailing whitespace and the backticks a human may have typed. Interior
+  # spaces are preserved on purpose — `not observable` is a valid value.
+  val="${val%"${val##*[![:space:]]}"}"
+  val="${val#\`}"; val="${val%\`}"
+  if [ -n "$val" ]; then printf '%s' "$val"; else printf '%s' "$def"; fi
+}
+
+# _mandatory_clause <heading> — the literal sentence a block must carry, or
+# empty when the block has none.
+#
+# The clause is part of the block, not a comment on it: a pact enforced
+# without its governing sentence is a pact enforced against a framing nobody
+# agreed to. Because detection is literal-string matching, the wording is a
+# published interface — only a spec-first change may reword it, and rewording
+# is a coordinated migration across every adopter.
+_mandatory_clause() {
+  case "$1" in
+    "Session WIP") printf '%s' 'It counts; it does not assess.' ;;
+    "Budgets")     printf '%s' 'Unspent budget is not a debt.' ;;
+    *)             printf '%s' '' ;;   # Sync cadence is reserved and inert
+  esac
+}
+
+# _flatten — collapse every run of whitespace, including newlines, to one
+# space. Clause matching runs through this.
+#
+# The clause's WORDS are the interface; its line breaks are not. Without this,
+# a markdown reflow that wraps the sentence across two lines silently
+# downgrades a perfectly good block to malformed — which is the brittleness
+# choice story #1 named when it accepted literal matching, and which the
+# shipped template hit on the very first run. Normalising keeps the wording
+# load-bearing and un-rewordable while letting a human wrap their own file.
+_flatten() { tr '\n' ' ' | tr -s '[:space:]' ' '; }
+
+# block_state <heading> — absent | malformed | declared. Always exits 0:
+# absence is never an error and malformed is never a gate.
+block_state() {
+  local heading="$1" span clause
+  span="$(_block_span "$heading")"
+  if [ -z "$span" ]; then printf '%s' 'absent'; return 0; fi
+
+  clause="$(_mandatory_clause "$heading")"
+  if [ -n "$clause" ] \
+     && ! printf '%s' "$span" | _flatten | grep -qF "$(printf '%s' "$clause" | _flatten)"; then
+    printf '%s' 'malformed'
+    return 0
+  fi
+  printf '%s' 'declared'
+}
+
+# block_absent_note <heading> — the fixed sentence, emitted by the library so
+# every consumer says the same thing rather than inventing its own phrasing.
+block_absent_note() {
+  printf 'no `%s` block declared — running in observe-only mode' "$1"
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Strict mode, applied only when this file is EXECUTED. `return` succeeds
+# solely inside a sourced context, so the `set` is skipped when a hook script
+# or a sentinel sources us. That matters: `set` mutates the CALLER's shell, and
+# a library whose whole purpose is being safely sourceable must not impose
+# -e/-u/-o pipefail on whatever sourced it. Satisfies the "Shell scripts use
+# strict mode" constraint (HARNESS.md) in the only context where strict mode
+# is meaningful for a library.
+(return 0 2>/dev/null) || set -euo pipefail
 # pact-blocks.sh — the one reader for ~/.claude/pacts.md.
 #
 # Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §3
@@ -133,5 +142,7 @@ block_state() {
 # block_absent_note <heading> — the fixed sentence, emitted by the library so
 # every consumer says the same thing rather than inventing its own phrasing.
 block_absent_note() {
+  # shellcheck disable=SC2016  # the backticks are markdown for the reader, not
+  # a shell expansion — single quotes are exactly what we want here.
   printf 'no `%s` block declared — running in observe-only mode' "$1"
 }

--- a/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# record-paths.sh — the open-record query for state-in-the-path records.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §5.1
+# Tests: tdad_tests/layer0_deterministic/test-record-contracts.sh (C3)
+#
+# Read-only. A sentinel may source this file.
+#
+# Why state lives in the filename. Constraint 7 says records are append-only,
+# and editing a `status:` key from `parked` to `resumed` IS an in-place edit —
+# the rule and the mechanism contradicted each other. So a transition writes a
+# NEW file whose name carries the new state, and nothing is ever edited or
+# deleted. "What is still open" then becomes a query over names rather than a
+# scan of mutable frontmatter, and the two finally agree.
+#
+# It also keeps the Coda honest: resuming a parked thread is a *write* by the
+# /coda command, not an *edit* of an existing record, so the read-only agent
+# never needs a mutation path it is forbidden to have.
+
+# records_open <dir> — records in <dir> that are still open, one path per line.
+#
+# A record is open unless it is itself a transition file (`*.resumed.md`,
+# `*.superseded.md`) or some transition names it in `supersedes:`. Both tests
+# matter: the first alone would report a superseded predecessor as open, and
+# the second alone would report the transition file itself.
+records_open() {
+  local dir="$1" f base superseded
+
+  [ -d "$dir" ] || return 0
+
+  # Every filename claimed by a transition's `supersedes:` field.
+  superseded="$(grep -hE '^supersedes:[[:space:]]*[^[:space:]]' "$dir"/*.md 2>/dev/null \
+    | sed -E 's/^supersedes:[[:space:]]*//; s/[[:space:]]+$//' \
+    | grep -v '^null$' || true)"
+
+  for f in "$dir"/*.md; do
+    [ -e "$f" ] || continue
+    base="$(basename "$f")"
+
+    case "$base" in
+      README.md|*.resumed.md|*.superseded.md|*.resolved.md) continue ;;
+    esac
+
+    if [ -n "$superseded" ] && printf '%s\n' "$superseded" | grep -qxF "$base"; then
+      continue
+    fi
+
+    printf '%s\n' "$f"
+  done
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Strict mode, applied only when this file is EXECUTED. `return` succeeds
+# solely inside a sourced context, so the `set` is skipped when a hook script
+# or a sentinel sources us. That matters: `set` mutates the CALLER's shell, and
+# a library whose whole purpose is being safely sourceable must not impose
+# -e/-u/-o pipefail on whatever sourced it. Satisfies the "Shell scripts use
+# strict mode" constraint (HARNESS.md) in the only context where strict mode
+# is meaningful for a library.
+(return 0 2>/dev/null) || set -euo pipefail
 # record-paths.sh — the open-record query for state-in-the-path records.
 #
 # Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §5.1
@@ -19,8 +28,9 @@
 
 # records_open <dir> — records in <dir> that are still open, one path per line.
 #
-# A record is open unless it is itself a transition file (`*.resumed.md`,
-# `*.superseded.md`) or some transition names it in `supersedes:`. Both tests
+# A record is open unless it is itself a transition file — `*.resumed.md`,
+# `*.superseded.md`, or `*.resolved.md`, the last being the consultation
+# record's transition — or some transition names it in `supersedes:`. Both tests
 # matter: the first alone would report a superseded predecessor as open, and
 # the second alone would report the transition file itself.
 records_open() {

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# session-registry-read.sh — the read surface of the session registry.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4
+# Tests: tdad_tests/layer0_deterministic/test-session-registry.sh (R4–R13)
+#
+# THIS FILE IS SOURCEABLE BY A SENTINEL. That is the reason it exists as a
+# separate file from session-registry-write.sh, and the reason it defines no
+# function that writes, deletes, or moves anything.
+#
+# sentinel-integrity-check.sh enforces the read-only boundary by rejecting
+# Write/Edit in an agent's `tools:` list, and explicitly permits Bash. Its own
+# header names the limit: an agent that reaches a write capability through an
+# undeclared channel is out of scope for a frontmatter check. A single shared
+# library exposing registry_prune to every sentinel would manufacture exactly
+# that case — CI green while a `role: sentinel` agent deletes files. So the
+# boundary is preserved here instead, by what a sentinel *can* reach rather
+# than by what it is trusted not to call. R9 is the test.
+#
+# registry_count is a PURE READ. Pruning happens on the Stop hook rail, never
+# on a read path, because the honesty flag has to be a property of the count
+# rather than of whoever read first. If a read pruned, the first consumer
+# would absorb the uncertainty and report `inferred` while every consumer
+# after it reported `observed` about the identical underlying state (R6).
+
+_SRR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$_SRR_DIR/pact-blocks.sh"
+
+# registry_dir — the registry location. $CLAUDE_SESSIONS_DIR overrides so
+# tests need no home directory. The default sits outside every work tree,
+# which is what makes a .gitignore entry unnecessary (R13).
+registry_dir() {
+  printf '%s' "${CLAUDE_SESSIONS_DIR:-$HOME/.claude/sessions}"
+}
+
+# _lease_hours — how long an entry stays valid without a heartbeat. Declared
+# in the pact file rather than compiled in: every other threshold in this
+# harness is human-tunable, and a slice premised on the human declaring their
+# pacts should not introduce the first one they cannot touch.
+_lease_hours() {
+  local v
+  v="$(block_key 'Session WIP' 'stale_after_hours' '12')"
+  case "$v" in ''|*[!0-9]*) v=12 ;; esac
+  printf '%s' "$v"
+}
+
+# _iso_to_epoch <iso8601> — seconds since epoch, 0 when unparseable. GNU date
+# takes -d; BSD/macOS needs -j -f. Both CI and this laptop must agree.
+_iso_to_epoch() {
+  local ts="$1"
+  date -u -d "$ts" +%s 2>/dev/null \
+    || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+    || printf '0'
+}
+
+# _json_field <file> <key> — a string field's value, or empty.
+_json_field() {
+  grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" 2>/dev/null \
+    | head -1 | sed -E 's/.*"[[:space:]]*:[[:space:]]*"([^"]*)"$/\1/'
+}
+
+# registry_list — one line per live entry: "<id> <repo> <started_at>".
+# This is what makes the `repo` field load-bearing: a consumer showing the
+# human their other live sessions needs to say where each one is.
+registry_list() {
+  local dir entry id repo started
+  dir="$(registry_dir)"
+  [ -d "$dir" ] || return 0
+  for entry in "$dir"/*.json; do
+    [ -e "$entry" ] || continue
+    id="$(_json_field "$entry" id)"
+    repo="$(_json_field "$entry" repo)"
+    started="$(_json_field "$entry" started_at)"
+    printf '%s %s %s\n' "$id" "$repo" "$started"
+  done
+}
+
+# registry_count — "<n> <observed|inferred>". Never mutates. Never fails.
+#
+# The flag derives from durable state, not from this read:
+#   - a retirement marker written by the pruner and still inside the current
+#     lease window means an entry aged out recently, and the pruner cannot
+#     tell a crashed session from a healthy long-running one;
+#   - an `unknown.json` entry means one file may stand for more than one
+#     session, because every hostile id sanitises to the same fallback.
+# Either way the count is inferred, and stays inferred for every subsequent
+# reader (R6).
+registry_count() {
+  local dir n flag marker lease now marker_epoch
+  dir="$(registry_dir)"
+  if [ ! -d "$dir" ]; then printf '0 observed\n'; return 0; fi
+
+  n="$(find "$dir" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l | tr -d '[:space:]')"
+  flag="observed"
+
+  marker="$dir/.retired"
+  if [ -f "$marker" ]; then
+    lease="$(_lease_hours)"
+    now="$(date -u +%s)"
+    marker_epoch="$(_iso_to_epoch "$(head -1 "$marker")")"
+    if [ "$marker_epoch" -gt 0 ] && [ $(( (now - marker_epoch) / 3600 )) -lt "$lease" ]; then
+      flag="inferred"
+    fi
+  fi
+
+  [ -f "$dir/unknown.json" ] && flag="inferred"
+
+  printf '%s %s\n' "$n" "$flag"
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Strict mode, applied only when this file is EXECUTED. `return` succeeds
+# solely inside a sourced context, so the `set` is skipped when a hook script
+# or a sentinel sources us. That matters: `set` mutates the CALLER's shell, and
+# a library whose whole purpose is being safely sourceable must not impose
+# -e/-u/-o pipefail on whatever sourced it. Satisfies the "Shell scripts use
+# strict mode" constraint (HARNESS.md) in the only context where strict mode
+# is meaningful for a library.
+(return 0 2>/dev/null) || set -euo pipefail
 # session-registry-read.sh — the read surface of the session registry.
 #
 # Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4
@@ -38,6 +47,15 @@ registry_dir() {
 # in the pact file rather than compiled in: every other threshold in this
 # harness is human-tunable, and a slice premised on the human declaring their
 # pacts should not introduce the first one they cannot touch.
+#
+# Deliberately reads the value without consulting `block_state`, so a
+# `malformed` Session WIP block still supplies a lease. The Null Object
+# contract is about GATING: a block whose governing clause was deleted must
+# not be used to hold its keeper to anything. Retention is not gating — it is
+# housekeeping on local state, and refusing to garbage-collect would punish
+# the human for a typo. S2's WIP Warden faces the same question for
+# `max_concurrent_sessions`, where the answer is the opposite: that value
+# advises a person, so a malformed block must degrade to observe-only.
 _lease_hours() {
   local v
   v="$(block_key 'Session WIP' 'stale_after_hours' '12')"
@@ -60,9 +78,15 @@ _json_field() {
     | head -1 | sed -E 's/.*"[[:space:]]*:[[:space:]]*"([^"]*)"$/\1/'
 }
 
-# registry_list — one line per live entry: "<id> <repo> <started_at>".
+# registry_list — one line per live entry: "<id>\t<started_at>\t<repo>".
 # This is what makes the `repo` field load-bearing: a consumer showing the
 # human their other live sessions needs to say where each one is.
+#
+# Tab-separated, with `repo` LAST, because `repo` is a filesystem path and
+# paths routinely contain spaces. A space-separated format with the free-form
+# field in the middle would hand every consumer doing the obvious
+# `read -r id started repo` a corrupted timestamp on `/Users/x/My Projects/y`.
+# S2–S5 are the consumers and none exists yet, so this is free to get right now.
 registry_list() {
   local dir entry id repo started
   dir="$(registry_dir)"
@@ -72,7 +96,7 @@ registry_list() {
     id="$(_json_field "$entry" id)"
     repo="$(_json_field "$entry" repo)"
     started="$(_json_field "$entry" started_at)"
-    printf '%s %s %s\n' "$id" "$repo" "$started"
+    printf '%s\t%s\t%s\n' "$id" "$started" "$repo"
   done
 }
 

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-read.sh
@@ -60,6 +60,12 @@ _lease_hours() {
   local v
   v="$(block_key 'Session WIP' 'stale_after_hours' '12')"
   case "$v" in ''|*[!0-9]*) v=12 ;; esac
+  # Floor at 1. `0` passes the digit test but means "expire everything
+  # immediately" — including the entry the sweep wrote one line earlier — while
+  # the honesty flag stays quiet, because 0 is not < 0. A human writing 0
+  # almost certainly means "never expire", which is the opposite. Treat it as
+  # the typo it is rather than silently disabling the registry.
+  [ "$v" -lt 1 ] && v=12
   printf '%s' "$v"
 }
 
@@ -73,9 +79,17 @@ _iso_to_epoch() {
 }
 
 # _json_field <file> <key> — a string field's value, or empty.
+#
+# Escape-aware in both directions: the match tolerates escaped quotes inside
+# the value, and the escapes are decoded on the way out. registry_touch
+# escapes `repo` on write, so a read path that stopped at the first quote —
+# escaped or not — would hand a truncated path to registry_list, which is the
+# surface a consumer uses to tell the human where their other sessions are.
 _json_field() {
-  grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" 2>/dev/null \
-    | head -1 | sed -E 's/.*"[[:space:]]*:[[:space:]]*"([^"]*)"$/\1/'
+  grep -oE "\"$2\"[[:space:]]*:[[:space:]]*\"([^\"\\\\]|\\\\.)*\"" "$1" 2>/dev/null \
+    | head -1 \
+    | sed -E 's/^[^:]*:[[:space:]]*"(.*)"$/\1/' \
+    | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g'
 }
 
 # registry_list — one line per live entry: "<id>\t<started_at>\t<repo>".
@@ -102,26 +116,58 @@ registry_list() {
 
 # registry_count — "<n> <observed|inferred>". Never mutates. Never fails.
 #
+# COUNTS ONLY ENTRIES WHOSE LEASE HAS NOT EXPIRED. Counting files instead was
+# a real defect, found at the code gate and reproduced: nothing removes an
+# entry when a session ends, because by design nothing knows a session ended —
+# the pruner is the only removal path and it runs on the Stop rail. So a
+# morning session, an afternoon session, and a live evening session are three
+# files, all with heartbeats inside a 12-hour lease, and the count returned
+# `3 observed`. Under `max_concurrent_sessions: 2` the WIP Warden would have
+# reported a confident breach on an ordinary working day.
+#
+# Filtering here is a pure read — no file is touched — so it costs nothing at
+# the trust boundary (R8, R9) and leaves the lease lifecycle exactly as the
+# spec gate adjudicated it.
+#
 # The flag derives from durable state, not from this read:
-#   - a retirement marker written by the pruner and still inside the current
-#     lease window means an entry aged out recently, and the pruner cannot
-#     tell a crashed session from a healthy long-running one;
-#   - an `unknown.json` entry means one file may stand for more than one
-#     session, because every hostile id sanitises to the same fallback.
-# Either way the count is inferred, and stays inferred for every subsequent
-# reader (R6).
+#   - an entry excluded because its lease expired but the pruner has not yet
+#     run: the same "crashed, or merely quiet?" uncertainty a retirement
+#     carries, seen a moment earlier;
+#   - a retirement marker still inside the current lease window, meaning an
+#     entry aged out recently;
+#   - an `unknown.json` entry, since every hostile id sanitises to that one
+#     fallback and the file may stand for more than one session.
+# Any of these makes the count inferred, and it stays inferred for every
+# subsequent reader (R6).
 registry_count() {
-  local dir n flag marker lease now marker_epoch
+  local dir n flag marker lease now marker_epoch entry hb hb_epoch
   dir="$(registry_dir)"
   if [ ! -d "$dir" ]; then printf '0 observed\n'; return 0; fi
 
-  n="$(find "$dir" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l | tr -d '[:space:]')"
+  lease="$(_lease_hours)"
+  now="$(date -u +%s)"
+  n=0
   flag="observed"
+
+  for entry in "$dir"/*.json; do
+    [ -e "$entry" ] || continue
+    hb="$(_json_field "$entry" heartbeat)"
+    hb_epoch="$(_iso_to_epoch "$hb")"
+    # An unparseable heartbeat is counted rather than discarded — discarding
+    # would let a corrupt entry quietly shrink the count — but it is not
+    # something we can claim to have observed.
+    if [ "$hb_epoch" -le 0 ]; then
+      n=$((n + 1)); flag="inferred"; continue
+    fi
+    if [ $(( (now - hb_epoch) / 3600 )) -ge "$lease" ]; then
+      flag="inferred"          # expired, awaiting the next sweep
+      continue
+    fi
+    n=$((n + 1))
+  done
 
   marker="$dir/.retired"
   if [ -f "$marker" ]; then
-    lease="$(_lease_hours)"
-    now="$(date -u +%s)"
     marker_epoch="$(_iso_to_epoch "$(head -1 "$marker")")"
     if [ "$marker_epoch" -gt 0 ] && [ $(( (now - marker_epoch) / 3600 )) -lt "$lease" ]; then
       flag="inferred"

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# session-registry-write.sh — the mutation surface of the session registry.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4.2, §4.4
+# Tests: tdad_tests/layer0_deterministic/test-session-registry.sh (R1–R3, R5, R7, R10)
+#
+# HOOK SCRIPTS ONLY. A sentinel must never source this file — that is the
+# whole point of splitting it from session-registry-read.sh, which a sentinel
+# may source freely. See the read library's header for why the frontmatter
+# check cannot enforce this on its own.
+#
+# The registry is a LEASE, not a liveness log. An entry is valid for
+# stale_after_hours from its last heartbeat; staying alive means renewing.
+# Nothing here deletes an entry because a session "ended" — the pruner retires
+# entries whose lease expired, and that is the only removal path.
+#
+# Why renewal rather than delete-on-Stop. The Stop hook fires when the main
+# agent finishes responding — many times per session, not once at session end.
+# All nine pre-existing Stop scripts declare "runs at session end" in their
+# headers and none carries a once-per-session guard; that is harmless for nine
+# idempotent advisories, whose worst failure is a duplicate nudge, and fatal
+# for a destructive one. A delete-on-Stop registry empties itself after each
+# session's first response, and the WIP Warden reports 1 while four sessions
+# run. Renewal makes correctness independent of how often Stop fires: once per
+# session, once per turn, or fifty times a turn all behave the same.
+
+_SRW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$_SRW_DIR/session-registry-read.sh"   # registry_dir, _lease_hours, _iso_to_epoch, _json_field
+
+_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# registry_sanitise_id <raw> — a session id safe to use as a path component.
+#
+# Already adjudicated once in this repo for the same field
+# (affordance-invocation-recorder.sh:55, after a code-time objection). A `/` or
+# `..` reaching a path context is strictly worse than the JSON-injection case
+# fixed there, because the write lands outside the intended directory. Every
+# hostile id collapses to the single fallback `unknown`, which is why a
+# registry containing unknown.json reports its count as inferred: that one
+# file may stand for more than one session.
+registry_sanitise_id() {
+  local id="$1"
+  printf '%s' "$id" | grep -qE '^[A-Za-z0-9._-]+$' || id="unknown"
+  printf '%s' "$id"
+}
+
+# registry_touch <session-id> <repo> — write the entry if absent, renew its
+# heartbeat if present. NEVER resets started_at: SessionStart fires on
+# startup, resume, clear and compact, and a reset started_at would mean a
+# genuinely long-running session never ages out (R2).
+registry_touch() {
+  local id repo dir entry now started tmp
+  id="$(registry_sanitise_id "$1")"
+  repo="${2:-$PWD}"
+  dir="$(registry_dir)"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  entry="$dir/$id.json"
+  now="$(_now_iso)"
+
+  started="$now"
+  [ -f "$entry" ] && started="$(_json_field "$entry" started_at)"
+  [ -n "$started" ] || started="$now"
+
+  tmp="$entry.$$.tmp"
+  printf '{"id":"%s","repo":"%s","started_at":"%s","heartbeat":"%s"}\n' \
+    "$id" "$repo" "$started" "$now" > "$tmp" 2>/dev/null || return 0
+  mv -f "$tmp" "$entry" 2>/dev/null || return 0
+}
+
+# registry_prune — retire every entry whose lease has expired, and record that
+# a retirement happened.
+#
+# The marker is what makes the honesty flag durable. Without it the flag would
+# have to be inferred from "did THIS read prune something", which hands the
+# uncertainty to whichever consumer happened to read first and hides it from
+# everyone after (R6). The pruner cannot distinguish a crashed session from a
+# healthy long-running one — it only knows the lease expired — so that
+# uncertainty belongs to the count from then on.
+registry_prune() {
+  local dir lease now entry hb hb_epoch retired
+  dir="$(registry_dir)"
+  [ -d "$dir" ] || return 0
+  lease="$(_lease_hours)"
+  now="$(date -u +%s)"
+  retired=0
+
+  for entry in "$dir"/*.json; do
+    [ -e "$entry" ] || continue
+    hb="$(_json_field "$entry" heartbeat)"
+    hb_epoch="$(_iso_to_epoch "$hb")"
+    [ "$hb_epoch" -gt 0 ] || continue          # unparseable: leave it alone
+    if [ $(( (now - hb_epoch) / 3600 )) -ge "$lease" ]; then
+      rm -f "$entry" 2>/dev/null && retired=1
+    fi
+  done
+
+  [ "$retired" -eq 1 ] && _now_iso > "$dir/.retired" 2>/dev/null
+  return 0
+}

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
@@ -97,7 +97,7 @@ registry_touch() {
 
   tmp="$entry.$$.tmp"
   printf '{"id":"%s","repo":"%s","started_at":"%s","heartbeat":"%s"}\n' \
-    "$id" "$(_json_escape "$repo")" "$started" "$now" > "$tmp" 2>/dev/null || return 0
+    "$id" "$(_json_escape "$repo")" "$(_json_escape "$started")" "$now" > "$tmp" 2>/dev/null || return 0
   # Rename, so a reader never observes a half-written entry. Several sessions
   # run these hooks against one shared registry directory at the same time.
   mv -f "$tmp" "$entry" 2>/dev/null || return 0

--- a/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/session-registry-write.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Strict mode, applied only when this file is EXECUTED. `return` succeeds
+# solely inside a sourced context, so the `set` is skipped when a hook script
+# or a sentinel sources us. That matters: `set` mutates the CALLER's shell, and
+# a library whose whole purpose is being safely sourceable must not impose
+# -e/-u/-o pipefail on whatever sourced it. Satisfies the "Shell scripts use
+# strict mode" constraint (HARNESS.md) in the only context where strict mode
+# is meaningful for a library.
+(return 0 2>/dev/null) || set -euo pipefail
 # session-registry-write.sh — the mutation surface of the session registry.
 #
 # Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4.2, §4.4
@@ -45,6 +54,30 @@ registry_sanitise_id() {
   printf '%s' "$id"
 }
 
+# _json_escape <string> — escape backslash and double-quote for a JSON string.
+#
+# `repo` is a filesystem path, and a path may legally contain a `"`. Without
+# this, such a path closes the JSON string early and injects arbitrary keys —
+# and because `_json_field` takes the FIRST match, an injected `heartbeat`
+# wins over the real one:
+#
+#     repo='/w/a","heartbeat":"2099-01-01T00:00:00Z'
+#       -> heartbeat reads back as 2099-01-01T00:00:00Z
+#
+# Lease expiry is the ONLY removal path in this design, so that entry becomes
+# immortal: it inflates the WIP count for every sentinel on the machine,
+# permanently, recoverable only by a human deleting the file. That is a worse
+# outcome than the injection case this repo already adjudicated for the
+# sibling `session_id` field, and it is why `repo` gets escaped rather than
+# merely truncated. Backslash must be replaced first, or it would double-escape
+# the quotes added after it.
+_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '%s' "$s"
+}
+
 # registry_touch <session-id> <repo> — write the entry if absent, renew its
 # heartbeat if present. NEVER resets started_at: SessionStart fires on
 # startup, resume, clear and compact, and a reset started_at would mean a
@@ -64,7 +97,9 @@ registry_touch() {
 
   tmp="$entry.$$.tmp"
   printf '{"id":"%s","repo":"%s","started_at":"%s","heartbeat":"%s"}\n' \
-    "$id" "$repo" "$started" "$now" > "$tmp" 2>/dev/null || return 0
+    "$id" "$(_json_escape "$repo")" "$started" "$now" > "$tmp" 2>/dev/null || return 0
+  # Rename, so a reader never observes a half-written entry. Several sessions
+  # run these hooks against one shared registry directory at the same time.
   mv -f "$tmp" "$entry" 2>/dev/null || return 0
 }
 
@@ -94,6 +129,12 @@ registry_prune() {
       rm -f "$entry" 2>/dev/null && retired=1
     fi
   done
+
+  # A hook killed at its 10s timeout between the write and the rename leaves a
+  # temp behind. It cannot corrupt a count — `*.tmp` matches neither the
+  # `*.json` glob nor the find — but nothing else would ever collect it, and
+  # the pruner is already the janitor on this rail.
+  find "$dir" -maxdepth 1 -name '*.tmp' -mmin +$(( lease * 60 )) -exec rm -f {} + 2>/dev/null || true
 
   [ "$retired" -eq 1 ] && _now_iso > "$dir/.retired" 2>/dev/null
   return 0

--- a/ai-literacy-superpowers/hooks/scripts/session-registry-start.sh
+++ b/ai-literacy-superpowers/hooks/scripts/session-registry-start.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# session-registry-start.sh — SessionStart hook: write or renew this session's
+# registry entry.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4.5
+# Tests: tdad_tests/layer0_deterministic/test-session-registry.sh (R1, R2, R10)
+#
+# SessionStart fires on startup, resume, clear and compact, so this runs more
+# than once per session. It is idempotent by construction: write if absent,
+# renew the heartbeat if present, and never touch started_at.
+#
+# Exits 0 unconditionally. A registry failure must never surface to a session
+# or interfere with it — the same contract every other hook script here holds.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/session-registry-write.sh" 2>/dev/null || exit 0
+
+input="$(cat 2>/dev/null || true)"
+
+session="$(printf '%s' "$input" \
+  | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$session" ] || session="unknown"
+
+repo="$(printf '%s' "$input" \
+  | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$repo" ] || repo="$PWD"
+
+registry_touch "$session" "$repo" 2>/dev/null || true
+exit 0

--- a/ai-literacy-superpowers/hooks/scripts/session-registry-start.sh
+++ b/ai-literacy-superpowers/hooks/scripts/session-registry-start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 # session-registry-start.sh — SessionStart hook: write or renew this session's
 # registry entry.
 #
@@ -19,14 +19,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 input="$(cat 2>/dev/null || true)"
 
+# Every extraction below ends in `|| true`: under set -e + pipefail a grep
+# that matches nothing would abort the script, defeating both the fallback on
+# the next line and this hook's exits-0-unconditionally contract.
+
 session="$(printf '%s' "$input" \
   | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
-  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
 [ -n "$session" ] || session="unknown"
 
 repo="$(printf '%s' "$input" \
   | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
-  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
 [ -n "$repo" ] || repo="$PWD"
 
 registry_touch "$session" "$repo" 2>/dev/null || true

--- a/ai-literacy-superpowers/hooks/scripts/session-registry-sweep.sh
+++ b/ai-literacy-superpowers/hooks/scripts/session-registry-sweep.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# session-registry-sweep.sh — Stop hook: renew this session's lease, then
+# retire any that have expired.
+#
+# Spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md §4.5
+# Tests: tdad_tests/layer0_deterministic/test-session-registry.sh (R3, R5, R7)
+#
+# This hook RENEWS. It does not delete this session's entry, and R3 is the
+# test that says so: Stop fires when the agent finishes responding, many times
+# per session, so a delete here would empty the registry after each session's
+# first answer.
+#
+# Pruning lives here, on the hook rail, rather than in any read path. That is
+# what keeps registry_count pure and the honesty flag a property of the count
+# rather than of whoever read first.
+#
+# Exits 0 unconditionally.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/session-registry-write.sh" 2>/dev/null || exit 0
+
+input="$(cat 2>/dev/null || true)"
+
+session="$(printf '%s' "$input" \
+  | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$session" ] || session="unknown"
+
+repo="$(printf '%s' "$input" \
+  | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$repo" ] || repo="$PWD"
+
+registry_touch "$session" "$repo" 2>/dev/null || true
+registry_prune 2>/dev/null || true
+exit 0

--- a/ai-literacy-superpowers/hooks/scripts/session-registry-sweep.sh
+++ b/ai-literacy-superpowers/hooks/scripts/session-registry-sweep.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 # session-registry-sweep.sh — Stop hook: renew this session's lease, then
 # retire any that have expired.
 #
@@ -23,14 +23,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 input="$(cat 2>/dev/null || true)"
 
+# Every extraction below ends in `|| true`: under set -e + pipefail a grep
+# that matches nothing would abort the script, defeating both the fallback on
+# the next line and this hook's exits-0-unconditionally contract.
+
 session="$(printf '%s' "$input" \
   | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
-  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
 [ -n "$session" ] || session="unknown"
 
 repo="$(printf '%s' "$input" \
   | grep -oE '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
-  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+  | sed -E 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
 [ -n "$repo" ] || repo="$PWD"
 
 registry_touch "$session" "$repo" 2>/dev/null || true

--- a/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
+++ b/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
@@ -220,6 +220,49 @@ Two tests, when a record is in question. **Who authored the claim?** If
 the agent did, it is about the person. **Would the person recognise it as
 something they said?** If not, it is about them.
 
+### The third category: hook-authored operational state
+
+Those two tests are necessary and not sufficient, because they classify one
+legitimate artefact wrongly. A hook that records *that a session exists* —
+its id, when it started, which project it is in — was authored by an agent,
+and no human would recognise the entry as something they said. Both tests say
+"about the person". Yet a concurrency limit cannot be honoured without knowing
+how many sessions are live, and knowing that is not an assessment of anyone.
+
+So there are three categories, not two:
+
+| Category | Example | Rule |
+| --- | --- | --- |
+| **By the person** | a budget, a stop hour, a disposition, a next action | Durable and reviewable. Often required. |
+| **About the person** | inference, telemetry, scoring, a claim about capacity or state | Forbidden, however softly worded. |
+| **Operational state** | the session registry | Permitted **only** under the four conditions below. |
+
+Operational state is permitted only when all four hold. Fail any one and it is
+a record about the person wearing a different hat:
+
+1. **Local and never committed.** It lives outside every work tree and enters
+   no repository's history.
+2. **Bounded.** It expires on a declared schedule rather than accumulating. A
+   record with no expiry is an archive, and an archive of where someone worked
+   is a surveillance artefact whatever it was built for.
+3. **Nothing in it judges.** It records facts about *sessions* — exists,
+   started, last active — never about the person running them. No score, no
+   assessment, no derived state.
+4. **Disclosed and declinable.** What it contains, how long it persists, and
+   how to switch it off are documented where the person will find them.
+
+The session registry (`~/.claude/sessions/`) is the worked example and meets
+all four. It was nearly not disclosed, which is what prompted this section: the
+pact file — the *permitted*, human-authored side of the line — shipped with a
+careful adoption ramp, while the registry was going to be created for every
+user silently. That asymmetry was backwards. The artefact on the contested side
+of a boundary needs *more* disclosure than the one safely inside it, not less.
+
+**When in doubt, this category does not apply.** It is a narrow carve-out for
+plumbing a sentinel needs and cannot infer, not a route around the rule. If you
+are reaching for it to justify storing something you find useful, you are in
+the second category.
+
 One corollary for anything a sentinel may *reach*, not merely write: a
 shared library that exposes a mutation function to a sentinel breaches
 this boundary through a channel the frontmatter check cannot see, because

--- a/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
+++ b/ai-literacy-superpowers/skills/sentinel-design/SKILL.md
@@ -194,6 +194,40 @@ An agent that does any of these has left the category, whatever its
    pipeline without a person disposing it, S2 is violated and the human
    has been removed from their own decision.
 
+### The boundary of anti-pattern 2: *by* the person versus *about* them
+
+"Persist nothing about the human" is not "persist nothing the human
+appears in". The line runs between two kinds of claim, and a sentinel
+author needs it drawn before they design any record:
+
+- **About the person — forbidden.** Anything the *agent* concluded:
+  inference, telemetry, scoring, an assertion about capacity, attention,
+  or state. "Tired at 21:00" is the canonical violation, and it stays a
+  violation however softly it is worded.
+- **By the person — permitted, and often required.** A declaration the
+  *human* authored: a budget, a stop hour, a disposition, a next action
+  they wrote themselves. A pact that is not durable is not a pact, so
+  refusing to persist these would not protect anyone — it would only make
+  the person's own decisions unenforceable by them.
+
+`## Cognitive reservoir` has always sat on the permitted side: it holds a
+self-declared `chronotype` in a file the human edits, while its own prose
+forbids recording any claim about cognitive state. The pact file
+(`~/.claude/pacts.md`) generalises that shape, and it is why parking
+records and consultation dispositions are legitimate durable artefacts.
+
+Two tests, when a record is in question. **Who authored the claim?** If
+the agent did, it is about the person. **Would the person recognise it as
+something they said?** If not, it is about them.
+
+One corollary for anything a sentinel may *reach*, not merely write: a
+shared library that exposes a mutation function to a sentinel breaches
+this boundary through a channel the frontmatter check cannot see, because
+`Bash` is permitted and the check reads only the declared `tools:` list.
+Split such libraries — a read surface a sentinel may source, a write
+surface only hooks and commands may. The boundary should hold by what an
+agent *can* reach, not by what it is trusted not to call.
+
 ## When you have a candidate
 
 1. Check S1, S2, S3 against the candidate. All three, or it is not a

--- a/ai-literacy-superpowers/templates/pacts.md
+++ b/ai-literacy-superpowers/templates/pacts.md
@@ -1,0 +1,78 @@
+# Pacts
+
+Your pacts — the limits you set for yourself, in advance, in clear weather.
+
+This file lives at `~/.claude/pacts.md`. It is yours, it is per-machine, and
+it is never committed. It belongs to **you**, not to any repository: a stop
+hour and a concurrency limit are properties of a person, not of a project.
+`HARNESS.md` remains the repo's declaration surface and does not hold pacts.
+
+Nothing here gates anything. Every block is optional, and a sentinel that
+finds its block missing says so and carries on in observe-only mode. A block
+you have not declared is not a failure — it is simply a pact you have not
+made.
+
+**Authoring.** Run `/mast tune`. Budgets that hold are budgets their keeper
+authored deliberately; a default someone else chose for you is not a pact, so
+nothing writes this file on your behalf.
+
+**One rule about editing.** Keep every value on its own clean `key: value`
+line, and keep notes in prose below the values — never as a trailing `#`
+comment on a value line. The parser reads everything after the first colon, so
+an inline comment silently becomes part of the value.
+
+---
+
+## Session WIP
+
+- max_concurrent_sessions: 2
+- max_switches_per_hour: 4
+- stale_after_hours: 12
+- enforcement: advisory
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.
+
+Field notes. `max_concurrent_sessions` is how many sessions you are willing to
+have live at once, counted across every repository on this machine.
+`max_switches_per_hour` is optional. `stale_after_hours` is how long a session
+may go without finishing a turn before it is treated as gone — raise it if you
+routinely leave a session parked mid-thought. `enforcement: advisory` reports
+a breach and proceeds; `strict` asks you to park something or say, on the
+record, what was urgent enough. There is always an override, and it is always
+yours to take.
+
+## Budgets
+
+- daily_cost_ceiling: not observable
+- sessions_per_day: 3
+- hard_stop_hour: 18:30
+- focus_blocks: 09:00-12:00, 14:00-17:00
+- notification_policy_after_stop: digest
+- authored_at: 2026-01-01
+- authored_via: tune
+
+Unspent budget is not a debt.
+
+Field notes. `daily_cost_ceiling` may honestly be `not observable` — say so
+rather than let something estimate it. `hard_stop_hour` is local, 24-hour.
+`focus_blocks` is a comma-separated list of ranges.
+`notification_policy_after_stop` records what you want to happen after the
+line; enforcing it is the platform's business, not this plugin's.
+`authored_at` and `authored_via` record that you made this pact rather than
+inherited it.
+
+The clause above is part of the block. Delete it and the block reads as
+malformed, and every sentinel drops back to observe-only rather than hold you
+to a pact whose governing sentence is gone.
+
+## Sync cadence
+
+- interrupt_mode: coalesced
+- sync_points: 09:00, 16:00
+
+Reserved. No sentinel reads this block yet. Values declared here are inert;
+the slice that adds a consumer will define their behaviour.
+
+Field notes. `interrupt_mode` is `streaming` or `coalesced`. `sync_points` is
+a comma-separated list of times, or the literal `on-demand`.

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -114,6 +114,30 @@ The narrative: the decision-discipline triad guards *decisions*; the
 `reservoir-warden` guards *the decider*; the `cost-estimator` guards
 *the decision's inputs*.
 
+### A second declaration surface: the pact file
+
+The **cadence sentinels** now under construction — the Coda, the Mast,
+the WIP Warden, and the Convener — read a surface that did not exist
+before them: `~/.claude/pacts.md`, documented at
+[Pact file format](../reference/pacts-format.md).
+
+The split matters, and it is not an accident of filing. `HARNESS.md` is
+the **repository's** declaration surface: what this project requires of
+anyone who works on it. The pact file is the **person's**: what one human
+has decided about how they work. A stop hour and a concurrency limit
+belong to a person, not to a project, so they live outside every work
+tree and are never committed — nothing about the human is written into
+any repository's history.
+
+That boundary is the sentinel ethic applied to storage. It also draws a
+line that every sentinel author needs: *persist nothing about the person*
+forbids claims an agent makes **about** someone — inference, telemetry,
+scoring. It does not forbid a pact the person authored themselves, which
+is a statement **by** them. A pact that is not durable is not a pact.
+`## Cognitive reservoir` has always worked this way, holding a
+self-declared `chronotype` while forbidding any recorded claim about
+cognitive state.
+
 ## The near-miss gallery
 
 The signature has a trap. **Read-only plus advisory is not sufficient.**

--- a/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md
@@ -1,0 +1,91 @@
+# Consultation record format
+
+A **consultation record** names the voices a spec affects, the concrete
+question worth asking each of them, and what was decided about each — either
+that they were consulted, or that they deliberately were not, and why.
+
+Records live in `docs/superpowers/consultations/`. They are written by the
+`/convene` command after the human disposes; the `convener` agent is
+`role: sentinel` and read-only.
+
+The Convener maps voices and drafts questions. It never contacts anyone, and
+it never treats an agent as a consultable voice.
+
+Owned by the Cadence Sentinels S1 slice. A consumer never mutates the contract
+it consumes.
+
+## Filename
+
+```text
+docs/superpowers/consultations/<YYYY-MM-DD>-<slug>.md
+```
+
+State lives **in the filename**, and a transition writes a new file:
+
+```text
+2026-08-08-retry-semantics.md              # open
+2026-08-09-retry-semantics.resolved.md     # resolved — supersedes the above
+2026-08-10-retry-semantics.superseded.md   # superseded on spec revision
+```
+
+## Append-only
+
+Records are append-only. A record is **never edited in place and never
+deleted**.
+
+Because dispositions accumulate during a review, a consultation record is
+written once per **revision**: disposing voices produces a new `.resolved.md`
+file carrying the full voice list with its dispositions filled in, naming the
+open record in `supersedes:`. The frontmatter of a written record is never
+edited — which is what keeps the rule true, since editing a per-voice
+`disposition` inside an existing file would be an in-place edit of a record
+the rule says is immutable.
+
+`records_open` in `hooks/scripts/lib/record-paths.sh` answers "which
+consultations are still open" from the filenames.
+
+## Frontmatter
+
+```yaml
+---
+spec: <path to the spec under approval>
+date: <YYYY-MM-DD>
+state: open | resolved | superseded
+supersedes: <filename> | null
+voices:
+  - voice: <role or group>
+    source_flag: observed | inferred | asked
+    question: <the concrete question worth asking them>
+    disposition: pending | consulted | deliberately-not-consulted
+    outcome: <one line> | null
+---
+```
+
+| Field | Meaning |
+| --- | --- |
+| `spec` | The spec under approval. |
+| `date` | The date the record was written. |
+| `state` | Restates the filename, for readability. The **filename is authoritative**. |
+| `supersedes` | The record this one replaces, or `null`. |
+| `voices` | One entry per material voice. |
+
+### Per-voice fields
+
+| Field | Meaning |
+| --- | --- |
+| `voice` | A role or group — never a named individual, and never an agent. |
+| `source_flag` | How the voice was identified. `observed`: a declared stakeholder map named it. `inferred`: derived from the change itself. `asked`: the human named it. |
+| `question` | The actual question worth asking them. Not "sync with X". |
+| `disposition` | `pending` until a human decides. |
+| `outcome` | One line. **Required** when the disposition is `deliberately-not-consulted` — that path needs its because. |
+
+## The gate is soft
+
+At plan approval, unresolved voices are **listed, not blocking**. An
+agent-verified merge-time check flags a spec whose consultation record still
+carries a voice with no disposition. It is never escalated to deterministic
+enforcement.
+
+A voice recorded as `deliberately-not-consulted` with a stated because is a
+complete, healthy disposition — not a debt. The record exists to make the
+decision visible, not to require that everyone be asked.

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -238,6 +238,32 @@ reports its count as `inferred`. The registry is local, per-machine,
 outside every work tree, and never committed. Exits 0 unconditionally —
 a registry failure must never surface to a session.
 
+**What it stores, and for how long.** One small JSON file per session,
+under `~/.claude/sessions/`, holding four fields: the sanitised session
+id, the project directory, when the session started, and when it last
+completed a turn. Nothing else — no prompts, no file contents, no
+assessment of any kind. An entry is retired once it goes
+`stale_after_hours` without a heartbeat (12 by default, declared in your
+pact file), so the registry is bounded rather than an accumulating
+archive.
+
+Under the `sentinel-design` skill's persistence rules this is
+**hook-authored operational state**, a narrow third category alongside
+records a human authored and claims an agent made about them. It is
+permitted only because it is local, bounded, judges nothing, and is
+disclosed here.
+
+**To switch it off**, remove the `session-registry-start.sh` and
+`session-registry-sweep.sh` entries from `hooks/hooks.json`. Everything
+else in the plugin continues to work; the cadence sentinels that read
+the registry will report `no Session WIP block declared — running in
+observe-only mode`.
+
+**`$CLAUDE_SESSIONS_DIR`** overrides the registry location. It exists so
+the deterministic tests need no home directory and is **not intended for
+production use** — pointing it inside a work tree defeats the guarantee
+that nothing can be committed by accident.
+
 ---
 
 ## Configuration

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -182,11 +182,33 @@ hungry-judges figure. See the `cognitive-reservoir` skill and the
 [Watching the Verifier](../explanation/watching-the-verifier.md)
 concept page.
 
+### Session registry sweep (command)
+
+- **Event**: Stop
+- **Matcher**: `*`
+- **Type**: command
+- **Script**: `hooks/scripts/session-registry-sweep.sh`
+- **Timeout**: 10s
+
+Renews this session's registry lease, then retires any lease that has
+expired. It **renews — it never deletes this session's entry.** That is
+the load-bearing detail: `Stop` fires each time the main agent finishes
+responding, so a hook that deleted its own entry here would empty the
+registry after the session's first answer, and the WIP Warden would
+report one live session while four ran. Retirement happens only by lease
+expiry, whose length is `stale_after_hours` in the pact file (default
+12). Pruning lives on this rail rather than in any read path, which is
+what keeps `registry_count` a pure read and the honesty flag a property
+of the count rather than of whoever read first. Exits 0 unconditionally.
+See [Pact file format](pacts-format.md).
+
 ---
 
 ## SessionStart Hooks
 
-These hooks fire once when a new Claude Code session begins.
+These hooks fire when a Claude Code session begins — **and also on
+resume, clear, and compact**, so a `SessionStart` hook runs more than
+once in the life of a session and must be idempotent.
 
 ### Template currency check
 
@@ -199,6 +221,22 @@ Compares the `<!-- template-version: X.Y.Z -->` marker in
 version, nudges you to run `/harness-upgrade` to adopt new
 template content. Exits silently if `HARNESS.md` does not exist
 or the marker is absent.
+
+### Session registry start
+
+- **Script**: `hooks/scripts/session-registry-start.sh`
+- **Timeout**: 10s
+
+Writes this session's entry in the machine-global session registry
+(`~/.claude/sessions/`), or renews its heartbeat if one already exists.
+Idempotent by construction, because `SessionStart` re-fires on resume,
+clear, and compact: it never resets `started_at`, since doing so would
+mean a genuinely long-running session never ages out. The session id is
+sanitised before it is used as a path component; a hostile id collapses
+to `unknown`, which is one reason a registry containing `unknown.json`
+reports its count as `inferred`. The registry is local, per-machine,
+outside every work tree, and never committed. Exits 0 unconditionally —
+a registry failure must never surface to a session.
 
 ---
 

--- a/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
@@ -144,3 +144,15 @@ scaffolds a default one at install.
 That is deliberate. Limits a person set for themselves hold; limits that
 arrived as somebody else's default do not. Authorship is the active
 ingredient, so the authoring dialogue proposes nothing — it asks.
+
+## `$CLAUDE_PACTS_FILE`
+
+The reader honours a `$CLAUDE_PACTS_FILE` environment variable in place of
+`~/.claude/pacts.md`. It exists so the deterministic tests need no home
+directory, and it is **not intended for production use**.
+
+Worth knowing it is there, because the whole clear-weather argument turns on
+authorship: a pact holds because its keeper wrote it. Anything that can set an
+environment variable for a session — a direnv file, a project rc, a wrapper
+script — can therefore substitute the pact a sentinel reads, and no sentinel
+can tell. If you use it, use it knowingly.

--- a/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
@@ -1,0 +1,146 @@
+# Pact file format
+
+`~/.claude/pacts.md` holds the limits you set for yourself, in advance, in
+clear weather. The cadence sentinels read it; none of them writes it except
+`/mast tune`, and nothing creates it on your behalf.
+
+## Why it is not in `HARNESS.md`
+
+`HARNESS.md` is the **repository's** declaration surface. A pact file is the
+**person's**.
+
+A stop hour, a focus window, and a concurrency limit are properties of a
+human, not of a project. A repo-scoped pact file cannot answer "whose pact is
+this" in a project with five contributors, and a per-repo concurrency limit
+compared against a machine-global session count is a units mismatch — the same
+three live sessions would be compliant in one repo and in breach in another,
+with the advisory depending on which directory you happened to be sitting in.
+
+The pact file is per-machine, per-person, and never committed. Nothing about
+you is written into any repository's history.
+
+`## Cognitive reservoir` stays in `HARNESS.md` and is unchanged.
+
+## Everything here is optional
+
+A sentinel that finds its block missing says so and carries on:
+
+```text
+no `Budgets` block declared — running in observe-only mode
+```
+
+Absence is never an error, never a warning, and never a gate. A block you have
+not declared is not a failure — it is a pact you have not made.
+
+## Three states
+
+| State | Meaning | Behaviour |
+| --- | --- | --- |
+| **Absent** | No file, or no such heading | Observe-only note, continue |
+| **Malformed** | Heading present, but a mandatory clause is missing | Observe-only note plus a line naming what is missing, continue |
+| **Declared** | Heading present and well-formed | Read it |
+
+Malformed degrades to observe-only, never to a gate. If you delete a block's
+governing clause, no sentinel will hold you to that pact.
+
+## Writing values
+
+Keep each value on its own clean `key: value` line, and keep notes in prose
+**below** the values — never as a trailing `#` comment on a value line. The
+parser reads everything after the first colon, so an inline comment silently
+becomes part of the value.
+
+Values may contain colons and spaces. `hard_stop_hour: 18:30` reads as
+`18:30`, and `daily_cost_ceiling: not observable` keeps its space.
+
+## `## Session WIP`
+
+```text
+- max_concurrent_sessions: 2
+- max_switches_per_hour: 4
+- stale_after_hours: 12
+- enforcement: advisory
+```
+
+| Key | Grammar | Required | Meaning |
+| --- | --- | --- | --- |
+| `max_concurrent_sessions` | integer | yes | How many live sessions you will accept, counted across every repository on this machine |
+| `max_switches_per_hour` | integer | no | |
+| `stale_after_hours` | integer | no (default 12) | How long a session may go without finishing a turn before it is treated as gone |
+| `enforcement` | `advisory` \| `strict` | no (default `advisory`) | See below |
+
+**Mandatory clause:** *This is a gate on sessions, never on the person. It
+counts; it does not assess.*
+
+`enforcement: advisory` reports a breach and proceeds. `enforcement: strict`
+asks for a **disposition** before the session proceeds — park an existing
+session, or override on the record with one line naming what was urgent
+enough. There is always an override, and it is always yours to take; `strict`
+never means an unconditional refusal.
+
+`stale_after_hours` is the registry lease length. Raise it if you routinely
+leave a session parked mid-thought: liveness is measured as *recency of a
+completed turn*, so a session where you are reading or thinking emits no
+heartbeat.
+
+## `## Budgets`
+
+```text
+- daily_cost_ceiling: not observable
+- sessions_per_day: 3
+- hard_stop_hour: 18:30
+- focus_blocks: 09:00-12:00, 14:00-17:00
+- notification_policy_after_stop: digest
+- authored_at: 2026-08-08
+- authored_via: tune
+```
+
+| Key | Grammar | Meaning |
+| --- | --- | --- |
+| `daily_cost_ceiling` | free text | The literal `not observable` is a valid, honest value — better than an estimate nobody can ground |
+| `sessions_per_day` | integer | |
+| `hard_stop_hour` | `HH:MM`, 24-hour, local | Contains a colon |
+| `focus_blocks` | comma-separated `HH:MM-HH:MM` ranges | Contains colons and spaces |
+| `notification_policy_after_stop` | `digest` \| `none` | Declared intent only — see below |
+| `authored_at` | `YYYY-MM-DD` | |
+| `authored_via` | `tune` | Records that you made this pact rather than inherited it |
+
+**Mandatory clause:** *Unspent budget is not a debt.*
+
+The clause is part of the block, not a comment on it. Delete it and the block
+reads as malformed. Because detection is literal-string matching, the wording
+is an interface: you may re-wrap the sentence across lines, but rewording it
+is a spec-first change and a coordinated migration.
+
+> **`notification_policy_after_stop` is declared intent.** It records the
+> pact so a platform hook can honour it where one exists. Push and digest
+> enforcement is platform-side and outside this plugin's hands, so it sits at
+> the **Unverified** rung of the hardening ladder by design.
+
+## `## Sync cadence` (reserved)
+
+```text
+- interrupt_mode: coalesced
+- sync_points: 09:00, 16:00
+```
+
+| Key | Grammar |
+| --- | --- |
+| `interrupt_mode` | `streaming` \| `coalesced` |
+| `sync_points` | comma-separated `HH:MM` times, or the literal `on-demand` |
+
+> **Reserved.** No sentinel reads this block yet. Values declared here are
+> **inert**; the slice that adds a consumer will define their behaviour.
+>
+> It ships now so the vocabulary arrives whole rather than block by block, and
+> it is marked reserved so a value you declare in good faith does not bind a
+> future consumer to behaviour nobody has designed.
+
+## Authoring
+
+Run `/mast tune`. Nothing writes this file on your behalf, and nothing
+scaffolds a default one at install.
+
+That is deliberate. Limits a person set for themselves hold; limits that
+arrived as somebody else's default do not. Authorship is the active
+ingredient, so the authoring dialogue proposes nothing — it asks.

--- a/docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md
@@ -1,0 +1,100 @@
+# Parking record format
+
+A **parking record** captures one live thread of work at the moment a session
+closes, so that stopping costs nothing and resuming starts from a concrete
+step rather than from a cold read of yesterday's diff.
+
+Records live in `docs/superpowers/parked/`. They are written by the `/coda`
+command after the human has confirmed the next action — never by the `coda`
+agent, which is `role: sentinel` and read-only.
+
+Owned by the Cadence Sentinels S1 slice. A consumer never mutates the contract
+it consumes: a slice that needs a new field carves its own contract-owning
+slice with its own adversarial pass.
+
+## Filename
+
+```text
+docs/superpowers/parked/<YYYY-MM-DD>-<slug>.md
+```
+
+State lives **in the filename**, and a transition writes a new file:
+
+```text
+2026-08-08-retry-branch.md              # parked
+2026-08-09-retry-branch.resumed.md      # resumed — supersedes the above
+2026-08-09-retry-branch.superseded.md   # superseded
+```
+
+## Append-only
+
+Records are append-only. A record is **never edited in place and never
+deleted**. Resuming a parked thread writes a `.resumed.md` file naming its
+predecessor in `supersedes:`; it does not change the predecessor.
+
+This is why state is in the path rather than in a mutable `status:` key —
+editing a key from `parked` to `resumed` *is* an in-place edit, so a single
+mutable field would have contradicted the append-only rule it claimed to obey.
+
+The query for "what is still parked" follows from the same rule: every `*.md`
+that is not itself a transition file and is not named by any transition's
+`supersedes:`. It ships as `records_open` in
+`hooks/scripts/lib/record-paths.sh` rather than as prose, so consumers share
+one answer.
+
+## Frontmatter
+
+```yaml
+---
+session: <sanitised session id>
+repo: <absolute path to project root>
+created: <YYYY-MM-DD>
+state: parked | resumed | superseded
+supersedes: <filename> | null
+next_action_flag: asked
+---
+```
+
+| Field | Meaning |
+| --- | --- |
+| `session` | Opaque provenance only — **never a lookup key**. See the warning below. |
+| `repo` | Where the parked work lives. |
+| `created` | The date the record was written. |
+| `state` | Restates what the filename says, for readability. The **filename is authoritative**. |
+| `supersedes` | The record this one replaces, or `null`. |
+| `next_action_flag` | Always `asked`. The next action comes from the human, never from inference. |
+
+> **`session` is not a lookup key.** The session registry forgets an entry one
+> lease after its last heartbeat (12 hours by default). A parking record is
+> permanent. Resolving a record's `session` against the live registry will
+> therefore fail for every record older than a lease, and succeed misleadingly
+> for a reused id. Treat it as provenance and nothing more.
+
+## Body
+
+Two sections, both required.
+
+```markdown
+## Context
+
+One paragraph: what this thread is, and what state it was left in.
+
+## Next action
+
+A single concrete resume step.
+```
+
+### The next action is validated
+
+`next_action` is **mandatory and validated**. A vague next action is refused
+with a reprompt, because a vague plan does not do the work a written plan
+does:
+
+- ❌ "continue work"
+- ❌ "carry on with the parser"
+- ✅ "implement the retry branch of slice 7's error path, starting from the
+  failing test in `test_retry.py`"
+
+Specificity is the active ingredient, not completeness. A thread parked with a
+concrete next step stops pulling at the person who parked it; one parked with
+"continue work" does not.

--- a/docs/superpowers/consultations/README.md
+++ b/docs/superpowers/consultations/README.md
@@ -1,0 +1,21 @@
+# Consultation records
+
+The voices a spec affects, the question worth asking each of them, and what
+was decided about each — written by `/convene` after a human disposes.
+
+**The format lives in the reference documentation**, not here:
+
+- [Consultation record format](../../plugins/ai-literacy-superpowers/reference/consultation-record-format.md)
+
+This directory holds records; the reference page holds the contract. Keeping
+them apart is deliberate — `mkdocs.yml` excludes `docs/superpowers/` from the
+published site, so a schema written here would be the one format contract in
+the repo an adopter cannot read. It would also be a second copy, free to drift
+from the first.
+
+Two rules that govern everything in this directory:
+
+- **Append-only.** No record is ever edited in place or deleted. Disposing
+  voices writes a new `.resolved.md` file.
+- **State is in the filename.** `<date>-<slug>.md` is open;
+  `<date>-<slug>.resolved.md` supersedes it.

--- a/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md
+++ b/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md
@@ -9,78 +9,78 @@ objections:
     severity: critical
     claim: "registry_count counts every entry file with no freshness test, so a session that ended normally is still counted as live for a full lease window, and the count is flagged `observed` — the published semantics is 'live sessions' but the delivered semantics is 'sessions that completed a turn in the last 12 hours'."
     evidence: "session-registry-read.sh registry_count uses `find -name '*.json' | wc -l` with no heartbeat comparison; the only removal path is registry_prune, which runs solely on the Stop rail. reference/pacts-format.md publishes `max_concurrent_sessions` as 'How many live sessions you will accept'. Reproduced: three sequential sessions (7h old, 3h old, live) yield '3 observed'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "registry_count now excludes entries whose heartbeat is past the lease -- a pure read, so R8 and the trust boundary are untouched -- and flags inferred whenever it excluded one, because an expired-unpruned entry is exactly the 'crashed or merely quiet' uncertainty the flag already carries. The false-positive direction of the lease is now disclosed in the spec and the reference page alongside the false-negative direction that was already there. The lease lifecycle itself stands; only the count's filter and flag change."
   - id: O2
     category: risk
     severity: high
     claim: "The two behavioural contracts the spec names for the new hooks — 'Both exit 0 unconditionally' and 'nothing in this slice blocks, warns, or requires a disposition' — are asserted by no test, and the test harness actively discards the evidence for both."
     evidence: "Every hook invocation in test-session-registry.sh is `bash \"$HOOK\" >/dev/null 2>&1 || true`. The redirect discards the stream that would prove no-gating; the `|| true` discards the status that would prove exits-0. Spec 4.5 and 6 both state the contracts explicitly."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Both hooks now assert an empty stdout and exit 0, including with the registry directory unwritable and HOME unset. The property that makes this slice safe was the one property guarded by a redirect."
   - id: O3
     category: risk
     severity: high
     claim: "The registry writes an agent-authored durable record of which project the human was in and when, for every user of the plugin from the moment they upgrade — with no opt-in, no disclosure of contents or retention at the point of writing, and no documented way to decline; and this slice's own newly promoted BY/ABOUT test classifies such a record as about the person."
     evidence: "session-registry-write.sh writes repo (the session cwd) and started_at; hooks.json wires the writer to SessionStart with matcher '*' for every user. skills/sentinel-design/SKILL.md, added in this branch: 'Who authored the claim? If the agent did, it is about the person.' The skill's permitted list names the pact file, parking records and consultation dispositions; the registry is absent. Contrast templates/pacts.md: 'nothing writes this file on your behalf'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "sentinel-design gains a THIRD category: hook-authored operational state, distinct from both a human's own declarations and an agent's claims about them -- bounded, local, never committed, and never read by anything that judges the person. reference/hooks.md gains what the entries contain, how long they persist, and how to disable the hooks. Settling this explicitly is the point: silence would have set the boundary by precedent, which spec section 2 argues is the weakest way to decide a constitutional question."
   - id: O4
     category: risk
     severity: medium
     claim: "A human-declared `stale_after_hours: 0` passes validation and makes registry_prune retire every entry — including the one registry_touch wrote milliseconds earlier on the same Stop — leaving the registry permanently empty while registry_count reports '0 observed'."
     evidence: "_lease_hours validates with `case \"$v\" in ''|*[!0-9]*) v=12 ;; esac`, which accepts 0. registry_prune's `-ge \"$lease\"` is true for a zero-age entry. registry_count's `-lt \"$lease\"` is false for 0 < 0, so the retirement is not disclosed. No lower bound is stated in the spec, the template, or the reference page."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "stale_after_hours is floored at 1 and the floor is documented. A reader who writes 0 means 'never expire', a common convention; the implementation meant 'expire everything immediately', and the honesty flag reported observed while doing it."
   - id: O5
     category: implementation
     severity: medium
     claim: "_block_span treats any line matching '^#{1,6}[[:space:]]+' as a markdown heading, so a standalone '# note to self' line in a human-authored pact file silently truncates the block — dropping every key below it and, with it, the mandatory clause, flipping a well-formed block to malformed."
     evidence: "pact-blocks.sh ends a span when `inblock && level <= want_level`; a '# ' line computes level 1, which is <= 2. The shipped guidance narrows the warning to value lines — 'never as a trailing # comment on a value line' — which reads as permission for a standalone # line. No fixture contains a #-prefixed line inside a block."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The span parser now recognises only the three known block headings as terminators, so an ordinary standalone # comment in a hand-edited pact file no longer truncates a block and silently flips it to malformed. Fixture added."
   - id: O6
     category: implementation
     severity: medium
     claim: "R9's transitive mutation guard is narrower than the guarantee it advertises: its source-closure walker recognises exactly one spelling of source, and its mutation regexes miss several common write forms — so a future library added to the read closure by any other idiom is invisible while the test still prints 'read library inert'."
     evidence: "The walker's grep requires the `.` builtin, an unbraced all-caps variable, a single path segment, and a lowercase-hyphen filename; `source x`, `. \"${DIR}/x.sh\"`, and `json_helpers.sh` all drop out. The mutation patterns miss redirects to literal paths, ln, chmod, install, dd, `exec 3>`, and writes inside an awk program."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The closure walker accepts `source` as well as `.`, braced and unbraced variables, nested path segments, and underscore/digit filenames; the forbidden-operation set gains redirects to literal paths, ln, chmod, install, dd, and exec redirections. The guarantee the record will be read as making now matches what the test covers."
   - id: O7
     category: risk
     severity: medium
     claim: "$CLAUDE_PACTS_FILE and $CLAUDE_SESSIONS_DIR are unauthenticated environment redirects with no origin check, so anything that sets an environment variable for a session can substitute the pact that S3-S5 will hold the human to, and can relocate the registry inside a work tree where it will be committed."
     evidence: "Both resolvers read the variable directly with a `:-` default. Spec 4.1 asserts 'nothing can accidentally commit it', which holds only while the override is unset; R13 tests the default path after an explicit unset. Neither variable is documented in reference/hooks.md or reference/pacts-format.md."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Both overrides documented as test-only in reference/pacts-format.md and reference/hooks.md, and the spec's 'nothing can accidentally commit it' claim is qualified to the default path. Authorship is the clear-weather rule's active ingredient, so a redirect that makes authorship unverifiable has to be visible."
   - id: O8
     category: specification quality
     severity: medium
     claim: "_flatten reverses an explicit, load-bearing sentence of the approved spec — the spec says a reflowed clause ceases to read as declared; the code says it still reads as declared. The reference page was updated to match the code; the spec, which is the document S2-S5 will be written from, was not."
     evidence: "Spec 3.4: 'the sentence cannot be reworded, translated, shortened, or reflowed across lines ... without the block silently ceasing to read as declared. That is deliberate.' pact-blocks.sh applies _flatten to both sides of the clause match. reference/pacts-format.md now says 'you may re-wrap the sentence across lines'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Spec amended to revision 4. The code is right -- the strict rule was unshippable against the slice's own template, whose Session WIP clause wraps -- and the spec claimed authority over the matching rule while stating one the library does not implement. S2-S5 are authored against section 3, so section 3 has to be true."
   - id: O9
     category: risk
     severity: medium
     claim: "The sweep is the tenth hook on the Stop rail and runs a full prune on every assistant turn — parsing the pact file with two awk passes and spawning several processes per registry entry — for every user of the plugin, before any consumer of the registry exists."
     evidence: "hooks.json adds session-registry-sweep.sh as the tenth Stop entry; the script calls registry_prune unconditionally per turn. registry_prune calls _lease_hours (two awk passes over the pact file), then per entry _json_field (grep + sed) and _iso_to_epoch (one or two date execs), then a find. Spec 6: S1 ships no consumer."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Consciously carried, on the record. The work is a handful of processes against a directory holding single-digit files, comparable to the nine existing Stop hooks. Revisit if it shows up in practice rather than optimising on a hunch; the throttle design is recorded in this objection should it be needed."
   - id: O10
     category: specification quality
     severity: low
     claim: "hooks.json's own description field still enumerates the pre-S1 hook set, so the file's self-description is wrong on the day it ships."
     evidence: "hooks.json line 2 ends with the reservoir check and the template currency check; neither session-registry-sweep.sh nor session-registry-start.sh appears. reference/hooks.md tells the reader the file contains 'A description field summarising the hook set'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "hooks.json description updated to enumerate the two new entries."
   - id: O11
     category: implementation
     severity: low
     claim: "The R14 escaping fix is one-directional: _json_escape is applied to repo on write but started_at is round-tripped from disk unescaped, and _json_field is not escape-aware on read, so a legitimately backslash- or quote-bearing repo path reads back truncated or doubled in registry_list."
     evidence: "registry_touch re-emits `started` (read via _json_field) without escaping while escaping repo. _json_field's `[^\"]*` stops at the first quote, escaped or not. registry_list is the surface that hands the value to a consumer, and spec 4.1 makes the field load-bearing."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "started_at is escaped on the round-trip and _json_field decodes escaped quotes and backslashes, so the pair is closed rather than one half of it."
 ---
 
 # Objection record — Cadence Sentinels S1 (code mode)

--- a/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md
+++ b/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md
@@ -1,0 +1,432 @@
+---
+spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+date: 2026-08-08
+mode: code
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: risk
+    severity: critical
+    claim: "registry_count counts every entry file with no freshness test, so a session that ended normally is still counted as live for a full lease window, and the count is flagged `observed` — the published semantics is 'live sessions' but the delivered semantics is 'sessions that completed a turn in the last 12 hours'."
+    evidence: "session-registry-read.sh registry_count uses `find -name '*.json' | wc -l` with no heartbeat comparison; the only removal path is registry_prune, which runs solely on the Stop rail. reference/pacts-format.md publishes `max_concurrent_sessions` as 'How many live sessions you will accept'. Reproduced: three sequential sessions (7h old, 3h old, live) yield '3 observed'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: risk
+    severity: high
+    claim: "The two behavioural contracts the spec names for the new hooks — 'Both exit 0 unconditionally' and 'nothing in this slice blocks, warns, or requires a disposition' — are asserted by no test, and the test harness actively discards the evidence for both."
+    evidence: "Every hook invocation in test-session-registry.sh is `bash \"$HOOK\" >/dev/null 2>&1 || true`. The redirect discards the stream that would prove no-gating; the `|| true` discards the status that would prove exits-0. Spec 4.5 and 6 both state the contracts explicitly."
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: risk
+    severity: high
+    claim: "The registry writes an agent-authored durable record of which project the human was in and when, for every user of the plugin from the moment they upgrade — with no opt-in, no disclosure of contents or retention at the point of writing, and no documented way to decline; and this slice's own newly promoted BY/ABOUT test classifies such a record as about the person."
+    evidence: "session-registry-write.sh writes repo (the session cwd) and started_at; hooks.json wires the writer to SessionStart with matcher '*' for every user. skills/sentinel-design/SKILL.md, added in this branch: 'Who authored the claim? If the agent did, it is about the person.' The skill's permitted list names the pact file, parking records and consultation dispositions; the registry is absent. Contrast templates/pacts.md: 'nothing writes this file on your behalf'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: risk
+    severity: medium
+    claim: "A human-declared `stale_after_hours: 0` passes validation and makes registry_prune retire every entry — including the one registry_touch wrote milliseconds earlier on the same Stop — leaving the registry permanently empty while registry_count reports '0 observed'."
+    evidence: "_lease_hours validates with `case \"$v\" in ''|*[!0-9]*) v=12 ;; esac`, which accepts 0. registry_prune's `-ge \"$lease\"` is true for a zero-age entry. registry_count's `-lt \"$lease\"` is false for 0 < 0, so the retirement is not disclosed. No lower bound is stated in the spec, the template, or the reference page."
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: implementation
+    severity: medium
+    claim: "_block_span treats any line matching '^#{1,6}[[:space:]]+' as a markdown heading, so a standalone '# note to self' line in a human-authored pact file silently truncates the block — dropping every key below it and, with it, the mandatory clause, flipping a well-formed block to malformed."
+    evidence: "pact-blocks.sh ends a span when `inblock && level <= want_level`; a '# ' line computes level 1, which is <= 2. The shipped guidance narrows the warning to value lines — 'never as a trailing # comment on a value line' — which reads as permission for a standalone # line. No fixture contains a #-prefixed line inside a block."
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: implementation
+    severity: medium
+    claim: "R9's transitive mutation guard is narrower than the guarantee it advertises: its source-closure walker recognises exactly one spelling of source, and its mutation regexes miss several common write forms — so a future library added to the read closure by any other idiom is invisible while the test still prints 'read library inert'."
+    evidence: "The walker's grep requires the `.` builtin, an unbraced all-caps variable, a single path segment, and a lowercase-hyphen filename; `source x`, `. \"${DIR}/x.sh\"`, and `json_helpers.sh` all drop out. The mutation patterns miss redirects to literal paths, ln, chmod, install, dd, `exec 3>`, and writes inside an awk program."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: risk
+    severity: medium
+    claim: "$CLAUDE_PACTS_FILE and $CLAUDE_SESSIONS_DIR are unauthenticated environment redirects with no origin check, so anything that sets an environment variable for a session can substitute the pact that S3-S5 will hold the human to, and can relocate the registry inside a work tree where it will be committed."
+    evidence: "Both resolvers read the variable directly with a `:-` default. Spec 4.1 asserts 'nothing can accidentally commit it', which holds only while the override is unset; R13 tests the default path after an explicit unset. Neither variable is documented in reference/hooks.md or reference/pacts-format.md."
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: specification quality
+    severity: medium
+    claim: "_flatten reverses an explicit, load-bearing sentence of the approved spec — the spec says a reflowed clause ceases to read as declared; the code says it still reads as declared. The reference page was updated to match the code; the spec, which is the document S2-S5 will be written from, was not."
+    evidence: "Spec 3.4: 'the sentence cannot be reworded, translated, shortened, or reflowed across lines ... without the block silently ceasing to read as declared. That is deliberate.' pact-blocks.sh applies _flatten to both sides of the clause match. reference/pacts-format.md now says 'you may re-wrap the sentence across lines'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: risk
+    severity: medium
+    claim: "The sweep is the tenth hook on the Stop rail and runs a full prune on every assistant turn — parsing the pact file with two awk passes and spawning several processes per registry entry — for every user of the plugin, before any consumer of the registry exists."
+    evidence: "hooks.json adds session-registry-sweep.sh as the tenth Stop entry; the script calls registry_prune unconditionally per turn. registry_prune calls _lease_hours (two awk passes over the pact file), then per entry _json_field (grep + sed) and _iso_to_epoch (one or two date execs), then a find. Spec 6: S1 ships no consumer."
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: specification quality
+    severity: low
+    claim: "hooks.json's own description field still enumerates the pre-S1 hook set, so the file's self-description is wrong on the day it ships."
+    evidence: "hooks.json line 2 ends with the reservoir check and the template currency check; neither session-registry-sweep.sh nor session-registry-start.sh appears. reference/hooks.md tells the reader the file contains 'A description field summarising the hook set'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: implementation
+    severity: low
+    claim: "The R14 escaping fix is one-directional: _json_escape is applied to repo on write but started_at is round-tripped from disk unescaped, and _json_field is not escape-aware on read, so a legitimately backslash- or quote-bearing repo path reads back truncated or doubled in registry_list."
+    evidence: "registry_touch re-emits `started` (read via _json_field) without escaping while escaping repo. _json_field's `[^\"]*` stops at the first quote, escaped or not. registry_list is the surface that hands the value to a consumer, and spec 4.1 makes the field load-bearing."
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Objection record — Cadence Sentinels S1 (code mode)
+
+Code-mode adversarial review of branch `cadence-sentinels-s1-infrastructure`
+against spec revision 3. Eleven objections: one critical, two high, six
+medium, two low.
+
+The implementation is materially better than the spec that produced it. The
+first-delimiter extraction rule is implemented correctly and B8 is a genuinely
+falsifying fixture rather than a confirming one. The read/write library split
+is real, not nominal. The `_json_escape` fix is correct, including the
+non-obvious ordering constraint. `records_open` implements both halves of the
+open-record test rather than the easy half.
+
+The objections concentrate in three places that quality does not reach: what
+`registry_count` actually means as opposed to what it is documented to mean
+(O1, O4); which of this slice's constitutional promises are guarded by a test
+and which are merely asserted in a header comment (O2, O6); and what the
+registry persists about a person who never asked for it (O3, O7).
+
+**Dispatcher verification note (2026-08-08).** O1 was reproduced empirically
+before this record was written: a registry holding one live entry and two from
+earlier sessions the same day (7 hours and 3 hours old, both inside the
+12-hour lease) returns `3 observed`. Under `max_concurrent_sessions: 2` the
+WIP Warden would report a confidently-flagged breach on an ordinary working
+day. The diaboli's verification of the two fixes it was asked to scrutinise
+was also checked and stands: the guarded strict-mode form discriminates
+correctly in bash, and `_json_escape` genuinely closes the immortal-entry case
+rather than relocating it.
+
+## O1 — risk — critical
+
+### Claim
+
+`registry_count` has no freshness test. It counts files. The only thing that
+removes a file is `registry_prune`, and `registry_prune` runs only on the
+`Stop` rail. Nothing removes an entry when a session ends, because by design
+nothing knows a session has ended.
+
+The consequence is not an edge case — it is the ordinary working day. A human
+who runs a morning session, an afternoon session, and an evening session has
+three entries by evening, all with heartbeats inside the 12-hour default
+lease, all counted. One session is running.
+
+The count's published name is "live sessions". Its delivered meaning is
+"sessions that completed a turn within the lease window". Those are different
+quantities, and the honesty flag asserts the stronger one.
+
+### Evidence
+
+`registry_count` sizes the count with `find -name '*.json' | wc -l` and makes
+no comparison against `heartbeat` anywhere; the lease is consulted only to
+size the `.retired` marker window. The write library states the retirement
+rule plainly: "Nothing here deletes an entry because a session 'ended' — the
+pruner retires entries whose lease expired, and that is the only removal
+path." And `reference/pacts-format.md` publishes the consuming key as "How
+many **live sessions** you will accept".
+
+The spec discloses one direction of the lease's imprecision and not the other
+(§4.2, "Known limit of the lease, disclosed"): the renewal interval is
+unbounded above, so a live session may look dead. The false-*positive*
+direction — a dead session looks live for up to `stale_after_hours`, and every
+sequential session of the day accumulates — is never stated, in the spec, the
+reference page, or the hook documentation.
+
+Two secondary observations sharpen it. First, the unpruned window is at its
+widest exactly when a WIP Warden would read: `SessionStart` fires, writes the
+new entry, and returns, with no `Stop` yet in that session and therefore no
+prune. Second, the flag fails toward overclaiming — a `find` failing on a
+permission error, an unreadable `.retired` marker, and an unresolvable
+registry directory all yield `observed`.
+
+No test covers the gap. R4 counts two entries both freshly written in the same
+process; R5 counts *after* a prune. No scenario has an expired-but-unpruned
+entry present when `registry_count` runs, which is the state the registry
+spends most of its life in.
+
+### Why this matters
+
+The count-plus-flag pair is Component 2's entire deliverable. The `.retired`
+marker machinery is correct and works — but it guards the wrong quantity. It
+discloses uncertainty introduced by *pruning*, and says nothing about
+uncertainty introduced by *not having pruned yet*, which is the larger and far
+more common source.
+
+Three slices consume this. S4's WIP Warden is the one this component exists to
+serve, and under `max_concurrent_sessions: 2` a normal day puts its keeper in
+permanent, confidently-asserted breach. Because S1 gates nothing, the defect
+ships green and surfaces first as a sentinel nobody believes — the worst
+outcome for a category whose entire value is trust.
+
+This does not reverse the spec-time disposition of O1. The lease with
+heartbeat renewal is the right design. Two things follow from it that the
+implementation has not drawn: `registry_count` should exclude entries whose
+heartbeat is past the lease (a pure read — no mutation, no trust-boundary
+change), and it should flag `inferred` whenever it saw one, because an
+unpruned expired entry is exactly the "crashed or merely quiet?" uncertainty
+the flag already exists to carry. Failing that, the quantity needs renaming
+everywhere it is published.
+
+## O2 — risk — high
+
+### Claim
+
+This slice's headline constitutional promise is that it gates nothing. The
+mechanism by which a hook gates something is writing to stdout or exiting
+non-zero. Neither new hook is tested for either property, and the harness
+suppresses both signals on every invocation.
+
+### Evidence
+
+Every hook invocation in the registry test takes the form
+`hook_input "sess-alpha" | bash "$START_HOOK" >/dev/null 2>&1 || true`. The
+redirect discards the stream that would prove the no-gating property; the
+`|| true` discards the status that would prove exits-0. Both contracts are
+named explicitly in spec §4.5 and §6, and in each script's own header.
+
+Both scripts are in fact silent and do exit 0 today. That is not the
+objection. The objection is that the property is guarded by nothing, in a
+slice whose sole justification is that it is a substrate three later slices
+build on without re-deriving it. Any future edit that adds a `printf` outside
+a redirect turns silent plumbing into a per-turn nudge, and the suite stays
+green.
+
+The adjacent gap: no test runs either hook with the registry unwritable,
+absent, or `HOME` unset — the paths the exits-0 contract exists for.
+
+### Why this matters
+
+Constraint 6 is the constraint the epic's safety argument rests on, and the
+one a human reviewing this PR most needs mechanised. A one-line assertion
+costs less than the comment currently standing in for it. Every other
+constitutional property in this slice got a test — R8 for purity, R9 for the
+trust boundary, R10 for sanitisation, R13 for the work tree. The one property
+that is *this slice's* reason to be safe got a `>/dev/null`.
+
+## O3 — risk — high
+
+### Claim
+
+From the moment a user upgrades to 0.67.0, every session start writes a file
+recording which project directory that person was working in and when. The
+record is authored by an agent, not the human. It accumulates across
+repositories. There is no opt-in, no notice at the point of writing, no
+retention statement, and no documented way to decline short of editing the
+plugin's `hooks.json`.
+
+The rule this branch promotes into `sentinel-design` — expressly so S2–S5
+inherit it rather than re-derive it — classifies exactly this record as being
+*about* the person.
+
+### Evidence
+
+`registry_touch` writes `repo` (the session's `cwd`) and `started_at`;
+`hooks.json` wires the writer to `SessionStart` with `matcher: "*"`, for
+everyone. The promoted rule reads: "Who authored the claim? If the agent did,
+it is about the person. Would the person recognise it as something they said?
+If not, it is about them." A hook authored the entry, and no human would
+recognise `{"repo":"/Users/x/code/foo","started_at":"..."}` as something they
+said. The skill's permitted list is explicit — a budget, a stop hour, a
+disposition, a next action they wrote themselves — and names the pact file,
+parking records and consultation dispositions. The registry is absent.
+
+There is a real steel-man, and the disposition may well be to write it down:
+the boundary section is scoped to *sentinel*-authored records, the registry is
+hook-authored operational state, and spec §2 argues it "records nothing about
+who is in it". That defence covers `id` and `heartbeat`. It covers `repo` less
+comfortably, because §4.1 makes that field load-bearing precisely so a
+consumer can tell the human where their other sessions are — which is to say,
+the field exists to describe where the person works.
+
+The asymmetry inside the slice is the sharpest evidence. The pact file — which
+the human authors about themselves, the *permitted* side of the line — got a
+deliberate adoption ramp and an argument for why nothing writes it on their
+behalf. The registry — agent-authored, on the contested side — is created for
+everyone, silently, with no ramp. `reference/hooks.md` says only "local,
+per-machine, outside every work tree, and never committed"; it does not say
+what entries contain, how long they persist, or how to turn the hook off. The
+repo has a precedent for the missing piece: the AGENTS.md readback hook
+shipped with a documented "Disable the hook entirely" path.
+
+### Why this matters
+
+The BY/ABOUT distinction was promoted in this branch specifically so S2–S5 do
+not each invent their own boundary. Shipping the rule alongside an unaddressed
+counterexample is worse than shipping neither: the next author reads the rule,
+sees the registry, and concludes the rule is advisory. The disposition need not
+be "remove the registry" — it can be "the registry is hook-authored
+operational state, not a sentinel record; here is the carve-out, written into
+the skill", plus a documented opt-out and a retention sentence. What it cannot
+be is silence, because silence sets the boundary by precedent, which spec §2
+itself argues is the weakest way to settle a constitutional question.
+
+## O4 — risk — medium
+
+`stale_after_hours` accepts any digit string including `0`. With `0` declared,
+`registry_prune` retires every entry on every `Stop` — including the one
+`registry_touch` wrote one line earlier in the same script, since `0 -ge 0` is
+true — and `registry_count` then reports `0 observed`, because `0 -lt 0` is
+false so the retirement is not disclosed. A single character disables the
+registry and the honesty flag says nothing.
+
+No bound is stated in the spec's §3.3 table, the template, or the reference
+page, which says only "Raise it if you routinely leave a session parked
+mid-thought". R7 tests `2` and `24`. This is the same defect class §3.6 and
+Note A exist to prevent — a human tunes a declared value in good faith and gets
+silent degradation — except that here the degradation is total, and a reader
+who takes `0` to mean "never expire", a common convention, gets the exact
+opposite.
+
+## O5 — implementation — medium
+
+`_block_span` recognises a heading as any line of one to six `#` followed by
+whitespace, and ends the span at a heading of equal-or-higher level. A
+standalone `# revisit this in Q4` computes level 1, ends the span, and drops
+every key below it — including the mandatory clause, flipping the block from
+`declared` to `malformed`. Sub-headings are safe: `#### Notes` computes level 4
+and the span continues.
+
+The shipped guidance narrows the warning to value lines only — "never as a
+trailing `#` comment **on a value line**" — which a careful reader takes as
+licence for a `#` comment on its own line. No fixture exercises it.
+
+The failure direction is safe: malformed degrades to observe-only, never to a
+gate. It is a silent-degradation defect in the file the spec expects a human to
+hand-edit, and the symptom is that the pact they wrote stopped being read with
+no line telling them which sentence broke it.
+
+## O6 — implementation — medium
+
+R9's closure walk, added this cycle in response to a correct finding, asserts a
+stronger property than it verifies. The walker requires the `.` builtin (not
+`source`), an unbraced all-caps variable (not `${DIR}`), a single path segment,
+and a lowercase-hyphen filename — so `source "$DIR/x.sh"`, `. "${DIR}/x.sh"`,
+`. "$DIR/util/x.sh"`, and `json_helpers.sh` all drop silently out. The mutation
+patterns miss redirects to literal paths, `ln`, `chmod`, `install`, `dd`,
+`exec 3>file`, and any write inside an `awk` program.
+
+The canary is the right instinct but is satisfied by the one library that
+happens to use the recognised idiom, and would stay satisfied while a second,
+unwalked library sat one `.` away from every sentinel. The architectural split
+is right and R9's runtime half is a real test; the objection is to the textual
+half, which is what the record will be read as guaranteeing.
+
+## O7 — risk — medium
+
+Both location overrides are read straight from the environment with no origin
+check. They exist so tests need no home directory, but they are live in
+production: anything that sets an environment variable for a session — direnv,
+a project rc file, a wrapper — can substitute the pact S3 and S4 will hold the
+human to, and can relocate the registry inside a work tree where it will be
+committed. Spec §4.1's "nothing can accidentally commit it" holds only while
+the override is unset, and R13 tests the default path after an explicit
+`unset`. Neither variable is documented.
+
+The clear-weather argument turns on authorship: a pact holds because its keeper
+wrote it. An override that redirects which pact is read makes authorship
+unverifiable, and `block_state` returns `declared` regardless of who wrote the
+file. This matters little in S1, where nothing consumes a pact; it matters a
+great deal in S3 and S4, and S1 is the slice that fixes the contract.
+
+## O8 — specification quality — medium
+
+`_flatten` deliberately reverses an explicit sentence of the approved spec.
+§3.4 says a reflowed clause ceases to read as declared and calls that
+deliberate; the code normalises whitespace so a reflowed clause still reads as
+declared. The reference page was updated to match the code; the spec was not.
+
+The behavioural change is right — the shipped template's own `Session WIP`
+clause wraps, so the strict rule was unshippable, and B10 pins it. The
+objection is to what did not happen alongside it: §3.4 claims authority over
+this sentence's matching rule ("Only a spec-first change may reword it") and
+was not amended when the rule changed. S2–S5 will be authored against §3, and
+§3 states a matching rule the library does not implement. The remedy is a
+revision-4 amendment, not a change to the code.
+
+## O9 — risk — medium
+
+The sweep is the tenth `Stop` hook and runs a full prune every assistant turn:
+two `awk` passes over the pact file, then per entry a `grep`, a `sed`, and one
+or two `date` execs, then a `find`. That lands on every user from the upgrade
+onward, in service of a count nothing in this slice reads.
+
+This does not gate anything. It is a proportionality point about where the cost
+sits. The slice's protective argument for the pact file is that nothing is
+imposed on someone who has not asked for it — §3.7, "nothing in this epic
+should happen to someone who never asked for it." Per-turn work on the rail
+that runs at the end of every response is something happening to everyone who
+upgrades, months before the sentinel that would justify it exists. The pruner
+does not need to run every turn; the lease is measured in hours.
+
+## O10 — specification quality — low
+
+`hooks.json`'s `description` field still enumerates the pre-S1 hook set, so the
+file's summary of itself is wrong in the commit that changes it. Small, and
+purely a currency defect — worth a line because this description is the first
+thing a reader of `hooks.json` sees, and because the rest of the slice's
+documentation work is thorough enough that the omission reads as an oversight.
+
+## O11 — implementation — low
+
+The escaping fix is one-directional. `_json_escape` is applied to `repo` on
+write, but `started_at` is read back from disk and re-emitted unescaped, and
+`_json_field`'s `[^"]*` stops at the first quote, escaped or not — so a repo
+path legitimately containing a backslash or quote round-trips truncated or
+doubled into `registry_list`, the surface that hands the value to a consumer.
+
+Low, because the write-side injection R14 was about is genuinely closed. What
+remains is a read-side asymmetry with a cosmetic worst case today and no
+consumer to be wrong at yet. Worth recording because the reasoning in the
+`_json_escape` comment is about correctness under a hostile value, and the same
+reasoning applied to the read path would close the pair rather than one half.
+
+## Explicitly not objecting to
+
+- **The guarded strict-mode form.** `(return 0 2>/dev/null) || set -euo pipefail`
+  discriminates correctly in bash; the shebang and `hooks.json`'s `bash ...`
+  invocation guarantee bash; CI exercises Layer 0 on both Ubuntu and macOS. The
+  `HOME`-unset path degrades safely to an empty directory, a failed `mkdir`,
+  and `exit 0` with nothing on stderr.
+- **The `_json_escape` fix and R14.** Correct, including the non-obvious
+  requirement to replace the backslash before the quote. The injected key
+  cannot match `_json_field`'s pattern, so the immortal-entry case is closed
+  rather than moved.
+- **The lease with heartbeat renewal.** Adjudicated at the spec gate and the
+  reasoning holds. O1 objects to what `registry_count` counts and what flag it
+  attaches, not to the lifecycle.
+- **The read/write library split.** The right architecture, correctly
+  implemented; R9's runtime half is a real test. O6 objects only to the reach
+  of the textual half.
+- **Session-id sanitisation.** Reuses the pattern this repo already adjudicated
+  for the same field, and R10 checks the fallback path and that nothing landed
+  outside the directory.
+- **The first-delimiter extraction rule and block scoping.** B7 and B8 are
+  genuinely falsifying rather than confirming; `shared-key.md` is the fixture a
+  lazier test would have skipped.
+- **`records_open`.** Implements both halves of the open-record test — the
+  transition-suffix exclusion *and* the `supersedes` walk — where either alone
+  would be wrong in an opposite direction, and C3 asserts both.
+- **The Reservoir Warden.** Untouched. `reservoir-check.sh` is unmodified and
+  appears in the new code only as a cited comparison in comments; constraint 5
+  holds.
+- **Language discipline.** No occurrence of "addiction", "addictive",
+  "dopamine", or loose "reinforcing" in any new or changed file. Constraint 8
+  holds.
+- **`_flatten`'s behaviour.** Normalising whitespace before clause matching is
+  the right call — the strict rule was unshippable against the slice's own
+  template. O8 objects to the spec not being amended, not to the change.

--- a/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md
@@ -9,85 +9,85 @@ objections:
     severity: critical
     claim: "The registry lifecycle assumes the Stop hook fires once per session, but Stop fires at the end of every assistant turn; a session removes its own entry after its first response and reads as not-live for the rest of its life."
     evidence: "Spec 4.2: 'Stop hook removes this session entry and prunes stale ones... Stop is used rather than SessionEnd because hooks.json already runs nine Stop hooks... gives the pruner the same firing guarantees the reservoir check already relies on.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Heartbeat design adopted: Stop refreshes a heartbeat rather than deleting, and staleness alone retires entries, so correctness no longer depends on unverified Stop firing semantics. SessionStart re-fire refreshes without resetting started_at."
   - id: O2
     category: implementation
     severity: high
     claim: "The registry is project-local, so it counts sessions per repo, not per human; the concurrency the WIP Warden exists to see is cross-repo, and the entry repo field is vestigial under this location."
     evidence: "Spec 4.1: '.claude/sessions/<session-id>.json' with '\"repo\": \"<absolute path to project root>\"', justified by gitignored per-project precedents, and scenario 12 asserting 'git status --porcelain' sees nothing."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Registry moves to machine-global ~/.claude/sessions/. Thrash-switching is a property of the human, not the repo; the limit stays declared per-repo in HARNESS.md while the count is global, which makes the repo field load-bearing."
   - id: O3
     category: alternatives
     severity: high
     claim: "A per-session, timestamped, sanitised session log already exists in this repo (observability/affordance-invocations.json); the spec never weighs deriving the live-session count from it against building a new hook-driven mutable registry."
     evidence: "affordance-invocation-recorder.sh:68 emits '{\"tool\":...,\"session\":\"%s\",\"ts\":\"%s\"}'; spec 4 introduces a new registry, two new hook scripts, a staleness constant, and a pruner without mentioning this existing data source."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "The invocation recorder's PostToolUse matcher is 'Bash|mcp__.*', so a session that only reads and edits files never appears in the log. Deriving the count from it would silently undercount exactly the long-running sessions the WIP Warden exists to notice. Rejection recorded on the record per the objection's own request; the 'asked' fallback remains available to S4 as an honesty option."
   - id: O4
     category: risk
     severity: high
     claim: "registry_count mutates shared state as a side effect of a read, which makes the observed/inferred flag a property of who read first rather than of the count, and leaves concurrent pruning unspecified."
     evidence: "Spec 4.3 table plus scenario 7: 'when registry_count runs, then the stale entry is removed and the count is flagged inferred.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Prune splits from count. Pruning runs on the hook rail only; registry_count becomes a pure read and derives its flag from durable state (a retired-entry marker), not from whether this particular read happened to prune."
   - id: O5
     category: implementation
     severity: high
     claim: "block_key is specified as read_key plus block scoping, but read_key greedy-matches the last colon and strips all whitespace, so every HH:MM and multi-token value the new vocabulary mandates parses to garbage."
     evidence: "reservoir-check.sh:37-41 uses 's/.*[:=][[:space:]]*//' then 'tr -d [:space:]'; spec 3.3 mandates 'hard_stop_hour: <HH:MM local>' and 'focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>'; spec 3.7 describes block_key as differing from read_key only in scope."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Spec gains an explicit value grammar per key, and block_key splits on the FIRST delimiter and trims only at the ends. Verified empirically at the gate: the inherited greedy extraction turns 18:30 into 30 and 09:00-12:00, 14:00-17:00 into 00."
   - id: O6
     category: specification quality
     severity: high
     claim: "Component 3 claims its schemas are declared in this slice to make S1 a complete reviewable unit, but no schema is given and no acceptance scenario covers it."
     evidence: "Spec 5: 'Declaring the schemas here rather than in S2 and S5 is deliberate... the substrate is fully specified before anything consumes it'; the only field named anywhere is 'status: resumed', and scenarios 1-12 cover only blocks and the registry."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Both record schemas written out in full in the spec, with acceptance scenarios covering them. The objection's own argument is decisive: without the schemas, S1 is the half-feature it claims not to be."
   - id: O7
     category: premise
     severity: high
     claim: "Constraint 4 (persist nothing about the person) is scoped only to the registry, while 3.5 commits the person's working day into permanent git history via the activated Budgets block."
     evidence: "Spec 2: 'The registry records that a session exists... It records nothing about who is in it'; spec 3.5: 'All three blocks are additionally activated (uncommented, with values) in this repo own root HARNESS.md', where Budgets carries hard_stop_hour, focus_blocks, and sessions_per_day."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Constraint 4 targets inference and telemetry -- claims an agent makes ABOUT the person. A pact the person authored is a statement BY them, and a pact that is not durable is not a pact. The distinction is written into the spec and carried into the sentinel-design skill so S2-S5 inherit it rather than re-deriving it."
   - id: O8
     category: risk
     severity: high
     claim: "Every consuming sentinel is told to source a library whose read path deletes files, which breaches the read-only trust boundary through the exact Bash channel the CI check names as its known limit."
     evidence: "Spec 4.4: 'The SessionStart and Stop scripts and every consuming sentinel source this one file' exposing registry_write, registry_remove, registry_prune; sentinel-integrity-check.sh:21-22 'Bash is permitted' and :30-33 'an agent that reaches a write capability through an undeclared channel is out of scope here.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The library splits along the trust boundary: a read-only surface sentinels may source, and a mutation surface reachable only from hook scripts. Generalises the Note D reasoning the objection correctly identifies as already-found-and-not-applied."
   - id: O9
     category: risk
     severity: medium
     claim: "The session id becomes a filesystem path component with no stated source and no sanitisation rule, in a repo that has already adjudicated hostile session ids once."
     evidence: "Spec 4.1: '.claude/sessions/<session-id>.json'; affordance-invocation-recorder.sh:55 'grep -qE ^[A-Za-z0-9._-]+$ || session=unknown' and tdad_tests/layer0_deterministic/test-affordance-recorder.sh:83-86 'Hostile session_id carrying JSON metacharacters: must be sanitised to unknown.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Session id sanitised with the recorder's existing pattern before use as a path component, with a stated collision rule so two ids sanitising to the same fallback cannot silently corrupt the count."
   - id: O10
     category: scope
     severity: medium
     claim: "The slice adds three HARNESS.md block schemas and two hook entries but does not update the reference pages that document exactly those two surfaces, which are stale the day it ships."
     evidence: "Spec 9 enumerates 'Five CI-checked version locations plus the README plugin-table cell' and nothing else; docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md and reference/hooks.md exist and go unmentioned; CLAUDE.md requires docs changes in the same PR."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "reference/harness-md-format.md and reference/hooks.md added to the rollout checklist, per the CLAUDE.md docs-in-the-same-PR convention."
   - id: O11
     category: specification quality
     severity: medium
     claim: "The vocabulary introduces enforcement tokens with no semantics and no override path, in a slice that claims to gate nothing, which pre-authorises hard enforcement in S4 without the on-the-record override constraint 6 requires."
     evidence: "Spec 3.2: 'enforcement: advisory | strict' with only the advisory default defined; spec 3.3: 'hard_stop_hour', 'notification_policy_after_stop: digest | none'; spec 6: 'No gating. Nothing in this slice blocks, warns, or requires a disposition.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "enforcement: strict gains a one-line semantics and a named override location in S1, so S4 inherits a defined token rather than defining one that is already declared in the wild."
   - id: O12
     category: specification quality
     severity: medium
     claim: "The acceptance scenarios omit the one behaviour that justifies building a second parser (block-scoped key isolation) and leave present-but-malformed block behaviour undefined."
     evidence: "Spec 3.7 justifies block_key because read_key 'searches the entire document, which is safe for its unique keys but not for a vocabulary of three blocks that may share key names'; scenario 11 tests only a single active Budgets block; spec 3.6 defines absent-block behaviour only, while 3.3 asserts 'A Budgets block whose prose has lost the clause is a malformed block.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Two-block fixture added asserting key isolation, which is the property that justifies building block_key at all. Malformed-block behaviour defined explicitly as a third state distinct from absent."
 ---
 
 # Objection record — Cadence Sentinels S1: Shared Infrastructure

--- a/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md
@@ -1,0 +1,751 @@
+---
+spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+date: 2026-08-08
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "The registry lifecycle assumes the Stop hook fires once per session, but Stop fires at the end of every assistant turn; a session removes its own entry after its first response and reads as not-live for the rest of its life."
+    evidence: "Spec 4.2: 'Stop hook removes this session entry and prunes stale ones... Stop is used rather than SessionEnd because hooks.json already runs nine Stop hooks... gives the pruner the same firing guarantees the reservoir check already relies on.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: implementation
+    severity: high
+    claim: "The registry is project-local, so it counts sessions per repo, not per human; the concurrency the WIP Warden exists to see is cross-repo, and the entry repo field is vestigial under this location."
+    evidence: "Spec 4.1: '.claude/sessions/<session-id>.json' with '\"repo\": \"<absolute path to project root>\"', justified by gitignored per-project precedents, and scenario 12 asserting 'git status --porcelain' sees nothing."
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: alternatives
+    severity: high
+    claim: "A per-session, timestamped, sanitised session log already exists in this repo (observability/affordance-invocations.json); the spec never weighs deriving the live-session count from it against building a new hook-driven mutable registry."
+    evidence: "affordance-invocation-recorder.sh:68 emits '{\"tool\":...,\"session\":\"%s\",\"ts\":\"%s\"}'; spec 4 introduces a new registry, two new hook scripts, a staleness constant, and a pruner without mentioning this existing data source."
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: risk
+    severity: high
+    claim: "registry_count mutates shared state as a side effect of a read, which makes the observed/inferred flag a property of who read first rather than of the count, and leaves concurrent pruning unspecified."
+    evidence: "Spec 4.3 table plus scenario 7: 'when registry_count runs, then the stale entry is removed and the count is flagged inferred.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: implementation
+    severity: high
+    claim: "block_key is specified as read_key plus block scoping, but read_key greedy-matches the last colon and strips all whitespace, so every HH:MM and multi-token value the new vocabulary mandates parses to garbage."
+    evidence: "reservoir-check.sh:37-41 uses 's/.*[:=][[:space:]]*//' then 'tr -d [:space:]'; spec 3.3 mandates 'hard_stop_hour: <HH:MM local>' and 'focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>'; spec 3.7 describes block_key as differing from read_key only in scope."
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: specification quality
+    severity: high
+    claim: "Component 3 claims its schemas are declared in this slice to make S1 a complete reviewable unit, but no schema is given and no acceptance scenario covers it."
+    evidence: "Spec 5: 'Declaring the schemas here rather than in S2 and S5 is deliberate... the substrate is fully specified before anything consumes it'; the only field named anywhere is 'status: resumed', and scenarios 1-12 cover only blocks and the registry."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: premise
+    severity: high
+    claim: "Constraint 4 (persist nothing about the person) is scoped only to the registry, while 3.5 commits the person's working day into permanent git history via the activated Budgets block."
+    evidence: "Spec 2: 'The registry records that a session exists... It records nothing about who is in it'; spec 3.5: 'All three blocks are additionally activated (uncommented, with values) in this repo own root HARNESS.md', where Budgets carries hard_stop_hour, focus_blocks, and sessions_per_day."
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: risk
+    severity: high
+    claim: "Every consuming sentinel is told to source a library whose read path deletes files, which breaches the read-only trust boundary through the exact Bash channel the CI check names as its known limit."
+    evidence: "Spec 4.4: 'The SessionStart and Stop scripts and every consuming sentinel source this one file' exposing registry_write, registry_remove, registry_prune; sentinel-integrity-check.sh:21-22 'Bash is permitted' and :30-33 'an agent that reaches a write capability through an undeclared channel is out of scope here.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: risk
+    severity: medium
+    claim: "The session id becomes a filesystem path component with no stated source and no sanitisation rule, in a repo that has already adjudicated hostile session ids once."
+    evidence: "Spec 4.1: '.claude/sessions/<session-id>.json'; affordance-invocation-recorder.sh:55 'grep -qE ^[A-Za-z0-9._-]+$ || session=unknown' and tdad_tests/layer0_deterministic/test-affordance-recorder.sh:83-86 'Hostile session_id carrying JSON metacharacters: must be sanitised to unknown.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: scope
+    severity: medium
+    claim: "The slice adds three HARNESS.md block schemas and two hook entries but does not update the reference pages that document exactly those two surfaces, which are stale the day it ships."
+    evidence: "Spec 9 enumerates 'Five CI-checked version locations plus the README plugin-table cell' and nothing else; docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md and reference/hooks.md exist and go unmentioned; CLAUDE.md requires docs changes in the same PR."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: specification quality
+    severity: medium
+    claim: "The vocabulary introduces enforcement tokens with no semantics and no override path, in a slice that claims to gate nothing, which pre-authorises hard enforcement in S4 without the on-the-record override constraint 6 requires."
+    evidence: "Spec 3.2: 'enforcement: advisory | strict' with only the advisory default defined; spec 3.3: 'hard_stop_hour', 'notification_policy_after_stop: digest | none'; spec 6: 'No gating. Nothing in this slice blocks, warns, or requires a disposition.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O12
+    category: specification quality
+    severity: medium
+    claim: "The acceptance scenarios omit the one behaviour that justifies building a second parser (block-scoped key isolation) and leave present-but-malformed block behaviour undefined."
+    evidence: "Spec 3.7 justifies block_key because read_key 'searches the entire document, which is safe for its unique keys but not for a vocabulary of three blocks that may share key names'; scenario 11 tests only a single active Budgets block; spec 3.6 defines absent-block behaviour only, while 3.3 asserts 'A Budgets block whose prose has lost the clause is a malformed block.'"
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Objection record — Cadence Sentinels S1: Shared Infrastructure
+
+Spec-mode adversarial review. Twelve objections: one critical, seven high,
+four medium. The spec is unusually well-argued — its divergence notes, its
+disposed open decisions, and its explicit non-goals all raise the review
+floor. The objections below concentrate where that quality does not reach:
+the runtime semantics of the hook rail it borrows, the parser it inherits,
+and the constitutional constraints it interprets narrowly.
+
+**Dispatcher verification note (2026-08-08).** Three claims were verified
+independently before this record was written. O5 was confirmed empirically:
+piping `hard_stop_hour: 18:30` through `read_key`'s extraction yields `30`,
+and `focus_blocks: 09:00-12:00, 14:00-17:00` yields `00`. O3 was confirmed
+by reading `affordance-invocation-recorder.sh:68`. O1 was confirmed by
+absence: `reflection-prompt.sh`, `curation-nudge.sh`, `gc-rotate.sh`, and
+`snapshot-staleness-check.sh` each declare "runs at session end (Stop hook)"
+and carry no dedup, marker, or once-per-session guard — the belief is
+repo-wide, asserted, and nowhere verified.
+
+## O1 — implementation — critical
+
+### Claim
+
+The session registry's lifecycle rests on the assumption that the `Stop`
+hook fires once, at the end of a session. `Stop` fires when the main agent
+finishes responding — many times per session. Under that semantics, a
+session writes its entry at `SessionStart`, deletes it at the end of its
+first response turn, and is invisible to every count taken thereafter. The
+WIP Warden — the sentinel this component exists to serve — would
+systematically undercount exactly the concurrent long-running sessions it
+was built to notice.
+
+### Evidence
+
+> **`Stop` hook** removes this session's entry and prunes stale ones.
+>
+> `Stop` is used rather than `SessionEnd` because `hooks.json` already runs
+> nine `Stop` hooks and none on `SessionEnd`; adding to the existing rail
+> keeps the hook surface honest and gives the pruner the same firing
+> guarantees the reservoir check already relies on. — §4.2
+
+The nine existing scripts each open with `# ... — runs at session end (Stop
+hook).` That comment is a repo-wide assumption, not a verified fact, and it
+is harmless for all nine because every one of them is idempotent and
+advisory: firing five times per session produces at most a duplicate
+nudge. The guarantee the reservoir check "relies on" is precisely *no*
+guarantee — it needs only to fire often enough. That property does not
+transfer to a destructive mutation.
+
+Acceptance scenario 6 encodes the assumption rather than testing it:
+
+> **Prune on stop.** Given entries for X and Y, when the `Stop` hook runs
+> in session X, then X's entry is gone and Y's remains.
+
+The scenario passes whether or not session X is still alive.
+
+The mirror-image gap is `SessionStart`, which fires on startup, resume,
+clear, and compact under the existing `matcher: "*"` in `hooks.json`. The
+spec says only "`SessionStart` hook writes the entry" (§4.2) and does not
+say whether a re-fire resurrects a removed entry or resets `started_at` —
+and a reset `started_at` means a genuinely long-running session never ages
+out of the staleness window in §4.3.
+
+### Why this matters
+
+This is the load-bearing claim of Component 2. If `Stop` is per-turn, the
+registry is not a live-session registry — it is a record of sessions that
+have not yet answered once. Three later slices consume it. Because the
+component gates nothing in S1, the defect ships green, and the first
+symptom is a WIP Warden in S4 that reports `1` while four sessions run.
+The spec should either cite the firing semantics it depends on, or make
+removal idempotent under repeated firing (for example, refresh a heartbeat
+on `Stop` and let staleness alone retire entries) so correctness does not
+depend on which reading is true.
+
+## O2 — implementation — high
+
+### Claim
+
+`.claude/sessions/` is inside the project directory, so the registry counts
+sessions *per repository*. The concurrency problem a WIP Warden addresses
+is one human running several sessions across several repos. Under this
+location, three sessions in three repos each read a count of `1`. The
+`repo` field in the entry schema is the tell: it is invariant within any
+registry that can observe it, and only becomes meaningful in a registry
+this spec does not build.
+
+### Evidence
+
+> `.claude/sessions/<session-id>.json`, one file per live session:
+> `{ "id": ..., "repo": "<absolute path to project root>", "started_at": ... }` — §4.1
+
+The location argument is explicitly per-project:
+
+> Per-machine local session state already lives in `.claude/` —
+> `.claude/.harness-upgrade-dismissed` and `.claude/affordance-discovery-*.md`
+> are both there and both gitignored. — §4.1
+
+Both cited precedents are repo-relative (they appear in this repo's
+`.gitignore` as project paths), and scenario 12 confirms the reading by
+testing with `git status --porcelain`, which only sees paths inside the
+work tree.
+
+Meanwhile §1 states the need in person-scoped terms — "how many sessions
+are live" — and §3.2 names the consumed key `max_concurrent_sessions`, not
+`max_concurrent_sessions_per_repo`.
+
+### Why this matters
+
+The scope of "live" is the substrate's most consequential design decision
+and the spec never states it in one sentence. If per-repo is intended, the
+`repo` field is dead weight and S4's threshold semantics need renaming so a
+human does not read a cross-repo promise into a per-repo number. If
+cross-repo is intended, the location is wrong and `.gitignore` is
+irrelevant, because a machine-global registry (for example under
+`~/.claude/`) is never in a work tree at all. Deciding this after S4 starts
+means changing the on-disk contract while three consumers hold it.
+
+## O3 — alternatives — high
+
+### Claim
+
+This repo already writes a per-session, timestamped, sanitised, gitignored,
+size-bounded record of session activity on every tool call. A live-session
+count with an honest confidence flag is derivable from it — distinct
+`session` values with a `ts` inside a recency window — with no new hooks,
+no lifecycle assumption, no pruner, no staleness constant, and no race. The
+spec does not mention this option, so the reader cannot tell whether it was
+rejected or unseen.
+
+### Evidence
+
+`ai-literacy-superpowers/hooks/scripts/affordance-invocation-recorder.sh:68`:
+
+```text
+printf '{"tool":"%s","program":%s,"invoker":"%s","session":"%s","ts":"%s"}\n' \
+  "$tool" "$prog" "$invoker" "$session" "$ts" >> "$file"
+```
+
+The session id is already sanitised (`:55`), the file is already gitignored
+(`.gitignore:11`), and the recorder already bounds it at ~2 MB (`:76`).
+
+The spec's justification for building instead is stated only in terms of
+duplication, not in terms of alternatives:
+
+> Built per-sentinel, that becomes three near-identical `HARNESS.md`
+> parsers, three incompatible notions of "a live session"... — §1
+
+That argument justifies *one* implementation. It does not justify a *new*
+one.
+
+A second unweighed alternative sits inside the epic's own vocabulary:
+constraint 3 blesses `asked` as a first-class honesty flag. A WIP Warden
+that asks "how many sessions do you have open?" is strictly more accurate
+than any proxy, needs no substrate at all, and is the honest answer when
+the machine cannot observe cross-repo state (O2).
+
+### Why this matters
+
+Spec time is the only moment where this question is cheap. The registry
+carries a permanent cost — two hook entries on a rail that already runs
+nine, a staleness heuristic, a pruning race, and a flag rule whose
+correctness is contested in O4. If a derived read of an existing log gets
+80% of the value at 10% of the surface, the whole of Component 2 is scope
+that could be cut, and S1 shrinks to blocks plus record directories.
+Recording the rejection would also satisfy the spec's own standard — it
+disposed the `.superpowers/` path question on the record (§4.1) but not
+this larger one.
+
+## O4 — risk — high
+
+### Claim
+
+`registry_count` is specified as a read that deletes files. Two
+consequences follow. First, the `observed`/`inferred` flag becomes a
+property of *read ordering* rather than of the count: whichever consumer
+reads first absorbs the prune and reports `inferred`, and every consumer
+after it reports `observed` for the identical underlying uncertainty.
+Second, concurrent sessions prune the same directory with no stated
+serialisation.
+
+### Evidence
+
+> `registry_count` (emitting count and flag) — §4.4
+
+The acceptance scenario makes the side effect explicit:
+
+> **Stale entry pruned, count flagged inferred.** Given an entry older than
+> `SESSION_STALE_HOURS`, when `registry_count` runs, then the stale entry is
+> removed and the count is flagged `inferred`. — scenario 7
+
+And the rule the flag is meant to express:
+
+> A count that followed a prune is `inferred` because the pruner cannot
+> distinguish a crashed session from a long-running healthy one — it only
+> knows the entry aged out. — §4.3
+
+That reasoning is right, and it is exactly what the mechanism cannot
+deliver. The epistemic damage — a possibly-live session removed from the
+count — persists for every subsequent read, but the flag that discloses it
+survives only the first. Constraint 3 asks the flag to travel with the
+observation; here it travels with the reader.
+
+The repo's own CUPID lens (`templates/CLAUDE.md`, "Predictable — does it
+behave as its name suggests, with no hidden side effects?") names the
+shape: `registry_count` does not behave as its name suggests.
+
+### Why this matters
+
+The honesty flag is the stated point of Component 2 ("The flag rule is the
+point of this component", §4.3). If the flag is unreliable in exactly the
+scenario it was designed for, the component's headline claim is
+unsupported, and three consumers inherit a confidence signal that
+under-reports uncertainty. Separating prune from count — prune on the hook
+rail, count as a pure read, and derive the flag from a durable property
+(for example, whether any entry within the window was retired) — preserves
+the rule the spec actually wants. Concurrency is the secondary concern:
+nine `Stop` hooks already run in parallel-ish across sessions, and the
+recorder at `:71-79` shows the repo has met and solved this class of
+problem before with unique temp files.
+
+## O5 — implementation — high
+
+### Claim
+
+§3.7 specifies `block_key` as `read_key` with block scoping — "scoped to
+that block's span rather than the whole file" is the only stated
+difference. `read_key`'s extraction is greedy on `[:=]`. Applied to the
+values this spec mandates, `hard_stop_hour: 18:30` yields `30`,
+`focus_blocks: 09:00-12:00, 14:00-17:00` yields `00`, and
+`sync_points: 09:00, 16:00` yields `00`. The whitespace strip independently
+destroys `daily_cost_ceiling: not observable`, which becomes
+`notobservable`. An implementer who follows the spec ships a parser that
+mangles the majority of the new vocabulary.
+
+### Evidence
+
+`reservoir-check.sh:37-41`:
+
+```bash
+val=$(grep -iE "^[[:space:]]*[-*]?[[:space:]]*${key}[[:space:]]*[:=]" "$HARNESS_FILE" 2>/dev/null \
+      | head -1 \
+      | sed -E "s/.*[:=][[:space:]]*//" \
+      | tr -d '[:space:]' \
+      | tr -d '`' || true)
+```
+
+`.*[:=]` is greedy: it consumes through the *last* colon on the line.
+`read_key` is safe today only because every reservoir value is a bare
+integer or a single word.
+
+The spec then mandates colon-bearing and space-bearing values:
+
+> `- hard_stop_hour: <HH:MM local>` / `- focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>` — §3.3
+> `- sync_points: <HH:MM, HH:MM | on-demand>` — §3.4
+> `- daily_cost_ceiling: <amount, or "not observable">` — §3.3
+
+§3.1 diagnoses the inherited parser's *other* defect in careful detail:
+
+> The `read_key` helper in `hooks/scripts/reservoir-check.sh` strips
+> whitespace from a matched value but does not strip a trailing `# comment`
+
+The spec found the trailing-comment trap and stopped there. The greedy
+colon and the space strip are the same class of defect and bite harder,
+because they hit values the spec itself requires rather than comments a
+human might add.
+
+### Why this matters
+
+Silent degradation is the failure mode the spec is trying to prevent, and
+the design as written reproduces it in a worse place: a `hard_stop_hour`
+that parses to `30` is not obviously wrong to a reader, and S3's clear-
+weather rule would then hold a budget nobody authored. Scenario 11 would
+catch this only if the implementer happens not to reuse the greedy `sed`.
+The spec should state the value grammar (which keys are single-token,
+which are time-valued, which are lists) and state that `block_key` returns
+the raw remainder after the *first* delimiter, trimmed at the ends only.
+
+## O6 — specification quality — high
+
+### Claim
+
+§5 asserts that declaring the record schemas in S1 is what makes the slice
+a complete reviewable unit, and then declares no schema. One field name
+appears in the whole section. There are also zero acceptance scenarios for
+Component 3, so nothing in the TDAD set would notice its absence.
+
+### Evidence
+
+> Two directories, each with a `README.md` that carries its schema:
+> `docs/superpowers/parked/` ... `docs/superpowers/consultations/` — §5
+
+And the rationale that objection turns on:
+
+> Declaring the schemas here rather than in S2 and S5 is deliberate. It
+> makes S1 a complete, reviewable unit — the substrate is fully specified
+> before anything consumes it — rather than half a feature waiting for its
+> other half. — §5
+
+The only field named anywhere is `status: resumed`. Nothing states the
+required keys, the filename convention, the honesty-flag carriage (does a
+parking record carry `observed`/`inferred`/`asked` per constraint 3?), or
+what "marked superseded" looks like as a field.
+
+§7 lists twelve scenarios; scenarios 1-3 and 9-11 cover blocks, 4-8 and 12
+cover the registry. None covers a record directory or its README.
+
+### Why this matters
+
+The section's own stated rationale is the objection: if the schemas are not
+here, S1 *is* half a feature, and S2 and S5 will invent the schemas mid-
+slice — the precise failure §1 says this slice exists to prevent ("two
+record directories invented mid-slice with schemas that drift apart").
+Committing two empty directories whose READMEs are written during
+implementation without spec review also means the append-only rule
+(constraint 7) ships as prose nobody has agreed the shape of, and the first
+`status: superseded` entry will discover its own format.
+
+## O7 — premise — high
+
+### Claim
+
+The spec interprets constraint 4 ("persist nothing about the person") as
+binding the session registry, and then activates a `Budgets` block in this
+repo's committed `HARNESS.md` containing the human's working hours, focus
+windows, and daily session capacity. That is durable, permanent,
+publicly-distributed state describing the person. The spec never asks
+whether a declared pact falls inside or outside constraint 4, so the
+constraint's boundary is left undefined at exactly the moment the substrate
+fixes it.
+
+### Evidence
+
+The spec's reading of constraint 4 covers one component:
+
+> **Persist nothing about the person (constraint 4).** The registry records
+> that a session exists, when it started, and against which repo. It
+> records nothing about who is in it or how they are doing. — §2
+
+The activation:
+
+> All three blocks are additionally **activated** (uncommented, with
+> values) in this repo's own root `HARNESS.md`, exactly as `## Cognitive
+> reservoir` is. — §3.5
+
+And the fields being activated:
+
+> `- hard_stop_hour: <HH:MM local>` / `- focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>`
+> / `- sessions_per_day: <int>` — §3.3
+
+The `## Cognitive reservoir` precedent it invokes points the other way. That
+block's live text says explicitly:
+
+> never records a claim about your cognitive state to disk (you edit this
+> block yourself) — `HARNESS.md:1019-1020`
+
+The reservoir block holds `chronotype: intermediate` — one coarse,
+self-declared token — and the block's own prose argues that this is
+acceptable *because* it is self-authored and not a claim. Nobody has made
+that argument for a full daily schedule, and git history is append-only by
+nature: constraint 7's append-only rule and constraint 4's persist-nothing
+rule meet here, and the spec resolves neither.
+
+### Why this matters
+
+There is a strong steel-man for the spec: a *declared pact* is a statement
+by the person, not an observation about them, and constraint 4 plausibly
+targets inference and telemetry. If that is the intended reading, it should
+be written down, because it is the distinction on which every later slice's
+persistence decisions rest — S2's parking records and S5's consultation
+dispositions are both records about how the human works. Left undefined,
+the constraint provides no guidance to S2-S5 and cannot be enforced by
+anything. Left undefined *and* precedent-set by §3.5, the effective rule
+becomes "whatever S1 did", which is the weakest possible way to settle a
+constitutional question. Note also that S3's Tune will replace placeholders
+with real values and commit them; the placeholder framing defers the
+question by one slice rather than answering it.
+
+## O8 — risk — high
+
+### Claim
+
+`sentinel-integrity-check.sh` enforces the read-only boundary by rejecting
+`Write`/`Edit` in an agent's `tools:` list and explicitly permitting `Bash`.
+§4.4 instructs every consuming sentinel to source a shell library that
+deletes files — and, per O4, deletes them even on the read path. CI stays
+green while a `role: sentinel` agent removes files from disk. S1 does not
+merely brush against the check's known limit; it manufactures the case the
+limit was disclaimed for.
+
+### Evidence
+
+> `ai-literacy-superpowers/hooks/scripts/lib/session-registry.sh` owns the
+> implementation: `registry_write`, `registry_remove`, `registry_prune`,
+> `registry_count` (emitting count and flag). The `SessionStart` and `Stop`
+> scripts and every consuming sentinel source this one file. — §4.4
+
+`sentinel-integrity-check.sh:21-22`:
+
+> 2\. If `role: sentinel`, the `tools:` list must NOT contain Write or Edit
+> (case-insensitive). Bash is permitted — read-only inspection (git log,
+> date) is within the boundary.
+
+`sentinel-integrity-check.sh:30-33`:
+
+> Known limit (by design). This is a deterministic backstop to human PR
+> review, not a sandbox. It reads the declared `tools:` line; an agent that
+> reaches a write capability through an undeclared channel is out of scope
+> here...
+
+The spec's own Note D shows the correct pattern was already found for the
+sibling case and simply not applied here:
+
+> The Coda cannot hold `Write`. Its agent returns record content; the
+> `/coda` command persists it after a human disposes — the `cost-estimator`
+> precedent. — §8, Note D
+
+### Why this matters
+
+Constraint 1 is CI-enforced precisely so the category stays load-bearing
+rather than decorative. A shared library that hands every sentinel a
+mutation primitive through the permitted channel converts a green check
+into a false assurance — the exact outcome the check's author warned
+about. The Note D reasoning generalises: sentinels should call a
+count-only, side-effect-free entry point, with `registry_write`,
+`registry_remove`, and `registry_prune` reachable only from the hook
+scripts. Splitting the library along the trust boundary (a read surface and
+a mutation surface) costs one file and preserves the constraint. Deciding
+this in S1 is far cheaper than in S4, when three agents already source it.
+
+## O9 — risk — medium
+
+### Claim
+
+The session id becomes a filesystem path component. The spec never states
+where the id comes from, what shape it may take, or what happens when it is
+hostile or empty — in a repo that has already found, tested, and fixed this
+exact hazard for the same field.
+
+### Evidence
+
+> `.claude/sessions/<session-id>.json`, one file per live session — §4.1
+
+The existing treatment, `affordance-invocation-recorder.sh:53-55`:
+
+```bash
+session=$(printf '%s' "$input" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 ...)
+printf '%s' "$session" | grep -qE '^[A-Za-z0-9._-]+$' || session="unknown"
+```
+
+And the test that exists because it was raised as a code-time objection on
+that feature (`docs/superpowers/objections/affordance-runtime-recorder-design-code.md`,
+O-entry naming "a hostile `session_id` carrying JSON metacharacters"),
+`tdad_tests/layer0_deterministic/test-affordance-recorder.sh:83-86`:
+
+> `# Hostile session_id carrying JSON metacharacters: must be sanitised to unknown.`
+
+A value containing `/` or `..` in a path context is a strictly worse
+outcome than the JSON-injection case already adjudicated, because the write
+lands outside the intended directory.
+
+Note also that no existing hook script except the recorder reads stdin at
+all; `reservoir-check.sh` does not. The spec's two new scripts must, and
+the spec does not say so.
+
+### Why this matters
+
+The mitigation is one `grep -qE` and it is already written down in this
+repo — the cost of specifying it is a sentence. The cost of omitting it is
+that an implementer copies `reservoir-check.sh` (which reads no stdin) and
+invents id extraction from scratch, and the resulting path handling is
+reviewed only if a code-time reviewer happens to think of it. Sanitising
+to a fixed fallback also needs a stated collision rule: if two sessions
+both sanitise to `unknown`, the count is silently wrong.
+
+## O10 — scope — medium
+
+### Claim
+
+The slice adds three `HARNESS.md` block schemas and two hook-rail entries.
+Both surfaces have dedicated reference pages in the docs site. §9 lists the
+version locations to touch and stops there, so the reference pages are
+wrong on the day the slice ships.
+
+### Evidence
+
+> Minor version bump, 0.66.2 → 0.67.0 ... Five CI-checked version locations
+> plus the README plugin-table cell. — §9
+
+The affected pages exist:
+
+- `docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md`
+- `docs/plugins/ai-literacy-superpowers/reference/hooks.md`
+
+And `CLAUDE.md` makes this non-optional:
+
+> **When a feature changes a format or schema**: check whether reference
+> pages are current. ... Include docs changes in the same PR as the
+> implementation, not as a follow-up.
+
+### Why this matters
+
+`harness-md-format.md` is the document a downstream project reads to learn
+what may appear in `HARNESS.md`. §9 states that `/harness-upgrade` will
+surface the three new blocks to downstream projects — so adopters are
+actively pushed toward blocks the reference does not document, including
+the value-grammar rules from O5 that they most need. This is a checklist
+omission rather than a design flaw, but the spec is otherwise meticulous
+about rollout mechanics, which makes the gap easy to miss precisely because
+§9 reads as complete.
+
+## O11 — specification quality — medium
+
+### Claim
+
+The block vocabulary introduces enforcement-flavoured tokens —
+`enforcement: strict`, `hard_stop_hour`, `notification_policy_after_stop`
+— and defines the semantics of none of them, in a slice whose non-goals
+say it gates nothing. A vocabulary is a commitment; shipping `strict` with
+no definition and no override path pre-authorises S4 to interpret it as
+blocking, which is the shape constraint 6 exists to prevent.
+
+### Evidence
+
+> `- enforcement: advisory | strict` — §3.2
+
+with only the default defined:
+
+> `enforcement` defaults to `advisory` when the block is present but the
+> key is absent. — §3.2
+
+against:
+
+> **No gating.** Nothing in this slice blocks, warns, or requires a
+> disposition. — §6
+
+and the epic's constraint 6, which requires new constraints to ship
+Unverified or Agent-verified first, "always with an on-the-record human
+override, never a bypass". Nothing in §3.2 or §3.3 describes where that
+override is recorded, or what a human does at 18:31 when `hard_stop_hour`
+is `18:30`.
+
+The `## Cognitive reservoir` precedent the spec models itself on takes the
+opposite approach, writing the boundary into the block text:
+
+> Do not promote it into a blocking gate — that would defeat its purpose
+> and overclaim a precision the proxies cannot support. — `HARNESS.md:1020-1022`
+
+### Why this matters
+
+S1 fixes the vocabulary; S4 inherits it. A downstream human who declares
+`enforcement: strict` in good faith has expressed an intent that no
+document defines, and S4 will define it after the declaration exists in the
+wild. Either the token needs a one-line semantics and an override location
+now, or it should be omitted until S4 defines it — the spec argues in §3.4
+that vocabulary should ship whole, which is a reason to define `strict`,
+not a reason to leave it undefined. The `Budgets` block already
+demonstrates the good pattern with its mandatory "Unspent budget is not a
+debt" clause; `Session WIP` has no equivalent guard against being read as a
+gate.
+
+## O12 — specification quality — medium
+
+### Claim
+
+The acceptance scenarios do not test the property that justifies building
+`block_key` at all — key isolation between blocks — and leave
+present-but-malformed block behaviour undefined, even though §3.3 defines a
+malformed state.
+
+### Evidence
+
+The justification for a second parser:
+
+> `block_key <block-heading> <key> <default>` — the value, scoped to that
+> block's span rather than the whole file (the reservoir `read_key` searches
+> the entire document, which is safe for its unique keys but not for a
+> vocabulary of three blocks that may share key names in future) — §3.7
+
+The scenario that is supposed to cover it:
+
+> **Block-scoped key read.** Given an active `Budgets` block, when
+> `block_key Budgets hard_stop_hour` runs, then it returns the declared
+> value, and a key absent from the block returns the supplied default. — scenario 11
+
+A single-block fixture cannot distinguish block-scoped lookup from
+whole-file lookup; `read_key` passes scenario 11 unmodified. The scenario
+that would falsify it — two active blocks declaring the same key, asserting
+each lookup returns its own block's value — is absent.
+
+Separately, §3.6 defines behaviour for an absent block only:
+
+> A consumer that finds its block absent reports: `no <block name> block
+> declared — running in observe-only mode` and continues. Absence is never
+> an error, never a warning, and never a gate.
+
+while §3.3 creates a distinct third state:
+
+> A `Budgets` block whose prose has lost the clause is a malformed block,
+> and S3's critic check will say so.
+
+Nothing states what `block_active` returns for a malformed block, or what a
+consumer does with one — degrade to observe-only per §3.6, or something
+else.
+
+### Why this matters
+
+Scenario 11 as written is a test that cannot fail for the reason it exists,
+which means the library's differentiating property ships unverified — and
+per O5 the parser has other defects that a single-block fixture also hides.
+The malformed state matters because it is reachable by an ordinary human
+action: someone uncomments the template block, deletes prose they read as
+boilerplate, and now has a block that is present, active, parseable, and
+malformed. Whether that reads as declared or as absent decides whether S3
+holds them to a budget or reports observe-only, and the substrate is where
+that should be settled.
+
+## Explicitly not objecting to
+
+- **The `.claude/` versus `.superpowers/` location decision (Note B).**
+  Disposed on the record in §4.1 with cited precedent; the objection worth
+  raising is about registry *scope* (O2), not about which directory name
+  won, and a bare "why not `.superpowers/`" is decision archaeology for the
+  Choice Cartographer, not a failure class.
+- **Shipping `## Sync cadence` with no consumer.** This is real YAGNI, but
+  §3.4 discloses it explicitly ("Its consumer is future work, on the
+  record"), gives a coherent reason (a vocabulary introduced piecemeal
+  leaves the template internally inconsistent), and the failure class is
+  small and reversible — a downstream human authors two values nothing yet
+  reads.
+- **The missing `.gitignore` deliverable.** §4.1 asserts the registry is
+  gitignored and §9 does not list the `.gitignore` edit, but scenario 12
+  tests it directly (`git status --porcelain` sees no `.claude/sessions/`
+  path), so the omission cannot ship silently.
+- **The version-bump reasoning in §9.** 0.66.2 → 0.67.0 for added hooks and
+  template content is a correct application of the repo's own semver rule
+  in `CLAUDE.md`; the five CI-checked locations are enumerated accurately.
+- **Deferring Note A's template inline-comment fix.** §6 and §8 give an
+  honest boundary argument (pre-existing, different block, would widen a
+  plumbing slice into a bug fix) and commit to a follow-up issue; O5
+  objects to the *new* blocks' value grammar, not to leaving the reservoir
+  block's trap alone.
+- **Carrying S2/S7 consequences in Note D.** Recording discoveries that
+  constrain later slices inside the slice that found them is good practice,
+  not scope creep — the alternative is that S7 rediscovers the roster
+  arithmetic.
+- **The `authored_via: placeholder` device.** Refusing to author a real
+  budget in a plumbing slice, so that the clear-weather rule is not
+  undermined by an imposed default, is the strongest single argument in the
+  spec; my objection at §3.5 (O7) is about what gets committed, not about
+  the placeholder mechanism.
+- **The "Unspent budget is not a debt" mandatory clause.** Putting a
+  normative sentence inside the block rather than in a skill file is
+  unusual, but it is deliberate, testable (scenario 2), and directly serves
+  the epic's language discipline; O12 objects only to the undefined
+  behaviour when the clause is missing.
+- **Language discipline.** The spec uses "compulsive pattern" in its
+  provenance line and never uses "addiction", "dopamine", or "reinforcing"
+  loosely; constraint 8 is satisfied throughout.

--- a/docs/superpowers/parked/README.md
+++ b/docs/superpowers/parked/README.md
@@ -1,0 +1,21 @@
+# Parked records
+
+Live threads captured at session close by `/coda`, so that stopping costs
+nothing and resuming starts from a concrete step.
+
+**The format lives in the reference documentation**, not here:
+
+- [Parking record format](../../plugins/ai-literacy-superpowers/reference/parking-record-format.md)
+
+This directory holds records; the reference page holds the contract. Keeping
+them apart is deliberate — `mkdocs.yml` excludes `docs/superpowers/` from the
+published site, so a schema written here would be the one format contract in
+the repo an adopter cannot read. It would also be a second copy, free to drift
+from the first.
+
+Two rules that govern everything in this directory:
+
+- **Append-only.** No record is ever edited in place or deleted. A transition
+  writes a new file.
+- **State is in the filename.** `<date>-<slug>.md` is parked;
+  `<date>-<slug>.resumed.md` supersedes it.

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -1,0 +1,330 @@
+# Spec: Cadence Sentinels S1 — Shared Infrastructure
+
+**Status:** Approved
+**Date:** 2026-08-08
+**Issue:** #491
+**Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Scope:** `ai-literacy-superpowers` plugin, this repo's own `HARNESS.md`, and
+two new record directories
+**Explicitly out of scope:** every sentinel that consumes this plumbing. S1
+ships plumbing only and gates nothing.
+
+**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5, the roadmap
+sentinels) and *Compulsive Continuation — A Research Exploration* (evidence
+base), via the build spec *The Cadence Sentinels*.
+
+---
+
+## 1. Problem Statement
+
+Four new sentinels are planned — the Coda (S2), the Mast (S3), the WIP Warden
+(S4), and the Convener (S5). Three of them need to know the same two things:
+what pacts the human has declared, and how many sessions are live. Two of them
+need somewhere durable to put a record.
+
+Built per-sentinel, that becomes three near-identical `HARNESS.md` parsers,
+three incompatible notions of "a live session", and two record directories
+invented mid-slice with schemas that drift apart. Built once, it becomes a
+shared substrate the later slices consume and none of them re-derive.
+
+This slice builds it once.
+
+## 2. Design Principles Inherited
+
+Every constitutional constraint from the build spec binds this slice. Three
+bind it concretely:
+
+- **Honesty flags (constraint 3).** Every count this infrastructure yields
+  carries `observed` / `inferred` / `asked`. A session count derived from a
+  registry with no pruned entries is `observed`; the same count after stale
+  entries were pruned is `inferred`, and the consumer must be able to tell
+  which.
+- **Persist nothing about the person (constraint 4).** The registry records
+  that a session exists, when it started, and against which repo. It records
+  nothing about who is in it or how they are doing.
+- **Progressive hardening (constraint 6).** Nothing here enforces anything.
+  All three blocks are optional; every consumer degrades to observe-only.
+
+## 3. Component 1 — Three `HARNESS.md` Block Schemas
+
+### 3.1 Placement and shape
+
+The blocks are defined in `ai-literacy-superpowers/templates/HARNESS.md`,
+adjacent to the existing `## Cognitive reservoir` block, and follow its shape
+exactly: a commented-out optional block that a downstream project opts into by
+removing the `<!--` fence, values as clean `- key: value` lines, and prose
+field notes below the values.
+
+**Field notes go below the value lines, never on them.** This is not style.
+The `read_key` helper in `hooks/scripts/reservoir-check.sh` strips whitespace
+from a matched value but does not strip a trailing `# comment`, so
+`window_hours: 8  # how far back` parses to a non-numeric string and degrades
+silently to the built-in default. The live `HARNESS.md` block already states
+this rule; the shipped template violates it. See §8, Note A.
+
+### 3.2 `## Session WIP`
+
+```text
+- max_concurrent_sessions: <int>
+- max_switches_per_hour: <int>       (optional)
+- enforcement: advisory | strict
+```
+
+Consumed by the WIP Warden (S4). `enforcement` defaults to `advisory` when the
+block is present but the key is absent.
+
+### 3.3 `## Budgets`
+
+```text
+- daily_cost_ceiling: <amount, or "not observable">
+- sessions_per_day: <int>
+- hard_stop_hour: <HH:MM local>
+- focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>
+- notification_policy_after_stop: digest | none
+- authored_at: <YYYY-MM-DD>
+- authored_via: tune | placeholder
+```
+
+The block template carries a **mandatory literal clause** in its prose body:
+
+> Unspent budget is not a debt.
+
+The clause is part of the block, not a comment on it. A `Budgets` block whose
+prose has lost the clause is a malformed block, and S3's critic check will say
+so.
+
+`authored_at` and `authored_via` exist for S3's clear-weather rule: budgets
+that hold are budgets their keeper authored deliberately, so the block records
+*how* it came to hold its values. `authored_via: placeholder` is the honest
+value for a block that was scaffolded rather than authored.
+
+Consumed by the Mast (S3), which owns the only sanctioned editing path.
+
+### 3.4 `## Sync cadence`
+
+```text
+- interrupt_mode: streaming | coalesced
+- sync_points: <HH:MM, HH:MM | on-demand>
+```
+
+Declared here; no S1–S7 sentinel consumes it yet. It ships now because the
+three blocks form one vocabulary and splitting their introduction across slices
+would leave the template internally inconsistent. Its consumer is future work,
+on the record.
+
+### 3.5 Activation in this repo
+
+All three blocks are additionally **activated** (uncommented, with values) in
+this repo's own root `HARNESS.md`, exactly as `## Cognitive reservoir` is. The
+repo dogfoods its own harness; a sentinel written in S2–S5 against a block that
+exists nowhere real is a sentinel tested only against its own fixtures.
+
+`Budgets` is activated with provisional values and `authored_via: placeholder`.
+It is **not** authored in this slice — authoring it here would produce exactly
+the imposed-default budget the clear-weather rule says does not hold. S3's Tune
+dialogue is where the real pact gets made, and it will overwrite these values
+and set `authored_via: tune`.
+
+### 3.6 Absent-block behaviour
+
+Every block is optional. A consumer that finds its block absent reports:
+
+> no `<block name>` block declared — running in observe-only mode
+
+and continues. Absence is never an error, never a warning, and never a gate.
+
+### 3.7 Shared block reader
+
+`ai-literacy-superpowers/hooks/scripts/lib/harness-blocks.sh` owns block
+parsing, so the three near-identical parsers named in §1 never get written.
+It exposes:
+
+- `block_active <block-heading>` — true when an **uncommented** level-2..6
+  heading of that name exists, mirroring `reservoir-check.sh:30`'s
+  active-heading test so a commented template block never reads as declared
+- `block_key <block-heading> <key> <default>` — the value, scoped to that
+  block's span rather than the whole file (the reservoir `read_key` searches
+  the entire document, which is safe for its unique keys but not for a
+  vocabulary of three blocks that may share key names in future)
+- `block_absent_note <block-heading>` — the observe-only line from §3.6, so
+  every consumer emits the same sentence
+
+This library is the *only* thing in S1 that reads a block. It is plumbing, not
+a sentinel: it has no opinion, no threshold, and no output of its own beyond
+the value it was asked for.
+
+## 4. Component 2 — Session Registry
+
+### 4.1 Location and format
+
+`.claude/sessions/<session-id>.json`, one file per live session:
+
+```json
+{
+  "id": "<session id>",
+  "repo": "<absolute path to project root>",
+  "started_at": "<ISO-8601 UTC>"
+}
+```
+
+**Location disposition (open decision 1, disposed 2026-08-08):** the build spec
+proposed `.superpowers/sessions/`. This repo has no `.superpowers/` directory
+and no precedent for one. Per-machine local session state already lives in
+`.claude/` — `.claude/.harness-upgrade-dismissed` and
+`.claude/affordance-discovery-*.md` are both there and both gitignored.
+`.claude/sessions/` matches that practice. Append-only *logs* live in
+`observability/`; the registry is ephemeral live state, not a log, so that
+directory is the weaker fit.
+
+The registry is gitignored. It is operational state, not a record. Nothing in
+it is ever committed, and nothing downstream may treat it as history.
+
+### 4.2 Lifecycle
+
+- **`SessionStart` hook** writes the entry.
+- **`Stop` hook** removes this session's entry and prunes stale ones.
+
+`Stop` is used rather than `SessionEnd` because `hooks.json` already runs nine
+`Stop` hooks and none on `SessionEnd`; adding to the existing rail keeps the
+hook surface honest and gives the pruner the same firing guarantees the
+reservoir check already relies on.
+
+### 4.3 Staleness and the honesty flag
+
+A crashed session leaves an orphan entry. The pruner removes entries whose
+`started_at` is older than `SESSION_STALE_HOURS` (default 12).
+
+The flag rule is the point of this component:
+
+| Situation | Flag |
+| --- | --- |
+| Count read, no entries pruned this read | `observed` |
+| Count read, one or more stale entries pruned | `inferred` |
+| No registry directory at all | `observed` (count 0) |
+
+A consumer that reports a count must report its flag alongside. A count that
+followed a prune is `inferred` because the pruner cannot distinguish a crashed
+session from a long-running healthy one — it only knows the entry aged out.
+
+### 4.4 Shared library
+
+`ai-literacy-superpowers/hooks/scripts/lib/session-registry.sh` owns the
+implementation: `registry_write`, `registry_remove`, `registry_prune`,
+`registry_count` (emitting count and flag). The `SessionStart` and `Stop`
+scripts and every consuming sentinel source this one file. Three sentinels
+reading three parsers is the failure this component exists to prevent.
+
+`hooks/scripts/lib/` does not exist yet; `scripts/lib/` does, so the pattern is
+established in the repo and this follows it.
+
+## 5. Component 3 — Record Directories
+
+Two directories, each with a `README.md` that carries its schema:
+
+- `docs/superpowers/parked/` — parking records (schema consumed by S2)
+- `docs/superpowers/consultations/` — consultation dispositions (schema
+  consumed by S5)
+
+Both READMEs state the append-only rule (constraint 7): superseded entries are
+marked superseded, never edited; a resumed parking record gains
+`status: resumed`, and is never deleted.
+
+Declaring the schemas here rather than in S2 and S5 is deliberate. It makes S1
+a complete, reviewable unit — the substrate is fully specified before anything
+consumes it — rather than half a feature waiting for its other half.
+
+## 6. Non-Goals
+
+- **No gating.** Nothing in this slice blocks, warns, or requires a
+  disposition.
+- **No sentinel agents, skills, or commands.** S1 ships no `role: sentinel`
+  agent. The shared block reader (§3.7) is a parsing library, not a consumer:
+  it answers "what does the block say", never "what should be done about it".
+- **No changes to the Reservoir Warden**, its block, its hook, or its skill.
+- **No `Sync cadence` consumer.**
+- **No fix to the template's inline-comment trap** (§8, Note A). It is
+  pre-existing, it affects a different block, and folding it in would widen a
+  plumbing slice into a bug fix. Raised as a follow-up.
+
+## 7. Acceptance Scenarios (TDAD)
+
+1. **Template blocks present and commented.** Given `templates/HARNESS.md`,
+   then all three block headings exist inside comment fences, and no value line
+   in any of the three carries a trailing `#` comment.
+2. **Not-a-debt clause present.** Given the `Budgets` template block, then its
+   prose contains the literal string `Unspent budget is not a debt.`
+3. **Live activation.** Given this repo's root `HARNESS.md`, then all three
+   blocks are active (uncommented), and `Budgets` declares
+   `authored_via: placeholder`.
+4. **Registry write on start.** Given no registry entry for session X, when the
+   `SessionStart` hook runs, then `.claude/sessions/X.json` exists with `id`,
+   `repo`, and `started_at`.
+5. **Two overlapping sessions counted.** Given entries for sessions X and Y,
+   when `registry_count` runs, then it reports `2` flagged `observed`.
+6. **Prune on stop.** Given entries for X and Y, when the `Stop` hook runs in
+   session X, then X's entry is gone and Y's remains.
+7. **Stale entry pruned, count flagged inferred.** Given an entry older than
+   `SESSION_STALE_HOURS`, when `registry_count` runs, then the stale entry is
+   removed and the count is flagged `inferred`.
+8. **No registry directory.** Given `.claude/sessions/` does not exist, when
+   `registry_count` runs, then it reports `0` flagged `observed` and exits
+   cleanly.
+9. **Absent block, each of three.** Given a `HARNESS.md` with no
+    `Session WIP` / `Budgets` / `Sync cadence` heading, when
+    `block_absent_note` runs for it, then it emits the §3.6 observe-only line
+    and exits 0.
+10. **Commented block does not read as declared.** Given a `HARNESS.md`
+    carrying the three blocks still inside their comment fences, when
+    `block_active` runs for each, then each reports inactive — a template a
+    project has not opted into is not a declaration.
+11. **Block-scoped key read.** Given an active `Budgets` block, when
+    `block_key Budgets hard_stop_hour` runs, then it returns the declared
+    value, and a key absent from the block returns the supplied default.
+12. **Registry is gitignored.** Given a written registry entry, when
+    `git status --porcelain` runs, then no `.claude/sessions/` path appears.
+
+Scenarios 1–12 are deterministic and land in
+`tdad_tests/layer0_deterministic/test-session-registry.sh` (4–8, 12) and
+`test-cadence-blocks.sh` (1–3, 9–11).
+
+## 8. Notes and Divergences from the Build Spec
+
+**Note A — template inline-comment trap (pre-existing, out of scope).** The
+shipped `## Cognitive reservoir` template block carries inline `#` comments on
+its value lines (`templates/HARNESS.md:614–621`). A downstream project that
+uncomments the block and tunes a value gets a silent degrade to the built-in
+default, because `read_key` does not strip trailing comments. The live
+`HARNESS.md` block documents the rule correctly; the template does not follow
+it. Raised as a follow-up issue, not fixed here.
+
+**Note B — registry path.** `.claude/sessions/`, not `.superpowers/sessions/`.
+See §4.1.
+
+**Note C — `Stop`, not `SessionEnd`.** See §4.2.
+
+**Note D — the sentinel category is already load-bearing.** Build-spec
+constraint 9 anticipates a repo that has not yet adopted the sentinel category
+and asks for a docs-only introduction. The category shipped in v0.66.0 with a
+spec, the `sentinel-design` skill, a README section, `role: sentinel`
+frontmatter, and `scripts/sentinel-integrity-check.sh` gating both PRs and the
+weekly GC sweep. Consequences for later slices, recorded here because they were
+discovered in this slice's exploration:
+
+- Every new sentinel must satisfy S1–S3 and carry `role: sentinel`.
+- The Coda cannot hold `Write`. Its agent returns record content; the `/coda`
+  command persists it after a human disposes — the `cost-estimator` precedent.
+  Disposed by Russ, 2026-08-08.
+- S7's "create a sentinel category page" becomes "extend the existing one",
+  roster 5 → 9.
+- The rename open note in constraint 9 is moot.
+
+## 9. Migration & Rollout
+
+Minor version bump, 0.66.2 → 0.67.0 — the slice adds hooks and template
+content, which the repo's semver rule scopes as minor. Five CI-checked version
+locations plus the README plugin-table cell.
+
+No breaking changes. All three blocks are additive and optional; the registry
+is local, gitignored state that no existing hook reads; the record directories
+are new and empty but for their READMEs. `/harness-upgrade` surfaces the three
+new template blocks to downstream projects as optional adoptable content.

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -322,6 +322,10 @@ consumer lists the other live sessions and says where they are.
 Because the registry lives outside every work tree, no `.gitignore` entry is
 needed and nothing can accidentally commit it.
 
+`$CLAUDE_SESSIONS_DIR` overrides the location, mirroring `$CLAUDE_PACTS_FILE`
+for the pact reader (§3.8). It exists so the deterministic tests need no home
+directory, and it is the only supported way to relocate the registry.
+
 **Session id sanitisation.** The id arrives from the hook's stdin JSON
 (`session_id`) and becomes a filesystem path component, so it is sanitised
 before use with the pattern this repo already adjudicated for the same field
@@ -406,12 +410,24 @@ while a `role: sentinel` agent deleted files.
 
 | File | Exposes | Who may source it |
 | --- | --- | --- |
-| `hooks/scripts/lib/session-registry-read.sh` | `registry_count` (count + flag), `registry_list` | hook scripts **and** sentinels |
+| `hooks/scripts/lib/session-registry-read.sh` | `registry_dir`, `registry_count` (emitting `<n> <flag>`), `registry_list` | hook scripts **and** sentinels |
 | `hooks/scripts/lib/session-registry-write.sh` | `registry_touch`, `registry_prune` | hook scripts **only** |
 
 The read library performs no mutation on any path. This generalises the
 reasoning that keeps the Coda read-only (§8, Note D): the boundary is preserved
 by what the agent *can* reach, not by what it is trusted not to call.
+
+### 4.5 The two hook scripts
+
+| Script | Hook | Behaviour |
+| --- | --- | --- |
+| `hooks/scripts/session-registry-start.sh` | `SessionStart` | write the entry if absent, renew `heartbeat` if present, never reset `started_at` |
+| `hooks/scripts/session-registry-sweep.sh` | `Stop` | renew `heartbeat`, then prune expired leases |
+
+Both read `session_id` from the hook's stdin JSON and sanitise it per §4.1.
+Both exit 0 unconditionally: a registry failure must never surface to, or
+interfere with, a session. Pruning lives on the `Stop` rail rather than in any
+read path, which is what keeps `registry_count` pure (§4.3).
 
 ## 5. Component 3 — Record Directories and Schemas
 
@@ -449,6 +465,12 @@ docs/superpowers/parked/2026-08-09-retry-branch.superseded.md   <- superseded
 "What is still parked" is a glob: every `*.md` that is not itself a transition
 file and is not named by any transition's `supersedes` field. Nothing is ever
 edited, and nothing is ever deleted.
+
+That query is the one S2's resume path depends on, so it ships as code rather
+than as prose: `hooks/scripts/lib/record-paths.sh` exposes
+`records_open <dir>`, listing the records in a directory that are still open.
+Like the block reader it is plumbing, not a consumer — it answers "which
+records are open", never "what should be done about them".
 
 This also fits the Coda's trust boundary: resuming is a *write* by the `/coda`
 command, not an *edit* of an existing record, so the read-only agent never

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -1,6 +1,6 @@
 # Spec: Cadence Sentinels S1 — Shared Infrastructure
 
-**Status:** Approved (revision 3, post-cartographer)
+**Status:** Approved (revision 4, post-code-gate)
 **Date:** 2026-08-08
 **Issue:** #491
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
@@ -8,6 +8,8 @@
 — 12 objections, 11 accepted, 1 rejected
 **Choice stories:** `docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md`
 — 9 stories, all accepted, 3 dissolved structurally
+**Code-gate objections:** `docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md`
+— 11 objections, 10 accepted, 1 deferred on the record
 **Scope:** the `ai-literacy-superpowers` plugin and two new record directories
 **Explicitly out of scope:** every sentinel that consumes this plumbing. S1
 ships plumbing only and gates nothing.
@@ -186,14 +188,21 @@ The clause is part of the block, not a comment on it. A `Budgets` block whose
 prose has lost the clause is **malformed** — a distinct state from absent,
 defined in §3.7.
 
-**On the clause as an interface.** Because detection is literal-string
-matching, the sentence cannot be reworded, translated, shortened, or reflowed
-across lines in any adopter's file without the block silently ceasing to read
-as declared. That is deliberate — a pact enforced without its governing
-sentence is a pact enforced against a framing nobody agreed to — but it makes
-the wording a published interface. **Only a spec-first change may reword it**,
-and rewording is a coordinated migration across every adopter, not a template
-edit.
+**On the clause as an interface.** The clause's **words** are a published
+interface; its **line breaks are not**. Matching normalises whitespace, so an
+adopter may re-wrap the sentence freely, but rewording, translating, or
+shortening it makes the block cease to read as declared. That is deliberate — a
+pact enforced without its governing sentence is a pact enforced against a
+framing nobody agreed to. **Only a spec-first change may reword it**, and
+rewording is a coordinated migration across every adopter, not a template edit.
+
+*Revision 4 amendment (code gate, O8).* Revision 3 said a **reflowed** clause
+must also cease to read as declared, and called that deliberate. It was
+unshippable: this slice's own template wraps the `Session WIP` clause across
+two lines, so the rule failed against the first file it met. The behaviour is
+now whitespace-normalised and B10 pins it. The spec is amended rather than the
+code, because §3.4 claims authority over this matching rule and was stating one
+the library does not implement — and S2–S5 are authored from §3.
 
 `authored_at` and `authored_via` serve S3's clear-weather rule: budgets that
 hold are budgets their keeper authored deliberately, so the block records how
@@ -323,8 +332,13 @@ Because the registry lives outside every work tree, no `.gitignore` entry is
 needed and nothing can accidentally commit it.
 
 `$CLAUDE_SESSIONS_DIR` overrides the location, mirroring `$CLAUDE_PACTS_FILE`
-for the pact reader (§3.8). It exists so the deterministic tests need no home
-directory, and it is the only supported way to relocate the registry.
+for the pact reader (§3.8). Both exist so the deterministic tests need no home
+directory and are **not intended for production use**; both are documented as
+test-only in the reference pages. The commit-safety claim above holds for the
+default path — an override pointing inside a work tree defeats it, and neither
+reader can tell who set the variable. This matters little in S1, where nothing
+consumes a pact, and a great deal in S3 and S4, where the clear-weather rule
+turns on a pact having been authored by its keeper.
 
 **Session id sanitisation.** The id arrives from the hook's stdin JSON
 (`session_id`) and becomes a filesystem path component, so it is sanitised
@@ -372,12 +386,23 @@ Renewal makes correctness independent of how often `Stop` fires. Once per
 session, once per turn, or fifty times per turn all produce the same result: a
 live session stays fresh, a dead one expires.
 
-**Known limit of the lease, disclosed.** The renewal interval is "whenever the
-agent finishes a turn", which is unbounded above — a session where the human is
-reading, thinking, or waiting on a long tool run emits no heartbeat. Liveness
-here means *recency of a completed turn*, not "a window is open". A human who
-finds the default too short tunes `stale_after_hours`; that is what makes it a
-declared key rather than a constant.
+**Known limits of the lease, disclosed in both directions.**
+
+*False negative.* The renewal interval is "whenever the agent finishes a turn",
+which is unbounded above — a session where the human is reading, thinking, or
+waiting on a long tool run emits no heartbeat. Liveness here means *recency of
+a completed turn*, not "a window is open". A human who finds the default too
+short tunes `stale_after_hours`; that is what makes it a declared key rather
+than a constant.
+
+*False positive (revision 4, code gate O1).* Nothing removes an entry when a
+session **ends**, because nothing knows a session ended. A cleanly-finished
+session therefore remains within its lease, and looks live, until the lease
+expires. Three sequential sessions in one working day are three unexpired
+entries. `registry_count` filters expired entries on read (§4.3), which bounds
+the error at the lease length — it does not eliminate it. **No consumer may
+treat this count as an exact number of open windows.** Where exactness matters,
+constraint 3's `asked` flag is the honest instrument: ask the human.
 
 ### 4.3 The honesty flag
 
@@ -385,9 +410,15 @@ The flag is a property of the count, not of the reader. It derives from durable
 state — a retirement marker written by the pruner, and the presence of an
 `unknown` entry — never from whether *this particular read* pruned something.
 
+`registry_count` **counts only entries whose lease has not expired.** The
+filter is a pure read — no file is touched, so §4.4's trust boundary and the
+purity guarantee are untouched — and retirement remains the pruner's job alone.
+
 | Situation | Flag |
 | --- | --- |
-| No entry retired within the window; no `unknown` entry | `observed` |
+| Every entry within its lease; no retirement in the window; no `unknown` entry | `observed` |
+| An entry excluded because its lease expired but the pruner has not yet run | `inferred` |
+| An entry whose heartbeat is unparseable (counted, not discarded) | `inferred` |
 | One or more entries retired within the window | `inferred` |
 | An `unknown` entry present (§4.1) | `inferred` |
 | No registry directory at all | `observed`, count 0 |

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -1,13 +1,14 @@
 # Spec: Cadence Sentinels S1 — Shared Infrastructure
 
-**Status:** Approved (revision 2, post-diaboli)
+**Status:** Approved (revision 3, post-cartographer)
 **Date:** 2026-08-08
 **Issue:** #491
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
 **Objection record:** `docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md`
-— 12 objections, 11 accepted, 1 rejected on the record
-**Scope:** `ai-literacy-superpowers` plugin, this repo's own `HARNESS.md`, and
-two new record directories
+— 12 objections, 11 accepted, 1 rejected
+**Choice stories:** `docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md`
+— 9 stories, all accepted, 3 dissolved structurally
+**Scope:** the `ai-literacy-superpowers` plugin and two new record directories
 **Explicitly out of scope:** every sentinel that consumes this plumbing. S1
 ships plumbing only and gates nothing.
 
@@ -24,10 +25,10 @@ Four new sentinels are planned — the Coda (S2), the Mast (S3), the WIP Warden
 what pacts the human has declared, and how many sessions are live. Two of them
 need somewhere durable to put a record.
 
-Built per-sentinel, that becomes three near-identical `HARNESS.md` parsers,
-three incompatible notions of "a live session", and two record directories
-invented mid-slice with schemas that drift apart. Built once, it becomes a
-shared substrate the later slices consume and none of them re-derive.
+Built per-sentinel, that becomes three near-identical parsers, three
+incompatible notions of "a live session", and two record directories invented
+mid-slice with schemas that drift apart. Built once, it becomes a shared
+substrate the later slices consume and none of them re-derive.
 
 This slice builds it once.
 
@@ -48,10 +49,10 @@ cover a pact the person authored themselves. A declared budget is a statement
 is not a pact.
 
 The existing `## Cognitive reservoir` block already works this way: it holds
-`chronotype: intermediate`, self-declared, in committed `HARNESS.md`, while
-its own prose forbids recording "a claim about your cognitive state to disk".
-Self-authored declaration is on one side of the line; agent-authored assertion
-is on the other.
+`chronotype: intermediate`, self-declared, while its own prose forbids
+recording "a claim about your cognitive state to disk". Self-authored
+declaration is on one side of the line; agent-authored assertion is on the
+other.
 
 This distinction is load-bearing for S2–S5 — parking records and consultation
 dispositions are both records of how the human works — so it is carried into
@@ -60,31 +61,62 @@ dispositions are both records of how the human works — so it is carried into
 **Read-only trust boundary (constraint 1).** Any library a sentinel may source
 must be incapable of mutation. See §4.4.
 
-**Progressive hardening (constraint 6).** Nothing here enforces anything. All
-three blocks are optional; every consumer degrades to observe-only.
+**Progressive hardening (constraint 6).** Nothing here enforces anything. Every
+block is optional and every consumer degrades to observe-only.
 
-## 3. Component 1 — Three `HARNESS.md` Block Schemas
+## 3. Component 1 — The Pact File
 
-### 3.1 Placement and shape
+### 3.1 Location: user-scoped, not repo-scoped
 
-The blocks are defined in `ai-literacy-superpowers/templates/HARNESS.md`,
-adjacent to the existing `## Cognitive reservoir` block, and follow its shape
-exactly: a commented-out optional block that a downstream project opts into by
-removing the `<!--` fence, values as clean `- key: value` lines, and prose
-field notes below the values.
+Pacts live in **`~/.claude/pacts.md`** — one file per human, per machine, never
+committed.
+
+A stop hour, a focus window, a daily session ceiling, and a concurrency limit
+are all properties of **the person**, not of a repository. A repo-scoped pact
+file cannot answer "whose pact is this" in a project with five contributors,
+and a per-repo concurrency limit compared against a machine-global session
+count is a units mismatch: the same three live sessions would be compliant in
+one repo and in breach in another, with the advisory depending on which
+directory the human happened to be sitting in.
+
+This is symmetric with the session registry (§4.1), which is machine-global for
+exactly the same reason.
+
+**Divergence from the build spec, flagged for the PR.** The build spec located
+these blocks "in the plugin's harness-template source, wherever
+`Cognitive reservoir` is defined" — that is, in `HARNESS.md`. Disposed
+otherwise by Russ at the cartographer gate, 2026-08-08, on stories #4 and #5.
+`HARNESS.md` remains the *repo's* declaration surface and is untouched by this
+slice; `~/.claude/pacts.md` is the *person's*.
+
+`## Cognitive reservoir` stays in `HARNESS.md`, unchanged (constraint 5). It is
+not migrated, not reinterpreted, and gains only a documentation cross-reference.
+
+### 3.2 Shape
+
+`ai-literacy-superpowers/templates/pacts.md` ships the authored template: three
+level-2 blocks, values as clean `- key: value` lines, prose field notes below
+the values.
 
 **Field notes go below the value lines, never on them.** This is not style.
 The `read_key` helper in `hooks/scripts/reservoir-check.sh` strips whitespace
 from a matched value but does not strip a trailing `# comment`, so
 `window_hours: 8  # how far back` parses to a non-numeric string and degrades
-silently to the built-in default. The live `HARNESS.md` block already states
-this rule; the shipped template violates it. See §8, Note A.
+silently to the built-in default. The live `HARNESS.md` reservoir block states
+this rule; the shipped `HARNESS.md` template violates it. See §8, Note A.
 
-### 3.2 `## Session WIP`
+**Adoption ramp.** The file does not exist until it is authored. S3's Tune
+dialogue is the authoring path and creates it; until then every consumer
+reports observe-only (§3.7). Nothing in S1–S7 writes a default pact file, and
+nothing scaffolds one at install: an imposed default is precisely the budget
+the clear-weather rule says does not hold.
+
+### 3.3 `## Session WIP`
 
 ```text
 - max_concurrent_sessions: <int>
 - max_switches_per_hour: <int>
+- stale_after_hours: <int>
 - enforcement: advisory | strict
 ```
 
@@ -92,7 +124,14 @@ this rule; the shipped template violates it. See §8, Note A.
 | --- | --- | --- |
 | `max_concurrent_sessions` | single integer | yes |
 | `max_switches_per_hour` | single integer | no |
+| `stale_after_hours` | single integer | no (defaults 12) |
 | `enforcement` | one of `advisory`, `strict` | no (defaults `advisory`) |
+
+`stale_after_hours` is the registry lease length (§4.2). It is declared rather
+than compiled in because every other threshold in this harness — the whole
+`## Cognitive reservoir` block, `window_hours` through `chronotype` — is
+declared and human-tunable, and a slice premised on the human declaring their
+pacts should not introduce the first threshold they cannot touch.
 
 **`enforcement` semantics, defined here so S4 inherits a defined token rather
 than defining one already declared in the wild:**
@@ -108,16 +147,12 @@ naming what was urgent enough. That is the on-the-record human override
 constraint 6 requires; there is no bypass, and `strict` never means
 "unconditionally refuse".
 
-`max_concurrent_sessions` counts sessions **machine-wide**, not in this repo —
-see §4.1. The limit is declared per-repo; the count it is compared against is
-global.
-
-The block carries a mandatory prose clause, mirroring `Budgets`:
+Mandatory prose clause:
 
 > This is a gate on sessions, never on the person. It counts; it does not
 > assess.
 
-### 3.3 `## Budgets`
+### 3.4 `## Budgets`
 
 ```text
 - daily_cost_ceiling: <amount> | not observable
@@ -126,39 +161,45 @@ The block carries a mandatory prose clause, mirroring `Budgets`:
 - focus_blocks: <HH:MM-HH:MM>, <HH:MM-HH:MM>
 - notification_policy_after_stop: digest | none
 - authored_at: <YYYY-MM-DD>
-- authored_via: tune | placeholder
+- authored_via: tune
 ```
 
 | Key | Grammar | Notes |
 | --- | --- | --- |
 | `daily_cost_ceiling` | free text | the literal `not observable` is a valid, honest value |
 | `sessions_per_day` | single integer | |
-| `hard_stop_hour` | `HH:MM`, 24-hour, local time | **contains a colon** |
+| `hard_stop_hour` | `HH:MM`, 24-hour, local | **contains a colon** |
 | `focus_blocks` | comma-separated `HH:MM-HH:MM` ranges | **contains colons and spaces** |
 | `notification_policy_after_stop` | one of `digest`, `none` | |
 | `authored_at` | `YYYY-MM-DD` | |
-| `authored_via` | one of `tune`, `placeholder` | |
+| `authored_via` | `tune` | the only honest value; the file exists only if Tune authored it |
 
 The grammar column is not decoration. Three of these values contain colons and
 two contain spaces, which is precisely what the inherited parser destroys —
-see §3.7.
+see §3.6.
 
-The block template carries a **mandatory literal clause** in its prose body:
+Mandatory literal clause in the block's prose body:
 
 > Unspent budget is not a debt.
 
 The clause is part of the block, not a comment on it. A `Budgets` block whose
 prose has lost the clause is **malformed** — a distinct state from absent,
-defined in §3.6.
+defined in §3.7.
 
-`authored_at` and `authored_via` exist for S3's clear-weather rule: budgets
-that hold are budgets their keeper authored deliberately, so the block records
-*how* it came to hold its values. `authored_via: placeholder` is the honest
-value for a block that was scaffolded rather than authored.
+**On the clause as an interface.** Because detection is literal-string
+matching, the sentence cannot be reworded, translated, shortened, or reflowed
+across lines in any adopter's file without the block silently ceasing to read
+as declared. That is deliberate — a pact enforced without its governing
+sentence is a pact enforced against a framing nobody agreed to — but it makes
+the wording a published interface. **Only a spec-first change may reword it**,
+and rewording is a coordinated migration across every adopter, not a template
+edit.
 
-Consumed by the Mast (S3), which owns the only sanctioned editing path.
+`authored_at` and `authored_via` serve S3's clear-weather rule: budgets that
+hold are budgets their keeper authored deliberately, so the block records how
+it came to hold its values.
 
-### 3.4 `## Sync cadence`
+### 3.5 `## Sync cadence` (reserved)
 
 ```text
 - interrupt_mode: streaming | coalesced
@@ -170,66 +211,22 @@ Consumed by the Mast (S3), which owns the only sanctioned editing path.
 | `interrupt_mode` | one of `streaming`, `coalesced` |
 | `sync_points` | comma-separated `HH:MM` times, or the literal `on-demand` |
 
-Declared here; no S1–S7 sentinel consumes it yet. It ships now because the
-three blocks form one vocabulary and splitting their introduction across slices
-would leave the template internally inconsistent. Its consumer is future work,
-on the record.
+**This block is reserved.** No S1–S7 sentinel consumes it. It ships now because
+the three blocks form one vocabulary and introducing them piecemeal would leave
+the template internally inconsistent — but the block's prose and the reference
+page both carry a reserved marker:
 
-### 3.5 Activation in this repo
+> Reserved. No sentinel reads this block yet. Values declared here are inert;
+> the slice that adds a consumer will define their behaviour.
 
-All three blocks are additionally **activated** (uncommented, with values) in
-this repo's own root `HARNESS.md`, exactly as `## Cognitive reservoir` is. The
-repo dogfoods its own harness; a sentinel written in S2–S5 against a block that
-exists nowhere real is a sentinel tested only against its own fixtures.
+Without it, an adopter who writes `interrupt_mode: coalesced` in good faith
+binds a future consumer to a declaration made before any behaviour existed for
+it — the argument O11 made about `enforcement: strict`, which was accepted.
 
-Committing a `Budgets` block to public history is permitted by the boundary
-drawn in §2: these are pacts the keeper declared, not claims an agent made.
+### 3.6 The value-extraction rule
 
-`Budgets` is activated with provisional values and `authored_via: placeholder`.
-It is **not** authored in this slice — authoring it here would produce exactly
-the imposed-default budget the clear-weather rule says does not hold. S3's Tune
-dialogue is where the real pact gets made, and it will overwrite these values
-and set `authored_via: tune`.
-
-### 3.6 Three block states
-
-A block is in exactly one of three states, and consumers must distinguish them.
-
-| State | Test | Consumer behaviour |
-| --- | --- | --- |
-| **Absent** | no uncommented heading of that name | emit the observe-only note, continue |
-| **Malformed** | heading present, but a mandatory clause or required key is missing | emit the observe-only note **plus** a one-line note naming what is missing, continue |
-| **Declared** | heading present and well-formed | read it |
-
-The observe-only note is a fixed sentence, emitted by the library so every
-consumer says the same thing:
-
-> no `<block name>` block declared — running in observe-only mode
-
-**Malformed degrades to observe-only, never to a gate.** This is the reachable
-case: someone uncomments the template, deletes prose they read as boilerplate,
-and now holds a block that is present, active, parseable, and missing its
-not-a-debt clause. Treating that as declared would let S3 hold them to a pact
-whose governing clause they deleted. Absence is never an error, never a
-warning, and never a gate; malformed is a note, and also never a gate.
-
-### 3.7 Shared block reader
-
-`ai-literacy-superpowers/hooks/scripts/lib/harness-blocks.sh` owns block
-parsing, so the three near-identical parsers named in §1 never get written.
-It exposes:
-
-- `block_state <block-heading>` — `absent` | `malformed` | `declared`,
-  testing for an **uncommented** level-2..6 heading, mirroring
-  `reservoir-check.sh:30`'s active-heading test so a commented template block
-  never reads as declared
-- `block_key <block-heading> <key> <default>` — the value, scoped to that
-  block's span
-- `block_absent_note <block-heading>` — the fixed sentence from §3.6
-
-**The value-extraction rule.** `block_key` splits on the **first** delimiter
-and trims whitespace **at the ends only**. It does not reuse `read_key`'s
-extraction.
+`block_key` splits on the **first** delimiter and trims whitespace **at the
+ends only**. It does not reuse `read_key`'s extraction.
 
 `read_key`'s `sed -E "s/.*[:=][[:space:]]*//"` is greedy — `.*[:=]` consumes
 through the *last* colon on the line — and its `tr -d '[:space:]'` deletes
@@ -250,13 +247,56 @@ reader while S3 holds them to a budget nobody authored.
 
 **Block scoping.** A key lookup is confined to the span between its block's
 heading and the next heading of equal-or-higher level. This is the property
-that justifies a second parser at all, and §7 scenario 11 tests it with two
-active blocks declaring the same key — a single-block fixture cannot
-distinguish block-scoped lookup from whole-file lookup.
+that justifies a purpose-built parser, and B8 tests it with two blocks
+declaring the same key — a single-block fixture cannot distinguish
+block-scoped lookup from whole-file lookup.
 
-This library is the *only* thing in S1 that reads a block. It is plumbing, not
-a sentinel: it has no opinion, no threshold, and no output of its own beyond
-the value it was asked for.
+### 3.7 Three block states, and the Null Object contract
+
+A block is in exactly one of three states.
+
+| State | Test | Consumer behaviour |
+| --- | --- | --- |
+| **Absent** | no pact file, or no heading of that name | observe-only note, continue |
+| **Malformed** | heading present, mandatory clause or required key missing | observe-only note **plus** a line naming what is missing, continue |
+| **Declared** | heading present and well-formed | read it |
+
+The observe-only note is a fixed sentence, emitted by the library so every
+consumer says the same thing:
+
+> no `<block name>` block declared — running in observe-only mode
+
+**The Null Object contract.** `block_absent_note` plus `block_key`'s default
+argument exist so that **a consumer never branches on absence**. Every sentinel
+in S2–S5 runs one code path whether or not the block exists; the library
+supplies the null behaviour. This is why absent and malformed collapse to the
+same behaviour rather than that collapse being a coincidence, and it is the
+library's real contract to the later slices.
+
+**Malformed degrades to observe-only, never to a gate.** This is the reachable
+case: someone edits their pact file, deletes prose they read as boilerplate,
+and now holds a block that is present, parseable, and missing its governing
+clause. Treating that as declared would let S3 hold them to a pact whose
+governing clause they deleted.
+
+Absence is never an error, never a warning, and never a gate. Malformed is a
+note, and also never a gate. Observe-only is the expected resting state of a
+project whose human has not authored a pact file, and that is correct: nothing
+in this epic should happen to someone who never asked for it.
+
+### 3.8 Shared block reader
+
+`ai-literacy-superpowers/hooks/scripts/lib/pact-blocks.sh` exposes:
+
+- `pact_file` — the resolved path (`$CLAUDE_PACTS_FILE` if set, else
+  `~/.claude/pacts.md`); the override exists so tests need no home directory
+- `block_state <heading>` — `absent` | `malformed` | `declared`
+- `block_key <heading> <key> <default>` — per §3.6
+- `block_absent_note <heading>` — the fixed sentence
+
+This library is the only thing in S1 that reads a pact. It is plumbing, not a
+sentinel: it has no opinion, no threshold, and no output of its own beyond the
+value it was asked for.
 
 ## 4. Component 2 — Session Registry
 
@@ -273,14 +313,11 @@ the value it was asked for.
 }
 ```
 
-**Scope: machine-global, not per-repo.** Thrash-switching is a property of the
-human, not of a repository. Three sessions in three repos is exactly the case
-the WIP Warden exists to catch, and a per-repo registry reports `1` for each of
-them. The registry is therefore machine-global; the *limit* stays declared
-per-repo in `HARNESS.md` (this repo's opinion about your WIP), and the count it
-is compared against is global. This is what makes the `repo` field
-load-bearing rather than vestigial: it is how a consumer lists the other live
-sessions and where they are.
+**Scope: machine-global.** Thrash-switching is a property of the human, not of
+a repository. Three sessions in three repos is exactly the case the WIP Warden
+exists to catch, and a per-repo registry reports `1` for each of them. This is
+what makes the `repo` field load-bearing rather than vestigial: it is how a
+consumer lists the other live sessions and says where they are.
 
 Because the registry lives outside every work tree, no `.gitignore` entry is
 needed and nothing can accidentally commit it.
@@ -298,56 +335,65 @@ A value containing `/` or `..` in a path context is strictly worse than the
 JSON-injection case already fixed there, because the write lands outside the
 intended directory.
 
-**Collision rule.** Because sanitisation maps every hostile id to the single
-fallback `unknown`, at most one `unknown.json` can exist. A count that includes
-an `unknown` entry is flagged `inferred`, since that one file may stand for
-more than one session. A registry with no `unknown` entry is unaffected.
+**Collision rule.** Sanitisation maps every hostile id to the single fallback
+`unknown`, so at most one `unknown.json` can exist. A count including an
+`unknown` entry is flagged `inferred`, since that one file may stand for more
+than one session.
 
-### 4.2 Lifecycle — heartbeat, not delete
+### 4.2 Lifecycle — a lease with heartbeat renewal
 
-- **`SessionStart` hook** writes the entry if absent, and refreshes
-  `heartbeat` if present. It does **not** reset `started_at` — `SessionStart`
-  fires on startup, resume, clear, and compact, and a reset `started_at` would
-  mean a genuinely long-running session never ages out.
+The registry is a **lease**: an entry is valid for `stale_after_hours` from its
+last heartbeat, and staying alive means renewing.
+
+- **`SessionStart` hook** writes the entry if absent, and refreshes `heartbeat`
+  if present. It does **not** reset `started_at` — `SessionStart` fires on
+  startup, resume, clear, and compact, and a reset `started_at` would mean a
+  long-running session never ages out.
 - **`Stop` hook** refreshes `heartbeat`. It does **not** delete.
-- **Retirement** is by staleness alone: an entry whose `heartbeat` is older
-  than `SESSION_STALE_HOURS` (default 12) is retired by the pruner.
+- **Retirement** is by lease expiry alone: an entry whose `heartbeat` is older
+  than `stale_after_hours` (§3.3, default 12) is retired by the pruner.
 
-**Why heartbeat rather than delete-on-Stop.** The `Stop` hook fires when the
+**Why renewal rather than delete-on-`Stop`.** The `Stop` hook fires when the
 main agent finishes responding — many times per session, not once at session
 end. Every one of the nine existing `Stop` scripts declares "runs at session
 end" in its header comment and none carries a once-per-session guard; that is
 harmless for all nine, because each is an idempotent advisory whose worst
 failure is a duplicate nudge. The registry would be the first *destructive*
 consumer of that rail, and a destructive operation does not inherit an
-idempotent one's tolerance for unverified firing semantics. A delete-on-`Stop`
-registry would empty itself after each session's first response, and the WIP
-Warden would report `1` while four sessions ran.
+idempotent one's tolerance for unverified firing semantics. A
+delete-on-`Stop` registry would empty itself after each session's first
+response, and the WIP Warden would report `1` while four sessions ran.
 
-The heartbeat design makes correctness independent of how often `Stop` fires.
-Firing once per session, once per turn, or fifty times per turn all produce the
-same result: a live session stays fresh, a dead one goes stale.
+Renewal makes correctness independent of how often `Stop` fires. Once per
+session, once per turn, or fifty times per turn all produce the same result: a
+live session stays fresh, a dead one expires.
 
-### 4.3 Staleness and the honesty flag
+**Known limit of the lease, disclosed.** The renewal interval is "whenever the
+agent finishes a turn", which is unbounded above — a session where the human is
+reading, thinking, or waiting on a long tool run emits no heartbeat. Liveness
+here means *recency of a completed turn*, not "a window is open". A human who
+finds the default too short tunes `stale_after_hours`; that is what makes it a
+declared key rather than a constant.
 
-The flag is a property of the count, not of the reader. It is derived from
-durable state — the presence of a retirement marker written by the pruner,
-and the presence of an `unknown` entry — never from whether *this particular
-read* happened to prune something.
+### 4.3 The honesty flag
+
+The flag is a property of the count, not of the reader. It derives from durable
+state — a retirement marker written by the pruner, and the presence of an
+`unknown` entry — never from whether *this particular read* pruned something.
 
 | Situation | Flag |
 | --- | --- |
-| No entry retired within the staleness window; no `unknown` entry | `observed` |
+| No entry retired within the window; no `unknown` entry | `observed` |
 | One or more entries retired within the window | `inferred` |
-| An `unknown` entry present (see §4.1 collision rule) | `inferred` |
+| An `unknown` entry present (§4.1) | `inferred` |
 | No registry directory at all | `observed`, count 0 |
 
 A count that followed a retirement is `inferred` because the pruner cannot
 distinguish a crashed session from a long-running healthy one — it only knows
-the entry aged out. That uncertainty persists for every subsequent read, so
-the flag must persist with it. A flag that survived only the first read after
-a prune would disclose the uncertainty to whichever consumer happened to be
-first and hide it from all the others.
+the lease expired. That uncertainty persists for every subsequent read, so the
+flag must persist with it. A flag surviving only the first read after a prune
+would disclose the uncertainty to whichever consumer happened to be first and
+hide it from all the others.
 
 ### 4.4 Two libraries, split on the trust boundary
 
@@ -355,42 +401,68 @@ first and hide it from all the others.
 `Write`/`Edit` in an agent's `tools:` list, and explicitly permits `Bash`. Its
 own header names the limit: an agent reaching a write capability through an
 undeclared channel is out of scope. A single shared library exposing mutation
-functions to every sentinel would manufacture exactly that case, and CI would
-stay green while a `role: sentinel` agent deleted files.
-
-So the implementation splits:
+to every sentinel would manufacture exactly that case, and CI would stay green
+while a `role: sentinel` agent deleted files.
 
 | File | Exposes | Who may source it |
 | --- | --- | --- |
 | `hooks/scripts/lib/session-registry-read.sh` | `registry_count` (count + flag), `registry_list` | hook scripts **and** sentinels |
 | `hooks/scripts/lib/session-registry-write.sh` | `registry_touch`, `registry_prune` | hook scripts **only** |
 
-The read library performs no mutation on any path. This generalises the same
+The read library performs no mutation on any path. This generalises the
 reasoning that keeps the Coda read-only (§8, Note D): the boundary is preserved
 by what the agent *can* reach, not by what it is trusted not to call.
 
-`hooks/scripts/lib/` does not exist yet; `scripts/lib/` does, so the pattern is
-established in the repo and this follows it.
-
 ## 5. Component 3 — Record Directories and Schemas
 
-Two directories, each with a `README.md` carrying the schema below. Both
-schemas are declared here, in full, because a substrate that defers its
-schemas to its consumers is the half-feature §1 exists to prevent.
+Two directories, `docs/superpowers/parked/` and
+`docs/superpowers/consultations/`, each with a `README.md` that **points at**
+its format reference rather than duplicating it.
 
-Both records are **append-only** (constraint 7): a superseded entry gains
-`status: superseded` and a `superseded_by` pointer, and is never edited in
-place or deleted.
+The schemas themselves live at:
 
-### 5.1 Parking record — `docs/superpowers/parked/<YYYY-MM-DD>-<slug>.md`
+- `docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md`
+- `docs/plugins/ai-literacy-superpowers/reference/consultation-record-format.md`
+
+matching the repo's three existing `reference/*-format.md` pages. A README
+inside `docs/superpowers/` would be committed but never published —
+`mkdocs.yml:15` carries `exclude_docs: superpowers/` — so a format contract
+homed there is the one contract in the repo an adopter cannot read.
+
+**S1 owns these two contracts; S2 and S5 consume them.** Per the promoted
+ARCH_DECISION, a consumer never mutates the contract it consumes: the first
+time S2 needs a field the parking schema lacks, it carves a contract-owning
+slice with its own adversarial pass rather than editing the reference page.
+
+### 5.1 Append-only via state-in-the-path
+
+Constraint 7 says records are append-only. A single mutable `status` key
+contradicts that: editing `parked` to `resumed` in place *is* an in-place edit.
+So **state lives in the filename**, and a transition writes a new file.
+
+```text
+docs/superpowers/parked/2026-08-08-retry-branch.md              <- parked
+docs/superpowers/parked/2026-08-09-retry-branch.resumed.md      <- resumed
+docs/superpowers/parked/2026-08-09-retry-branch.superseded.md   <- superseded
+```
+
+"What is still parked" is a glob: every `*.md` that is not itself a transition
+file and is not named by any transition's `supersedes` field. Nothing is ever
+edited, and nothing is ever deleted.
+
+This also fits the Coda's trust boundary: resuming is a *write* by the `/coda`
+command, not an *edit* of an existing record, so the read-only agent never
+needs a mutation path.
+
+### 5.2 Parking record
 
 ```yaml
 ---
 session: <sanitised session id>
 repo: <absolute path to project root>
 created: <YYYY-MM-DD>
-status: parked | resumed | superseded
-superseded_by: <filename> | null
+state: parked | resumed | superseded
+supersedes: <filename> | null
 next_action_flag: asked
 ---
 ```
@@ -398,21 +470,23 @@ next_action_flag: asked
 Body: a `## Context` section (one paragraph) and a `## Next action` section
 (one concrete resume step).
 
-`next_action_flag` is always `asked` — the next action is supplied by the
-human at the ritual, never inferred by the agent. Recording the flag keeps
-constraint 3 satisfied without implying the Coda observed anything.
+`state` restates what the filename already says, for readability; the filename
+is authoritative. `next_action_flag` is always `asked` — the next action is
+supplied by the human at the ritual, never inferred by the agent. Recording the
+flag satisfies constraint 3 without implying the Coda observed anything.
 
-Resuming appends `status: resumed`; it never deletes the record. Consumed by
-S2.
+`session` is **opaque provenance, not a lookup key**. The registry forgets an
+entry one lease after its last heartbeat; a parking record is permanent. S2
+must never resolve a parking record's `session` against the live registry.
 
-### 5.2 Consultation record — `docs/superpowers/consultations/<YYYY-MM-DD>-<slug>.md`
+### 5.3 Consultation record
 
 ```yaml
 ---
 spec: <path to the spec under approval>
 date: <YYYY-MM-DD>
-status: open | resolved | superseded
-superseded_by: <filename> | null
+state: open | resolved | superseded
+supersedes: <filename> | null
 voices:
   - voice: <role or group>
     source_flag: observed | inferred | asked
@@ -423,108 +497,118 @@ voices:
 ```
 
 `source_flag` records how the voice was identified: `observed` when a declared
-stakeholder map named it, `inferred` when it was derived from the change
-itself, `asked` when the human named it. Every voice carries a disposition;
-`deliberately-not-consulted` requires an `outcome` giving the because.
+stakeholder map named it, `inferred` when derived from the change itself,
+`asked` when the human named it. `deliberately-not-consulted` requires an
+`outcome` giving the because.
 
-Consumed by S5.
+Because dispositions accumulate during a review, a consultation record is
+written once per **revision**: disposing voices produces a new `.resolved.md`
+file carrying the full voice list with dispositions filled, `supersedes`-ing
+the open one. The frontmatter of a written record is never edited.
 
 ## 6. Non-Goals
 
 - **No gating.** Nothing in this slice blocks, warns, or requires a
   disposition.
 - **No sentinel agents, skills, or commands.** S1 ships no `role: sentinel`
-  agent. The shared block reader (§3.7) is a parsing library, not a consumer:
-  it answers "what does the block say", never "what should be done about it".
-- **No changes to the Reservoir Warden**, its block, its hook, or its skill.
+  agent. The block reader (§3.8) is a parsing library, not a consumer: it
+  answers "what does the block say", never "what should be done about it".
+- **No changes to the Reservoir Warden**, its `HARNESS.md` block, its hook, or
+  its skill. `## Cognitive reservoir` is not migrated to the pact file.
 - **No `Sync cadence` consumer.**
-- **No fix to the template's inline-comment trap** (§8, Note A). It is
-  pre-existing, it affects a different block, and folding it in would widen a
-  plumbing slice into a bug fix. Raised as a follow-up.
+- **No pact file created for anyone.** S1 ships the template; S3's Tune
+  authors the file.
+- **No fix to the template's inline-comment trap** (§8, Note A).
 
 ## 7. Acceptance Scenarios (TDAD)
 
-Scenarios carry stable prefixed ids so later slices can cite them: **B** for
-block behaviour, **R** for the registry, **C** for the record schemas.
+Scenarios carry stable prefixed ids: **B** for block behaviour, **R** for the
+registry, **C** for the record contracts. Every block scenario runs against a
+**fixture** pact file via `$CLAUDE_PACTS_FILE`; no test asserts a value a human
+is expected to change.
 
-### 7.1 Blocks — `tdad_tests/layer0_deterministic/test-cadence-blocks.sh`
+### 7.1 Blocks — `tdad_tests/layer0_deterministic/test-pact-blocks.sh`
 
-- **B1 — Template blocks present and commented.** Given
-  `templates/HARNESS.md`, then all three block headings exist inside comment
-  fences, and no value line in any of the three carries a trailing `#`
-  comment.
-- **B2 — Not-a-debt clause present.** Given the `Budgets` template block, then
-  its prose contains the literal string `Unspent budget is not a debt.`
-- **B3 — Live activation.** Given this repo's root `HARNESS.md`, then all
-  three blocks are active, and `Budgets` declares `authored_via: placeholder`.
-- **B4 — Absent block, each of three.** Given a `HARNESS.md` with no such
-  heading, when `block_state` runs, then it reports `absent` and
-  `block_absent_note` emits the §3.6 sentence, exit 0.
-- **B5 — Commented block does not read as declared.** Given a `HARNESS.md`
-  carrying the three blocks still inside their comment fences, when
-  `block_state` runs for each, then each reports `absent` — a template a
-  project has not opted into is not a declaration.
-- **B6 — Malformed block.** Given an active `Budgets` block whose prose is
-  missing the not-a-debt clause, when `block_state` runs, then it reports
-  `malformed`, the consumer degrades to observe-only, and a note names the
-  missing clause. No gate fires.
-- **B7 — Colon- and space-bearing values survive.** Given an active `Budgets`
-  block, when `block_key` reads each key, then `hard_stop_hour` returns
-  `18:30` (not `30`), `focus_blocks` returns the full comma-separated ranges
-  (not `00`), and `daily_cost_ceiling` returns `not observable` with its
-  interior space intact.
-- **B8 — Block-scoped key isolation.** Given a `HARNESS.md` with **two**
-  active blocks that both declare a key of the same name with different
-  values, when `block_key` runs against each block, then each returns its own
-  block's value. A whole-file parser fails this scenario.
+- **B1 — Template well-formed.** Given `templates/pacts.md`, then all three
+  block headings exist, and no value line in any of the three carries a
+  trailing `#` comment.
+- **B2 — Mandatory clauses present.** Given `templates/pacts.md`, then the
+  `Budgets` prose contains `Unspent budget is not a debt.` and the
+  `Session WIP` prose contains its gate-on-sessions clause.
+- **B3 — Reserved marker present.** Given `templates/pacts.md`, then the
+  `Sync cadence` block prose carries the reserved marker.
+- **B4 — No pact file at all.** Given `$CLAUDE_PACTS_FILE` points nowhere, when
+  `block_state` runs for each of the three, then each reports `absent`,
+  `block_absent_note` emits the §3.7 sentence, exit 0.
+- **B5 — Absent block in a present file.** Given a pact file declaring only
+  `Budgets`, when `block_state Session WIP` runs, then it reports `absent`.
+- **B6 — Malformed block.** Given a pact file whose `Budgets` prose is missing
+  the not-a-debt clause, when `block_state` runs, then it reports `malformed`,
+  the consumer degrades to observe-only, and a note names the missing clause.
+  No gate fires.
+- **B7 — Colon- and space-bearing values survive.** Given a declared `Budgets`
+  block, when `block_key` reads each key, then `hard_stop_hour` returns `18:30`
+  (not `30`), `focus_blocks` returns the full comma-separated ranges (not
+  `00`), and `daily_cost_ceiling` returns `not observable` with its interior
+  space intact.
+- **B8 — Block-scoped key isolation.** Given a pact file with **two** blocks
+  declaring a key of the same name with different values, when `block_key` runs
+  against each, then each returns its own block's value. A whole-file parser
+  fails this scenario.
+- **B9 — Default returned for an absent key.** Given a declared block missing
+  an optional key, when `block_key` runs with a default, then the default is
+  returned and no error is raised.
 
 ### 7.2 Registry — `tdad_tests/layer0_deterministic/test-session-registry.sh`
 
-- **R1 — Write on start.** Given no entry for session X, when the
-  `SessionStart` hook runs, then `~/.claude/sessions/X.json` exists with `id`,
-  `repo`, `started_at`, and `heartbeat`.
+- **R1 — Write on start.** Given no entry for session X, when `SessionStart`
+  runs, then the entry exists with `id`, `repo`, `started_at`, `heartbeat`.
 - **R2 — `SessionStart` re-fire preserves `started_at`.** Given an existing
-  entry for X, when `SessionStart` fires again, then `heartbeat` advances and
+  entry, when `SessionStart` fires again, then `heartbeat` advances and
   `started_at` is unchanged.
-- **R3 — `Stop` refreshes, never deletes.** Given an entry for X, when the
-  `Stop` hook runs three times, then the entry still exists and `heartbeat`
-  has advanced. This is the scenario that would have caught the
-  delete-on-`Stop` design.
-- **R4 — Two overlapping sessions counted.** Given entries for X and Y, both
-  fresh, when `registry_count` runs, then it reports `2` flagged `observed`.
-- **R5 — Stale entry retired, count flagged inferred.** Given an entry whose
-  `heartbeat` is older than `SESSION_STALE_HOURS`, when the pruner runs and
-  `registry_count` follows, then the stale entry is gone and the count is
-  flagged `inferred`.
+- **R3 — `Stop` renews, never deletes.** Given an entry for X, when `Stop` runs
+  three times, then the entry still exists and `heartbeat` has advanced. This
+  is the scenario that would have caught the delete-on-`Stop` design.
+- **R4 — Two overlapping sessions counted.** Given fresh entries for X and Y,
+  when `registry_count` runs, then it reports `2` flagged `observed`.
+- **R5 — Expired lease retired, count flagged inferred.** Given an entry whose
+  `heartbeat` is older than the lease, when the pruner runs and
+  `registry_count` follows, then the entry is gone and the count is `inferred`.
 - **R6 — Flag survives repeated reads.** Given the state after R5, when
-  `registry_count` runs a second and third time, then every read still reports
-  `inferred`. The flag is a property of the count, not of the reader.
-- **R7 — `registry_count` mutates nothing.** Given any registry state, when
+  `registry_count` runs again twice, then every read still reports `inferred`.
+- **R7 — Lease length is declared.** Given a pact file declaring
+  `stale_after_hours: 2` and an entry whose heartbeat is 3 hours old, when the
+  pruner runs, then the entry is retired. Given `stale_after_hours: 24`, the
+  same entry survives.
+- **R8 — `registry_count` mutates nothing.** Given any registry state, when
   `registry_count` runs, then the directory's contents are byte-identical
   before and after.
-- **R8 — Read library exposes no mutation.** Given
+- **R9 — Read library exposes no mutation.** Given
   `lib/session-registry-read.sh`, then it defines no function that writes,
   deletes, or moves a file, and `registry_touch` / `registry_prune` are
   undefined after sourcing it alone.
-- **R9 — Hostile session id sanitised.** Given a hook input whose `session_id`
-  contains `/` or `..`, when the `SessionStart` hook runs, then the written
-  path is `~/.claude/sessions/unknown.json` and no file is created outside
-  that directory.
-- **R10 — `unknown` entry flags the count inferred.** Given a registry
-  containing an `unknown.json` entry, when `registry_count` runs, then the
-  count is flagged `inferred`.
-- **R11 — No registry directory.** Given `~/.claude/sessions/` does not exist,
+- **R10 — Hostile session id sanitised.** Given a hook input whose `session_id`
+  contains `/` or `..`, when `SessionStart` runs, then the written path is
+  `<registry>/unknown.json` and no file is created outside that directory.
+- **R11 — `unknown` entry flags the count inferred.** Given a registry
+  containing `unknown.json`, when `registry_count` runs, then the count is
+  flagged `inferred`.
+- **R12 — No registry directory.** Given the registry directory does not exist,
   when `registry_count` runs, then it reports `0` flagged `observed`, exit 0.
-- **R12 — Registry lives outside every work tree.** Given a written registry
-  entry, when `git status --porcelain` runs in this repo, then no session path
-  appears.
+- **R13 — Registry lives outside every work tree.** Given a written entry, when
+  `git status --porcelain` runs in this repo, then no session path appears.
 
-### 7.3 Record schemas — same block test file
+### 7.3 Record contracts — `tdad_tests/layer0_deterministic/test-record-contracts.sh`
 
-- **C1 — READMEs carry the declared schemas.** Given
-  `docs/superpowers/parked/README.md` and
-  `docs/superpowers/consultations/README.md`, then each contains every field
-  named in §5.1 and §5.2 respectively, and each states the append-only rule.
+- **C1 — Reference pages carry the schemas.** Given the two
+  `reference/*-record-format.md` pages, then each contains every field named in
+  §5.2 and §5.3 respectively, and each states the state-in-the-path rule.
+- **C2 — Directory READMEs point, not duplicate.** Given each record
+  directory's README, then it links its reference page and declares no field
+  set of its own.
+- **C3 — State-in-path glob.** Given a fixture directory containing a parked
+  record, its `.resumed.md` successor, and an unrelated parked record, then the
+  documented glob yields exactly the one still-parked record.
 
 ## 8. Notes and Divergences from the Build Spec
 
@@ -532,30 +616,25 @@ block behaviour, **R** for the registry, **C** for the record schemas.
 shipped `## Cognitive reservoir` template block carries inline `#` comments on
 its value lines (`templates/HARNESS.md:614–621`). A downstream project that
 uncomments the block and tunes a value gets a silent degrade to the built-in
-default, because `read_key` does not strip trailing comments. The live
-`HARNESS.md` block documents the rule correctly; the template does not follow
-it. Raised as a follow-up issue, not fixed here.
+default. Raised as a follow-up issue, not fixed here.
 
-**Note B — registry location.** `~/.claude/sessions/`, machine-global. The
-build spec proposed `.superpowers/sessions/`; the first revision of this spec
-proposed `.claude/sessions/` (per-repo). The diaboli gate established that
-per-repo scope cannot see the concurrency the WIP Warden exists to catch, and
-machine-global scope moots the `.gitignore` question entirely. See §4.1.
+**Note B — pacts are user-scoped.** `~/.claude/pacts.md`, not `HARNESS.md` and
+not `.superpowers/`. The build spec located the blocks in the harness template;
+disposed otherwise at the cartographer gate on stories #4 and #5. See §3.1.
+**Flag this in the PR description.**
 
-**Note C — heartbeat, not delete-on-`Stop`.** See §4.2.
+**Note C — lease with heartbeat renewal, not delete-on-`Stop`.** See §4.2.
 
 **Note D — the sentinel category is already load-bearing.** Build-spec
 constraint 9 anticipates a repo that has not yet adopted the sentinel category
 and asks for a docs-only introduction. The category shipped in v0.66.0 with a
 spec, the `sentinel-design` skill, a README section, `role: sentinel`
 frontmatter, and `scripts/sentinel-integrity-check.sh` gating both PRs and the
-weekly GC sweep. Consequences for later slices, recorded here because they were
-discovered in this slice's exploration:
+weekly GC sweep. Consequences for later slices:
 
 - Every new sentinel must satisfy S1–S3 and carry `role: sentinel`.
 - The Coda cannot hold `Write`. Its agent returns record content; the `/coda`
   command persists it after a human disposes — the `cost-estimator` precedent.
-  Disposed by Russ, 2026-08-08.
 - The same reasoning generalises to shared libraries, which is why §4.4 splits
   read from write rather than trusting sentinels not to call a mutator.
 - S7's "create a sentinel category page" becomes "extend the existing one",
@@ -564,18 +643,22 @@ discovered in this slice's exploration:
 
 **Note E — deriving the count from the invocation log was considered and
 rejected.** `observability/affordance-invocations.json` already records
-`{"session": ..., "ts": ...}` per tool call, sanitised and size-bounded, and a
-live-session count is derivable from it with no new hooks. It was rejected
-because the recorder's `PostToolUse` matcher is `Bash|mcp__.*`: a session that
-only reads and edits files never appears in the log, so the derived count would
-silently undercount exactly the long-running sessions the WIP Warden exists to
-notice. The `asked` fallback — a sentinel simply asking how many sessions are
-open — remains available to S4 as an honesty option when observation fails.
+`{"session": ..., "ts": ...}` per tool call. Rejected because the recorder's
+`PostToolUse` matcher is `Bash|mcp__.*`: a session that only reads and edits
+files never appears, so the derived count would silently undercount exactly the
+long-running sessions the WIP Warden exists to notice. The `asked` fallback
+remains available to S4 when observation fails.
+
+**Note F — nothing about the person is committed.** Revision 2 activated a
+`Budgets` block in this repo's public `HARNESS.md` and argued it was permitted
+by §2's BY/ABOUT boundary. Revision 3's user-scoped pact file moots the
+question: no pact is committed anywhere. The BY/ABOUT distinction still goes
+into `sentinel-design`, because S2's and S5's records *are* committed and need
+the rule.
 
 ## 9. Migration & Rollout
 
-Minor version bump, 0.66.2 → 0.67.0 — the slice adds hooks and template
-content, which the repo's semver rule scopes as minor.
+Minor version bump, 0.66.2 → 0.67.0.
 
 Version locations (five CI-checked, plus one human-facing):
 
@@ -586,16 +669,15 @@ Version locations (five CI-checked, plus one human-facing):
 - `.claude-plugin/marketplace.json` — this plugin's `plugins[].version`
 - `README.md` plugin-table row cell (not CI-checked)
 
-Reference pages updated in the same PR, per the `Docs Site Review` convention:
+Docs, in the same PR per the `Docs Site Review` convention:
 
-- `docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md` — the
-  three new blocks, including the value grammar from §3.2–§3.4, which is the
-  part adopters most need
-- `docs/plugins/ai-literacy-superpowers/reference/hooks.md` — the
-  `SessionStart` and `Stop` registry entries
+- `reference/pacts-format.md` — new; the three blocks and the value grammar
+- `reference/parking-record-format.md` and
+  `reference/consultation-record-format.md` — new; §5.2 and §5.3
+- `reference/hooks.md` — the `SessionStart` and `Stop` registry entries
+- `explanation/sentinels.md` — a pointer noting the pact file as a new
+  declaration surface distinct from `HARNESS.md`
 
-No breaking changes. All three blocks are additive and optional; the registry
-is machine-local state outside every work tree that no existing hook reads; the
-record directories are new and empty but for their READMEs.
-`/harness-upgrade` surfaces the three new template blocks to downstream
-projects as optional adoptable content.
+No breaking changes. `HARNESS.md` is untouched. The pact file does not exist
+until authored; the registry is machine-local state outside every work tree
+that no existing hook reads; the record directories are new.

--- a/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
@@ -1,9 +1,11 @@
 # Spec: Cadence Sentinels S1 — Shared Infrastructure
 
-**Status:** Approved
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-08
 **Issue:** #491
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Objection record:** `docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md`
+— 12 objections, 11 accepted, 1 rejected on the record
 **Scope:** `ai-literacy-superpowers` plugin, this repo's own `HARNESS.md`, and
 two new record directories
 **Explicitly out of scope:** every sentinel that consumes this plumbing. S1
@@ -31,19 +33,35 @@ This slice builds it once.
 
 ## 2. Design Principles Inherited
 
-Every constitutional constraint from the build spec binds this slice. Three
-bind it concretely:
+Every constitutional constraint from the build spec binds this slice. Four
+bind it concretely.
 
-- **Honesty flags (constraint 3).** Every count this infrastructure yields
-  carries `observed` / `inferred` / `asked`. A session count derived from a
-  registry with no pruned entries is `observed`; the same count after stale
-  entries were pruned is `inferred`, and the consumer must be able to tell
-  which.
-- **Persist nothing about the person (constraint 4).** The registry records
-  that a session exists, when it started, and against which repo. It records
-  nothing about who is in it or how they are doing.
-- **Progressive hardening (constraint 6).** Nothing here enforces anything.
-  All three blocks are optional; every consumer degrades to observe-only.
+**Honesty flags (constraint 3).** Every count this infrastructure yields
+carries `observed` / `inferred` / `asked`. The flag is a property of the
+*count*, not of the reader who happened to take it — see §4.3.
+
+**Persist nothing about the person (constraint 4), and its boundary.** The
+constraint targets **claims an agent makes *about* the person** — inference,
+telemetry, scoring, any assertion about capacity or state. It does **not**
+cover a pact the person authored themselves. A declared budget is a statement
+*by* the human, not an observation *about* them, and a pact that is not durable
+is not a pact.
+
+The existing `## Cognitive reservoir` block already works this way: it holds
+`chronotype: intermediate`, self-declared, in committed `HARNESS.md`, while
+its own prose forbids recording "a claim about your cognitive state to disk".
+Self-authored declaration is on one side of the line; agent-authored assertion
+is on the other.
+
+This distinction is load-bearing for S2–S5 — parking records and consultation
+dispositions are both records of how the human works — so it is carried into
+`skills/sentinel-design/SKILL.md` rather than left as a fact about this spec.
+
+**Read-only trust boundary (constraint 1).** Any library a sentinel may source
+must be incapable of mutation. See §4.4.
+
+**Progressive hardening (constraint 6).** Nothing here enforces anything. All
+three blocks are optional; every consumer degrades to observe-only.
 
 ## 3. Component 1 — Three `HARNESS.md` Block Schemas
 
@@ -66,32 +84,72 @@ this rule; the shipped template violates it. See §8, Note A.
 
 ```text
 - max_concurrent_sessions: <int>
-- max_switches_per_hour: <int>       (optional)
+- max_switches_per_hour: <int>
 - enforcement: advisory | strict
 ```
 
-Consumed by the WIP Warden (S4). `enforcement` defaults to `advisory` when the
-block is present but the key is absent.
+| Key | Grammar | Required |
+| --- | --- | --- |
+| `max_concurrent_sessions` | single integer | yes |
+| `max_switches_per_hour` | single integer | no |
+| `enforcement` | one of `advisory`, `strict` | no (defaults `advisory`) |
+
+**`enforcement` semantics, defined here so S4 inherits a defined token rather
+than defining one already declared in the wild:**
+
+- `advisory` — the WIP Warden reports the breach and proceeds. No disposition
+  required.
+- `strict` — the WIP Warden requires a **disposition** before the session
+  proceeds: either park an existing session, or override. It never blocks
+  without an override path, and the override is always available.
+
+The override is recorded in the new session's reflection entry, one line
+naming what was urgent enough. That is the on-the-record human override
+constraint 6 requires; there is no bypass, and `strict` never means
+"unconditionally refuse".
+
+`max_concurrent_sessions` counts sessions **machine-wide**, not in this repo —
+see §4.1. The limit is declared per-repo; the count it is compared against is
+global.
+
+The block carries a mandatory prose clause, mirroring `Budgets`:
+
+> This is a gate on sessions, never on the person. It counts; it does not
+> assess.
 
 ### 3.3 `## Budgets`
 
 ```text
-- daily_cost_ceiling: <amount, or "not observable">
+- daily_cost_ceiling: <amount> | not observable
 - sessions_per_day: <int>
-- hard_stop_hour: <HH:MM local>
-- focus_blocks: <HH:MM-HH:MM, HH:MM-HH:MM>
+- hard_stop_hour: <HH:MM>
+- focus_blocks: <HH:MM-HH:MM>, <HH:MM-HH:MM>
 - notification_policy_after_stop: digest | none
 - authored_at: <YYYY-MM-DD>
 - authored_via: tune | placeholder
 ```
+
+| Key | Grammar | Notes |
+| --- | --- | --- |
+| `daily_cost_ceiling` | free text | the literal `not observable` is a valid, honest value |
+| `sessions_per_day` | single integer | |
+| `hard_stop_hour` | `HH:MM`, 24-hour, local time | **contains a colon** |
+| `focus_blocks` | comma-separated `HH:MM-HH:MM` ranges | **contains colons and spaces** |
+| `notification_policy_after_stop` | one of `digest`, `none` | |
+| `authored_at` | `YYYY-MM-DD` | |
+| `authored_via` | one of `tune`, `placeholder` | |
+
+The grammar column is not decoration. Three of these values contain colons and
+two contain spaces, which is precisely what the inherited parser destroys —
+see §3.7.
 
 The block template carries a **mandatory literal clause** in its prose body:
 
 > Unspent budget is not a debt.
 
 The clause is part of the block, not a comment on it. A `Budgets` block whose
-prose has lost the clause is a malformed block, and S3's critic check will say
-so.
+prose has lost the clause is **malformed** — a distinct state from absent,
+defined in §3.6.
 
 `authored_at` and `authored_via` exist for S3's clear-weather rule: budgets
 that hold are budgets their keeper authored deliberately, so the block records
@@ -104,8 +162,13 @@ Consumed by the Mast (S3), which owns the only sanctioned editing path.
 
 ```text
 - interrupt_mode: streaming | coalesced
-- sync_points: <HH:MM, HH:MM | on-demand>
+- sync_points: <HH:MM>, <HH:MM> | on-demand
 ```
+
+| Key | Grammar |
+| --- | --- |
+| `interrupt_mode` | one of `streaming`, `coalesced` |
+| `sync_points` | comma-separated `HH:MM` times, or the literal `on-demand` |
 
 Declared here; no S1–S7 sentinel consumes it yet. It ships now because the
 three blocks form one vocabulary and splitting their introduction across slices
@@ -119,19 +182,36 @@ this repo's own root `HARNESS.md`, exactly as `## Cognitive reservoir` is. The
 repo dogfoods its own harness; a sentinel written in S2–S5 against a block that
 exists nowhere real is a sentinel tested only against its own fixtures.
 
+Committing a `Budgets` block to public history is permitted by the boundary
+drawn in §2: these are pacts the keeper declared, not claims an agent made.
+
 `Budgets` is activated with provisional values and `authored_via: placeholder`.
 It is **not** authored in this slice — authoring it here would produce exactly
 the imposed-default budget the clear-weather rule says does not hold. S3's Tune
 dialogue is where the real pact gets made, and it will overwrite these values
 and set `authored_via: tune`.
 
-### 3.6 Absent-block behaviour
+### 3.6 Three block states
 
-Every block is optional. A consumer that finds its block absent reports:
+A block is in exactly one of three states, and consumers must distinguish them.
+
+| State | Test | Consumer behaviour |
+| --- | --- | --- |
+| **Absent** | no uncommented heading of that name | emit the observe-only note, continue |
+| **Malformed** | heading present, but a mandatory clause or required key is missing | emit the observe-only note **plus** a one-line note naming what is missing, continue |
+| **Declared** | heading present and well-formed | read it |
+
+The observe-only note is a fixed sentence, emitted by the library so every
+consumer says the same thing:
 
 > no `<block name>` block declared — running in observe-only mode
 
-and continues. Absence is never an error, never a warning, and never a gate.
+**Malformed degrades to observe-only, never to a gate.** This is the reachable
+case: someone uncomments the template, deletes prose they read as boilerplate,
+and now holds a block that is present, active, parseable, and missing its
+not-a-debt clause. Treating that as declared would let S3 hold them to a pact
+whose governing clause they deleted. Absence is never an error, never a
+warning, and never a gate; malformed is a note, and also never a gate.
 
 ### 3.7 Shared block reader
 
@@ -139,15 +219,40 @@ and continues. Absence is never an error, never a warning, and never a gate.
 parsing, so the three near-identical parsers named in §1 never get written.
 It exposes:
 
-- `block_active <block-heading>` — true when an **uncommented** level-2..6
-  heading of that name exists, mirroring `reservoir-check.sh:30`'s
-  active-heading test so a commented template block never reads as declared
+- `block_state <block-heading>` — `absent` | `malformed` | `declared`,
+  testing for an **uncommented** level-2..6 heading, mirroring
+  `reservoir-check.sh:30`'s active-heading test so a commented template block
+  never reads as declared
 - `block_key <block-heading> <key> <default>` — the value, scoped to that
-  block's span rather than the whole file (the reservoir `read_key` searches
-  the entire document, which is safe for its unique keys but not for a
-  vocabulary of three blocks that may share key names in future)
-- `block_absent_note <block-heading>` — the observe-only line from §3.6, so
-  every consumer emits the same sentence
+  block's span
+- `block_absent_note <block-heading>` — the fixed sentence from §3.6
+
+**The value-extraction rule.** `block_key` splits on the **first** delimiter
+and trims whitespace **at the ends only**. It does not reuse `read_key`'s
+extraction.
+
+`read_key`'s `sed -E "s/.*[:=][[:space:]]*//"` is greedy — `.*[:=]` consumes
+through the *last* colon on the line — and its `tr -d '[:space:]'` deletes
+interior spaces. Verified empirically at the spec gate:
+
+| Input line | `read_key` yields | Correct |
+| --- | --- | --- |
+| `hard_stop_hour: 18:30` | `30` | `18:30` |
+| `focus_blocks: 09:00-12:00, 14:00-17:00` | `00` | `09:00-12:00, 14:00-17:00` |
+| `daily_cost_ceiling: not observable` | `notobservable` | `not observable` |
+| `window_hours: 8` | `8` | `8` |
+
+`read_key` is safe today only because every reservoir value is a bare integer
+or a single word. Three of the seven `Budgets` keys break it. This is the same
+class of silent-degradation defect as Note A, and it bites harder, because a
+`hard_stop_hour` that parses to `30` looks like nothing in particular to a
+reader while S3 holds them to a budget nobody authored.
+
+**Block scoping.** A key lookup is confined to the span between its block's
+heading and the next heading of equal-or-higher level. This is the property
+that justifies a second parser at all, and §7 scenario 11 tests it with two
+active blocks declaring the same key — a single-block fixture cannot
+distinguish block-scoped lookup from whole-file lookup.
 
 This library is the *only* thing in S1 that reads a block. It is plumbing, not
 a sentinel: it has no opinion, no threshold, and no output of its own beyond
@@ -155,83 +260,174 @@ the value it was asked for.
 
 ## 4. Component 2 — Session Registry
 
-### 4.1 Location and format
+### 4.1 Location, scope, and format
 
-`.claude/sessions/<session-id>.json`, one file per live session:
+`~/.claude/sessions/<sanitised-session-id>.json`, one file per live session:
 
 ```json
 {
-  "id": "<session id>",
+  "id": "<sanitised session id>",
   "repo": "<absolute path to project root>",
-  "started_at": "<ISO-8601 UTC>"
+  "started_at": "<ISO-8601 UTC>",
+  "heartbeat": "<ISO-8601 UTC>"
 }
 ```
 
-**Location disposition (open decision 1, disposed 2026-08-08):** the build spec
-proposed `.superpowers/sessions/`. This repo has no `.superpowers/` directory
-and no precedent for one. Per-machine local session state already lives in
-`.claude/` — `.claude/.harness-upgrade-dismissed` and
-`.claude/affordance-discovery-*.md` are both there and both gitignored.
-`.claude/sessions/` matches that practice. Append-only *logs* live in
-`observability/`; the registry is ephemeral live state, not a log, so that
-directory is the weaker fit.
+**Scope: machine-global, not per-repo.** Thrash-switching is a property of the
+human, not of a repository. Three sessions in three repos is exactly the case
+the WIP Warden exists to catch, and a per-repo registry reports `1` for each of
+them. The registry is therefore machine-global; the *limit* stays declared
+per-repo in `HARNESS.md` (this repo's opinion about your WIP), and the count it
+is compared against is global. This is what makes the `repo` field
+load-bearing rather than vestigial: it is how a consumer lists the other live
+sessions and where they are.
 
-The registry is gitignored. It is operational state, not a record. Nothing in
-it is ever committed, and nothing downstream may treat it as history.
+Because the registry lives outside every work tree, no `.gitignore` entry is
+needed and nothing can accidentally commit it.
 
-### 4.2 Lifecycle
+**Session id sanitisation.** The id arrives from the hook's stdin JSON
+(`session_id`) and becomes a filesystem path component, so it is sanitised
+before use with the pattern this repo already adjudicated for the same field
+in `affordance-invocation-recorder.sh:55`:
 
-- **`SessionStart` hook** writes the entry.
-- **`Stop` hook** removes this session's entry and prunes stale ones.
+```bash
+printf '%s' "$session" | grep -qE '^[A-Za-z0-9._-]+$' || session="unknown"
+```
 
-`Stop` is used rather than `SessionEnd` because `hooks.json` already runs nine
-`Stop` hooks and none on `SessionEnd`; adding to the existing rail keeps the
-hook surface honest and gives the pruner the same firing guarantees the
-reservoir check already relies on.
+A value containing `/` or `..` in a path context is strictly worse than the
+JSON-injection case already fixed there, because the write lands outside the
+intended directory.
+
+**Collision rule.** Because sanitisation maps every hostile id to the single
+fallback `unknown`, at most one `unknown.json` can exist. A count that includes
+an `unknown` entry is flagged `inferred`, since that one file may stand for
+more than one session. A registry with no `unknown` entry is unaffected.
+
+### 4.2 Lifecycle — heartbeat, not delete
+
+- **`SessionStart` hook** writes the entry if absent, and refreshes
+  `heartbeat` if present. It does **not** reset `started_at` — `SessionStart`
+  fires on startup, resume, clear, and compact, and a reset `started_at` would
+  mean a genuinely long-running session never ages out.
+- **`Stop` hook** refreshes `heartbeat`. It does **not** delete.
+- **Retirement** is by staleness alone: an entry whose `heartbeat` is older
+  than `SESSION_STALE_HOURS` (default 12) is retired by the pruner.
+
+**Why heartbeat rather than delete-on-Stop.** The `Stop` hook fires when the
+main agent finishes responding — many times per session, not once at session
+end. Every one of the nine existing `Stop` scripts declares "runs at session
+end" in its header comment and none carries a once-per-session guard; that is
+harmless for all nine, because each is an idempotent advisory whose worst
+failure is a duplicate nudge. The registry would be the first *destructive*
+consumer of that rail, and a destructive operation does not inherit an
+idempotent one's tolerance for unverified firing semantics. A delete-on-`Stop`
+registry would empty itself after each session's first response, and the WIP
+Warden would report `1` while four sessions ran.
+
+The heartbeat design makes correctness independent of how often `Stop` fires.
+Firing once per session, once per turn, or fifty times per turn all produce the
+same result: a live session stays fresh, a dead one goes stale.
 
 ### 4.3 Staleness and the honesty flag
 
-A crashed session leaves an orphan entry. The pruner removes entries whose
-`started_at` is older than `SESSION_STALE_HOURS` (default 12).
-
-The flag rule is the point of this component:
+The flag is a property of the count, not of the reader. It is derived from
+durable state — the presence of a retirement marker written by the pruner,
+and the presence of an `unknown` entry — never from whether *this particular
+read* happened to prune something.
 
 | Situation | Flag |
 | --- | --- |
-| Count read, no entries pruned this read | `observed` |
-| Count read, one or more stale entries pruned | `inferred` |
-| No registry directory at all | `observed` (count 0) |
+| No entry retired within the staleness window; no `unknown` entry | `observed` |
+| One or more entries retired within the window | `inferred` |
+| An `unknown` entry present (see §4.1 collision rule) | `inferred` |
+| No registry directory at all | `observed`, count 0 |
 
-A consumer that reports a count must report its flag alongside. A count that
-followed a prune is `inferred` because the pruner cannot distinguish a crashed
-session from a long-running healthy one — it only knows the entry aged out.
+A count that followed a retirement is `inferred` because the pruner cannot
+distinguish a crashed session from a long-running healthy one — it only knows
+the entry aged out. That uncertainty persists for every subsequent read, so
+the flag must persist with it. A flag that survived only the first read after
+a prune would disclose the uncertainty to whichever consumer happened to be
+first and hide it from all the others.
 
-### 4.4 Shared library
+### 4.4 Two libraries, split on the trust boundary
 
-`ai-literacy-superpowers/hooks/scripts/lib/session-registry.sh` owns the
-implementation: `registry_write`, `registry_remove`, `registry_prune`,
-`registry_count` (emitting count and flag). The `SessionStart` and `Stop`
-scripts and every consuming sentinel source this one file. Three sentinels
-reading three parsers is the failure this component exists to prevent.
+`sentinel-integrity-check.sh` enforces the read-only boundary by rejecting
+`Write`/`Edit` in an agent's `tools:` list, and explicitly permits `Bash`. Its
+own header names the limit: an agent reaching a write capability through an
+undeclared channel is out of scope. A single shared library exposing mutation
+functions to every sentinel would manufacture exactly that case, and CI would
+stay green while a `role: sentinel` agent deleted files.
+
+So the implementation splits:
+
+| File | Exposes | Who may source it |
+| --- | --- | --- |
+| `hooks/scripts/lib/session-registry-read.sh` | `registry_count` (count + flag), `registry_list` | hook scripts **and** sentinels |
+| `hooks/scripts/lib/session-registry-write.sh` | `registry_touch`, `registry_prune` | hook scripts **only** |
+
+The read library performs no mutation on any path. This generalises the same
+reasoning that keeps the Coda read-only (§8, Note D): the boundary is preserved
+by what the agent *can* reach, not by what it is trusted not to call.
 
 `hooks/scripts/lib/` does not exist yet; `scripts/lib/` does, so the pattern is
 established in the repo and this follows it.
 
-## 5. Component 3 — Record Directories
+## 5. Component 3 — Record Directories and Schemas
 
-Two directories, each with a `README.md` that carries its schema:
+Two directories, each with a `README.md` carrying the schema below. Both
+schemas are declared here, in full, because a substrate that defers its
+schemas to its consumers is the half-feature §1 exists to prevent.
 
-- `docs/superpowers/parked/` — parking records (schema consumed by S2)
-- `docs/superpowers/consultations/` — consultation dispositions (schema
-  consumed by S5)
+Both records are **append-only** (constraint 7): a superseded entry gains
+`status: superseded` and a `superseded_by` pointer, and is never edited in
+place or deleted.
 
-Both READMEs state the append-only rule (constraint 7): superseded entries are
-marked superseded, never edited; a resumed parking record gains
-`status: resumed`, and is never deleted.
+### 5.1 Parking record — `docs/superpowers/parked/<YYYY-MM-DD>-<slug>.md`
 
-Declaring the schemas here rather than in S2 and S5 is deliberate. It makes S1
-a complete, reviewable unit — the substrate is fully specified before anything
-consumes it — rather than half a feature waiting for its other half.
+```yaml
+---
+session: <sanitised session id>
+repo: <absolute path to project root>
+created: <YYYY-MM-DD>
+status: parked | resumed | superseded
+superseded_by: <filename> | null
+next_action_flag: asked
+---
+```
+
+Body: a `## Context` section (one paragraph) and a `## Next action` section
+(one concrete resume step).
+
+`next_action_flag` is always `asked` — the next action is supplied by the
+human at the ritual, never inferred by the agent. Recording the flag keeps
+constraint 3 satisfied without implying the Coda observed anything.
+
+Resuming appends `status: resumed`; it never deletes the record. Consumed by
+S2.
+
+### 5.2 Consultation record — `docs/superpowers/consultations/<YYYY-MM-DD>-<slug>.md`
+
+```yaml
+---
+spec: <path to the spec under approval>
+date: <YYYY-MM-DD>
+status: open | resolved | superseded
+superseded_by: <filename> | null
+voices:
+  - voice: <role or group>
+    source_flag: observed | inferred | asked
+    question: <the concrete question worth asking them>
+    disposition: pending | consulted | deliberately-not-consulted
+    outcome: <one line> | null
+---
+```
+
+`source_flag` records how the voice was identified: `observed` when a declared
+stakeholder map named it, `inferred` when it was derived from the change
+itself, `asked` when the human named it. Every voice carries a disposition;
+`deliberately-not-consulted` requires an `outcome` giving the because.
+
+Consumed by S5.
 
 ## 6. Non-Goals
 
@@ -248,44 +444,87 @@ consumes it — rather than half a feature waiting for its other half.
 
 ## 7. Acceptance Scenarios (TDAD)
 
-1. **Template blocks present and commented.** Given `templates/HARNESS.md`,
-   then all three block headings exist inside comment fences, and no value line
-   in any of the three carries a trailing `#` comment.
-2. **Not-a-debt clause present.** Given the `Budgets` template block, then its
-   prose contains the literal string `Unspent budget is not a debt.`
-3. **Live activation.** Given this repo's root `HARNESS.md`, then all three
-   blocks are active (uncommented), and `Budgets` declares
-   `authored_via: placeholder`.
-4. **Registry write on start.** Given no registry entry for session X, when the
-   `SessionStart` hook runs, then `.claude/sessions/X.json` exists with `id`,
-   `repo`, and `started_at`.
-5. **Two overlapping sessions counted.** Given entries for sessions X and Y,
-   when `registry_count` runs, then it reports `2` flagged `observed`.
-6. **Prune on stop.** Given entries for X and Y, when the `Stop` hook runs in
-   session X, then X's entry is gone and Y's remains.
-7. **Stale entry pruned, count flagged inferred.** Given an entry older than
-   `SESSION_STALE_HOURS`, when `registry_count` runs, then the stale entry is
-   removed and the count is flagged `inferred`.
-8. **No registry directory.** Given `.claude/sessions/` does not exist, when
-   `registry_count` runs, then it reports `0` flagged `observed` and exits
-   cleanly.
-9. **Absent block, each of three.** Given a `HARNESS.md` with no
-    `Session WIP` / `Budgets` / `Sync cadence` heading, when
-    `block_absent_note` runs for it, then it emits the §3.6 observe-only line
-    and exits 0.
-10. **Commented block does not read as declared.** Given a `HARNESS.md`
-    carrying the three blocks still inside their comment fences, when
-    `block_active` runs for each, then each reports inactive — a template a
-    project has not opted into is not a declaration.
-11. **Block-scoped key read.** Given an active `Budgets` block, when
-    `block_key Budgets hard_stop_hour` runs, then it returns the declared
-    value, and a key absent from the block returns the supplied default.
-12. **Registry is gitignored.** Given a written registry entry, when
-    `git status --porcelain` runs, then no `.claude/sessions/` path appears.
+Scenarios carry stable prefixed ids so later slices can cite them: **B** for
+block behaviour, **R** for the registry, **C** for the record schemas.
 
-Scenarios 1–12 are deterministic and land in
-`tdad_tests/layer0_deterministic/test-session-registry.sh` (4–8, 12) and
-`test-cadence-blocks.sh` (1–3, 9–11).
+### 7.1 Blocks — `tdad_tests/layer0_deterministic/test-cadence-blocks.sh`
+
+- **B1 — Template blocks present and commented.** Given
+  `templates/HARNESS.md`, then all three block headings exist inside comment
+  fences, and no value line in any of the three carries a trailing `#`
+  comment.
+- **B2 — Not-a-debt clause present.** Given the `Budgets` template block, then
+  its prose contains the literal string `Unspent budget is not a debt.`
+- **B3 — Live activation.** Given this repo's root `HARNESS.md`, then all
+  three blocks are active, and `Budgets` declares `authored_via: placeholder`.
+- **B4 — Absent block, each of three.** Given a `HARNESS.md` with no such
+  heading, when `block_state` runs, then it reports `absent` and
+  `block_absent_note` emits the §3.6 sentence, exit 0.
+- **B5 — Commented block does not read as declared.** Given a `HARNESS.md`
+  carrying the three blocks still inside their comment fences, when
+  `block_state` runs for each, then each reports `absent` — a template a
+  project has not opted into is not a declaration.
+- **B6 — Malformed block.** Given an active `Budgets` block whose prose is
+  missing the not-a-debt clause, when `block_state` runs, then it reports
+  `malformed`, the consumer degrades to observe-only, and a note names the
+  missing clause. No gate fires.
+- **B7 — Colon- and space-bearing values survive.** Given an active `Budgets`
+  block, when `block_key` reads each key, then `hard_stop_hour` returns
+  `18:30` (not `30`), `focus_blocks` returns the full comma-separated ranges
+  (not `00`), and `daily_cost_ceiling` returns `not observable` with its
+  interior space intact.
+- **B8 — Block-scoped key isolation.** Given a `HARNESS.md` with **two**
+  active blocks that both declare a key of the same name with different
+  values, when `block_key` runs against each block, then each returns its own
+  block's value. A whole-file parser fails this scenario.
+
+### 7.2 Registry — `tdad_tests/layer0_deterministic/test-session-registry.sh`
+
+- **R1 — Write on start.** Given no entry for session X, when the
+  `SessionStart` hook runs, then `~/.claude/sessions/X.json` exists with `id`,
+  `repo`, `started_at`, and `heartbeat`.
+- **R2 — `SessionStart` re-fire preserves `started_at`.** Given an existing
+  entry for X, when `SessionStart` fires again, then `heartbeat` advances and
+  `started_at` is unchanged.
+- **R3 — `Stop` refreshes, never deletes.** Given an entry for X, when the
+  `Stop` hook runs three times, then the entry still exists and `heartbeat`
+  has advanced. This is the scenario that would have caught the
+  delete-on-`Stop` design.
+- **R4 — Two overlapping sessions counted.** Given entries for X and Y, both
+  fresh, when `registry_count` runs, then it reports `2` flagged `observed`.
+- **R5 — Stale entry retired, count flagged inferred.** Given an entry whose
+  `heartbeat` is older than `SESSION_STALE_HOURS`, when the pruner runs and
+  `registry_count` follows, then the stale entry is gone and the count is
+  flagged `inferred`.
+- **R6 — Flag survives repeated reads.** Given the state after R5, when
+  `registry_count` runs a second and third time, then every read still reports
+  `inferred`. The flag is a property of the count, not of the reader.
+- **R7 — `registry_count` mutates nothing.** Given any registry state, when
+  `registry_count` runs, then the directory's contents are byte-identical
+  before and after.
+- **R8 — Read library exposes no mutation.** Given
+  `lib/session-registry-read.sh`, then it defines no function that writes,
+  deletes, or moves a file, and `registry_touch` / `registry_prune` are
+  undefined after sourcing it alone.
+- **R9 — Hostile session id sanitised.** Given a hook input whose `session_id`
+  contains `/` or `..`, when the `SessionStart` hook runs, then the written
+  path is `~/.claude/sessions/unknown.json` and no file is created outside
+  that directory.
+- **R10 — `unknown` entry flags the count inferred.** Given a registry
+  containing an `unknown.json` entry, when `registry_count` runs, then the
+  count is flagged `inferred`.
+- **R11 — No registry directory.** Given `~/.claude/sessions/` does not exist,
+  when `registry_count` runs, then it reports `0` flagged `observed`, exit 0.
+- **R12 — Registry lives outside every work tree.** Given a written registry
+  entry, when `git status --porcelain` runs in this repo, then no session path
+  appears.
+
+### 7.3 Record schemas — same block test file
+
+- **C1 — READMEs carry the declared schemas.** Given
+  `docs/superpowers/parked/README.md` and
+  `docs/superpowers/consultations/README.md`, then each contains every field
+  named in §5.1 and §5.2 respectively, and each states the append-only rule.
 
 ## 8. Notes and Divergences from the Build Spec
 
@@ -297,10 +536,13 @@ default, because `read_key` does not strip trailing comments. The live
 `HARNESS.md` block documents the rule correctly; the template does not follow
 it. Raised as a follow-up issue, not fixed here.
 
-**Note B — registry path.** `.claude/sessions/`, not `.superpowers/sessions/`.
-See §4.1.
+**Note B — registry location.** `~/.claude/sessions/`, machine-global. The
+build spec proposed `.superpowers/sessions/`; the first revision of this spec
+proposed `.claude/sessions/` (per-repo). The diaboli gate established that
+per-repo scope cannot see the concurrency the WIP Warden exists to catch, and
+machine-global scope moots the `.gitignore` question entirely. See §4.1.
 
-**Note C — `Stop`, not `SessionEnd`.** See §4.2.
+**Note C — heartbeat, not delete-on-`Stop`.** See §4.2.
 
 **Note D — the sentinel category is already load-bearing.** Build-spec
 constraint 9 anticipates a repo that has not yet adopted the sentinel category
@@ -314,17 +556,46 @@ discovered in this slice's exploration:
 - The Coda cannot hold `Write`. Its agent returns record content; the `/coda`
   command persists it after a human disposes — the `cost-estimator` precedent.
   Disposed by Russ, 2026-08-08.
+- The same reasoning generalises to shared libraries, which is why §4.4 splits
+  read from write rather than trusting sentinels not to call a mutator.
 - S7's "create a sentinel category page" becomes "extend the existing one",
   roster 5 → 9.
 - The rename open note in constraint 9 is moot.
 
+**Note E — deriving the count from the invocation log was considered and
+rejected.** `observability/affordance-invocations.json` already records
+`{"session": ..., "ts": ...}` per tool call, sanitised and size-bounded, and a
+live-session count is derivable from it with no new hooks. It was rejected
+because the recorder's `PostToolUse` matcher is `Bash|mcp__.*`: a session that
+only reads and edits files never appears in the log, so the derived count would
+silently undercount exactly the long-running sessions the WIP Warden exists to
+notice. The `asked` fallback — a sentinel simply asking how many sessions are
+open — remains available to S4 as an honesty option when observation fails.
+
 ## 9. Migration & Rollout
 
 Minor version bump, 0.66.2 → 0.67.0 — the slice adds hooks and template
-content, which the repo's semver rule scopes as minor. Five CI-checked version
-locations plus the README plugin-table cell.
+content, which the repo's semver rule scopes as minor.
+
+Version locations (five CI-checked, plus one human-facing):
+
+- `ai-literacy-superpowers/.claude-plugin/plugin.json`
+- `README.md` shields.io badge
+- `CHANGELOG.md` top heading
+- `.claude-plugin/marketplace.json` — `plugin_version`
+- `.claude-plugin/marketplace.json` — this plugin's `plugins[].version`
+- `README.md` plugin-table row cell (not CI-checked)
+
+Reference pages updated in the same PR, per the `Docs Site Review` convention:
+
+- `docs/plugins/ai-literacy-superpowers/reference/harness-md-format.md` — the
+  three new blocks, including the value grammar from §3.2–§3.4, which is the
+  part adopters most need
+- `docs/plugins/ai-literacy-superpowers/reference/hooks.md` — the
+  `SessionStart` and `Stop` registry entries
 
 No breaking changes. All three blocks are additive and optional; the registry
-is local, gitignored state that no existing hook reads; the record directories
-are new and empty but for their READMEs. `/harness-upgrade` surfaces the three
-new template blocks to downstream projects as optional adoptable content.
+is machine-local state outside every work tree that no existing hook reads; the
+record directories are new and empty but for their READMEs.
+`/harness-upgrade` surfaces the three new template blocks to downstream
+projects as optional adoptable content.

--- a/docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md
@@ -7,48 +7,48 @@ stories:
   - id: 1
     lens: [forces, patterns]
     title: Prose promoted to a required field
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Deliberate and testable; kept. Spec gains a note naming who may reword the clause and the coordinated-migration cost of doing so, so the brittleness is disclosed rather than discovered."
   - id: 2
     lens: [patterns, consequences]
     title: Observe-only is the resting state
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "This is constraint 6 working as intended. The Null Object framing is adopted into the spec: block_absent_note plus block_key's default let consumers run one path, and S2-S5 are told never to branch on absence."
   - id: 3
     lens: [patterns, alternatives]
     title: Sync cadence published before its consumer
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Sync cadence ships, marked reserved in its prose and in the reference page, reusing the placeholder device the spec already invented. An adopter who declares values knows they are inert, so the eventual consumer is not bound by declarations made before its behaviour existed."
   - id: 4
     lens: [forces, consequences]
     title: One keeper per repo, assumed silently
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Resolved structurally rather than by note: pacts move to a user-scoped ~/.claude/pacts.md. A stop hour is a property of the human, not of a repository, and a file with one author and many readers could never answer 'whose pact is this'. The story is dissolved, not carried."
   - id: 5
     lens: [coherence, forces]
     title: A repo's limit against a person's count
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Dissolved by the same move as #4. With pacts user-scoped, limit and count are both person-scoped and the units mismatch disappears; no combination rule is needed because there is only one declaration."
   - id: 6
     lens: [consequences, coherence]
     title: The live harness pinned as fixture
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Largely dissolved by the #4 move -- the live pact file is no longer in the repo, so no deterministic test can pin it. The residue is fixed as proposed: block tests run against fixtures, and no test asserts a value the human is expected to change. Second worked instance of the AGENTS.md:481 pin-a-copy decision."
   - id: 7
     lens: [defaults, consequences]
     title: Twelve untunable hours define liveness
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "stale_after_hours becomes a declarable key in the Session WIP block, default 12. Every other threshold in this harness is human-tunable; a slice premised on the human declaring the pacts should not introduce the first one they cannot. The lease-with-heartbeat-renewal naming is adopted into the spec."
   - id: 8
     lens: [defaults, patterns]
     title: Record schemas homed in directory READMEs
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Schemas move to reference/parking-record-format.md and reference/consultation-record-format.md, matching the repo's three existing format pages and actually reaching the published site. The record-directory READMEs point at them rather than duplicating them, which also removes the two-copies problem the story identifies."
   - id: 9
     lens: [coherence, patterns]
     title: Append-only declared, transitions written in place
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "State moves into the path: a transition writes a new file rather than editing a key. Append-only and the state read then agree, 'what is still parked' stays a glob, and S2's resume path becomes a write -- which fits the Coda's read-only agent and its command-writes dispatcher."
 ---
 
 # Choice stories — Cadence Sentinels S1: Shared Infrastructure

--- a/docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md
@@ -1,0 +1,552 @@
+---
+spec: docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md
+date: 2026-08-08
+mode: spec
+cartographer_model: claude-opus-5[1m]
+stories:
+  - id: 1
+    lens: [forces, patterns]
+    title: Prose promoted to a required field
+    disposition: pending
+    disposition_rationale: null
+  - id: 2
+    lens: [patterns, consequences]
+    title: Observe-only is the resting state
+    disposition: pending
+    disposition_rationale: null
+  - id: 3
+    lens: [patterns, alternatives]
+    title: Sync cadence published before its consumer
+    disposition: pending
+    disposition_rationale: null
+  - id: 4
+    lens: [forces, consequences]
+    title: One keeper per repo, assumed silently
+    disposition: pending
+    disposition_rationale: null
+  - id: 5
+    lens: [coherence, forces]
+    title: A repo's limit against a person's count
+    disposition: pending
+    disposition_rationale: null
+  - id: 6
+    lens: [consequences, coherence]
+    title: The live harness pinned as fixture
+    disposition: pending
+    disposition_rationale: null
+  - id: 7
+    lens: [defaults, consequences]
+    title: Twelve untunable hours define liveness
+    disposition: pending
+    disposition_rationale: null
+  - id: 8
+    lens: [defaults, patterns]
+    title: Record schemas homed in directory READMEs
+    disposition: pending
+    disposition_rationale: null
+  - id: 9
+    lens: [coherence, patterns]
+    title: Append-only declared, transitions written in place
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Choice stories — Cadence Sentinels S1: Shared Infrastructure
+
+Nine stories from a spec that is already unusually decision-complete. Its
+divergence notes, its adjudicated objection record, and its explicit
+non-goals cover most of what it chose deliberately. These nine concentrate
+where that coverage does not reach: the vocabulary the substrate publishes,
+the scope its pacts assume, and the numbers and locations it fixed without
+naming them as choices. Every one of them binds S2–S5 through the substrate
+this slice creates.
+
+**Dispatcher verification note (2026-08-08).** Two citations were checked
+before this record was written. Story #6's ARCH_DECISION is real and sits at
+`AGENTS.md:481`, promoted 2026-07-22, with the `Skills-36` pin at
+`AGENTS.md:487` as its worked example. Story #8's publication claim is
+correct: `mkdocs.yml:15-16` carries `exclude_docs: superpowers/`, so a README
+in a record directory is committed but never published, unlike the three
+`reference/*-format.md` pages it would otherwise sit beside.
+
+## Story #1 — Prose promoted to a required field
+
+**Source:** spec §3.2, §3.3, §3.6
+**Lens:** forces, patterns
+**Refs:** —
+
+**Context.** §3.3 mandates the literal sentence `Unspent budget is not a
+debt.` inside the `Budgets` block's prose body, and §3.2 mandates a matching
+clause for `Session WIP`. §3.6 makes a missing mandatory clause one of the
+two triggers for the `malformed` state, and B2 tests for the literal string.
+English sentences are now parsed data with a state transition attached to
+their presence.
+
+**Forces.** A pact declared without its governing sentence can be enforced
+against a person who never agreed to the framing — that is the spec's stated
+worry, and it is a good one. Pulling the other way: a checker that matches
+literal English is brittle to rewording, localisation, a typo fix, or a
+markdown reflow, and what it verifies is bytes, not assent. The spec
+resolved toward literal-presence checking without naming the brittleness,
+and without saying who may reword the clause or how a reworded clause
+migrates across adopters.
+
+**Options not taken.**
+
+- Home the normative sentence in `skills/sentinel-design/SKILL.md`, where
+  every other normative rule in this epic lives, and leave the block to
+  values only. This spec already carries one distinction into that skill
+  (§2's BY/ABOUT boundary), so the precedent is in the document itself.
+- Make acknowledgement a key — `debt_clause_ack: true` — so the check runs
+  against structured data and the prose stays freely editable.
+- Check for a stable marker (an HTML comment, a heading anchor) rather than
+  the sentence, decoupling wording from detection.
+
+**Choice as written.** The sentence is the unit of both meaning and
+detection, and its absence downgrades the entire block to `malformed`.
+
+**Consequences.** The clause becomes an interface. It cannot be reworded,
+translated, shortened, or split across lines in any downstream `HARNESS.md`
+without the block silently ceasing to read as `declared`. Because
+`Session WIP` already carries an equivalent clause, the substrate has
+committed to a convention where each block in the sentinel vocabulary ships
+English that a script matches — S2–S5 will inherit the expectation. And
+since `/harness-upgrade` pushes template content downstream, any future
+rewording is a coordinated migration across every adopter rather than a
+template edit.
+
+**Pattern.** No catalogue pattern fits cleanly. The closest working frame is
+a *checksum on intent* — the sentence functions the way a magic-number
+header functions in a file format: its content is meaningful to humans, its
+bytes are meaningful to the parser, and the two must not drift. Distant
+relative: literate configuration.
+
+**Notes.** The diaboli explicitly declined to object here ("unusual, but it
+is deliberate, testable, and directly serves the epic's language
+discipline"), which routes the decision to this record rather than that one.
+
+## Story #2 — Observe-only is the resting state
+
+**Source:** spec §3.1, §3.6, §6
+**Lens:** patterns, consequences
+**Refs:** #1
+
+**Context.** §3.1 ships all three blocks commented out. §3.6 gives absent and
+malformed the same behaviour — observe-only, plus a fixed sentence emitted
+by the library so every consumer says the same thing. §6 confirms nothing
+gates. The only route from absent to declared is a human deleting a `<!--`
+fence, or `/harness-upgrade` surfacing the template as adoptable content
+(§9).
+
+**Forces.** Progressive hardening (constraint 6) and the plugin's standing
+"hook scripts never block, only warn" decision push hard toward opt-in and
+silence. Pulling the other way: a substrate nobody opts into does nothing for
+anybody — S2, S3, S4 and S5 each degrade to a note. The spec resolved toward
+opt-in and then supplied no adoption ramp, which makes observe-only the
+expected steady state of a downstream project rather than a transient one.
+
+**Options not taken.**
+
+- Ship the blocks activated in the template with conservative defaults, so
+  declaration is the default and opting *out* is the edit. Rejected
+  implicitly, and for a good reason the spec states elsewhere (§3.5: an
+  imposed default is exactly what the clear-weather rule says does not
+  hold) — but the reason is never connected to the adoption question.
+- Give each block an authoring dialogue the way S3's Tune authors `Budgets`.
+  One of the three blocks gets an authoring path anywhere in S1–S7; the
+  other two get none.
+- Emit the observe-only note once per project per period rather than once
+  per consumer per invocation.
+
+**Choice as written.** Opt-in by uncommenting, with a fixed sentence emitted
+per consumer. Chosen substantially by silence: the spec never describes how
+a human comes to declare a block.
+
+**Consequences.** The modal downstream experience of the whole Cadence epic
+is several sentinels each reporting "no `X` block declared — running in
+observe-only mode". The un-adopted project is the noisiest one, and the noise
+scales with the number of consumers rather than the number of undeclared
+blocks. Because absent and malformed both land in observe-only, an adopter
+who half-adopts is behaviourally indistinguishable from one who never
+adopted — only the accompanying note differs. S2's and S5's record
+directories will exist and stay empty in every project that never opts in.
+
+**Pattern.** **Null Object** (Woolf, *Pattern Languages of Program Design 3*,
+1997). `block_absent_note` plus `block_key`'s default argument let every
+consumer run one code path whether or not the block exists — that is exactly
+the Null Object guarantee, and naming it explains *why* absent and malformed
+collapse to one behaviour rather than that collapse being a coincidence. It
+also states the library's real contract to S2–S5: consumers never branch on
+absence.
+
+## Story #3 — Sync cadence published before its consumer
+
+**Source:** spec §3.4, §3.5, §9
+**Lens:** patterns, alternatives
+**Refs:** O11, #2
+
+**Context.** §3.4 defines `interrupt_mode` and `sync_points`; §6 states no
+S1–S7 sentinel consumes them; §3.5 activates the block anyway in this repo's
+root `HARNESS.md`; §9 adds it to the `harness-md-format.md` reference page
+that adopters read to learn what may appear in a harness. The spec's stated
+reason is vocabulary coherence — splitting the three blocks across slices
+would leave the template internally inconsistent.
+
+**Forces.** Template coherence against declaration-without-definition. The
+spec names the first force and discloses the trade honestly. What it does not
+weigh is the *cost of publication*: once a downstream human writes
+`interrupt_mode: coalesced` in good faith, the eventual consumer must honour
+a declaration made before any behaviour was defined for it.
+
+**Options not taken.**
+
+- Ship the two consumed blocks now and `Sync cadence` in the slice that
+  consumes it. The internal-inconsistency argument is a template-aesthetics
+  argument; a template that grows one block per slice is ordinary.
+- Ship it in the template but do not activate it here. Activating a block
+  nothing reads tests nothing — B1 and B3 only assert that the text exists.
+- Ship it with an explicit reserved marker in the block prose, so an adopter
+  knows a declaration is inert today. The spec has the machinery for exactly
+  this: `authored_via: placeholder` is that device, applied to `Budgets`.
+
+**Choice as written.** Full publication — template, this repo's live harness,
+and the public reference page.
+
+**Consequences.** The vocabulary is now a contract with adopters. The future
+consumer inherits `interrupt_mode`'s two tokens without having chosen them
+and cannot rename or re-enumerate them without a migration — which is
+precisely the argument O11 made about `enforcement: strict`. That objection
+was accepted and `strict` gained semantics in S1; `interrupt_mode` and
+`sync_points` shipped under the same publication risk and gained none. The
+cheapest correction — delete the block — is foreclosed the moment an adopter
+holds values in it.
+
+**Pattern.** **Published Language** (Evans, *Domain-Driven Design*, 2003) — a
+shared vocabulary published ahead of the systems that speak it. The pattern's
+own caveat is the material point: a published language is expensive to
+change, which is why it is normally published *after* consumers have agreed
+on it rather than before the first one exists. Fowler's *speculative
+generality* smell also reads on this, though the spec's coherence argument is
+a genuine counterweight rather than an excuse.
+
+## Story #4 — One keeper per repo, assumed silently
+
+**Source:** spec §3.2, §3.3, §3.5
+**Lens:** forces, consequences
+**Refs:** O7
+
+**Context.** §3.2 describes `max_concurrent_sessions` as "this repo's opinion
+about your WIP". §3.3 gives `Budgets` a `hard_stop_hour`, `focus_blocks`, and
+`sessions_per_day`. §3.5 activates both in this repo's committed root
+`HARNESS.md`. §2 settles, per O7, that a declared pact is a statement *by* the
+person rather than a claim *about* them. It does not settle *which* person,
+in an artefact every contributor clones, reviews, and edits.
+
+**Forces.** A pact that is not durable is not a pact (the spec's argument),
+and `HARNESS.md` is the harness's declaration surface, so putting pacts there
+is the path of least resistance. Pulling the other way: every value in both
+blocks is singular-possessive — one human's stop hour, one human's focus
+windows, one human's session ceiling — while the file has more readers than
+authors. The spec resolved toward the repo-scoped home without naming that
+mismatch.
+
+**Options not taken.**
+
+- A user-scoped pact file (`~/.claude/...`), symmetric with the machine-global
+  registry this same spec chose for this same reason — thrash-switching is a
+  property of the human, and so is a stop hour.
+- A keyed block, so a shared repo can hold several pacts and a sentinel reads
+  the current author's.
+- Scope the committed blocks to single-keeper repos explicitly in the block
+  prose, the way the reservoir block scopes itself with "you edit this block
+  yourself".
+
+**Choice as written.** Repo-scoped, committed, single-valued, and
+unqualified — chosen by silence. The spec never says who the "you" in "your
+WIP" is when the repo has five contributors.
+
+**Consequences.** In a multi-contributor project the pact either belongs to
+whoever wrote it — and the others are held to a stop hour they never
+declared — or it belongs to nobody, in which case S3's clear-weather rule
+cannot be evaluated at all: `authored_via: tune` records *how* the values
+came to hold, not *whose* they are. S3 inherits this directly, because Tune
+writes over a shared file. Adding an owner dimension later means changing the
+block schema after adopters hold values in it. The reservoir block has had
+the same shape at one-token scale (`chronotype: intermediate`); S1 scales it
+to a full working day, which is where the single-keeper assumption starts to
+bind.
+
+**Pattern.** — . The closest useful frame is an aggregate without a root
+(Evans, DDD): the pact carries no owner identity, so it belongs to whatever
+container it sits in.
+
+## Story #5 — A repo's limit against a person's count
+
+**Source:** spec §3.2, §4.1
+**Lens:** coherence, forces
+**Refs:** O2, #4
+
+**Context.** §4.1 makes the registry machine-global because thrash-switching
+is a property of the human; §3.2 keeps `max_concurrent_sessions` declared
+per-repo. The spec states the split in one sentence — "The limit is declared
+per-repo; the count it is compared against is global" — and stops. No rule
+combines limits when the human is working in more than one declaring repo,
+which is the exact situation the global count exists to see.
+
+**Forces.** The count must be person-scoped or it cannot observe cross-repo
+concurrency (O2, accepted, correctly). The limit must be repo-scoped because
+`HARNESS.md` is the only declaration surface the harness has (see #4). These
+two forces pull in opposite directions, and the spec resolves each on its own
+terms without resolving the pair — which is what makes this a coherence
+story rather than two separate choices.
+
+**Options not taken.**
+
+- Declare the limit where the count lives — a user-level pact — making both
+  sides person-scoped.
+- Define the combination rule in S1: the effective limit is the minimum
+  across declaring repos, or the limit of the repo the new session starts in.
+  One sentence in S1; S4 then inherits a defined rule, exactly the move the
+  spec already made for `enforcement: strict`.
+- Keep both per-repo and accept the undercount, with Note E's `asked`
+  fallback as the honest cross-repo answer.
+
+**Choice as written.** By silence. The semantics that falls out of the spec
+as written is positional: whichever repo the human is sitting in supplies the
+threshold, so the same three live sessions are compliant in repo A (limit 4)
+and in breach in repo B (limit 2), and which advisory fires depends on where
+the human happens to be typing. Nothing in the spec says this, and nothing in
+the spec forbids it.
+
+**Consequences.** The pact's meaning becomes a property of location rather
+than of the person who declared it. S4 must invent the combination rule at
+implementation time, against declarations already live in the wild — the same
+failure shape §1 exists to prevent, transposed from parsers to thresholds. It
+also puts quiet pressure on the `Session WIP` mandatory clause: a limit that
+changes with the room the human is standing in still "counts and does not
+assess", but it advises inconsistently about one underlying state.
+
+**Pattern.** — . Structurally this is a units mismatch: a per-repo scalar
+compared against a per-person gauge, with no conversion declared.
+
+## Story #6 — The live harness pinned as fixture
+
+**Source:** spec §3.5, §7.1 B3
+**Lens:** consequences, coherence
+**Refs:** #4
+
+**Context.** §3.5 activates all three blocks in this repo's root `HARNESS.md`.
+B3 asserts, in the Layer 0 deterministic suite, that all three are active
+*and* that `Budgets` declares `authored_via: placeholder`. §3.5 also states
+that S3's Tune "will overwrite these values and set `authored_via: tune`".
+
+**Forces.** Dogfooding is real, and the spec argues it well — a sentinel
+tested only against its own fixtures is tested against nothing. Pulling the
+other way: a live artefact under test is an artefact a human can no longer
+edit freely, and this particular artefact is the one the entire epic exists
+to invite the human to author. The spec resolved toward dogfooding and pinned
+a literal without noticing which artefact it had pinned.
+
+**Options not taken.**
+
+- Assert presence and well-formedness of the three blocks in the live
+  harness, and assert the `placeholder`/`tune` enum only against a fixture.
+  Dogfooding survives; the human's own values stop being assertions.
+- Keep live-activation checking out of the deterministic suite and let
+  `/harness-audit` report it — the repo's established home for harness-state
+  reporting.
+- Pin the literal but carry the comment AGENTS.md requires, naming what makes
+  it change and why it was not derived.
+
+**Choice as written.** The repo's own declared pact is a test fixture, with
+one of its values pinned as a literal whose legitimate change is already
+scheduled in a named later slice.
+
+**Consequences.** Editing your own budget block becomes a CI event. The first
+act the epic is building toward — S3's Tune writing a real pact — turns B3
+red, so the human's experience of authoring their pact is a failing build.
+That inverts the sentinel ethic the spec otherwise holds carefully: a
+substrate built so nothing gates the person acquires one surface where the
+person's own declaration gates the build. It also quietly converts the
+reservoir block's "you edit this block yourself" invitation into "you edit
+this block yourself, and the suite has an opinion about the result".
+
+**Pattern.** The promoted ARCH_DECISION "harness artefacts derive from the
+source of truth — they do not pin a copy of it or re-derive it
+heuristically" (`AGENTS.md:481`, promoted 2026-07-22). Its own worked example
+is the `Skills-36` guard that went red for the *right* change when the 37th
+skill landed — a pin whose legitimate change was foreseeable, from this same
+sentinel epic three weeks ago. B3 is the same shape with the change already
+on the roadmap.
+
+**Notes.** Routing check applied deliberately: the B3-goes-red event is a
+single foreseeable CI failure at a known time, not an undetected class of
+failures, so it does not belong in the objection record. What belongs here is
+the decision the pin encodes — that the live harness is a tested artefact and
+the human's pact is therefore CI-load-bearing.
+
+## Story #7 — Twelve untunable hours define liveness
+
+**Source:** spec §4.2, §4.3, §5.1
+**Lens:** defaults, consequences
+**Refs:** O1, O4
+
+**Context.** §4.2 retires any registry entry whose `heartbeat` is older than
+`SESSION_STALE_HOURS` (default 12). Heartbeats are written only by
+`SessionStart` and `Stop`. §4.3 makes any retirement flag every subsequent
+count `inferred`, durably and correctly.
+
+**Forces.** Retire too eagerly and a genuinely long-running session vanishes
+from exactly the count the WIP Warden exists to take. Retire too slowly and
+crashed sessions accumulate as ghosts — and because §4.3's flag is durable,
+a ghost does not merely inflate a count, it flags every future count
+`inferred` permanently. Twelve hours sits at roughly one working day. The
+spec resolves the tension with a number and never states the model of "a
+session" that the number encodes.
+
+**Options not taken.**
+
+- Declare the threshold as a key in the `Session WIP` block. Every sibling
+  threshold in this substrate's own model — the whole `## Cognitive
+  reservoir` block, `window_hours` through `chronotype` — is declared in
+  `HARNESS.md` and tuned by the human. `SESSION_STALE_HOURS` is the first
+  threshold in this harness the human cannot tune, in a slice whose entire
+  premise is that the human declares the pacts.
+- Define liveness by process rather than by recency — is the pid alive, is
+  the tty open — which needs no threshold, no pruner, and no honesty flag.
+- Two-stage retirement (mark suspect, retire later), so `inferred` can
+  distinguish "aged out once" from "aged out and never came back".
+
+**Choice as written.** Liveness is *recency of a completed assistant turn*,
+capped at twelve hours, in a constant. A session where the human is reading,
+thinking, or waiting on a long tool run emits no heartbeat; a session left
+open overnight is dead by definition, whatever the human believes.
+
+**Consequences.** Three later slices inherit a definition of "live" that has
+no name in the spec. Because the flag is durable, any thirteen-hour gap on
+any machine flags every count `inferred` from then on — so the steady state
+of the honesty flag on a real developer's machine is plausibly `inferred`
+rather than `observed`, which drains information from the signal exactly
+where the spec wants it to carry weight. It also puts a clock on the parking
+record: §5.1 keys a permanent record to `session` and `repo`, borrowed from a
+store that forgets in twelve hours, so S2's resume path can only ever treat
+that id as opaque provenance, never as a lookup into the registry.
+
+**Pattern.** **Lease with heartbeat renewal** — the standard
+distributed-systems liveness idiom, and the right one; the spec arrived at it
+under adversarial pressure (O1) without naming it. Naming it earns something,
+because the idiom's known corollaries are precisely the questions left open:
+the renewal interval must be comfortably shorter than the lease, and the
+lease holder should own its own renewal. Here the renewal interval is
+"whenever the agent finishes a turn", which is unbounded above.
+
+## Story #8 — Record schemas homed in directory READMEs
+
+**Source:** spec §5, §7.3 C1
+**Lens:** defaults, patterns
+**Refs:** O6, O10
+
+**Context.** §5 declares both record schemas in full and states each will be
+carried in a `README.md` inside its new directory; C1 tests that each README
+contains every field named in §5.1 and §5.2. This repo already has three
+homes for a format contract, and S1 chose a fourth — in the same document
+that, per O10, adds two `reference/` pages for its other two surfaces.
+
+**Forces.** The schemas must be declared in S1 (O6, accepted), and S1 ships
+no agent, so the usual home — the emitting agent's skill, where the diaboli's
+objection-record format and the cartographer's own story format live — has no
+occupant yet. Pulling the other way: a schema co-located with its data rather
+than with its producer is a schema no producer owns. The spec resolved toward
+the directory README silently, without weighing the homes the repo already
+uses.
+
+**Options not taken.**
+
+- `docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md`,
+  matching `affordance-invocation-format.md` and
+  `governance-summary-format.md` — the repo's established home for a record
+  format that humans and machines both read, and the home §9 uses for this
+  slice's other two surfaces.
+- The emitting agent's skill, deferred to S2 and S5 — which is precisely what
+  O6 ruled out, and rightly.
+- `skills/sentinel-design/references/<contract>.md`, the shape the promoted
+  contract-ownership decision presumes and the one place in the epic that
+  already carries cross-slice normative content (§2's BY/ABOUT boundary).
+
+**Choice as written.** A `README.md` in each record directory — a location
+`mkdocs.yml:15-16` excludes from the site via `exclude_docs: superpowers/`,
+so unlike every other format contract in the repo, this one is committed but
+never published.
+
+**Consequences.** S1 now *owns* two contracts that S2 and S5 consume, which
+activates the promoted decision that "a change to a shared/merged contract
+gets its own owning slice with its own adversarial pass — a consumer never
+mutates the contract it consumes". The first time S2 needs a field the
+parking schema lacks, it must carve a contract-owning slice rather than edit
+the README. The spec does not say this, and placing the README *inside the
+consumer's own output directory* actively invites the opposite reading. C1
+also creates two copies of each schema — spec §5 and the README — with a test
+asserting the README carries the spec's fields, but nothing keeping §5
+current once the README moves on.
+
+**Pattern.** The AGENTS.md ARCH_DECISION on contract-owning slices (sourced
+from `stories/cost-estimator-agent-design.md` #5 and
+`stories/format-revision-per-stage-cost-design.md` #1). That entry carries an
+explicit Rule-of-Three watch item and has one worked instance; S1→S2/S5 would
+be the second, which is why recording the applicability now compounds rather
+than merely documents.
+
+## Story #9 — Append-only declared, transitions written in place
+
+**Source:** spec §5, §5.1, §5.2
+**Lens:** coherence, patterns
+**Refs:** O6, #8
+
+**Context.** §5 makes both records append-only per constraint 7: a superseded
+entry "gains `status: superseded` and a `superseded_by` pointer, and is never
+edited in place or deleted". §5.1 then defines the ordinary lifecycle
+transition as "Resuming appends `status: resumed`". Both schemas carry
+`status` as a single frontmatter key.
+
+**Forces.** Constraint 7 wants an unerasable history; the records want a
+cheaply readable current state — is this session parked or resumed, is this
+consultation open. That is the classic event-sourcing versus state-storage
+trade. The spec takes both halves: append-only as the stated rule, a mutable
+`status` key as the mechanism, without registering that they are in tension.
+
+**Options not taken.**
+
+- Put state in the path — `parked/` and `resumed/`, or a status suffix — so a
+  transition is a new file and the append-only rule and the state read agree.
+- Genuine append-only: transitions are new records pointing back with a
+  `supersedes` field, current state derived by following the chain.
+  `superseded_by` already implies this shape for one of the two transitions.
+- Drop append-only for these two records and say so. Git history is already
+  append-only, which is the argument §2 makes about a different question.
+
+**Choice as written.** A single `status` key edited in place for
+`parked → resumed`, and a supersession chain for `→ superseded`. Two
+transition mechanisms in one schema, chosen without noticing they are two.
+"Appends `status: resumed`" is ambiguous between adding a second `status`
+line and editing the existing one; only the second is expressible in YAML
+frontmatter, and only the first is append-only.
+
+**Consequences.** S2 must pick one of the two mechanisms at implementation
+time, and whichever it picks, "append-only" means something different for the
+two states in the same file. §5.2 inherits the tension more sharply: `voices`
+is a list inside frontmatter with a per-voice `disposition`, so adding or
+disposing a voice mid-review edits an existing record's frontmatter under a
+rule that says records are never edited in place. Worth noting that the spec
+demonstrates the alternative discipline one field earlier —
+`next_action_flag: asked` is a value fixed by policy rather than by
+mutation — applied to a single field and not to the state machine.
+
+**Pattern.** **Event Sourcing versus State Storage** (Fowler, 2005) — the
+records are specified with event sourcing's rule and state storage's schema.
+The coherence angle: §4.3 goes to real trouble to derive the honesty flag
+from durable state precisely so it does not depend on read order, and §5 then
+stores mutable state its own rule forbids restating. Note also that the
+sibling records these two sit beside — objections, stories — dodge the
+problem entirely by never transitioning: a human writes a disposition once
+and the record is not revisited. So the neighbouring precedent offers S2 and
+S5 no guidance here, which is part of why the gap is easy to miss.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/budgets-only.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/budgets-only.md
@@ -1,0 +1,19 @@
+# Pacts
+
+Fixture: a pact file declaring only `Budgets`. Exercises B5 — an absent block
+inside a file that exists — which is a different path from B4, where the file
+itself is missing.
+
+`sessions_per_day` is deliberately omitted so B9 can assert that `block_key`
+returns its supplied default for an absent optional key.
+
+## Budgets
+
+- daily_cost_ceiling: not observable
+- hard_stop_hour: 18:30
+- focus_blocks: 09:00-12:00, 14:00-17:00
+- notification_policy_after_stop: none
+- authored_at: 2026-08-08
+- authored_via: tune
+
+Unspent budget is not a debt.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/full.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/full.md
@@ -1,0 +1,36 @@
+# Pacts
+
+Fixture: a fully declared pact file. Every block well-formed, and the
+`Budgets` values deliberately chosen to break the inherited `read_key`
+extraction — a colon-bearing time, a comma-and-space-bearing list, and a
+two-word literal (spec §3.6).
+
+## Session WIP
+
+- max_concurrent_sessions: 2
+- max_switches_per_hour: 4
+- stale_after_hours: 12
+- enforcement: advisory
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.
+
+## Budgets
+
+- daily_cost_ceiling: not observable
+- sessions_per_day: 3
+- hard_stop_hour: 18:30
+- focus_blocks: 09:00-12:00, 14:00-17:00
+- notification_policy_after_stop: digest
+- authored_at: 2026-08-08
+- authored_via: tune
+
+Unspent budget is not a debt.
+
+## Sync cadence
+
+- interrupt_mode: coalesced
+- sync_points: 09:00, 16:00
+
+Reserved. No sentinel reads this block yet. Values declared here are inert;
+the slice that adds a consumer will define their behaviour.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/malformed-budgets.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/malformed-budgets.md
@@ -1,0 +1,21 @@
+# Pacts
+
+Fixture: a `Budgets` block that is present, active, and parseable, but whose
+prose has lost the mandatory clause. This is the reachable case — someone
+edits their pact file and deletes a sentence they read as boilerplate — and
+it must report `malformed`, not `declared` (spec §3.7).
+
+Treating this as declared would let the Mast hold its keeper to a pact whose
+governing clause they deleted.
+
+## Budgets
+
+- daily_cost_ceiling: not observable
+- sessions_per_day: 3
+- hard_stop_hour: 18:30
+- focus_blocks: 09:00-12:00, 14:00-17:00
+- notification_policy_after_stop: digest
+- authored_at: 2026-08-08
+- authored_via: tune
+
+The mandatory clause that belongs here has been deleted on purpose.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/shared-key.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/shared-key.md
@@ -1,0 +1,29 @@
+# Pacts
+
+Fixture for B8 — block-scoped key isolation.
+
+Both blocks declare `enforcement`, with different values. This is the only
+fixture that can distinguish a block-scoped parser from a whole-file one: a
+whole-file `read_key`-style lookup returns the first match in document order
+for both queries, so it returns `advisory` twice and passes a single-block
+test while failing this one.
+
+The key is shared deliberately. Nothing in today's vocabulary shares a key
+name, which is precisely why a single-block fixture would leave the property
+that justifies building a second parser entirely unverified (spec §3.6).
+
+## Session WIP
+
+- max_concurrent_sessions: 2
+- enforcement: advisory
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.
+
+## Budgets
+
+- sessions_per_day: 3
+- hard_stop_hour: 18:30
+- enforcement: strict
+
+Unspent budget is not a debt.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/with-comments.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-pacts/with-comments.md
@@ -1,0 +1,32 @@
+# Pacts
+
+Fixture for B11 — a hand-edited pact file carrying ordinary standalone
+comment lines inside a block.
+
+Under the general markdown rule "a span ends at the next heading of
+equal-or-higher level", `# revisit this in Q4` parses as a level-1 heading,
+truncates the block, drops every key below it AND the mandatory clause, and
+flips a perfectly good block to `malformed` with no line telling the human
+which sentence broke it.
+
+## Session WIP
+
+- max_concurrent_sessions: 2
+
+# revisit this in Q4
+
+- stale_after_hours: 6
+- enforcement: strict
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.
+
+## Budgets
+
+- hard_stop_hour: 18:30
+
+#### A sub-heading, which was always safe
+
+- sessions_per_day: 3
+
+Unspent budget is not a debt.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-01-retry-branch.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-01-retry-branch.md
@@ -1,0 +1,18 @@
+---
+session: sess-alpha
+repo: /tmp/toy
+created: 2026-08-01
+state: parked
+supersedes: null
+next_action_flag: asked
+---
+
+## Context
+
+Fixture: a parking record that was later resumed. Its successor below
+supersedes it, so the glob must NOT return this file.
+
+## Next action
+
+Implement the retry branch of slice 7's error path, starting from the
+failing test in test_retry.py.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-02-retry-branch.resumed.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-02-retry-branch.resumed.md
@@ -1,0 +1,17 @@
+---
+session: sess-beta
+repo: /tmp/toy
+created: 2026-08-02
+state: resumed
+supersedes: 2026-08-01-retry-branch.md
+next_action_flag: asked
+---
+
+## Context
+
+Fixture: the transition record. Append-only means the resume wrote this file
+rather than editing its predecessor's `state` key in place.
+
+## Next action
+
+Resumed — no further action pending.

--- a/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-03-parser-rewrite.md
+++ b/tdad_tests/layer0_deterministic/fixtures/cadence-records/parked/2026-08-03-parser-rewrite.md
@@ -1,0 +1,18 @@
+---
+session: sess-gamma
+repo: /tmp/toy
+created: 2026-08-03
+state: parked
+supersedes: null
+next_action_flag: asked
+---
+
+## Context
+
+Fixture: the one record that is still genuinely parked. This is the single
+file C3 expects the glob to return.
+
+## Next action
+
+Replace the greedy delimiter split in block_key with a first-delimiter split,
+starting from the failing B7 case.

--- a/tdad_tests/layer0_deterministic/test-pact-blocks.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-blocks.sh
@@ -55,13 +55,17 @@ if grep -nE '^[[:space:]]*-[[:space:]]*[a-z_]+[[:space:]]*:.*#' "$TEMPLATE"; the
 fi
 
 # --- B2: mandatory clauses present in the template ---------------------------
-grep -qF 'Unspent budget is not a debt.' "$TEMPLATE" \
+# Matched whitespace-normalised, exactly as the library matches them: the
+# clause's words are the interface, its line breaks are not. A template author
+# may wrap the sentence; they may not reword it.
+flat_template=$(tr '\n' ' ' < "$TEMPLATE" | tr -s '[:space:]' ' ')
+echo "$flat_template" | grep -qF 'Unspent budget is not a debt.' \
   || fail "B2: template Budgets block is missing the literal not-a-debt clause"
-grep -qF 'It counts; it does not assess.' "$TEMPLATE" \
+echo "$flat_template" | grep -qF 'It counts; it does not assess.' \
   || fail "B2: template Session WIP block is missing the gate-on-sessions clause"
 
 # --- B3: Sync cadence carries the reserved marker -----------------------------
-grep -qiF 'Reserved. No sentinel reads this block yet.' "$TEMPLATE" \
+echo "$flat_template" | grep -qiF 'Reserved. No sentinel reads this block yet.' \
   || fail "B3: template Sync cadence block is missing the reserved marker"
 
 # --- B4: no pact file at all — every block absent, note emitted, exit 0 -------

--- a/tdad_tests/layer0_deterministic/test-pact-blocks.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-blocks.sh
@@ -139,4 +139,27 @@ val=$(block_key 'Budgets' 'enforcement' '')
 [ "$val" = "strict" ] \
   || fail "B8: Budgets' enforcement must be 'strict', got '$val' — a whole-file parser returns 'advisory' here"
 
+# --- B10: a clause wrapped across lines still reads as declared --------------
+# Clause matching normalises whitespace, because the clause's WORDS are the
+# interface and its line breaks are not. Every block above whose clause happens
+# to sit on one line matches with or without normalisation, so none of them
+# guards this — B7's Budgets clause is single-line in every fixture.
+#
+# Session WIP's clause wraps mid-sentence in both the shipped template and
+# full.md, which makes it the one case that can fail. Without normalisation it
+# reads `malformed`, which is the exact regression that shipped and was caught
+# by hand on the first run.
+export CLAUDE_PACTS_FILE="$TEMPLATE"
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "B10: the template's Session WIP clause wraps across lines and must still read as declared"
+
+export CLAUDE_PACTS_FILE="$FIX/full.md"
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "B10: a wrapped Session WIP clause must read as declared in the full fixture too"
+
+# And the guard must not be so loose that a genuinely missing clause passes.
+export CLAUDE_PACTS_FILE="$FIX/malformed-budgets.md"
+[ "$(block_state 'Budgets')" = "malformed" ] \
+  || fail "B10: normalisation must not make a deleted clause look present"
+
 echo "PASS: pact-block reader — template well-formed, three states honoured, values survive extraction, keys scoped to their block"

--- a/tdad_tests/layer0_deterministic/test-pact-blocks.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-blocks.sh
@@ -162,4 +162,25 @@ export CLAUDE_PACTS_FILE="$FIX/malformed-budgets.md"
 [ "$(block_state 'Budgets')" = "malformed" ] \
   || fail "B10: normalisation must not make a deleted clause look present"
 
+# --- B11: a standalone # comment inside a block does not truncate it --------
+# The pact file is hand-edited, and the shipped guidance warns only against a
+# trailing `#` on a VALUE line — which reads as permission for a comment on its
+# own line. Under the general markdown rule that comment ends the span, taking
+# the mandatory clause with it and flipping a good block to malformed.
+export CLAUDE_PACTS_FILE="$FIX/with-comments.md"
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "B11: a standalone # comment must not truncate the block into malformed"
+val=$(block_key 'Session WIP' 'stale_after_hours' 'MISSING')
+[ "$val" = "6" ] \
+  || fail "B11: a key below a # comment must still be readable, got '$val'"
+[ "$(block_state 'Budgets')" = "declared" ] \
+  || fail "B11: a sub-heading inside a block must not truncate it"
+val=$(block_key 'Budgets' 'sessions_per_day' 'MISSING')
+[ "$val" = "3" ] || fail "B11: a key below a sub-heading must be readable, got '$val'"
+# The block must still END at the next real block heading — B8 would pass
+# trivially if a span simply ran to end-of-file.
+val=$(block_key 'Session WIP' 'hard_stop_hour' 'NOT-MINE')
+[ "$val" = "NOT-MINE" ] \
+  || fail "B11: Session WIP must not absorb Budgets' keys, got '$val'"
+
 echo "PASS: pact-block reader — template well-formed, three states honoured, values survive extraction, keys scoped to their block"

--- a/tdad_tests/layer0_deterministic/test-pact-blocks.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-blocks.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the pact-block reader
+# (spec 2026-08-08-cadence-sentinels-s1-infrastructure-design.md, §3; B1–B9).
+#
+# The reader is the one thing in S1 that parses a pact file. Three sentinels
+# consume it in S2–S5, so the properties tested here are the properties those
+# slices inherit — above all two of them:
+#
+#   1. The value-extraction rule (§3.6). The inherited `read_key` from
+#      reservoir-check.sh is greedy on `[:=]` and strips interior whitespace,
+#      so `hard_stop_hour: 18:30` yields `30` and `focus_blocks: 09:00-12:00,
+#      14:00-17:00` yields `00`. B7 is the test that forbids reusing it.
+#   2. Block scoping (§3.6). B8 is the ONLY scenario that can distinguish a
+#      block-scoped lookup from a whole-file one; a single-block fixture
+#      passes with `read_key` unmodified and proves nothing.
+#
+# Contract under test (spec §3.8), all from lib/pact-blocks.sh:
+#   pact_file                              -> resolved path ($CLAUDE_PACTS_FILE, else ~/.claude/pacts.md)
+#   block_state <heading>                  -> absent | malformed | declared
+#   block_key <heading> <key> <default>    -> value, first-delimiter split, ends-trimmed
+#   block_absent_note <heading>            -> the fixed observe-only sentence
+#
+# Absence is never an error and malformed is never a gate: every path here
+# exits 0 (spec §3.7, the Null Object contract).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+LIB="$PLUGIN/hooks/scripts/lib/pact-blocks.sh"
+TEMPLATE="$PLUGIN/templates/pacts.md"
+FIX="$SCRIPT_DIR/fixtures/cadence-pacts"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$LIB" ] || fail "pact-block reader not found at $LIB"
+[ -f "$TEMPLATE" ] || fail "pact template not found at $TEMPLATE"
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+for fn in pact_file block_state block_key block_absent_note; do
+  declare -F "$fn" >/dev/null || fail "lib must define $fn"
+done
+
+# --- B1: template well-formed, no trailing inline comments on value lines ----
+# The trap is real: read_key strips whitespace but keeps a trailing `#`, so a
+# tuned value with an inline comment degrades silently to its default. The
+# shipped HARNESS.md template makes this mistake; the pact template must not.
+for heading in "Session WIP" "Budgets" "Sync cadence"; do
+  grep -qE "^#{1,6}[[:space:]]+${heading}\$" "$TEMPLATE" \
+    || fail "B1: template is missing the '${heading}' heading"
+done
+if grep -nE '^[[:space:]]*-[[:space:]]*[a-z_]+[[:space:]]*:.*#' "$TEMPLATE"; then
+  fail "B1: a template value line carries a trailing '#' comment — read_key would swallow it into the value"
+fi
+
+# --- B2: mandatory clauses present in the template ---------------------------
+grep -qF 'Unspent budget is not a debt.' "$TEMPLATE" \
+  || fail "B2: template Budgets block is missing the literal not-a-debt clause"
+grep -qF 'It counts; it does not assess.' "$TEMPLATE" \
+  || fail "B2: template Session WIP block is missing the gate-on-sessions clause"
+
+# --- B3: Sync cadence carries the reserved marker -----------------------------
+grep -qiF 'Reserved. No sentinel reads this block yet.' "$TEMPLATE" \
+  || fail "B3: template Sync cadence block is missing the reserved marker"
+
+# --- B4: no pact file at all — every block absent, note emitted, exit 0 -------
+export CLAUDE_PACTS_FILE="$SCRIPT_DIR/fixtures/cadence-pacts/does-not-exist.md"
+for heading in "Session WIP" "Budgets" "Sync cadence"; do
+  set +e; state=$(block_state "$heading"); rc=$?; set -e
+  [ "$rc" -eq 0 ] || fail "B4: block_state must exit 0 when no pact file exists (got $rc)"
+  [ "$state" = "absent" ] || fail "B4: '$heading' must be absent when no pact file exists, got '$state'"
+  note=$(block_absent_note "$heading")
+  echo "$note" | grep -qF "running in observe-only mode" \
+    || fail "B4: absent note must carry the fixed observe-only sentence, got '$note'"
+  echo "$note" | grep -qF "$heading" \
+    || fail "B4: absent note must name the block, got '$note'"
+done
+
+# --- B5: absent block inside a file that exists -------------------------------
+export CLAUDE_PACTS_FILE="$FIX/budgets-only.md"
+[ "$(block_state 'Session WIP')" = "absent" ] \
+  || fail "B5: 'Session WIP' must be absent in a file declaring only Budgets"
+[ "$(block_state 'Budgets')" = "declared" ] \
+  || fail "B5: 'Budgets' must be declared in the budgets-only fixture"
+
+# --- B9: default returned for an absent optional key --------------------------
+# budgets-only.md deliberately omits sessions_per_day.
+set +e; val=$(block_key 'Budgets' 'sessions_per_day' 'FALLBACK'); rc=$?; set -e
+[ "$rc" -eq 0 ] || fail "B9: block_key must exit 0 for an absent key (got $rc)"
+[ "$val" = "FALLBACK" ] || fail "B9: absent key must return the supplied default, got '$val'"
+
+# --- B6: malformed — clause deleted, degrades to observe-only, never a gate ---
+export CLAUDE_PACTS_FILE="$FIX/malformed-budgets.md"
+set +e; state=$(block_state 'Budgets'); rc=$?; set -e
+[ "$rc" -eq 0 ] || fail "B6: a malformed block must never gate — block_state must exit 0 (got $rc)"
+[ "$state" = "malformed" ] \
+  || fail "B6: a Budgets block missing the not-a-debt clause must be 'malformed', got '$state'"
+note=$(block_absent_note 'Budgets')
+echo "$note" | grep -qF "running in observe-only mode" \
+  || fail "B6: a malformed block must still emit the observe-only sentence, got '$note'"
+
+# --- B7: colon- and space-bearing values survive extraction -------------------
+# This is the scenario the inherited greedy parser fails. Verified empirically
+# at the spec gate: read_key turns 18:30 into 30 and the focus_blocks list
+# into 00.
+export CLAUDE_PACTS_FILE="$FIX/full.md"
+[ "$(block_state 'Budgets')" = "declared" ] || fail "B7: full fixture's Budgets must be declared"
+
+val=$(block_key 'Budgets' 'hard_stop_hour' '')
+[ "$val" = "18:30" ] || fail "B7: hard_stop_hour must be '18:30', got '$val' (greedy split yields '30')"
+
+val=$(block_key 'Budgets' 'focus_blocks' '')
+[ "$val" = "09:00-12:00, 14:00-17:00" ] \
+  || fail "B7: focus_blocks must survive whole, got '$val' (greedy split yields '00')"
+
+val=$(block_key 'Budgets' 'daily_cost_ceiling' '')
+[ "$val" = "not observable" ] \
+  || fail "B7: daily_cost_ceiling must keep its interior space, got '$val'"
+
+val=$(block_key 'Sync cadence' 'sync_points' '')
+[ "$val" = "09:00, 16:00" ] || fail "B7: sync_points must survive whole, got '$val'"
+
+# A bare integer must still work — the regression guard on the simple case.
+val=$(block_key 'Session WIP' 'max_concurrent_sessions' '')
+[ "$val" = "2" ] || fail "B7: a bare integer value must still parse, got '$val'"
+
+# --- B8: block-scoped key isolation ------------------------------------------
+# The only scenario that distinguishes block-scoped from whole-file lookup.
+export CLAUDE_PACTS_FILE="$FIX/shared-key.md"
+val=$(block_key 'Session WIP' 'enforcement' '')
+[ "$val" = "advisory" ] \
+  || fail "B8: Session WIP's enforcement must be 'advisory', got '$val'"
+val=$(block_key 'Budgets' 'enforcement' '')
+[ "$val" = "strict" ] \
+  || fail "B8: Budgets' enforcement must be 'strict', got '$val' — a whole-file parser returns 'advisory' here"
+
+echo "PASS: pact-block reader — template well-formed, three states honoured, values survive extraction, keys scoped to their block"

--- a/tdad_tests/layer0_deterministic/test-record-contracts.sh
+++ b/tdad_tests/layer0_deterministic/test-record-contracts.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the two record contracts S1 owns and S2/S5 consume
+# (spec 2026-08-08-cadence-sentinels-s1-infrastructure-design.md, §5; C1–C3).
+#
+# Two properties are under test, and both exist because of a choice story.
+#
+#   1. WHERE the contract lives (#8). mkdocs.yml carries
+#      `exclude_docs: superpowers/`, so a schema homed in a record directory's
+#      README is the one format contract in this repo an adopter cannot read.
+#      The schemas therefore live in published reference/ pages, and the
+#      READMEs point rather than duplicate — which also removes the
+#      two-copies-drift problem a duplicated schema would create.
+#
+#   2. HOW state transitions (#9). Constraint 7 says records are append-only,
+#      and editing a `status` key from parked to resumed IS an in-place edit.
+#      So state lives in the filename and a transition writes a new file.
+#      C3 tests the glob that falls out of that: it is the query S2's resume
+#      path depends on, and it is only correct if transitions are files.
+#
+# S1 owns these contracts; per the promoted ARCH_DECISION a consumer never
+# mutates the contract it consumes, so S2 needing a new field carves its own
+# contract-owning slice rather than editing the reference page.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REF="$ROOT/docs/plugins/ai-literacy-superpowers/reference"
+PARKED_README="$ROOT/docs/superpowers/parked/README.md"
+CONSULT_README="$ROOT/docs/superpowers/consultations/README.md"
+LIB="$ROOT/ai-literacy-superpowers/hooks/scripts/lib/record-paths.sh"
+FIX="$SCRIPT_DIR/fixtures/cadence-records/parked"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- C1: the reference pages carry the schemas -------------------------------
+PARKING_REF="$REF/parking-record-format.md"
+CONSULT_REF="$REF/consultation-record-format.md"
+[ -f "$PARKING_REF" ] || fail "C1: parking record format page not found at $PARKING_REF"
+[ -f "$CONSULT_REF" ] || fail "C1: consultation record format page not found at $CONSULT_REF"
+
+for field in session repo created state supersedes next_action_flag; do
+  grep -qF "$field" "$PARKING_REF" \
+    || fail "C1: parking-record-format.md is missing the '$field' field"
+done
+for field in spec date state supersedes voices source_flag question disposition outcome; do
+  grep -qF "$field" "$CONSULT_REF" \
+    || fail "C1: consultation-record-format.md is missing the '$field' field"
+done
+
+# Both pages must state the rule that makes append-only true, not merely claim
+# append-only while describing a mutable key.
+for page in "$PARKING_REF" "$CONSULT_REF"; do
+  grep -qiF "append-only" "$page" || fail "C1: $(basename "$page") must state the append-only rule"
+  grep -qiE "filename|state-in-the-path|in the path" "$page" \
+    || fail "C1: $(basename "$page") must state that state lives in the filename"
+done
+
+# `next_action` is the field the Coda validates; the contract has to say it is
+# mandatory or S2 inherits an optional field it is required to enforce.
+grep -qiF "next_action" "$PARKING_REF" \
+  || fail "C1: parking-record-format.md must name the mandatory next_action"
+
+# --- C2: the directory READMEs point, they do not duplicate ------------------
+[ -f "$PARKED_README" ] || fail "C2: $PARKED_README not found"
+[ -f "$CONSULT_README" ] || fail "C2: $CONSULT_README not found"
+
+grep -qF "parking-record-format" "$PARKED_README" \
+  || fail "C2: parked/README.md must link its reference page"
+grep -qF "consultation-record-format" "$CONSULT_README" \
+  || fail "C2: consultations/README.md must link its reference page"
+
+# A README that declares its own field set is a second copy of the contract,
+# which is the drift the reference-page home exists to prevent.
+for readme in "$PARKED_README" "$CONSULT_README"; do
+  if grep -qE '^\s*(session|voices|next_action_flag|source_flag):' "$readme"; then
+    fail "C2: $(basename "$(dirname "$readme")")/README.md declares a field set — it must point, not duplicate"
+  fi
+done
+
+# --- C3: the state-in-the-path glob ------------------------------------------
+[ -f "$LIB" ] || fail "C3: record path helper not found at $LIB"
+# shellcheck source=/dev/null
+. "$LIB"
+declare -F records_open >/dev/null || fail "C3: lib must define records_open"
+
+open=$(records_open "$FIX" | sort)
+expected="$FIX/2026-08-03-parser-rewrite.md"
+[ "$open" = "$expected" ] || fail "C3: expected exactly the still-parked record
+  expected: $expected
+  got:      $open"
+
+# The two guards that make C3 meaningful rather than a filename coincidence.
+# No match is the passing case, so these cannot sit in an `&&` chain — under
+# `set -e` a failing grep would abort the script exactly when the test passes.
+if echo "$open" | grep -q "retry-branch.resumed"; then
+  fail "C3: a transition file must never be reported as open"
+fi
+if echo "$open" | grep -q "2026-08-01-retry-branch.md"; then
+  fail "C3: a record named by a transition's supersedes must not be reported as open"
+fi
+
+echo "PASS: record contracts — schemas published in reference pages, READMEs point not duplicate, open-record glob honours state-in-the-path"

--- a/tdad_tests/layer0_deterministic/test-session-registry.sh
+++ b/tdad_tests/layer0_deterministic/test-session-registry.sh
@@ -105,6 +105,35 @@ read -r count flag <<<"$(registry_count)"
 [ "$count" = "2" ] || fail "R4: two live sessions must count 2, got '$count'"
 [ "$flag" = "observed" ] || fail "R4: an unpruned count must be flagged observed, got '$flag'"
 
+# --- R16: an expired-but-unpruned entry is not counted as live ---------------
+# The critical finding from the code gate, reproduced before it was fixed:
+# nothing removes an entry when a session ENDS, because nothing knows a session
+# ended — the pruner is the only removal path and it runs on the Stop rail. So
+# a morning session, an afternoon session and a live evening session were three
+# files inside one 12-hour lease, and the count returned `3 observed`. Under
+# `max_concurrent_sessions: 2` that is a confident breach on an ordinary day.
+#
+# The filter is a pure read (R8 still holds), and the flag goes `inferred`
+# because an expired-unpruned entry carries the same "crashed, or merely
+# quiet?" uncertainty a retirement does — seen a moment earlier.
+# Per-command env rather than a subshell export: a subshell would make every
+# later reference to CLAUDE_SESSIONS_DIR look modified-and-lost to ShellCheck,
+# which is a CI gate here.
+r16="$TMP/r16"
+hook_input "r16-live"  | CLAUDE_SESSIONS_DIR="$r16" bash "$START_HOOK" >/dev/null 2>&1 || true
+hook_input "r16-stale" | CLAUDE_SESSIONS_DIR="$r16" bash "$START_HOOK" >/dev/null 2>&1 || true
+ts_old=$(date -u -v-20H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "20 hours ago" +%Y-%m-%dT%H:%M:%SZ)
+sed -i.bak -E "s#(\"heartbeat\"[[:space:]]*:[[:space:]]*\")[^\"]*#\1${ts_old}#" "$r16/r16-stale.json"
+rm -f "$r16/r16-stale.json.bak"
+
+read -r count flag <<<"$(CLAUDE_SESSIONS_DIR="$r16" registry_count)"
+[ "$count" = "1" ] \
+  || fail "R16: an expired-but-unpruned entry must not be counted as live, got '$count'"
+[ "$flag" = "inferred" ] \
+  || fail "R16: a count that skipped an expired entry must be flagged inferred, got '$flag'"
+# And the file is still there — counting filtered it, it did not delete it.
+[ -f "$r16/r16-stale.json" ] || fail "R16: registry_count must not remove the entry it skipped"
+
 # --- R8: registry_count mutates nothing --------------------------------------
 before=$(find "$CLAUDE_SESSIONS_DIR" -type f | sort | xargs cksum 2>/dev/null || true)
 registry_count >/dev/null
@@ -131,13 +160,19 @@ after=$(find "$CLAUDE_SESSIONS_DIR" -type f | sort | xargs cksum 2>/dev/null || 
 #
 # The forbidden set is wider than rm/mv for the same reason: truncation and
 # in-place edit destroy just as thoroughly.
+# Accepts both spellings of the builtin (`.` and `source`), braced and
+# unbraced variables, nested path segments, and filenames with underscores or
+# digits. A walker that recognised one idiom would silently skip a library
+# added by any other and still print "read library inert".
 closure_of() {
-  local f="$1" dir sourced
+  local f="$1" dir rel
   printf '%s\n' "$f"
   dir="$(dirname "$f")"
-  sourced=$(grep -oE '^[[:space:]]*\.[[:space:]]+"\$[A-Z_]+/[a-z-]+\.sh"' "$f" 2>/dev/null \
-            | grep -oE '[a-z-]+\.sh' || true)
-  for s in $sourced; do [ -f "$dir/$s" ] && closure_of "$dir/$s"; done
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -f "$dir/$rel" ] && closure_of "$dir/$rel"
+  done < <(grep -oE '^[[:space:]]*(\.|source)[[:space:]]+"?\$\{?[A-Za-z_][A-Za-z0-9_]*\}?/[A-Za-z0-9_./-]+\.sh"?' "$f" 2>/dev/null \
+           | sed -E 's#.*\}?/##' | sed -E 's/"$//' || true)
 }
 
 CLOSURE=$(closure_of "$READ_LIB" | sort -u)
@@ -147,15 +182,20 @@ echo "$CLOSURE" | grep -q "pact-blocks.sh" \
 for f in $CLOSURE; do
   # No match is the passing case, so this must not sit in an `&&` chain: under
   # `set -e` a failing grep would abort exactly when the test passes.
-  if grep -nE '(^|[^[:alnum:]_])(rm|rmdir|mv|cp|tee|mkdir|truncate)[[:space:]]' "$f" \
+  if grep -nE '(^|[^[:alnum:]_])(rm|rmdir|mv|cp|ln|dd|tee|mkdir|touch|chmod|chown|install|truncate)[[:space:]]' "$f" \
      | grep -vqE ':[[:space:]]*#'; then
     fail "R9: $(basename "$f") is in the read closure and contains a mutation command"
   fi
-  if grep -nE '(^|[[:space:]])(>|>>)[[:space:]]*"?\$' "$f" | grep -vqE ':[[:space:]]*#'; then
+  # Any redirect that creates or appends to a file, whether the target is a
+  # variable or a literal path, plus exec-style descriptor redirection.
+  if grep -nE '(^|[[:space:]])(>|>>)[[:space:]]*[^&[:space:]]' "$f" | grep -vqE ':[[:space:]]*#'; then
     fail "R9: $(basename "$f") is in the read closure and redirects to a file"
   fi
-  if grep -nE 'sed[[:space:]]+-i' "$f" | grep -vqE ':[[:space:]]*#'; then
-    fail "R9: $(basename "$f") is in the read closure and edits in place"
+  if grep -nE 'exec[[:space:]]+[0-9]*>' "$f" | grep -vqE ':[[:space:]]*#'; then
+    fail "R9: $(basename "$f") is in the read closure and opens a write descriptor"
+  fi
+  if grep -nE '(sed[[:space:]]+-i|awk[^|]*[[:space:]]>[[:space:]]*")' "$f" | grep -vqE ':[[:space:]]*#'; then
+    fail "R9: $(basename "$f") is in the read closure and edits or writes in place"
   fi
 done
 
@@ -262,5 +302,46 @@ repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
 case "$default_dir" in
   "$repo_root"/*) fail "R13: the default registry must not live inside a work tree ($default_dir)" ;;
 esac
+
+# --- R15: the hooks gate nothing and always exit 0 ---------------------------
+# This slice's headline constitutional promise is that it gates nothing, and
+# the mechanism by which a hook gates something is writing to stdout or exiting
+# non-zero. Every other invocation in this file is `>/dev/null 2>&1 || true`,
+# which is right for the scenarios they test and discards exactly the evidence
+# for these two contracts. Both are silent and exit 0 today; nothing guarded it.
+assert_silent_and_zero() {
+  local label="$1" hook="$2" input="$3" out rc
+  set +e
+  out="$(printf '%s' "$input" | bash "$hook" 2>/dev/null)"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "R15 ($label): hook must exit 0 unconditionally, got $rc"
+  [ -z "$out" ] || fail "R15 ($label): hook must write nothing to stdout — anything here is a per-turn nudge. Got: $out"
+}
+
+export CLAUDE_SESSIONS_DIR="$TMP/r15"
+assert_silent_and_zero "start, normal"  "$START_HOOK" '{"session_id":"r15","cwd":"/tmp"}'
+assert_silent_and_zero "sweep, normal"  "$SWEEP_HOOK" '{"session_id":"r15","cwd":"/tmp"}'
+assert_silent_and_zero "start, no session_id" "$START_HOOK" '{}'
+assert_silent_and_zero "sweep, empty stdin"   "$SWEEP_HOOK" ''
+assert_silent_and_zero "start, junk stdin"    "$START_HOOK" 'not json at all'
+
+# The paths the exits-0 contract exists for: a registry that cannot be created,
+# and a machine with no HOME.
+blocked="$TMP/blocked"
+: > "$blocked"                     # a FILE where the registry directory must go
+CLAUDE_SESSIONS_DIR="$blocked/sessions" \
+  assert_silent_and_zero "start, unwritable registry" "$START_HOOK" '{"session_id":"r15","cwd":"/tmp"}'
+CLAUDE_SESSIONS_DIR="$blocked/sessions" \
+  assert_silent_and_zero "sweep, unwritable registry" "$SWEEP_HOOK" '{"session_id":"r15","cwd":"/tmp"}'
+
+set +e
+out="$(printf '{"session_id":"r15","cwd":"/tmp"}' | env -u HOME -u CLAUDE_SESSIONS_DIR bash "$START_HOOK" 2>/dev/null)"
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "R15 (start, HOME unset): must exit 0, got $rc"
+[ -z "$out" ] || fail "R15 (start, HOME unset): must stay silent, got: $out"
+
+export CLAUDE_SESSIONS_DIR="$TMP/sessions"
 
 echo "PASS: session registry — lease renewed not deleted, flag durable, read library inert, hostile ids sanitised"

--- a/tdad_tests/layer0_deterministic/test-session-registry.sh
+++ b/tdad_tests/layer0_deterministic/test-session-registry.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the session registry
+# (spec 2026-08-08-cadence-sentinels-s1-infrastructure-design.md, §4; R1–R13).
+#
+# The registry is a LEASE, not a liveness log. Entries are written on
+# SessionStart, renewed on Stop, and retired only by lease expiry. That design
+# exists because of R3: the Stop hook fires when the main agent finishes
+# responding — many times per session, not once at session end. Every one of
+# the nine existing Stop scripts declares "runs at session end" in its header
+# and none carries a once-per-session guard, which is harmless for nine
+# idempotent advisories and fatal for a destructive one. A delete-on-Stop
+# registry empties itself after each session's first response, and the WIP
+# Warden reports 1 while four sessions run.
+#
+# R3 is the test that would have caught the design this replaced. R8 and R9
+# are the trust-boundary tests: a sentinel may source the read library, so the
+# read library must be incapable of mutation (spec §4.4).
+#
+# Contract under test:
+#   lib/session-registry-read.sh   registry_count -> "<n> <observed|inferred>", registry_list
+#   lib/session-registry-write.sh  registry_touch, registry_prune
+#   session-registry-start.sh      SessionStart hook — write-if-absent, renew
+#   session-registry-sweep.sh      Stop hook — renew, then prune expired
+#
+# $CLAUDE_SESSIONS_DIR overrides the registry location so tests need no home
+# directory, mirroring $CLAUDE_PACTS_FILE for the pact reader.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+READ_LIB="$PLUGIN/hooks/scripts/lib/session-registry-read.sh"
+WRITE_LIB="$PLUGIN/hooks/scripts/lib/session-registry-write.sh"
+START_HOOK="$PLUGIN/hooks/scripts/session-registry-start.sh"
+SWEEP_HOOK="$PLUGIN/hooks/scripts/session-registry-sweep.sh"
+PACT_FIX="$SCRIPT_DIR/fixtures/cadence-pacts"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+for f in "$READ_LIB" "$WRITE_LIB" "$START_HOOK" "$SWEEP_HOOK"; do
+  [ -f "$f" ] || fail "not found: $f"
+done
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_SESSIONS_DIR="$TMP/sessions"
+
+# hook_input <session-id> — the stdin JSON shape the hooks receive.
+hook_input() { printf '{"session_id":"%s","cwd":"%s"}' "$1" "$TMP"; }
+
+# heartbeat_of <session-id>
+heartbeat_of() { grep -o '"heartbeat"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLAUDE_SESSIONS_DIR/$1.json" | head -1; }
+started_of()   { grep -o '"started_at"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLAUDE_SESSIONS_DIR/$1.json" | head -1; }
+
+# age_entry <session-id> <hours> — backdate an entry's heartbeat.
+age_entry() {
+  local id="$1" hours="$2" ts
+  if date -u -v-"${hours}"H +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+    ts=$(date -u -v-"${hours}"H +%Y-%m-%dT%H:%M:%SZ)          # BSD/macOS
+  else
+    ts=$(date -u -d "${hours} hours ago" +%Y-%m-%dT%H:%M:%SZ) # GNU
+  fi
+  sed -i.bak -E "s#(\"heartbeat\"[[:space:]]*:[[:space:]]*\")[^\"]*#\1${ts}#" \
+    "$CLAUDE_SESSIONS_DIR/$id.json"
+  rm -f "$CLAUDE_SESSIONS_DIR/$id.json.bak"
+}
+
+# --- R1: write on start -------------------------------------------------------
+hook_input "sess-alpha" | bash "$START_HOOK" >/dev/null 2>&1 || true
+entry="$CLAUDE_SESSIONS_DIR/sess-alpha.json"
+[ -f "$entry" ] || fail "R1: SessionStart must write $entry"
+for key in id repo started_at heartbeat; do
+  grep -q "\"$key\"" "$entry" || fail "R1: entry must carry '$key'"
+done
+
+# --- R2: SessionStart re-fire renews heartbeat, never resets started_at -------
+# SessionStart fires on startup, resume, clear and compact. A reset started_at
+# would mean a long-running session never ages out.
+started_before=$(started_of sess-alpha)
+age_entry sess-alpha 1
+hb_before=$(heartbeat_of sess-alpha)
+hook_input "sess-alpha" | bash "$START_HOOK" >/dev/null 2>&1 || true
+[ "$(started_of sess-alpha)" = "$started_before" ] \
+  || fail "R2: SessionStart re-fire must not reset started_at"
+[ "$(heartbeat_of sess-alpha)" != "$hb_before" ] \
+  || fail "R2: SessionStart re-fire must renew heartbeat"
+
+# --- R3: Stop renews, never deletes ------------------------------------------
+# The scenario that would have caught the delete-on-Stop design.
+age_entry sess-alpha 1
+hb_before=$(heartbeat_of sess-alpha)
+for _ in 1 2 3; do
+  hook_input "sess-alpha" | bash "$SWEEP_HOOK" >/dev/null 2>&1 || true
+done
+[ -f "$entry" ] || fail "R3: Stop must NOT delete the entry — Stop fires per turn, not per session"
+[ "$(heartbeat_of sess-alpha)" != "$hb_before" ] || fail "R3: Stop must renew heartbeat"
+
+# --- R4: two overlapping sessions counted, flagged observed ------------------
+# shellcheck source=/dev/null
+. "$READ_LIB"
+declare -F registry_count >/dev/null || fail "read lib must define registry_count"
+declare -F registry_list  >/dev/null || fail "read lib must define registry_list"
+
+hook_input "sess-beta" | bash "$START_HOOK" >/dev/null 2>&1 || true
+read -r count flag <<<"$(registry_count)"
+[ "$count" = "2" ] || fail "R4: two live sessions must count 2, got '$count'"
+[ "$flag" = "observed" ] || fail "R4: an unpruned count must be flagged observed, got '$flag'"
+
+# --- R8: registry_count mutates nothing --------------------------------------
+before=$(find "$CLAUDE_SESSIONS_DIR" -type f | sort | xargs cksum 2>/dev/null || true)
+registry_count >/dev/null
+after=$(find "$CLAUDE_SESSIONS_DIR" -type f | sort | xargs cksum 2>/dev/null || true)
+[ "$before" = "$after" ] || fail "R8: registry_count must be a pure read — contents changed"
+
+# --- R9: the read library exposes no mutation --------------------------------
+# A sentinel may source this file. sentinel-integrity-check.sh permits Bash and
+# names its own limit: a write capability reached through an undeclared channel
+# is out of scope for it. So the boundary has to hold here instead.
+( unset -f registry_touch registry_prune 2>/dev/null || true
+  # shellcheck source=/dev/null
+  . "$READ_LIB"
+  if declare -F registry_touch >/dev/null || declare -F registry_prune >/dev/null; then
+    echo "FAIL: R9: sourcing the read library must not define a mutation function" >&2
+    exit 1
+  fi
+) || exit 1
+# No match is the passing case, so this must not sit in an `&&` chain: under
+# `set -e` a failing grep would abort the script exactly when the test passes.
+if grep -nE '(^|[^[:alnum:]_])(rm|mv)[[:space:]]' "$READ_LIB" | grep -vqE ':[[:space:]]*#'; then
+  fail "R9: the read library must contain no delete/move operation"
+fi
+
+# --- R5: expired lease retired, count flagged inferred -----------------------
+age_entry sess-beta 20
+hook_input "sess-alpha" | bash "$SWEEP_HOOK" >/dev/null 2>&1 || true
+[ ! -f "$CLAUDE_SESSIONS_DIR/sess-beta.json" ] \
+  || fail "R5: an entry past its lease must be retired"
+read -r count flag <<<"$(registry_count)"
+[ "$count" = "1" ] || fail "R5: count after retirement must be 1, got '$count'"
+[ "$flag" = "inferred" ] \
+  || fail "R5: a count following a retirement must be flagged inferred, got '$flag'"
+
+# --- R6: the flag survives repeated reads ------------------------------------
+# The flag is a property of the count, not of whoever read first.
+for _ in 1 2; do
+  read -r _ flag <<<"$(registry_count)"
+  [ "$flag" = "inferred" ] \
+    || fail "R6: the inferred flag must persist across reads, got '$flag'"
+done
+
+# --- R7: the lease length is declared, not compiled in -----------------------
+hook_input "sess-gamma" | bash "$START_HOOK" >/dev/null 2>&1 || true
+age_entry sess-gamma 3
+
+export CLAUDE_PACTS_FILE="$TMP/short-lease.md"
+cat > "$CLAUDE_PACTS_FILE" <<'EOF'
+## Session WIP
+
+- max_concurrent_sessions: 2
+- stale_after_hours: 2
+
+This is a gate on sessions, never on the person. It counts; it does not
+assess.
+EOF
+hook_input "sess-alpha" | bash "$SWEEP_HOOK" >/dev/null 2>&1 || true
+[ ! -f "$CLAUDE_SESSIONS_DIR/sess-gamma.json" ] \
+  || fail "R7: with stale_after_hours: 2, a 3-hour-old entry must be retired"
+
+hook_input "sess-delta" | bash "$START_HOOK" >/dev/null 2>&1 || true
+age_entry sess-delta 3
+export CLAUDE_PACTS_FILE="$PACT_FIX/full.md"   # stale_after_hours: 12
+hook_input "sess-alpha" | bash "$SWEEP_HOOK" >/dev/null 2>&1 || true
+[ -f "$CLAUDE_SESSIONS_DIR/sess-delta.json" ] \
+  || fail "R7: with stale_after_hours: 12, a 3-hour-old entry must survive"
+unset CLAUDE_PACTS_FILE
+
+# --- R10: hostile session id sanitised ---------------------------------------
+# Already adjudicated once in this repo for the same field
+# (affordance-invocation-recorder.sh:55). A `/` or `..` in a path context is
+# strictly worse than the JSON-injection case fixed there.
+printf '{"session_id":"../../escaped","cwd":"%s"}' "$TMP" | bash "$START_HOOK" >/dev/null 2>&1 || true
+[ -f "$CLAUDE_SESSIONS_DIR/unknown.json" ] \
+  || fail "R10: a hostile session id must be sanitised to 'unknown'"
+[ ! -e "$TMP/escaped.json" ] || fail "R10: no file may be written outside the registry directory"
+[ "$(find "$CLAUDE_SESSIONS_DIR" -maxdepth 1 -name '*.json' | wc -l | tr -d ' ')" \
+  = "$(find "$CLAUDE_SESSIONS_DIR" -name '*.json' | wc -l | tr -d ' ')" ] \
+  || fail "R10: sanitisation must keep every entry flat inside the registry directory"
+
+# --- R11: an unknown entry flags the count inferred --------------------------
+# One unknown.json may stand for more than one session, so the count is not
+# something the registry can claim to have observed.
+read -r _ flag <<<"$(registry_count)"
+[ "$flag" = "inferred" ] \
+  || fail "R11: a registry containing unknown.json must flag the count inferred, got '$flag'"
+
+# --- R12: no registry directory at all ---------------------------------------
+export CLAUDE_SESSIONS_DIR="$TMP/nonexistent"
+set +e; out=$(registry_count); rc=$?; set -e
+[ "$rc" -eq 0 ] || fail "R12: registry_count must exit 0 when the directory is absent (got $rc)"
+read -r count flag <<<"$out"
+[ "$count" = "0" ] || fail "R12: absent registry must count 0, got '$count'"
+[ "$flag" = "observed" ] || fail "R12: absent registry must be flagged observed, got '$flag'"
+
+# --- R13: the default registry lives outside every work tree -----------------
+unset CLAUDE_SESSIONS_DIR
+default_dir=$(registry_dir)
+case "$default_dir" in
+  "$HOME"/.claude/sessions*) : ;;
+  *) fail "R13: the default registry must resolve under ~/.claude/sessions, got '$default_dir'" ;;
+esac
+repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+case "$default_dir" in
+  "$repo_root"/*) fail "R13: the default registry must not live inside a work tree ($default_dir)" ;;
+esac
+
+echo "PASS: session registry — lease renewed not deleted, flag durable, read library inert, hostile ids sanitised"

--- a/tdad_tests/layer0_deterministic/test-session-registry.sh
+++ b/tdad_tests/layer0_deterministic/test-session-registry.sh
@@ -123,11 +123,41 @@ after=$(find "$CLAUDE_SESSIONS_DIR" -type f | sort | xargs cksum 2>/dev/null || 
     exit 1
   fi
 ) || exit 1
-# No match is the passing case, so this must not sit in an `&&` chain: under
-# `set -e` a failing grep would abort the script exactly when the test passes.
-if grep -nE '(^|[^[:alnum:]_])(rm|mv)[[:space:]]' "$READ_LIB" | grep -vqE ':[[:space:]]*#'; then
-  fail "R9: the read library must contain no delete/move operation"
-fi
+# The textual guard must walk the TRANSITIVE source closure, not just this one
+# file. session-registry-read.sh sources pact-blocks.sh, and a sentinel that
+# sources the read library reaches everything pact-blocks.sh defines — so a
+# mutation function added there would sit one `.` away from a sentinel while
+# this test still announced "read library inert".
+#
+# The forbidden set is wider than rm/mv for the same reason: truncation and
+# in-place edit destroy just as thoroughly.
+closure_of() {
+  local f="$1" dir sourced
+  printf '%s\n' "$f"
+  dir="$(dirname "$f")"
+  sourced=$(grep -oE '^[[:space:]]*\.[[:space:]]+"\$[A-Z_]+/[a-z-]+\.sh"' "$f" 2>/dev/null \
+            | grep -oE '[a-z-]+\.sh' || true)
+  for s in $sourced; do [ -f "$dir/$s" ] && closure_of "$dir/$s"; done
+}
+
+CLOSURE=$(closure_of "$READ_LIB" | sort -u)
+echo "$CLOSURE" | grep -q "pact-blocks.sh" \
+  || fail "R9: the closure walk found no sourced libraries — it is not actually walking"
+
+for f in $CLOSURE; do
+  # No match is the passing case, so this must not sit in an `&&` chain: under
+  # `set -e` a failing grep would abort exactly when the test passes.
+  if grep -nE '(^|[^[:alnum:]_])(rm|rmdir|mv|cp|tee|mkdir|truncate)[[:space:]]' "$f" \
+     | grep -vqE ':[[:space:]]*#'; then
+    fail "R9: $(basename "$f") is in the read closure and contains a mutation command"
+  fi
+  if grep -nE '(^|[[:space:]])(>|>>)[[:space:]]*"?\$' "$f" | grep -vqE ':[[:space:]]*#'; then
+    fail "R9: $(basename "$f") is in the read closure and redirects to a file"
+  fi
+  if grep -nE 'sed[[:space:]]+-i' "$f" | grep -vqE ':[[:space:]]*#'; then
+    fail "R9: $(basename "$f") is in the read closure and edits in place"
+  fi
+done
 
 # --- R5: expired lease retired, count flagged inferred -----------------------
 age_entry sess-beta 20
@@ -184,6 +214,27 @@ printf '{"session_id":"../../escaped","cwd":"%s"}' "$TMP" | bash "$START_HOOK" >
 [ "$(find "$CLAUDE_SESSIONS_DIR" -maxdepth 1 -name '*.json' | wc -l | tr -d ' ')" \
   = "$(find "$CLAUDE_SESSIONS_DIR" -name '*.json' | wc -l | tr -d ' ')" ] \
   || fail "R10: sanitisation must keep every entry flat inside the registry directory"
+
+# --- R14: a quote-bearing repo path cannot inject JSON -----------------------
+# `repo` defaults to $PWD, and a filesystem path may legally contain a `"`.
+# Unescaped, such a path closes the string early and injects keys — and since
+# _json_field takes the FIRST match, an injected heartbeat wins. Because lease
+# expiry is the only removal path in this design, the entry would then be
+# immortal: it inflates the count for every sentinel on the machine forever,
+# recoverable only by a human deleting the file.
+# shellcheck source=/dev/null
+. "$WRITE_LIB"
+registry_touch "sess-inject" '/w/a","heartbeat":"2099-01-01T00:00:00Z'
+injected="$CLAUDE_SESSIONS_DIR/sess-inject.json"
+[ -f "$injected" ] || fail "R14: the entry must still be written"
+hb=$(_json_field "$injected" heartbeat)
+case "$hb" in
+  2099-*) fail "R14: a quote in repo injected a heartbeat ($hb) — the entry would never expire" ;;
+esac
+age_entry sess-inject 20
+registry_prune
+[ ! -f "$injected" ] \
+  || fail "R14: an entry written from a quote-bearing repo must still be prunable"
 
 # --- R11: an unknown entry flags the count inferred --------------------------
 # One unknown.json may stand for more than one session, so the count is not

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -63,6 +63,13 @@ BASH_TEST_SCRIPTS = [
     # harness-health badge writer — mirrors the authoritative Health line
     # rather than re-deriving it (regression: "Trend alerts: none").
     "test-update-health-badge",
+    # Cadence Sentinels S1 — the shared substrate S2–S5 consume: the pact
+    # block reader, the session registry lease, and the two record contracts.
+    # RED until S1 ships lib/pact-blocks.sh, the two registry libraries and
+    # their hooks, lib/record-paths.sh, and the reference format pages.
+    "test-pact-blocks",
+    "test-session-registry",
+    "test-record-contracts",
 ]
 
 


### PR DESCRIPTION
Closes #491. First slice of **The Cadence Sentinels** epic (#491–#497).

Ships the plumbing the four cadence sentinels will consume, once, so none of them re-derives it. **Nothing in this slice gates anything.**

## What's here

- **The pact file** — `~/.claude/pacts.md`, a new user-scoped declaration surface carrying `Session WIP`, `Budgets`, and a reserved `Sync cadence`. Template ships; nothing creates the file.
- **`lib/pact-blocks.sh`** — one reader, three block states (absent / malformed / declared), and a Null Object contract so no sentinel ever branches on absence.
- **The session registry** — machine-global at `~/.claude/sessions/`, a lease renewed by `SessionStart` and `Stop`, retired only by expiry.
- **Two libraries split on the sentinel trust boundary** — sentinels may source the read surface; mutation is reachable only from hooks.
- **Record contracts** — parking and consultation formats as published reference pages, with state in the filename so append-only is true rather than merely claimed.
- **27 Layer-0 scenarios** across three new test files.

## Divergence from the build spec — please read

**Pacts live in `~/.claude/pacts.md`, not `HARNESS.md`.** The build spec located these blocks "in the plugin's harness-template source, wherever `Cognitive reservoir` is defined". Disposed otherwise at the cartographer gate on stories #4 and #5: a stop hour and a concurrency limit are properties of a *person*, not a repository, and a repo-scoped pact file cannot say whose pact it is. `HARNESS.md` is untouched by this slice, and nothing about the person is committed anywhere.

Two further notes where the build spec had gone stale against repo reality:

- **The sentinel category is already load-bearing** (shipped v0.66.0 with CI enforcement), so constraint 9's "introduce it in docs only" does not apply. Every new sentinel must satisfy S1–S3 and carry `role: sentinel`; S7 *extends* the roster page rather than creating it, and the rename open note is moot.
- **The Coda cannot hold `Write`.** Its agent will return record content and the `/coda` command will persist it — the `cost-estimator` precedent. Disposed at the design gate.

## What the gates caught

Four adversarial passes, each finding what the previous one could not.

| Gate | Outcome |
|---|---|
| Diaboli (spec) | 12 objections — 11 accepted, 1 rejected on the record |
| Choice Cartographer | 9 stories — all accepted, 3 dissolved structurally |
| Code review | 5 blocking findings — all fixed, 3 verified by killing its own mutants |
| Diaboli (code) | 11 objections — 10 accepted, 1 deferred |

Three worth your attention:

1. **`Stop` fires per assistant turn, not per session.** A delete-on-`Stop` registry would have emptied itself after each session's first response, and S4's WIP Warden would have reported `1` while four sessions ran. Now a lease with heartbeat renewal, so correctness no longer depends on firing semantics nobody had verified. All nine pre-existing `Stop` scripts assert "runs at session end" in their headers; none is guarded, which is harmless for idempotent advisories and was fatal here.

2. **The inherited `read_key` is greedy on `:`.** `hard_stop_hour: 18:30` parses to `30`. Three of seven `Budgets` keys would have been silently mangled. `block_key` splits on the first delimiter instead, and B7 forbids the greedy form returning.

3. **`registry_count` counted files with no freshness test.** Three sequential sessions in one day returned `3 observed` with one live. It now filters expired entries on read — still a pure read — and flags `inferred` when it did.

## Constitutional additions

`sentinel-design` gains a **third persistence category**: hook-authored operational state, alongside records a human authored and claims an agent made about them. Permitted only when local, bounded, judging nothing, and disclosed. The registry is the worked example and was nearly shipped silently while the pact file — the safely-permitted side of the line — got a careful adoption ramp. That asymmetry was backwards; the contested artefact needs *more* disclosure, not less.

## Records

- Spec (revision 4): `docs/superpowers/specs/2026-08-08-cadence-sentinels-s1-infrastructure-design.md`
- Spec-gate objections: `docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design.md`
- Code-gate objections: `docs/superpowers/objections/cadence-sentinels-s1-infrastructure-design-code.md`
- Choice stories: `docs/superpowers/stories/cadence-sentinels-s1-infrastructure-design.md`

## Follow-ups raised, not fixed here

- The shipped `HARNESS.md` template's `Cognitive reservoir` block carries inline `#` comments on value lines, which `read_key` swallows into the value — a downstream project that uncomments and tunes it degrades silently to the default. Pre-existing, different block; deliberately not folded into a plumbing slice.
- The per-turn prune (code-gate O9) is deferred on the record: comparable to the nine existing `Stop` hooks. Measure before optimising; the throttle design is in the objection record.

Version: 0.66.2 → 0.67.0 across all five CI-checked locations.