### PR TITLE
Cadence Sentinels S2 — the Coda: closing a session by decision, not by attrition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.67.0",
+  "plugin_version": "0.68.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.67.0"
+      "version": "0.68.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.68.0 — 2026-08-09
+
+### Cadence Sentinels S2 — the Coda
+
+The closing ritual. A session that ends by decision rather than by attrition,
+with every open thread written down and a concrete step to resume from.
+
+- **`/coda`** — survey what landed and what is still live, park each open
+  thread, write the closure summary through `/reflect`, and close. Stoppable at
+  any point by saying so.
+- **`/coda resume <record>`** closes a parked thread by writing a `.resumed.md`
+  transition. Nothing is ever edited or deleted.
+- **The `coda` agent is `role: sentinel` and read-only.** It returns
+  parking-record content; the command persists it after the human confirms.
+- **Parking happens before reflection, and records are committed there.**
+  `/reflect` stages only the reflection paths and, where a *Reflections via PR
+  workflow* constraint is declared, relocates the tree to `main` — so a ritual
+  that reflected first would have published a summary describing records it
+  left behind uncommitted, on a branch it had just left.
+- **Nothing is refused.** `scripts/next-action-hint.sh` asks one more question
+  when it finds no anchor; whatever the human answers is parked, including the
+  same words again. It renders no verdict, so there is no gate.
+- **The anchor grammar carries a decision row** — a question word, a named
+  person, `ask` / `decide` / `choose between` — because the other five kinds
+  are all artefacts of code-shaped work, and much of what gets parked is a
+  spec, a piece of prose, or a decision.
+- **The override lives in the record's prose, in the human's own voice**, not
+  in a frontmatter flag. A flag recording that someone's answer failed a check
+  would be an agent-authored verdict about them, permanent and countable across
+  records. `next_action_flag` stays `asked`, so S2 consumes S1's contract
+  without mutating it.
+- **Thread grouping is proposed and default-accepted.** Deciding that nine
+  modified files are two threads is the judgement that shapes the whole
+  handoff, so it is the human's — but the proposal stands unless they change
+  it, because this step lands after they have decided they are finished.
+- **Parked records surface once, on startup only.** `SessionStart` re-fires on
+  resume, clear and compact; handing a thread back mid-session is the surface
+  this epic exists to reduce. The guard reads the hook's own `source` field and
+  writes no marker file.
+- **`sentinel-design`** gains the Coda to its roster; sentinels 5 → 6.
+- **19 new Layer-0 scenarios** across `test-next-action.sh`,
+  `test-parked-resume.sh`, and the extended `test-record-contracts.sh`.
+
 ## 0.67.0 — 2026-08-08
 
 ### Cadence Sentinels S1 — the shared substrate

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.68.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
-[![Agents](https://img.shields.io/badge/Agents-16-2E8B57?style=flat-square)](#agents-16)
-[![Commands](https://img.shields.io/badge/Commands-28-2E8B57?style=flat-square)](#commands-28)
+[![Skills](https://img.shields.io/badge/Skills-38-2E8B57?style=flat-square)](#skills-38)
+[![Agents](https://img.shields.io/badge/Agents-17-2E8B57?style=flat-square)](#agents-17)
+[![Commands](https://img.shields.io/badge/Commands-29-2E8B57?style=flat-square)](#commands-29)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (37)
+### Skills (38)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -199,7 +199,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
 | sentinel-design | Defines the sentinel agent category — the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery (why code-reviewer and harness-auditor don't qualify), the honesty-rule-before-detection-logic discipline, and the three anti-patterns (scoring the human, persisting human-state records, gating automatically) |
 
-### Agents (16)
+### Agents (17)
 
 A coordinated team that handles the full development lifecycle. It
 splits into two families: **sentinels**, whose object of care is the
@@ -258,7 +258,7 @@ The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (28)
+### Commands (29)
 
 | Command | What it does |
 | ------- | ------------ |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.67.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.68.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
 [![Skills](https://img.shields.io/badge/Skills-37-2E8B57?style=flat-square)](#skills-37)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.67.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **37 skills, 16 agents, 28 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.68.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **38 skills, 17 agents, 29 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/coda.agent.md
+++ b/ai-literacy-superpowers/agents/coda.agent.md
@@ -1,0 +1,97 @@
+---
+name: coda
+description: Use at session close via /coda — surveys what landed and what is still live, proposes a thread grouping for the human to confirm, and returns parking-record content with a concrete next action per thread; read-only by design, it writes nothing and never decides that a session should end
+tools: [Read, Glob, Grep, Bash]
+role: sentinel
+---
+
+# Coda Agent
+
+You close a session properly. An agentic session has no terminal cue — no
+compile, no deploy, no colleague standing up to leave — so sessions end by
+attrition, and the threads left open keep their pull because nothing wrote
+down where they were.
+
+You survey, you propose, you draft. You do not decide that the session should
+end, you do not decide what counts as one thread, and you do not write
+anything.
+
+## Your first action
+
+Read the `coda` skill in full:
+
+```text
+ai-literacy-superpowers/skills/coda/SKILL.md
+```
+
+It carries the ritual, the anchor grammar, the evidence behind the next-action
+question, and the anti-patterns. Inherit your grounding from it — do not
+re-derive it here.
+
+## Trust boundary
+
+You hold no `Write` and no `Edit`, and this is not an oversight to work
+around. You return parking-record content as a string; the `/coda` command
+persists it after the human has confirmed. That is the `cost-estimator`
+precedent, and it is what keeps you inside the sentinel category.
+
+`Bash` is for reading only — `git log`, `git status`, `gh pr list`, `date`.
+Never a mutation, never a commit, never a `gh pr merge`.
+
+## What you return
+
+A survey, then one draft parking record per thread the human confirmed.
+
+Every claim carries its flag:
+
+| Item | Flag |
+| --- | --- |
+| Commits, working-tree state, dispositions in records | `observed` |
+| Merged PRs, open-PR check state | `observed` when `gh` succeeded; `inferred` when it did not |
+| Which files constitute one thread | `asked` |
+
+If `gh` fails, say so. Reporting "no merged PRs" because the call errored,
+flagged `observed`, is the laundering of inference as observation that the
+honesty rule exists to stop.
+
+## The grouping is the human's
+
+Deciding that nine modified files are *two* threads rather than one or nine is
+the judgement that determines how many records exist and what each one says.
+It is not yours.
+
+Propose a grouping with your reasoning, and let it stand unless the human
+changes it. Propose-and-default-accept is deliberate: this step lands after
+the human has already decided they are finished, and demanding a full manual
+partition there would put the ritual's heaviest synthesis on whoever is least
+equipped to do it.
+
+## The next action
+
+Ask for one concrete resume step per thread. Run
+`scripts/next-action-hint.sh` against the answer.
+
+**Exit 1 means ask once more. It never means refuse.** Whatever the human
+answers next is parked, including the same words again. If they repeat
+themselves, the record's `## Next action` section carries their answer plus a
+line in *their own voice* noting they were asked for a starting point and
+confirmed this was enough to go on.
+
+You are not grading their wording. A frontmatter flag recording that a human's
+answer failed a check would be an agent-authored verdict about the person,
+committed permanently and countable across records — which is the anti-pattern
+`sentinel-design` names.
+
+## What you never do
+
+- **Never write a file.** Every record is persisted by the command.
+- **Never decide the session should end.** The human invoked you.
+- **Never continue the ritual when asked to stop.** If they say plainly that
+  they want to keep working, stop and state exactly what has already been
+  written. Records are append-only; nothing already written can be withdrawn,
+  so say what exists rather than implying it can be undone.
+- **Never open new work in the closing breath.** A "while we're here" request
+  after the ritual starts gets parked, not executed — that drift is what you
+  are here for.
+- **Never record why the human stopped.** That a session closed and what was
+  parked is the record. Why is not.

--- a/ai-literacy-superpowers/commands/coda.md
+++ b/ai-literacy-superpowers/commands/coda.md
@@ -1,0 +1,143 @@
+---
+name: coda
+description: Close a session deliberately — survey what landed and what is still live, park each open thread with a concrete next action, write the closure summary through /reflect, and end. Dispatches the read-only coda agent and persists what it returns after you confirm.
+---
+
+# /coda [resume RECORD]
+
+The good ending. A ritual that closes a session on purpose rather than by
+attrition, so the threads you leave open stop pulling at you and the next
+session opens warm.
+
+Nothing here gates you. You can stop the ritual at any point by saying so.
+
+## When to use
+
+- **`/coda`** — when you are finishing for the day, or finishing with this
+  piece of work.
+- **`/coda resume RECORD`** — when a thread you parked earlier is done.
+
+## `/coda` versus `/reflect`
+
+`/reflect` writes a learning. `/coda` closes a session, and calls `/reflect`
+as part of doing so.
+
+If you want to capture one surprise and carry on working, that is `/reflect`.
+If you are stopping, that is `/coda`.
+
+## Process
+
+### 1. Read the skill
+
+Read `skills/coda/SKILL.md` in full before anything else. It carries the
+ritual, the anchor grammar, the evidence, and the anti-patterns.
+
+### 2. Dispatch the coda agent
+
+Pass the project root. The agent surveys what landed and what is still live,
+flags each item, proposes a thread grouping with its reasoning, and returns
+draft parking-record content.
+
+The agent is `role: sentinel` and holds no `Write`. Everything it produces is
+returned to you as text — **you** persist it, and only after the human has
+confirmed.
+
+### 3. Confirm the grouping
+
+Show the proposed grouping. **It stands unless the human changes it.** Do not
+require them to approve each thread; require only that they can change it.
+
+This step lands after they have already decided they are finished. Demanding a
+full manual partition here would put the ritual's heaviest thinking on the
+person least equipped, at the moment they least want it.
+
+### 4. Ask for a next action per thread
+
+For each thread, ask for one concrete resume step.
+
+Run the answer through `scripts/next-action-hint.sh`:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/next-action-hint.sh" "$answer"
+```
+
+- **exit 0** — an anchor was found. Move on.
+- **exit 1** — ask once more, using the script's own question. It names a
+  file, a test, or a decision. **Do not add a judgement of your own** and do
+  not describe their answer as vague.
+
+Whatever they say next is parked, **including the same words again**. If they
+repeat themselves, write their answer into `## Next action` followed by a line
+in their voice:
+
+```text
+(Asked again for a starting point; confirmed this is enough to go on.)
+```
+
+### 5. Write and commit the records
+
+Write one record per thread to `docs/superpowers/parked/<YYYY-MM-DD>-<slug>.md`
+per `reference/parking-record-format.md`. `next_action_flag` is always `asked`.
+
+**Commit them before step 6.** `/reflect` stages only the reflection paths and
+then relocates the tree to `main`; without this commit the ritual would publish
+a summary describing records left behind uncommitted.
+
+### 6. Ask about records already open
+
+For each record `records_open` returns from a previous session, ask whether it
+is still live. A "no longer live" answer writes its `.resumed.md` transition
+now — see `/coda resume` below.
+
+### 7. Closure summary and reflection
+
+Invoke `/reflect`, supplying the optional `Closed` field:
+
+```text
+- **Closed**: [what landed this session; the filename of each record parked]
+```
+
+Filenames rather than a count: a count asserts that three threads were parked
+without saying which three, and nothing can check it.
+
+### 8. Close
+
+Say what landed, what was parked, and stop.
+
+## Stopping the ritual
+
+If the human says plainly that they want to keep working, **stop**. Then say
+exactly what has already been written — records are append-only, so nothing can
+be withdrawn, and implying otherwise would be a lie about the artefacts.
+
+- Stopped during or before the survey: nothing was written.
+- Stopped after records exist: name each one and offer to supersede it.
+- Stopped after `/reflect`: the fragment is committed and merged. Say so.
+
+A request for *new work* after the ritual starts is different — park it, do not
+execute it. That drift is what the ritual is for. A request to *abandon the
+ritual* is the human changing their mind, which is always theirs to do.
+
+## `/coda resume RECORD`
+
+Writes a `.resumed.md` transition naming its predecessor in `supersedes:`, per
+the S1 contract. Never edits or deletes the original.
+
+```text
+docs/superpowers/parked/2026-08-08-retry-branch.md            <- parked
+docs/superpowers/parked/2026-08-09-retry-branch.resumed.md    <- supersedes it
+```
+
+## Validation checkpoint
+
+After writing records, read them back and check against
+`reference/parking-record-format.md`:
+
+1. Frontmatter carries `session`, `repo`, `created`, `state`, `supersedes`,
+   `next_action_flag`
+2. `next_action_flag` is `asked` — S2 adds no other value
+3. Both `## Context` and `## Next action` sections are present and non-empty
+4. The filename carries the state: no suffix for parked, `.resumed.md` for a
+   transition
+
+Fix deviations in place. Do not re-dispatch the agent.

--- a/ai-literacy-superpowers/hooks/hooks.json
+++ b/ai-literacy-superpowers/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry.",
+  "description": "Harness engineering hooks: constraint gate (PreToolUse) warns on violations; affordance invocation recorder (PostToolUse) logs Bash/MCP tool calls to gitignored observability; drift check, snapshot staleness, reflection prompt, framework-change prompt, rotating GC check, curation nudge, governance drift check, reservoir check, and session-registry sweep (Stop) close all feedback loops and renew the session lease at the end of every turn; template currency check and session-registry start (SessionStart) nudge on plugin upgrade and record this session's local, never-committed registry entry and surface any parking records left open by an earlier session.",
   "hooks": {
     "PreToolUse": [
       {
@@ -99,6 +99,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-registry-start.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/parked-resume-check.sh",
             "timeout": 10
           }
         ]

--- a/ai-literacy-superpowers/hooks/scripts/parked-resume-check.sh
+++ b/ai-literacy-superpowers/hooks/scripts/parked-resume-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# parked-resume-check.sh — SessionStart hook: surface still-open parking
+# records, once, at the start of a session.
+#
+# Spec: docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md §2.5
+# Tests: tdad_tests/layer0_deterministic/test-parked-resume.sh (H1–H8)
+#
+# This is the payoff that makes parking trustworthy. A record nobody ever sees
+# again is a diary, not a handoff — so if a thread was parked with a concrete
+# next action, the next session opens with it in view.
+#
+# ONCE, AND ONLY ON STARTUP. `SessionStart` also fires on resume, clear and
+# compact (S1 §4.2), so an unguarded hook would re-inject the parked list into
+# the middle of an unrelated working session, every compact, for the rest of
+# the day. That is not merely noisy: a parking record exists to release a
+# thread's pull so the person can stop holding it, and printing it back at them
+# while they are deepest in something else hands the thread straight back. The
+# mechanism meant to reduce the epic's target surface would have produced it.
+#
+# The guard is the `source` field, not a marker file. A per-session marker in
+# `~/.claude/sessions/` would have inherited that store's location guarantees
+# without its retention contract — the registry's only removal path is the
+# lease pruner, which retires `*.json` by heartbeat and sweeps `*.tmp`, so a
+# file in neither shape accumulates one per session for the life of the
+# machine. Against a carve-out whose second condition is *bounded*, and whose
+# own text warns that "a record with no expiry is an archive". Reading a field
+# that already arrives on stdin writes nothing at all.
+#
+# An ABSENT source stays quiet. Unknown provenance is exactly the case where
+# re-injection is possible, so silence is the safe reading — the cost of a
+# missed surfacing is one session opening cold, and the cost of a wrong one is
+# the failure mode above.
+#
+# Exits 0 unconditionally. A hook that surfaces a handoff must never be able to
+# interfere with the session it opens.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/record-paths.sh" 2>/dev/null || exit 0
+
+input="$(cat 2>/dev/null || true)"
+
+# Only a genuine startup surfaces. See the header for why absence is silence.
+source_field="$(printf '%s' "$input" \
+  | grep -oE '"source"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
+  | sed -E 's/.*"source"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' || true)"
+[ "$source_field" = "startup" ] || exit 0
+
+parked_dir="${CLAUDE_PARKED_DIR:-$PWD/docs/superpowers/parked}"
+[ -d "$parked_dir" ] || exit 0
+
+open_records="$(records_open "$parked_dir" 2>/dev/null || true)"
+[ -n "$open_records" ] || exit 0
+
+# next_action_of <file> — the first non-empty line under `## Next action`.
+# Read rather than summarised: the whole point is that the human's own words
+# come back to them.
+next_action_of() {
+  awk '
+    /^##[[:space:]]+Next action/ { inside = 1; next }
+    /^##[[:space:]]/             { inside = 0 }
+    inside && NF                 { print; exit }
+  ' "$1" 2>/dev/null
+}
+
+lines=""
+while IFS= read -r rec; do
+  [ -n "$rec" ] || continue
+  action="$(next_action_of "$rec")"
+  lines="${lines}- $(basename "$rec")
+  ${action}
+"
+done <<EOF
+$open_records
+EOF
+
+[ -n "$lines" ] || exit 0
+
+# A plain report, not a nudge. It says what is parked and stops; deciding
+# whether to pick any of it up is the human's, and nothing here should read as
+# an instruction to resume.
+# shellcheck disable=SC2016  # the backticks are markdown for the reader, not a shell expansion
+printf 'Parked from an earlier session:\n\n%s\nRun `/coda resume <record>` when one of these is finished.\n' "$lines"
+exit 0

--- a/ai-literacy-superpowers/scripts/next-action-hint.sh
+++ b/ai-literacy-superpowers/scripts/next-action-hint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# next-action-hint.sh — decides whether the Coda should ask once more for a
+# starting point.
+#
+# Spec: docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md §3
+# Tests: tdad_tests/layer0_deterministic/test-next-action.sh (N1–N8)
+#
+#     exit 0  — an anchor was found; do not ask again
+#     exit 1  — no anchor; ASK ONE MORE QUESTION
+#
+# EXIT 1 IS NOT A FAILURE, AND THIS IS NOT A VALIDATOR. It renders no verdict
+# on the human's wording, and whatever they answer next is parked either way —
+# including the same words again. That is why nothing here writes to stderr and
+# why no message uses the vocabulary of rejection: a caller that mistook a
+# trigger for a fault would turn a question into a gate.
+#
+# Why it was demoted. The first design made this a check that refused to write
+# a parking record until the text passed. It measures lexical form, not
+# specificity — "keep going in src/" carries an anchor and passes — and its
+# errors run systematically along the code/non-code axis rather than randomly.
+# A heuristic that is reliably unfair to one kind of work is worse than one
+# that is merely noisy, and the Coda parks decision-shaped threads by design.
+# Demoted to a trigger, both error directions cost the same thing: one extra
+# question.
+#
+# The evidence underneath it. A written plan for an unfinished task releases
+# its pull, and specificity is the active ingredient rather than the writing —
+# "continue work" is a written plan that does nothing. So the ritual asks for a
+# starting point. It does not grade the answer.
+#
+# The grammar below is published verbatim in skills/coda/SKILL.md and
+# reference/parking-record-format.md. A rule whose decisive term lives only in
+# the implementation cannot be argued with, and this one is meant to be.
+
+text="${1-}"
+
+# Normalise once: collapse whitespace so a wrapped next action reads the same
+# as a single-line one.
+text="$(printf '%s' "$text" | tr '\n' ' ' | tr -s '[:space:]' ' ')"
+text="${text#"${text%%[![:space:]]*}"}"
+text="${text%"${text##*[![:space:]]}"}"
+
+ask() {
+  # Names what is missing — a file, a test, or a first step — never a judgement
+  # on the wording. "Too vague" would be a verdict; this is a question.
+  printf '%s\n' \
+    "What is the first step? Naming a file, a test, or the decision to make will make this easy to pick up."
+  exit 1
+}
+
+[ -n "$text" ] || ask
+
+# --- The anchor grammar (spec §3.3) ------------------------------------------
+#
+# Six kinds. Five are artefacts of code-shaped work; the sixth exists because
+# this plugin's own work is mostly specs, prose and decisions, and without it
+# the table would tax the dominant kind of thread with an extra question at
+# every close — from a published rule that reads as the house definition of a
+# concrete next step.
+#
+# A bare English noun is deliberately NOT an anchor. "parser" names a thing;
+# it does not name where to start. That is what separates "more work on the
+# parser" from "add the B12 fixture".
+# shellcheck disable=SC2016  # the backtick row is a regex matching literal
+# backticks, not a shell expansion. Directives must sit in front of a complete
+# command, so it lives here rather than on the branch it applies to.
+anchor() {
+  case "$1" in
+    path)       printf '%s' '(^| )[A-Za-z0-9_.-]*/[A-Za-z0-9_./-]+|[A-Za-z0-9_-]+\.(sh|py|md|rs|ts|js|json|ya?ml|toml|txt)' ;;
+    identifier) printf '%s' '[A-Za-z0-9_]+\(\)|[A-Za-z0-9]+_[A-Za-z0-9_]+|[A-Za-z0-9]+::[A-Za-z0-9]+|\b[A-Z][a-z0-9]+\.[A-Z][a-z0-9]+' ;;
+    backtick)   printf '%s' '`[^`]+`' ;;
+    scenario)   printf '%s' '(^| )#[0-9]+|(^| )[A-Z]+[0-9]+([^A-Za-z0-9]|$)' ;;
+    linereg)    printf '%s' '[A-Za-z0-9_.-]+:[0-9]+|§[0-9]|\bline [0-9]+' ;;
+    decision)   printf '%s' '\b(ask|decide|choose between|confirm with|agree with)\b|\b(whether|which|why)\b' ;;
+  esac
+}
+
+for kind in path identifier backtick scenario linereg decision; do
+  if printf '%s' "$text" | grep -qE "$(anchor "$kind")"; then
+    exit 0
+  fi
+done
+
+ask

--- a/ai-literacy-superpowers/skills/coda/SKILL.md
+++ b/ai-literacy-superpowers/skills/coda/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: coda
+description: Use when closing an agentic session deliberately rather than by attrition — carries the four-step ritual (survey, park, closure summary and reflection, close), the anchor grammar behind the next-action question, the evidence for why a specific written plan releases an unfinished thread, and the anti-patterns that would turn a closing ritual into a gate on the person
+---
+
+# The Coda
+
+An agentic session has no terminal cue. There is no compile, no deploy, no
+colleague standing up to leave — the medium supplies nothing that says *this is
+finished*. So sessions end by attrition: the human stops when something
+external interrupts, and the work is left in whatever state the interruption
+found it.
+
+Two costs follow. The unfinished threads keep their pull, because nothing wrote
+down where they were. And the next session opens cold, re-deriving from a diff
+what the previous session already knew.
+
+> **The Coda** — the good ending. A ritual that closes a session deliberately,
+> records what landed, and parks every live thread with a concrete resume step.
+
+**What it attacks:** *drift* — the "while we're here" extension nobody
+deliberately chose — and the cold-start cost of an unrecorded stop.
+
+Not compulsive continuation itself. The Coda's only defence against continuing
+is a refusal that steps aside the moment the human plainly asks it to, and a
+plain request to continue is the shape that failure mode takes. Claiming
+otherwise would be an overclaim in the sentence that names the sentinel.
+
+## The ritual
+
+Four steps, same order every time.
+
+| # | Step |
+| --- | --- |
+| 1 | **Survey** — what landed, what is still live |
+| 2 | **Park** — one record per thread, committed |
+| 3 | **Closure summary and reflection** — via `/reflect` |
+| 4 | **Close** |
+
+### Why parking comes before reflection
+
+The portable reason: the closure summary names what was parked, and it can
+only do that if parking has already happened.
+
+The local reason, where a *Reflections via PR workflow* constraint is declared:
+`/reflect` is not a write-a-fragment-and-return operation. It branches,
+commits, pushes, opens a PR, waits on CI, merges, and pulls `main`. Run before
+parking, it would move the working tree off the branch holding the very
+uncommitted work the survey had just enumerated. A closing ritual that
+rearranges your git state is the most expensive way to stop yet designed.
+
+Parking records are committed at step 2, before `/reflect` runs — `/reflect`
+stages only the reflection paths, so without an explicit commit the ritual
+would publish a summary describing records it left behind uncommitted in a
+tree it had just relocated.
+
+## The survey is flagged per item
+
+<!-- evidence: the honesty discipline generalised from the reservoir warden —
+     a blanket confidence claim over a mixed-provenance list is the failure it
+     exists to prevent. -->
+
+| Item | Flag |
+| --- | --- |
+| Commits, working-tree state, dispositions in records | `observed` |
+| Merged PRs, open-PR check state | `observed` when `gh` succeeds; `inferred` when it does not |
+| Which files constitute one thread | `asked` |
+
+**Thread grouping is the central epistemic act.** Nine modified files are an
+observation; that they are *two* threads is a judgement, and it decides how
+many records exist and what each says. The Coda proposes a grouping and it
+stands unless the human changes it — propose-and-default-accept, because this
+step lands after the human has already decided they are finished.
+
+Flags are **ritual-scoped**. They are shown during the survey and do not travel
+into the record: parking records are handoffs, not provenance artefacts. Where
+provenance matters for a thread, it goes in the record's `## Context` prose.
+
+## The next action, and why it is asked for
+
+<!-- evidence: Masicampo & Baumeister 2011 — a specific written plan, not
+     completion, releases the unfinished-task pull. Specificity is the active
+     ingredient, which is why the ritual asks for a starting point. It is also
+     why the check that follows must not become a grade: the effect comes from
+     the human having a plan they believe, not from passing a test. -->
+
+A written plan releases an unfinished thread's pull, and **specificity is the
+active ingredient** rather than the writing. "Continue work" is a written plan
+and does nothing.
+
+So the ritual asks for one concrete resume step per thread, and
+`scripts/next-action-hint.sh` decides whether to ask **once more**.
+
+### The anchor grammar
+
+A next action carries an anchor when it contains at least one of:
+
+| Anchor | Pattern |
+| --- | --- |
+| A path | a token containing `/` or a known file extension |
+| A code identifier | a token containing `_`, `::`, or `()`, or in `Some.Case` form |
+| A backticked span | anything inside backticks |
+| A scenario or ticket id | a letter-digit token such as `B12`, `R4`, `#492` |
+| A line or section reference | `file:12`, `§3.2`, `line 40` |
+| A decision | a question word, a named person, or `ask` / `decide` / `choose between` |
+
+**This is a trigger heuristic, and its complement is not "vague".** A next
+action carrying no anchor gets one question. It does not get a verdict, and it
+is not being called imprecise. The table says what makes the Coda *stop
+asking*, not what makes a next action good.
+
+The decision row exists because the other five are all artefacts of code-shaped
+work, and much of what gets parked is a spec, a piece of prose, or a decision.
+Without it the check would tax the dominant kind of thread at every close.
+
+### When the human repeats themselves
+
+Park it. The record's `## Next action` carries their answer plus a line in
+their own voice noting they were asked for a starting point and confirmed this
+was enough.
+
+That line, not a frontmatter flag, is where the override lives. A flag
+recording that a human's answer failed a check would be an agent-authored
+verdict about the person — permanent, committed, and countable across records.
+
+## Closing a record
+
+A parking record is closed by writing a `.resumed.md` transition, never by
+editing or deleting. When the ritual runs and open records exist, the Coda asks
+per record whether it is still live; a "no" writes the transition immediately.
+
+Without that, closure would depend on someone remembering a command and the
+corpus would only ever grow. Note the asymmetry: a session registry entry is a
+*lease*, where forgetting costs nothing because it expires. A parking record is
+the inverse — open by default until an act of bookkeeping closes it — so
+forgetting produces an overcount, and the overcount is what a human sees at
+every session start.
+
+## Anti-patterns
+
+An implementation doing any of these has stopped being a Coda:
+
+1. **Refusing a next action.** The check asks; it never rejects. A sentinel
+   that traps someone at the end of a session has become the thing it was
+   built to prevent.
+2. **Deciding the grouping alone.** That judgement determines the whole shape
+   of the handoff and belongs to the human.
+3. **Recording why the human stopped.** That a session closed and what was
+   parked is the record. Why is not, ever.
+4. **Continuing the ritual after being asked to stop.** Say what has already
+   been written — records are append-only, so nothing can be withdrawn — and
+   stop.
+5. **Writing a file from the agent.** The agent returns content; the command
+   persists it.
+6. **Surfacing parked records more than once a session.** `SessionStart`
+   re-fires on resume, clear and compact. Handing a thread back mid-session is
+   the surface this exists to reduce.

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -109,10 +109,13 @@ build goes red. S2 and S3 are agent-verifiable via the harness-enforcer.
 | `choice-cartographer` | Understanding of implicit decisions | Read-only; choice stories disposed at a soft gate; six-lens map declares what was found vs. inferred |
 | `reservoir-warden` | The decider — the verifier's cognitive reservoir | Read-only (no Write/Edit); single decide-your-stop-first recommendation; observed/inferred/asked flags; persists no record of human state |
 | `cost-estimator` | The decision's inputs — what a choice will cost before it is made | Read-only; human disposes the estimate record; refuses rather than fabricating an ungroundable estimate |
+| `coda` | The ending — that a session stops by decision rather than by attrition | Read-only; returns record content for `/coda` to persist; per-item observed/inferred/asked flags; never refuses a next action and never records why someone stopped |
 
 The narrative: the decision-discipline triad guards *decisions*; the
 `reservoir-warden` guards *the decider*; the `cost-estimator` guards
-*the decision's inputs*.
+*the decision's inputs*; and the `coda` guards *the ending* — that a
+session stops by decision rather than by attrition, and that what was
+left open is written down rather than carried.
 
 ### A second declaration surface: the pact file
 

--- a/docs/plugins/ai-literacy-superpowers/how-to/closing-a-session.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/closing-a-session.md
@@ -1,0 +1,97 @@
+---
+title: Closing a session
+---
+# Closing a session
+
+An agentic session has no terminal cue. There is no compile, no deploy, no
+colleague standing up to leave — nothing in the medium says *this is finished*.
+So sessions tend to end by attrition: you stop when something interrupts, and
+the work stays in whatever state the interruption found it.
+
+`/coda` is the deliberate alternative.
+
+## Run it
+
+```text
+/coda
+```
+
+That is the whole invocation. It takes a few minutes and asks you a small
+number of questions.
+
+## What happens
+
+**1. It surveys.** What landed — commits, merged PRs, dispositions you
+resolved. What is still live — uncommitted files, an open PR, records still
+carrying `pending`, and anything parked in an earlier session.
+
+Each line is flagged. `observed` for what it read off disk, `inferred` where a
+`gh` call failed and it is telling you so rather than reporting an empty
+result, `asked` for the one judgement it does not make alone.
+
+**2. It proposes a grouping, and you correct it if it is wrong.** Nine modified
+files might be one thread or three. That judgement decides how many records get
+written and what each says, so it is yours — but the proposal stands unless you
+change it. You are finishing, not starting; the ritual should not hand you its
+hardest thinking at the moment you least want it.
+
+**3. It asks for a next action per thread.** One concrete resume step.
+
+If your answer carries nothing to start from, it asks once more — naming a
+file, a test, or a decision. **It never refuses.** Whatever you say next is
+parked, including the same words again; if you repeat yourself, the record
+notes in your own voice that you were asked and confirmed this was enough.
+
+That question exists for a reason worth knowing: a written plan for an
+unfinished task releases its pull, and *specificity* is the active ingredient
+rather than the writing. "Continue work" is a written plan and does nothing.
+
+**4. It writes and commits the records**, then runs `/reflect` for the closure
+summary, then stops.
+
+## Picking a thread back up
+
+Parked records surface at the start of your next session — once, on startup
+only, so a compact or a resume never hands them back mid-session.
+
+When one is finished:
+
+```text
+/coda resume 2026-08-08-retry-branch.md
+```
+
+That writes a `.resumed.md` transition naming its predecessor. Nothing is ever
+edited or deleted; the trail stays intact.
+
+`/coda` also asks about anything still open each time it runs, so a thread you
+finished quietly gets closed without you having to remember a command.
+
+## Stopping the ritual
+
+Say so. It stops, and tells you exactly what has already been written.
+
+Records are append-only, so a record already written cannot be withdrawn — it
+will say which ones exist rather than pretending they can be undone.
+
+One thing it will *not* do is take on new work once the ritual has started. A
+"while we're here" request gets parked instead of executed. That drift is the
+thing `/coda` is for: the ritual that was about to end the session becoming the
+preamble to another hour.
+
+Changing your mind about stopping is different, and always yours.
+
+## `/coda` or `/reflect`?
+
+| You want to | Run |
+| --- | --- |
+| Capture one surprise and keep working | `/reflect` |
+| Stop for the day, or stop with this piece of work | `/coda` |
+
+`/coda` calls `/reflect` as part of its own ritual, so you never need both.
+
+## What it will never do
+
+- Decide that your session should end. You invoke it.
+- Grade your wording. The check asks a question; it renders no verdict.
+- Record *why* you stopped. That a session closed and what was parked is the
+  record. Why is not, ever.

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -12,7 +12,7 @@ Cutting across those groups is a fourth, cross-cutting family — the
 **[sentinels](../explanation/sentinels.md)**. A sentinel is any agent
 whose object of care is the human's understanding and judgement rather
 than an artefact: `carpaccio`, `advocatus-diaboli`,
-`choice-cartographer`, `reservoir-warden`, and `cost-estimator`. Each
+`choice-cartographer`, `reservoir-warden`, `cost-estimator`, and `coda`. Each
 declares `role: sentinel` in its frontmatter, is read-only (criterion
 S1, enforced deterministically by the Sentinel integrity constraint),
 emits advisory output a human disposes (S2), and carries an explicit
@@ -174,6 +174,26 @@ does not block progression. The merge-time HARNESS constraint
 
 This release is spec-mode only. Code-mode behaviour is tracked under
 [issue #209](https://github.com/Habitat-Thinking/ai-literacy-superpowers/issues/209).
+
+### coda
+
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+
+Closes a session deliberately rather than by attrition. Surveys what landed and
+what is still live, proposes a thread grouping for the human to confirm, and
+returns one draft parking record per thread with a concrete next action.
+
+Holds no `Write`: it returns record content as a string and the `/coda` command
+persists it after the human confirms — the `cost-estimator` precedent, and what
+keeps the Coda inside the sentinel category.
+
+Three things it never does. It never decides that a session should end; the
+human invoked it. It never decides what counts as one thread; that judgement
+determines the whole shape of the handoff and belongs to the person. And it
+never records *why* someone stopped — that a session closed and what was parked
+is the record.
+
+See the `coda` skill and [Closing a session](../how-to/closing-a-session.md).
 
 ### cost-estimator
 
@@ -419,6 +439,7 @@ is a precaution under uncertainty. See the
 | spec-writer | x | x | x | x | x | | | | read-write |
 | advocatus-diaboli | x | | | x | x | | | | read-only |
 | choice-cartographer | x | | | x | x | | | | read-only |
+| coda | x | | | x | x | | | | read-only |
 | cost-estimator | x | | | x | x | | | | read-only |
 | tdd-agent | x | x | x | x | x | x | | | read-write |
 | code-reviewer | x | | | x | x | x | | | read-only |

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -528,6 +528,44 @@ Manage git worktrees for parallel agent isolation. Three modes:
 - **`/worktree clean [name]`** — Remove the named worktree and its
   branch.
 
+### /coda
+
+- **Skills read**: `coda`
+- **Agents dispatched**: `coda` (survey and draft records)
+
+Closes a session deliberately rather than by attrition. Four steps, same order
+every time: **survey** what landed and what is still live, **park** each open
+thread with a concrete next action, write the **closure summary** through
+`/reflect`, and **close**.
+
+`/coda resume <record>` closes a parked thread by writing a `.resumed.md`
+transition naming its predecessor — never by editing or deleting the original.
+
+**`/coda` versus `/reflect`.** `/reflect` writes a learning. `/coda` closes a
+session, and calls `/reflect` as part of doing so. Capturing one surprise and
+carrying on is `/reflect`; stopping is `/coda`.
+
+Two design points worth knowing before you use it:
+
+- **Parking happens before reflection**, and records are committed there.
+  `/reflect` stages only the reflection paths and, where a *Reflections via PR
+  workflow* constraint is declared, relocates the tree to `main` — so a ritual
+  that reflected first would publish a summary describing records it left
+  behind uncommitted.
+- **Nothing is refused.** The next-action check asks one more question when it
+  finds no anchor; whatever you answer is parked, including the same words
+  again. It renders no verdict on your wording.
+
+Stoppable at any point. If you say plainly that you want to keep working, the
+ritual stops and states exactly what has already been written — records are
+append-only, so nothing can be withdrawn. A request for *new work* mid-ritual
+is different: that gets parked, because it is the drift the ritual exists for.
+
+See the `coda` skill, [Closing a session](../how-to/closing-a-session.md), and
+[Parking record format](parking-record-format.md).
+
+---
+
 ### /reservoir
 
 - **Skills read**: `cognitive-reservoir`

--- a/docs/plugins/ai-literacy-superpowers/reference/hooks.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/hooks.md
@@ -264,6 +264,35 @@ the deterministic tests need no home directory and is **not intended for
 production use** — pointing it inside a work tree defeats the guarantee
 that nothing can be committed by accident.
 
+### Parked resume check
+
+- **Script**: `hooks/scripts/parked-resume-check.sh`
+- **Timeout**: 10s
+
+Surfaces parking records left open by an earlier session — id and next
+action, nothing more — so a thread you parked with a concrete resume step
+comes back to you. A record nobody ever sees again is a diary, not a
+handoff.
+
+**Fires on `startup` only.** `SessionStart` also fires on resume, clear
+and compact, and an unguarded hook would re-inject the parked list into
+the middle of an unrelated working session for the rest of the day. That
+is not merely noisy: a parking record exists to release a thread's pull
+so you can stop holding it, and printing it back at you mid-session hands
+it straight back. An **absent** `source` also stays quiet — unknown
+provenance is exactly where re-injection is possible, so silence is the
+safe reading.
+
+The guard reads the `source` field off the hook's own stdin and **writes
+nothing**. A per-session marker file in `~/.claude/sessions/` would have
+inherited that store's location guarantees without its retention
+contract, and accumulated one file per session for the life of the
+machine.
+
+Records superseded by a `.resumed.md` transition are not surfaced. Exits
+0 unconditionally. `$CLAUDE_PARKED_DIR` overrides the directory and is
+test-only.
+
 ---
 
 ## Configuration

--- a/docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/parking-record-format.md
@@ -98,3 +98,49 @@ does:
 Specificity is the active ingredient, not completeness. A thread parked with a
 concrete next step stops pulling at the person who parked it; one parked with
 "continue work" does not.
+
+### The anchor grammar
+
+`scripts/next-action-hint.sh` decides whether the Coda asks **once more**. A
+next action carries an anchor when it contains at least one of:
+
+| Anchor | Pattern |
+| --- | --- |
+| A path | a token containing `/` or a known file extension |
+| A code identifier | a token containing `_`, `::`, or `()`, or in `Some.Case` form |
+| A backticked span | anything inside backticks |
+| A scenario or ticket id | a letter-digit token such as `B12`, `R4`, `#492` |
+| A line or section reference | `file:12`, `§3.2`, `line 40` |
+| A decision | a question word, a named person, or `ask` / `decide` / `choose between` |
+
+**This is a trigger heuristic, and its complement is not "vague".** A next
+action carrying no anchor gets one question. It does not get a verdict, and it
+is not being called imprecise. The table says what makes the Coda *stop
+asking* — not what makes a next action good.
+
+The decision row exists because the other five are artefacts of code-shaped
+work, and much of what gets parked is a spec, a piece of prose, or a decision.
+Without it the check would tax the dominant kind of thread at every close.
+
+### When the author was asked twice
+
+The Coda never refuses a next action. If the check triggers and the author
+gives the same answer again, the record is written with their answer plus a
+line in their own voice:
+
+```markdown
+## Next action
+
+continue work
+
+(Asked again for a starting point; confirmed this is enough to go on.)
+```
+
+**That line, not a frontmatter flag, is where the override lives.**
+`next_action_flag` is `asked` for every record; there is no second value.
+
+A flag recording that someone's answer failed a check would be an
+agent-authored verdict about the person — permanent, committed, and countable
+across records. That is a claim *about* the human rather than *by* them, which
+the `sentinel-design` boundary forbids, and the operational-state carve-out
+cannot rescue it because these records are committed and permanent.

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -45,6 +45,17 @@ Generating human-readable onboarding documentation from harness state. Covers th
 
 The shared drift-detection layer that backs both `/harness-audit` (read-only) and `/harness-sync`. Produces a structured drift report covering convention files, ONBOARDING.md, snapshot staleness, template drift, constraint regressions, recurring reflection patterns, and HARNESS.md Status section accuracy.
 
+### coda
+
+The closing ritual: survey, park, closure summary and reflection, close.
+
+Carries the anchor grammar behind the next-action question, the evidence for
+why a *specific* written plan releases an unfinished thread (specificity is the
+active ingredient, not the writing), and the anti-patterns that would turn a
+closing ritual into a gate on the person.
+
+Read it before implementing or changing anything in the Coda's path.
+
 ### cognitive-reservoir
 
 The shared grounding for the reservoir-warden agent and the reservoir-check Stop hook — the framework's watch on the one actor it cannot verify, the human verifier. Defines the four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed` / `inferred` / `asked` confidence discipline, the disjunctive default thresholds, the one firm principle (decide your stop before the next session begins), the six-level scaling guidance, and the honesty rule that keeps the contested science (ego depletion, the hungry-judges study) separate from the robust basis (vigilance decrement, task-switching cost). Advisory-only; never a fatigue score, never a gate.

--- a/docs/superpowers/objections/cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s2-coda-design.md
@@ -9,85 +9,85 @@ objections:
     severity: critical
     claim: "Invoking /reflect as ritual step 3 will, in this repo, create a branch, commit, push, open a PR, merge, and pull main — relocating the working tree away from the branch holding the uncommitted work the survey just enumerated, before any parking record is written."
     evidence: "Spec 2.3 'The Coda invokes the existing /reflect flow'; commands/reflect.md:159-173 'git checkout -b add-reflection-${slug}' ... 'gh pr merge <n> --squash --delete-branch and git pull on main'; HARNESS.md:413 'Reflections via PR workflow ... Applies to all /reflect invocations'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Ritual reordered: survey, park, then closure summary and reflect, then close. Parking completes while the working tree is still where the human left it, and /reflect's PR cycle runs last. This diverges from the build spec's fixed sequence, which placed reflection third — flagged in the PR. The reorder also dissolves O2, since the Closed field is now written after parking and can name what was parked."
   - id: O2
     category: specification quality
     severity: high
     claim: "The Closed field's stated content cannot be known when the field is written: it names what was parked and how many, but parking is step 4 and the fragment is written (and committed) at step 3."
     evidence: "Spec 4.2 '- **Closed**: [what landed this session; what was parked, and how many]'; the ritual table places Reflection at 3 and Park at 4; section 2 defends that order as 'the design'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Dissolved by the O1 reorder rather than fixed in place."
   - id: O3
     category: implementation
     severity: high
     claim: "'Abandons the ritual cleanly — no half-closed session, no partial parking' is unachievable after step 3 or mid-step-4, because /reflect has already committed a fragment and parking records are append-only and never deleted."
     evidence: "Spec 2.5 and A3; reference/parking-record-format.md 'never edited in place and never deleted'; commands/reflect.md step 8 'Commit the new fragment and the regenerated aggregate'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The promise is narrowed to what append-only can deliver. Abandonment before step 2 leaves nothing written and is genuinely clean; after any record exists, the Coda says plainly what has already been written and offers to write a .superseded.md transition for each — which S2 now ships anyway per O9. 'No partial parking' is replaced by 'nothing silently half-done'."
   - id: O4
     category: risk
     severity: high
     claim: "The survey's blanket observed flag is false for at least two enumerated items — merged PRs and an open PR awaiting checks come from the GitHub API, not disk — and the grouping of modified files into 'threads' is itself an inference."
     evidence: "Spec 2.1 'Enumerate, all flagged observed because all of it is read from disk:' followed by 'merged PRs' and 'an open PR awaiting checks'; and 'Nothing here is inferred.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Per-item honesty flags replace the blanket claim. Commits and working-tree state are observed; gh reads are observed when they succeed and inferred when they do not, never silently absent. Thread grouping becomes asked — which files constitute one thread is the human's call, and it is the judgement that determines how many records exist."
   - id: O5
     category: risk
     severity: high
     claim: "next_action_flag: asked-override is an agent-authored verdict about the human's own wording, persisted permanently in a committed repository file, and it fails both sentinel-design tests while being ineligible for the operational-state carve-out."
     evidence: "Spec 4.1 'Both values still mean the next action came from the human. Neither is an inference'; sentinel-design 'Who authored the claim? If the agent did, it is about the person'; the carve-out requires 'Local and never committed' and 'Bounded'; parking records are committed and permanent."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The override moves into the record's prose body as a human-authored line; next_action_flag stays asked always. What persists is then something the human said and would recognise, not a machine verdict aggregating across records. This also removes S2's change to the parking-record contract entirely, so the consumer-never-mutates rule no longer applies to it."
   - id: O6
     category: specification quality
     severity: high
     claim: "Section 3.2's rule is not implementable as a deterministic shell heuristic and rule 1 is subsumed by rule 2, so V1's 'more work on the parser' turns entirely on an anchor definition the spec never gives."
     evidence: "Spec 3.2 'where the remainder is a bare noun phrase' needs a parts-of-speech parser; 'identifier-shaped token' is undefined; any text consisting solely of a vague stem already fails rule 2. V1 requires 'more work on the parser' to fail while V2 requires 'add the B12 fixture for a malformed Sync cadence block' to pass."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The anchor grammar is defined explicitly, the subsumed rule is dropped, and V1/V2 are made jointly satisfiable. Under the O7 disposition the check no longer renders a verdict, so its precision matters less — but a rule stated in the skill and the reference page must still be the rule the code implements."
   - id: O7
     category: implementation
     severity: high
     claim: "The anchor test measures token shape, not plan specificity, so it passes 'continue work in src/' and rejects concrete non-code actions — which is not the property section 3.1's evidence supports."
     evidence: "Spec 3.1 'specificity is the active ingredient'; 3.2 'passes on any next action carrying at least one anchor'; V5 blesses the false-positive path explicitly. A decision-shaped next action such as 'ask Russ whether the reserved block should ship at all' carries no anchor and fails, and the survey generates parking records for exactly such threads."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The heuristic is demoted from judge to reprompt trigger. It decides only whether to ASK; the human always answers, and the answer is always parked. Both error directions then cost one question rather than a wrong verdict, and the systematic false negative on decision-shaped threads stops mattering. Since nothing is refused, there is no gate, and constraint 6's override machinery is not needed."
   - id: O8
     category: implementation
     severity: high
     claim: "The resume hook is specified as firing 'at session start', but SessionStart fires on startup, resume, clear and compact with matcher '*' — so the list of parked threads is re-injected mid-session, re-opening a question S1 settled."
     evidence: "Spec 2.6; S1 section 4.2 'SessionStart fires on startup, resume, clear, and compact'; hooks/hooks.json registers SessionStart with matcher '*'; session-registry-start.sh repeats the warning."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "A once-per-session marker, so a compact or a resume does not re-inject parked threads mid-session. Handing a thread back at the moment the human is deepest in something else is the surface this epic exists to reduce. A firing-frequency scenario is added; H1-H5 tested emptiness and error paths and none tested frequency."
   - id: O9
     category: scope
     severity: high
     claim: "S2 ships no writer for the .resumed.md transition, so every parking record it creates stays open forever, the resume hook's output grows without bound, and H4 tests behaviour whose producer does not exist in this slice."
     evidence: "Spec section 5's file table lists no resume/transition writer; H4 tests a .resumed.md record; S1 section 5.1 states 'That query is the one S2's resume path depends on' and 'resuming is a write by the /coda command'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "S2 ships the resume path. S1 assigned it here explicitly, and without it records_open returns a monotonically growing set and the hook becomes a standing list of stale obligations — which destroys the trust the surfacing exists to build."
   - id: O10
     category: premise
     severity: medium
     claim: "The advertised attack surface exceeds what the mechanism can reach: the only defence against continuation dissolves the moment the human plainly asks to continue, which is the shape the named failure mode takes."
     evidence: "Spec 1 'Attacks: compulsive continuation'; 2.5 'If the human says plainly that they want to keep working, the Coda abandons the ritual cleanly'; 3.3 sets the standard: 'pretending otherwise would be the overclaiming this epic exists to avoid'."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The epithet is narrowed to what the mechanism reaches: drift — the 'while we're here' extension nobody deliberately chose — and the cold-start cost of an unrecorded stop. Continuation may become an earnable claim in S3 when the hard stop arrives. The spec's own standard in section 3.3 forbids the overclaim it was making in its first sentence."
   - id: O11
     category: alternatives
     severity: medium
     claim: "The spec does not weigh extending /reflect with a closing mode against adding a fourth surface, even though its own argument against a second reflection path applies with equal force to a second session-closing ritual."
     evidence: "Spec 2.3 'duplicating any of that would create a second reflection path that drifts from the first'; section 5 adds an agent, skill, command, script and hook; 4.2 already extends /reflect's fragment schema. /reflect --mine is the established precedent for adding a mode rather than a command."
-    disposition: pending
-    disposition_rationale: null
+    disposition: rejected
+    disposition_rationale: "/coda stays its own command. The Coda dispatches a role: sentinel agent that surveys and returns content; /reflect is a command that commits. Different trust boundaries and different objects of care, and a sentinel agent dispatched from a committing command is an odd shape. The rejection is recorded with its reason, and both commands state plainly when to reach for which — which is the drift the objection was actually worried about."
   - id: O12
     category: specification quality
     severity: medium
     claim: "The 'Coda may be offered when the Warden's threshold is crossed' pathway has no implementation surface, and the same section forbids the only edit that would create one."
     evidence: "Spec 6 'No changes to the Reservoir Warden' alongside 'The Coda may be offered when the Warden's threshold is crossed'; the warden agent's output path never mentions /coda; section 8's docs list names no reservoir surface."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Stated plainly as the human's own move, mediated by no artefact. The Warden recommends deciding a stop; what the human does next is theirs. Nothing is wired, nothing is edited, and constraint 5 holds without ambiguity."
 ---
 
 # Objection record — Cadence Sentinels S2: The Coda (spec mode)

--- a/docs/superpowers/objections/cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s2-coda-design.md
@@ -1,0 +1,378 @@
+---
+spec: docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+date: 2026-08-09
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: implementation
+    severity: critical
+    claim: "Invoking /reflect as ritual step 3 will, in this repo, create a branch, commit, push, open a PR, merge, and pull main — relocating the working tree away from the branch holding the uncommitted work the survey just enumerated, before any parking record is written."
+    evidence: "Spec 2.3 'The Coda invokes the existing /reflect flow'; commands/reflect.md:159-173 'git checkout -b add-reflection-${slug}' ... 'gh pr merge <n> --squash --delete-branch and git pull on main'; HARNESS.md:413 'Reflections via PR workflow ... Applies to all /reflect invocations'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: specification quality
+    severity: high
+    claim: "The Closed field's stated content cannot be known when the field is written: it names what was parked and how many, but parking is step 4 and the fragment is written (and committed) at step 3."
+    evidence: "Spec 4.2 '- **Closed**: [what landed this session; what was parked, and how many]'; the ritual table places Reflection at 3 and Park at 4; section 2 defends that order as 'the design'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "'Abandons the ritual cleanly — no half-closed session, no partial parking' is unachievable after step 3 or mid-step-4, because /reflect has already committed a fragment and parking records are append-only and never deleted."
+    evidence: "Spec 2.5 and A3; reference/parking-record-format.md 'never edited in place and never deleted'; commands/reflect.md step 8 'Commit the new fragment and the regenerated aggregate'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: risk
+    severity: high
+    claim: "The survey's blanket observed flag is false for at least two enumerated items — merged PRs and an open PR awaiting checks come from the GitHub API, not disk — and the grouping of modified files into 'threads' is itself an inference."
+    evidence: "Spec 2.1 'Enumerate, all flagged observed because all of it is read from disk:' followed by 'merged PRs' and 'an open PR awaiting checks'; and 'Nothing here is inferred.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: risk
+    severity: high
+    claim: "next_action_flag: asked-override is an agent-authored verdict about the human's own wording, persisted permanently in a committed repository file, and it fails both sentinel-design tests while being ineligible for the operational-state carve-out."
+    evidence: "Spec 4.1 'Both values still mean the next action came from the human. Neither is an inference'; sentinel-design 'Who authored the claim? If the agent did, it is about the person'; the carve-out requires 'Local and never committed' and 'Bounded'; parking records are committed and permanent."
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: specification quality
+    severity: high
+    claim: "Section 3.2's rule is not implementable as a deterministic shell heuristic and rule 1 is subsumed by rule 2, so V1's 'more work on the parser' turns entirely on an anchor definition the spec never gives."
+    evidence: "Spec 3.2 'where the remainder is a bare noun phrase' needs a parts-of-speech parser; 'identifier-shaped token' is undefined; any text consisting solely of a vague stem already fails rule 2. V1 requires 'more work on the parser' to fail while V2 requires 'add the B12 fixture for a malformed Sync cadence block' to pass."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: implementation
+    severity: high
+    claim: "The anchor test measures token shape, not plan specificity, so it passes 'continue work in src/' and rejects concrete non-code actions — which is not the property section 3.1's evidence supports."
+    evidence: "Spec 3.1 'specificity is the active ingredient'; 3.2 'passes on any next action carrying at least one anchor'; V5 blesses the false-positive path explicitly. A decision-shaped next action such as 'ask Russ whether the reserved block should ship at all' carries no anchor and fails, and the survey generates parking records for exactly such threads."
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: implementation
+    severity: high
+    claim: "The resume hook is specified as firing 'at session start', but SessionStart fires on startup, resume, clear and compact with matcher '*' — so the list of parked threads is re-injected mid-session, re-opening a question S1 settled."
+    evidence: "Spec 2.6; S1 section 4.2 'SessionStart fires on startup, resume, clear, and compact'; hooks/hooks.json registers SessionStart with matcher '*'; session-registry-start.sh repeats the warning."
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: scope
+    severity: high
+    claim: "S2 ships no writer for the .resumed.md transition, so every parking record it creates stays open forever, the resume hook's output grows without bound, and H4 tests behaviour whose producer does not exist in this slice."
+    evidence: "Spec section 5's file table lists no resume/transition writer; H4 tests a .resumed.md record; S1 section 5.1 states 'That query is the one S2's resume path depends on' and 'resuming is a write by the /coda command'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: premise
+    severity: medium
+    claim: "The advertised attack surface exceeds what the mechanism can reach: the only defence against continuation dissolves the moment the human plainly asks to continue, which is the shape the named failure mode takes."
+    evidence: "Spec 1 'Attacks: compulsive continuation'; 2.5 'If the human says plainly that they want to keep working, the Coda abandons the ritual cleanly'; 3.3 sets the standard: 'pretending otherwise would be the overclaiming this epic exists to avoid'."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: alternatives
+    severity: medium
+    claim: "The spec does not weigh extending /reflect with a closing mode against adding a fourth surface, even though its own argument against a second reflection path applies with equal force to a second session-closing ritual."
+    evidence: "Spec 2.3 'duplicating any of that would create a second reflection path that drifts from the first'; section 5 adds an agent, skill, command, script and hook; 4.2 already extends /reflect's fragment schema. /reflect --mine is the established precedent for adding a mode rather than a command."
+    disposition: pending
+    disposition_rationale: null
+  - id: O12
+    category: specification quality
+    severity: medium
+    claim: "The 'Coda may be offered when the Warden's threshold is crossed' pathway has no implementation surface, and the same section forbids the only edit that would create one."
+    evidence: "Spec 6 'No changes to the Reservoir Warden' alongside 'The Coda may be offered when the Warden's threshold is crossed'; the warden agent's output path never mentions /coda; section 8's docs list names no reservoir surface."
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Objection record — Cadence Sentinels S2: The Coda (spec mode)
+
+Twelve objections: one critical, eight high, three medium. The
+agent-emits / command-persists split is the strongest structural choice in
+the spec and is not objected to. The objections concentrate in three
+places: what `/reflect` actually does when invoked (O1–O3), whether the
+validator can be built and whether it measures the right thing (O6, O7),
+and two questions S1 had already settled that S2 re-opens (O8, O9).
+
+**Dispatcher verification note (2026-08-09).** O1 was verified before
+recording: `commands/reflect.md:159-173` runs `git checkout -b`,
+`gh pr create`, `gh pr merge --squash --delete-branch` and `git pull` on
+main, and `HARNESS.md:413` declares that path binding on *all* `/reflect`
+invocations. The `/reflect --mine` mode cited in O11 exists. The
+command-invokes-command mechanism the spec relies on is real and has
+precedent (`/harness-sync` invokes `/convention-sync`), which is why the
+diaboli did not object to the mechanism itself — only to what the invoked
+command does at its final step.
+
+## O1 — implementation — critical
+
+Ritual step 3 delegates to `/reflect`, and `/reflect` in this repository is
+not a write-a-fragment-and-return operation. It is a full
+branch-commit-push-PR-merge-pull cycle. Running it as the third of five
+steps moves the working tree off the branch holding the uncommitted work
+the survey enumerated in step 1, and does so before a single parking record
+has been written in step 4.
+
+The concrete failure sequence: step 1 surveys modified-but-uncommitted
+files on the working branch; step 3 runs `git checkout -b
+add-reflection-…` (carrying the dirty tree with it, or failing on
+conflict), pushes, opens a PR, waits on CI, merges, deletes the branch, and
+pulls `main`. Step 4 then writes parking records — on `main`, or on a
+deleted branch, or wherever the merge left the tree. Step 5 "closes" a
+session whose working tree is now somewhere the human did not put it.
+
+This is worse than a bug, because the ritual's entire promise is that
+stopping costs nothing. A closing ritual that rearranges your git state and
+blocks on CI is the most expensive way to stop yet designed. §2.3's
+reasoning — do not reimplement reflection — is sound; what it did not do is
+examine what the delegated command does at its final step.
+
+## O2 — specification quality — high
+
+The `Closed` field is specified to carry "what was parked, and how many" —
+a fact produced by step 4 — but is written into the fragment at step 3.
+Under O1's PR path the fragment is not merely written by then but committed
+and merged, so back-filling means editing a merged artefact.
+
+An implementer has three incompatible readings: write at step 3 and drop
+the parked counts (making the field's own spec text wrong); defer the
+fragment until after step 4 (contradicting the order §2 calls "the
+design"); or write and amend (editing a merged file). The field is the only
+artefact §2.2 offers as the ritual's terminal cue, and a terminal cue whose
+content is undefined at write time is not a cue.
+
+## O3 — implementation — high
+
+Clean abandonment is asserted, not designed. Once step 3 has run a fragment
+is committed; once step 4 has begun, parking records exist and constraint 7
+forbids deleting them.
+
+The realistic abandonment point is late: a human who changes their mind
+about stopping typically does so while being asked for the fourth concrete
+next action, not before the survey. At that point three parking records are
+permanent, and the resume hook will surface them next session describing
+threads the human never actually parked, with next actions written in a
+moment of intended closure that never happened.
+
+A3 cannot pass except where abandonment occurs before step 3, and the spec
+gives no rule confining it there.
+
+## O4 — risk — high
+
+The survey's blanket `observed` flag is stated as following from "all of it
+is read from disk", which is not true of the list it flags. Merged PRs and
+an open PR's check state come from `gh` — network, auth, rate limits. A
+survey reporting "no merged PRs" because `gh` errored, flagged `observed`,
+is exactly the laundering of inference as observation constraint 3 exists
+to stop, and S1 §4.3 went to real trouble to make the flag a property of
+the value rather than of the reader for this reason.
+
+The thread-grouping problem is larger. Nine modified files are an
+observation; that they constitute *two* threads rather than one or nine is
+a judgement the Coda makes — and it is the judgement that determines how
+many parking records exist and what each says. This is the Coda's core
+epistemic act, and the spec flags it `observed` by assertion.
+`sentinel-design` asks that the honesty rule be written before the
+detection logic; S2 wrote the detection and declared the honesty rule to be
+"all of it is observed".
+
+## O5 — risk — high
+
+`next_action_flag: asked-override` records a machine verdict about the
+quality of the human's own words, authored by the agent, committed
+permanently. §4.1 asserts this is not a judgement about the person; both of
+`sentinel-design`'s tests say otherwise, and the operational-state
+carve-out cannot rescue it because that carve-out requires the record never
+be committed and be bounded, while parking records are committed and
+permanent.
+
+§4.1's defence conflates two claims. *That the next action came from the
+human* is by-the-person and fine. *That the human's answer failed a check
+and they insisted anyway* is agent-authored, and no human would describe
+what they said as "asked-override". The spec's own framing gives it away:
+"a later reader can see that the specificity check fired and that the human
+overrode it" — that reader is learning something about the person's
+behaviour at the end of a session, from a permanent committed file, and the
+accumulated set is a longitudinal record of how often someone's stopping
+answers were judged inadequate.
+
+This is not an argument against recording the override, which constraint 6
+requires. It is an argument that §4.1's justification does no work, and
+that the honest placement may be the record's prose body — which the human
+authored and would recognise — rather than a machine-legible enum that
+aggregates across records. S5's consultation dispositions will inherit
+whichever answer S2 sets.
+
+## O6 — specification quality — high
+
+§3.2 presents itself as "a deterministic heuristic, so it is testable", but
+its first rule contains a clause no shell script can evaluate ("where the
+remainder is a bare noun phrase" is a parts-of-speech judgement), its
+second rule depends on an undefined term ("`identifier`-shaped token"), and
+the two overlap such that rule 1 does no work — any text consisting solely
+of a vague stem already contains no anchor and fails rule 2.
+
+The acceptance scenarios then require the undefined term to draw a line the
+spec never draws: V1 requires `more work on the parser` to fail while V2
+requires `add the B12 fixture for a malformed Sync cadence block` to pass,
+so `parser` must not be an anchor while `B12` must be. V4 fixes one end of
+the anchor set; nothing fixes the other.
+
+§3.3 promises "the check is stated in the skill and the reference page, so
+a human can see why their wording failed". That promise cannot be kept if
+the check's decisive term exists only in the implementation.
+
+## O7 — implementation — high
+
+Even implemented perfectly, the anchor test measures the presence of a
+code-shaped token, not the specificity of a plan. V5 blesses the
+false-positive path explicitly: append a filename to any vague stem and it
+passes, so "keep going in `src/`" satisfies the rule.
+
+The symmetric false negative matters more. "Re-read the governing-clause
+matcher and decide whether reworking it needs its own spec-first change" is
+concrete, actionable and well-formed, with no path, identifier, test name,
+line reference or quoted string. So is "ask Russ whether the reserved block
+should ship at all". Both fail — and the survey generates parking records
+for exactly such threads, since it enumerates "objection or story records
+still carrying `pending` dispositions".
+
+The evidence in §3.1 concerns the specificity of the plan, a property of
+meaning. The validator tests a property of lexical form. Where they
+diverge, the mechanism does the opposite of what its evidence supports: it
+rewards adding a filename to "continue work" and penalises a genuinely
+concrete decision step. §3.3 discloses that a heuristic errs in both
+directions; it does not address that the errors are *systematic* along the
+code/non-code axis, and the Coda parks non-code threads by design.
+
+## O8 — implementation — high
+
+§2.6 specifies surfacing "at session start" and implements it as a
+`SessionStart` hook — but S1 established, documented twice, and designed
+around the fact that `SessionStart` fires on startup, resume, clear and
+compact.
+
+The behaviour is not merely noisy, it is counter-purposive. A parking
+record's function is to release a thread's pull so the person can stop
+holding it. A hook that prints "still parked: implement the retry branch of
+slice 7" into the middle of an unrelated session hands the thread back,
+repeatedly, at the moment the human is deepest in something else. That is
+the compulsive-continuation surface the epic exists to reduce, generated by
+the mechanism meant to reduce it.
+
+The fix is small — a `source` guard or a once-per-session marker — but the
+spec neither states it nor tests it: H1–H5 test emptiness, missing
+directories and unreadable directories, and none tests firing frequency.
+
+## O9 — scope — high
+
+S2 ships the writer for parking records and nothing that ever closes one.
+No path in this slice writes a `.resumed.md` or `.superseded.md`
+transition, so `records_open` returns a monotonically growing set forever,
+and H4 tests the handling of a file no component in S1 or S2 produces.
+
+S1 assumed S2 owned this: "That query is the one S2's resume path depends
+on", and "resuming is a *write* by the `/coda` command".
+
+Without a resume path the corpus only grows. Session 5 surfaces the records
+from sessions 1–4 whether or not those threads were finished, and combined
+with O8's firing frequency the hook becomes a standing list of stale
+obligations. §2.6 argues the surfacing "is the payoff that makes parking
+trustworthy"; a surfacing that cannot distinguish live parked work from
+work finished three days ago destroys precisely that trust.
+
+## O10 — premise — medium
+
+The headline claim is broader than the mechanism can reach. The only
+defence against continuation is a refusal that dissolves on a plain request
+to continue — and a plain request to continue is the form the named failure
+mode takes.
+
+This is not an argument for making the refusal firmer; the yield is
+required by constraint 2, was disposed at the design gate, and a ritual
+that could not be called off would be the gate-on-the-person anti-pattern.
+The objection is about the *claim*. §3.3 states the epic's own standard:
+"pretending otherwise would be the overclaiming this epic exists to avoid."
+An epithet saying the Coda attacks compulsive continuation, attached to a
+mechanism that by design steps aside for anyone who asks, is that same
+overclaim in the sentence that names the sentinel.
+
+What the Coda actually attacks is *drift* — the "while we're here"
+extension nobody deliberately chose — plus the cold-start cost of an
+unrecorded stop. Both are worth attacking, and naming them accurately sets
+the right expectation for S3, where the hard-stop trigger arrives and the
+continuation claim may become earnable.
+
+## O11 — alternatives — medium
+
+The spec does not weigh extending `/reflect` with a closing mode against
+introducing a fourth surface. It already extends `/reflect`'s schema and
+already delegates a ritual step to it, and its own argument against
+duplicating reflection applies with equal force to standing up a second
+session-closing ritual beside the one that exists. §4.2 records that a
+third *record directory* was considered and rejected; no comparable
+weighing appears for the *command* surface.
+
+There are now two commands a person might run at the end of a session, one
+of which calls the other, and no rule for which to reach for. That is the
+drift §2.3 warns about, relocated one level up: `/reflect` will accumulate
+closing-adjacent behaviour — it already has the `Closed` field and the
+commit step — while `/coda` accumulates reflection-adjacent behaviour, and
+in a year the boundary is folklore.
+
+A `/reflect --close` shape, mirroring the existing `--mine` mode, would
+carry the survey, the parking loop and the validator while leaving one
+entry point and one owner for the fragment schema — dissolving §4.2's
+contract-ownership problem entirely, since the field would then be added by
+its owner. It may still lose: the Coda needs a `role: sentinel` agent, and
+a mode flag on a command that commits is not obviously simpler. But it is
+cheaper on the axis the spec cares about, and the spec should say why it
+lost.
+
+## O12 — specification quality — medium
+
+§6 describes an interaction between the Reservoir Warden and the Coda while
+the same section forbids the only change that could implement it, and §8
+lists no surface where the offer would live. Nothing in the shipped tree
+will ever offer `/coda` at a threshold crossing, because no artefact
+mentions it and §6 forbids editing the ones that would.
+
+The stakes are constraint 5, so the ambiguity is worth removing. Stating it
+as a future possibility deferred to a later slice, or stating that the
+offer is the human's own move with no artefact mediating it, both resolve
+it. Prose describing an unbuilt mechanism next to a non-goal forbidding its
+construction does not.
+
+## Explicitly not objecting to
+
+- **"The Coda invokes `/reflect`" as a mechanism.** Established in this
+  plugin — `/harness-sync` invokes `/convention-sync` and
+  `/harness-health`; `/reflect` invokes `/harness-constrain`. O1 objects to
+  what the invoked command *does*, not to whether it can be invoked.
+- **The agent holding `Bash`.** `reservoir-warden` is already
+  `role: sentinel` with `Bash`, and S1 of the sentinel signature permits it
+  for read-only inspection, so the Coda's grant sets no new precedent.
+- **The agent-emits / command-persists split.** Exactly the
+  `cost-estimator` pattern and the AGENTS.md agent-emit + dispatcher-persist
+  decision; the strongest structural choice in the spec.
+- **The three design-gate dispositions.** Reprompt-once-then-defer, the
+  `Closed` field rather than a third record type, and abandon-on-plain-
+  request. O3 objects to whether abandonment can be *clean*, not to whether
+  it should happen; O6 objects to the rule's implementability, not to what
+  follows a failure.
+- **The version bump and CI-checked locations.** §8 matches `CLAUDE.md`
+  exactly, including the component counts.
+- **Ritual length being unbounded** (considered, below the cap): one
+  validated next action per live thread, no cap, no batching, so the
+  ritual's cost scales with the mess it finds at exactly the moment the
+  human wants to stop. Worth raising at the code gate.
+- **The `sentinel-design` roster table and README Sentinels section going
+  stale** (considered, below the cap): §8 updates
+  `explanation/sentinels.md` roster 5 → 6 but not the roster table in the
+  skill or the README section — a small instance of the pinned-copy
+  anti-pattern AGENTS.md names.

--- a/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
@@ -1,0 +1,310 @@
+# Spec: Cadence Sentinels S2 — The Coda
+
+**Status:** Approved (revision 1)
+**Date:** 2026-08-09
+**Issue:** #492
+**Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Depends on:** S1 (#491, merged as 0.67.0) — the parking-record contract,
+`records_open`, and the pact file
+**Scope:** `ai-literacy-superpowers` plugin; one new agent, skill, command,
+hook, and validator
+**Explicitly out of scope:** the Mast (S3), the WIP Warden (S4), the Convener
+(S5). S2 ships the ritual and the records it writes.
+
+**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
+*Compulsive Continuation — A Research Exploration*.
+
+---
+
+## 1. Problem Statement
+
+An agentic session has no terminal cue. There is no compile, no deploy, no
+colleague standing up to leave — the medium supplies nothing that says *this is
+finished*. So sessions end by attrition rather than by decision: the human stops
+when something external interrupts, and the work is left in whatever state the
+interruption found it.
+
+Two costs follow. The unfinished threads keep their pull, because nothing wrote
+down where they were. And the next session opens cold, re-deriving from a diff
+what the previous session knew.
+
+The Coda is the good ending: a ritual that closes a session deliberately,
+records what landed, and parks every live thread with a concrete resume step.
+
+**Epithet:** *the good ending.* **Attacks:** compulsive continuation.
+
+## 2. The Ritual
+
+The same sequence every invocation, no reordering. The order is the design: a
+survey before a summary so the summary is grounded; reflection before parking so
+the parked records inherit what was just learned; parking before closing so
+nothing is left holding.
+
+| # | Step | Produces |
+| --- | --- | --- |
+| 1 | **Survey** | landed work and live threads, all `observed` |
+| 2 | **Closure summary** | a "what landed" statement |
+| 3 | **Reflection** | invokes the existing `/reflect` flow |
+| 4 | **Park** | one parking record per live thread |
+| 5 | **Close** | the session ends |
+
+### 2.1 Survey
+
+Enumerate, all flagged `observed` because all of it is read from disk:
+
+- **Landed** — commits on the branch, merged PRs, resolved dispositions in
+  objection and story records touched this session.
+- **Live** — in-flight work: modified-but-uncommitted files, an open PR
+  awaiting checks, objection or story records still carrying `pending`
+  dispositions, and any `records_open` result already parked from a previous
+  session.
+
+Nothing here is inferred. If the Coda cannot see something, it does not guess
+at it — it asks.
+
+### 2.2 Closure summary
+
+A short "what landed" statement, written into the session's reflection fragment
+as a new optional field (§4). Closure needs an artifact; the medium supplies no
+terminal cue, so the ritual has to leave one behind.
+
+### 2.3 Reflection
+
+The Coda **invokes the existing `/reflect` flow**. It does not reimplement
+reflection, does not ask the three questions itself, and does not write the
+fragment directly. `/reflect` already owns the fragment schema, the signal
+classification, and the auto-constraint proposal; duplicating any of that would
+create a second reflection path that drifts from the first.
+
+### 2.4 Park
+
+For every live thread, one parking record per the S1 contract
+(`reference/parking-record-format.md`): frontmatter, a `## Context` paragraph,
+and a `## Next action` section carrying **one concrete resume step**.
+
+`next_action` is mandatory and validated — see §3, which is the substantive
+part of this slice.
+
+### 2.5 Close
+
+The Coda **refuses to open new work in the closing breath.** Any work request
+arriving after the ritual has started is parked, not executed.
+
+"Almost done" is the state hardest to leave, and the closing breath is where
+"while we're here" does its damage: the ritual that was about to end the session
+becomes the preamble to another hour.
+
+The refusal targets that drift, not the human's ability to change their mind.
+If the human says plainly that they want to keep working, the Coda **abandons
+the ritual cleanly** — no half-closed session, no partial parking — and says so.
+A ritual that cannot be called off would be a gate on the person, which is the
+anti-pattern `sentinel-design` names.
+
+### 2.6 Resumption
+
+At session start, if any parking record for this repo is still open, surface it:
+id and next action, nothing more. This is the payoff that makes parking
+trustworthy — a record nobody ever sees again is a diary, not a handoff.
+
+Implemented as a `SessionStart` hook over `records_open`
+(`hooks/scripts/lib/record-paths.sh`, shipped in S1). Advisory, silent when
+there is nothing parked, exit 0 unconditionally.
+
+## 3. The Next-Action Validator
+
+The single mechanism in this slice that does real work.
+
+### 3.1 Why it exists
+
+A written plan for an unfinished task releases its pull — but **specificity is
+the active ingredient**, not the writing. "Continue work" is a written plan and
+does nothing. "Implement the retry branch of slice 7's error path, starting from
+the failing test in `test_retry.py`" is a written plan that works.
+
+<!-- evidence: Masicampo & Baumeister 2011 — a specific written plan, not
+     completion, releases the unfinished-task pull. The specificity is what
+     carries the effect, which is why this is validated rather than merely
+     prompted for. -->
+
+### 3.2 What it checks
+
+`scripts/validate-next-action.sh <text>` — a deterministic heuristic, so it is
+testable and the command and the agent share one answer.
+
+A next action **fails** when either holds:
+
+1. It matches a vague-stem pattern and carries nothing else: `continue`,
+   `carry on`, `keep going`, `finish (this|it|up)`, `more work`, `pick up where
+   …`, `resume`, `carry on with …` where the remainder is a bare noun phrase.
+2. It contains **no concrete anchor** — no path-like token, no
+   `identifier`-shaped token, no test or function name, no line or section
+   reference, no quoted string.
+
+It **passes** on any next action carrying at least one anchor and not consisting
+solely of a vague stem.
+
+### 3.3 The heuristic is disclosed, not hidden
+
+A heuristic gets this wrong in both directions, and pretending otherwise would
+be the overclaiming this epic exists to avoid. So:
+
+- The failure message **names what was missing**, never merely "too vague": it
+  asks for a file, a test, or a first step.
+- The check is stated in the skill and the reference page, so a human can see
+  why their wording failed rather than guessing at a hidden rule.
+
+### 3.4 The override, on the record
+
+**Reprompt once, then defer to the human.** A first failure gets one reprompt
+naming what is missing. If the human gives the same answer again, the Coda
+**parks it anyway** and the record carries `next_action_flag: asked-override`.
+
+This is constraint 6 applied literally: no gate without an on-the-record human
+override, and never a bypass. The default stays firm because the evidence
+supports firmness; the human stays in charge because a sentinel that traps
+someone at the end of a session has become the thing it was built to prevent.
+
+The override is a *record* value, not a silence: a later reader can see that the
+specificity check fired and that the human overrode it.
+
+## 4. Contract Changes
+
+Two contracts owned elsewhere change here. Both are carved out explicitly rather
+than slipped in, per the promoted ARCH_DECISION that **a consumer never mutates
+the contract it consumes**. S2 is a consumer of both.
+
+This is the *second* worked instance of that decision (the first was
+`format-revision-per-stage-cost`), which its Rule-of-Three watch item asks to be
+recorded.
+
+### 4.1 Parking record: `next_action_flag` becomes an enum
+
+Owned by S1 (`reference/parking-record-format.md`).
+
+| Before | After |
+| --- | --- |
+| `next_action_flag: asked` | `next_action_flag: asked \| asked-override` |
+
+`asked` — the next action passed the specificity check.
+`asked-override` — it did not, and the human confirmed it anyway.
+
+Both values still mean the next action came from the human. Neither is an
+inference, so constraint 3 is unaffected: this records *how the human answered*,
+never a judgement about them.
+
+### 4.2 Reflection fragment: a new optional `Closed` field
+
+Owned by `/reflect` and `scripts/lib/reflection-log-helpers.sh`.
+
+```text
+- **Closed**: [what landed this session; what was parked, and how many]
+```
+
+Optional, and absent from every fragment `/reflect` writes on its own — only the
+Coda's invocation supplies it. The change is additive: `extract_field` resolves
+by name and `regenerate_log` concatenates fragments verbatim, so no existing
+fragment, parser, or archive path is affected.
+
+The alternative — a third record directory — was rejected at the design gate:
+the reflection fragment already *is* the session-scoped record, `/reflect`
+already runs inside the ritual, and a third schema would need its own
+contract-ownership treatment for no gain.
+
+## 5. Files
+
+| File | Purpose |
+| --- | --- |
+| `agents/coda.agent.md` | `role: sentinel`, `tools: [Read, Glob, Grep, Bash]` — surveys and returns record content |
+| `skills/coda/SKILL.md` | the ritual, the evidence, the anti-patterns |
+| `commands/coda.md` | dispatches the agent, runs the validator, persists records after the human disposes |
+| `scripts/validate-next-action.sh` | the specificity check |
+| `hooks/scripts/parked-resume-check.sh` | `SessionStart` — surfaces open parking records |
+
+**The agent holds no `Write`.** It returns parking-record content as a string;
+`/coda` persists it. That is the `cost-estimator` precedent and what keeps the
+Coda inside the sentinel category its own docs place it in.
+
+## 6. Non-Goals
+
+- **No reimplementation of reflection.** The Coda calls `/reflect`.
+- **No changes to the Reservoir Warden.** The Coda may be *offered* when the
+  Warden's threshold is crossed and the human accepts its decide-your-stop
+  recommendation — never invoked automatically from it.
+- **No automatic invocation at all in this slice.** S3 wires the hard-stop
+  trigger. `/coda` is manual here.
+- **No new gates on the pipeline.** The ritual gates a session's ending, which
+  the human started, and always yields to the human.
+- **No claim about why the human stopped.** Records say a session closed and
+  what was parked. Never why.
+
+## 7. Acceptance Scenarios (TDAD)
+
+Prefixed **V** for the validator, **P** for parking records, **H** for the
+resume hook, and **A** for agent-verified ritual behaviour.
+
+### 7.1 Validator — `tdad_tests/layer0_deterministic/test-next-action.sh`
+
+- **V1 — vague stems rejected.** `continue work`, `carry on`, `keep going`,
+  `finish this`, `pick up where I left off`, `more work on the parser` each exit
+  non-zero.
+- **V2 — concrete actions accepted.** `implement the retry branch of slice 7's
+  error path, starting from the failing test in test_retry.py`,
+  `fix block_key's handling of a trailing comment in pact-blocks.sh:88`, and
+  `add the B12 fixture for a malformed Sync cadence block` each exit 0.
+- **V3 — the message names what is missing.** A rejection mentions a file, a
+  test, or a first step — never only "too vague".
+- **V4 — anchor without a stem passes.** `test_retry.py` alone passes: it is
+  terse but concrete, and the check is for specificity, not prose.
+- **V5 — stem with an anchor passes.** `continue the retry branch in
+  test_retry.py` passes — a vague stem is only fatal when nothing else is there.
+- **V6 — empty and whitespace-only rejected.**
+
+### 7.2 Parking records — `test-record-contracts.sh` (extended)
+
+- **P1 — the enum is documented.** `reference/parking-record-format.md` names
+  both `asked` and `asked-override` and says what each means.
+- **P2 — an override record is well-formed.** A fixture carrying
+  `next_action_flag: asked-override` satisfies every other field of the S1
+  contract.
+- **P3 — an overridden record is still open.** `records_open` returns it: an
+  override changes the flag, never the record's state.
+
+### 7.3 Resume hook — `tdad_tests/layer0_deterministic/test-parked-resume.sh`
+
+- **H1 — silent when nothing is parked.** Empty stdout, exit 0.
+- **H2 — silent when the directory does not exist.** Exit 0.
+- **H3 — surfaces an open record.** Output names the record and its next
+  action.
+- **H4 — a resumed record is not surfaced.** A record superseded by a
+  `.resumed.md` transition does not appear.
+- **H5 — exits 0 unconditionally**, including when the parked directory is
+  unreadable.
+
+### 7.4 Ritual — agent-verified, recorded in the skill
+
+- **A1** — the ritual runs its five steps in order, no reordering.
+- **A2** — a post-ritual work request is parked, not executed.
+- **A3** — a human who says plainly they want to continue gets the ritual
+  abandoned cleanly, not half-completed.
+- **A4** — the Coda writes no file itself; every record is persisted by the
+  command after the human confirms.
+
+## 8. Migration & Rollout
+
+Minor bump, 0.67.0 → 0.68.0 — a new agent, skill, command, and hook.
+
+Version locations: the five CI-checked ones plus the README plugin-table cell,
+and the README component counts (37 skills → 38, 16 agents → 17, 28 commands →
+29).
+
+Docs, same PR:
+
+- `how-to/closing-a-session.md` — the ritual, when to use it, what it writes
+- `reference/parking-record-format.md` — the `next_action_flag` enum (§4.1)
+- `reference/hooks.md` — the resume hook
+- `reference/agents.md`, `reference/commands.md`, `reference/skills.md` — entries
+- `explanation/sentinels.md` — roster 5 → 6
+
+No breaking changes. `next_action_flag` gains a value and loses none; the
+reflection `Closed` field is optional and additive; the resume hook is silent
+until a parking record exists.

--- a/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
@@ -1,9 +1,11 @@
 # Spec: Cadence Sentinels S2 — The Coda
 
-**Status:** Approved (revision 1)
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-09
 **Issue:** #492
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Objections:** `docs/superpowers/objections/cadence-sentinels-s2-coda-design.md`
+— 12 objections, 11 accepted, 1 rejected on the record
 **Depends on:** S1 (#491, merged as 0.67.0) — the parking-record contract,
 `records_open`, and the pact file
 **Scope:** `ai-literacy-superpowers` plugin; one new agent, skill, command,
@@ -31,44 +33,91 @@ what the previous session knew.
 The Coda is the good ending: a ritual that closes a session deliberately,
 records what landed, and parks every live thread with a concrete resume step.
 
-**Epithet:** *the good ending.* **Attacks:** compulsive continuation.
+**Epithet:** *the good ending.*
+
+**Attacks:** *drift* — the "while we're here" extension nobody deliberately
+chose — and the cold-start cost of an unrecorded stop.
+
+Not, in this slice, compulsive continuation itself. The Coda's only defence
+against continuing is a refusal that steps aside the moment the human plainly
+asks it to (§2.5), and a plain request to continue is the shape the failure
+mode takes. Claiming otherwise would be the overclaim §3.3 forbids, in the
+sentence that names the sentinel. S3's hard stop may make that claim earnable;
+S2 does not earn it.
 
 ## 2. The Ritual
 
-The same sequence every invocation, no reordering. The order is the design: a
-survey before a summary so the summary is grounded; reflection before parking so
-the parked records inherit what was just learned; parking before closing so
-nothing is left holding.
+The same sequence every invocation, no reordering.
 
 | # | Step | Produces |
 | --- | --- | --- |
-| 1 | **Survey** | landed work and live threads, all `observed` |
-| 2 | **Closure summary** | a "what landed" statement |
-| 3 | **Reflection** | invokes the existing `/reflect` flow |
-| 4 | **Park** | one parking record per live thread |
-| 5 | **Close** | the session ends |
+| 1 | **Survey** | landed work and live threads, per-item honesty flags |
+| 2 | **Park** | one parking record per live thread |
+| 3 | **Closure summary + reflection** | the `Closed` field, via `/reflect` |
+| 4 | **Close** | the session ends |
+
+**Why parking comes before reflection.** `/reflect` in this repository is not a
+write-a-fragment-and-return operation: `HARNESS.md`'s *Reflections via PR
+workflow* constraint binds every invocation to `git checkout -b`, `gh pr
+create`, `gh pr merge --squash --delete-branch`, and `git pull` on main
+(`commands/reflect.md:159–173`). Run before parking, it would move the working
+tree off the branch holding the very uncommitted work the survey had just
+enumerated — and then write parking records from wherever the merge left the
+tree. A closing ritual that rearranges your git state and blocks on CI is the
+most expensive way to stop yet designed.
+
+So parking completes while the tree is still where the human left it, and
+`/reflect` runs last. The reorder pays a second dividend: the `Closed` field is
+written *after* parking and can therefore name what was parked, which it could
+not when reflection came first.
+
+**Divergence from the build spec, flagged for the PR.** The build spec fixed
+the sequence as survey → closure summary → reflection → park → close and said
+"no reordering". That order is unshippable here for the reason above.
 
 ### 2.1 Survey
 
-Enumerate, all flagged `observed` because all of it is read from disk:
+Each item carries its own flag. A blanket claim would be false: some of this is
+read from disk and some of it is a network call that can fail.
 
-- **Landed** — commits on the branch, merged PRs, resolved dispositions in
-  objection and story records touched this session.
-- **Live** — in-flight work: modified-but-uncommitted files, an open PR
-  awaiting checks, objection or story records still carrying `pending`
-  dispositions, and any `records_open` result already parked from a previous
-  session.
+| Item | Flag |
+| --- | --- |
+| Commits on the branch | `observed` |
+| Modified-but-uncommitted files | `observed` |
+| Dispositions in objection and story records | `observed` |
+| Records already parked (`records_open`) | `observed` |
+| Merged PRs, open-PR check state | `observed` when `gh` succeeds; **`inferred`** when it does not |
+| **Which files constitute one thread** | **`asked`** |
 
-Nothing here is inferred. If the Coda cannot see something, it does not guess
-at it — it asks.
+Two of these deserve their reasoning stated.
 
-### 2.2 Closure summary
+A `gh` read is a network call with auth and rate limits. Reporting "no merged
+PRs" because `gh` errored, flagged `observed`, is exactly the laundering of
+inference as observation constraint 3 exists to stop. When `gh` is unavailable
+the Coda says so; it never silently reports an empty result as an observation.
 
-A short "what landed" statement, written into the session's reflection fragment
-as a new optional field (§4). Closure needs an artifact; the medium supplies no
-terminal cue, so the ritual has to leave one behind.
+**Thread grouping is `asked`, and this is the Coda's central epistemic act.**
+Nine modified files are an observation. That they constitute *two* threads
+rather than one or nine is a judgement — and it is the judgement that decides
+how many parking records exist and what each one says. The Coda proposes a
+grouping and the human confirms or regroups it. It does not decide.
 
-### 2.3 Reflection
+### 2.2 Park
+
+For every live thread, one parking record per the S1 contract
+(`reference/parking-record-format.md`): frontmatter, a `## Context` paragraph,
+and a `## Next action` section carrying one concrete resume step.
+
+Every next action is **asked for**, and every answer the human gives is
+**parked**. The Coda never refuses a next action — see §3, which is where the
+prompting rule lives.
+
+**S2 changes nothing in this contract.** `next_action_flag` stays `asked` for
+every record. The first revision of this spec proposed an `asked-override`
+value; it was removed at the gate (O5), which means S2 consumes S1's contract
+without mutating it and the contract-ownership rule does not engage.
+
+### 2.3 Closure summary and reflection
 
 The Coda **invokes the existing `/reflect` flow**. It does not reimplement
 reflection, does not ask the three questions itself, and does not write the
@@ -76,16 +125,11 @@ fragment directly. `/reflect` already owns the fragment schema, the signal
 classification, and the auto-constraint proposal; duplicating any of that would
 create a second reflection path that drifts from the first.
 
-### 2.4 Park
+The closure summary — a short "what landed, what was parked" statement — is
+supplied to `/reflect` as the optional `Closed` field (§4). Closure needs an
+artifact; the medium supplies no terminal cue, so the ritual leaves one behind.
 
-For every live thread, one parking record per the S1 contract
-(`reference/parking-record-format.md`): frontmatter, a `## Context` paragraph,
-and a `## Next action` section carrying **one concrete resume step**.
-
-`next_action` is mandatory and validated — see §3, which is the substantive
-part of this slice.
-
-### 2.5 Close
+### 2.4 Close
 
 The Coda **refuses to open new work in the closing breath.** Any work request
 arriving after the ritual has started is parked, not executed.
@@ -94,27 +138,51 @@ arriving after the ritual has started is parked, not executed.
 "while we're here" does its damage: the ritual that was about to end the session
 becomes the preamble to another hour.
 
-The refusal targets that drift, not the human's ability to change their mind.
-If the human says plainly that they want to keep working, the Coda **abandons
-the ritual cleanly** — no half-closed session, no partial parking — and says so.
-A ritual that cannot be called off would be a gate on the person, which is the
-anti-pattern `sentinel-design` names.
+The refusal targets that drift, not the human's ability to change their mind. If
+the human says plainly that they want to keep working, the Coda stops the ritual
+and says exactly what has already been written.
 
-### 2.6 Resumption
+**What "stopping cleanly" can and cannot mean.** Records are append-only, so
+nothing already written can be withdrawn. The honest promise is therefore not
+"no partial parking" but **nothing silently half-done**:
 
-At session start, if any parking record for this repo is still open, surface it:
-id and next action, nothing more. This is the payoff that makes parking
-trustworthy — a record nobody ever sees again is a diary, not a handoff.
+- Stopped during or before the survey — nothing has been written. Genuinely
+  clean.
+- Stopped after one or more records exist — the Coda names each record it
+  wrote and offers to supersede it (§2.6), which is a write, not a deletion.
+- Stopped after `/reflect` — the fragment is committed and merged; the Coda
+  says so and does not pretend otherwise.
 
-Implemented as a `SessionStart` hook over `records_open`
-(`hooks/scripts/lib/record-paths.sh`, shipped in S1). Advisory, silent when
-there is nothing parked, exit 0 unconditionally.
+The first revision promised clean abandonment at any point. That was
+unachievable under constraint 7 and is corrected here (O3).
 
-## 3. The Next-Action Validator
+### 2.5 Resumption, and closing a parked record
 
-The single mechanism in this slice that does real work.
+**Surfacing.** If any parking record for this repo is still open, surface it
+once per session: id and next action, nothing more. This is the payoff that
+makes parking trustworthy — a record nobody ever sees again is a diary, not a
+handoff.
 
-### 3.1 Why it exists
+**Once per session is load-bearing.** `SessionStart` fires on startup, resume,
+clear and compact (S1 §4.2), so an unguarded hook would re-inject the parked
+list mid-session, every compact, for the rest of the day. A hook that prints
+"still parked: implement the retry branch" while the human is deepest in
+something unrelated hands the thread back — which is the surface this epic
+exists to reduce, generated by the mechanism meant to reduce it. The hook writes
+a per-session marker under the S1 registry directory and stays silent if one
+already exists.
+
+**Closing a record.** `/coda resume <record>` writes a `.resumed.md` transition
+naming its predecessor in `supersedes:`, exactly as the S1 contract specifies.
+S2 ships this because S1 assigned it here, and because without it
+`records_open` returns a monotonically growing set: session five surfaces the
+records of sessions one to four whether or not those threads were ever
+finished, and a surfacing that cannot tell live parked work from work finished
+three days ago destroys the trust it exists to build.
+
+## 3. Asking for the Next Action
+
+### 3.1 Why the next action matters
 
 A written plan for an unfinished task releases its pull — but **specificity is
 the active ingredient**, not the writing. "Continue work" is a written plan and
@@ -122,77 +190,86 @@ does nothing. "Implement the retry branch of slice 7's error path, starting from
 the failing test in `test_retry.py`" is a written plan that works.
 
 <!-- evidence: Masicampo & Baumeister 2011 — a specific written plan, not
-     completion, releases the unfinished-task pull. The specificity is what
-     carries the effect, which is why this is validated rather than merely
-     prompted for. -->
+     completion, releases the unfinished-task pull. Specificity carries the
+     effect, which is why the ritual asks for a starting point rather than
+     accepting whatever arrives first. -->
 
-### 3.2 What it checks
+### 3.2 The check triggers a question — it never renders a verdict
 
-`scripts/validate-next-action.sh <text>` — a deterministic heuristic, so it is
-testable and the command and the agent share one answer.
+`scripts/next-action-hint.sh <text>` exits 0 when a next action carries a
+concrete anchor and 1 when it does not. **Exit 1 means "ask once more". It does
+not mean "reject".**
 
-A next action **fails** when either holds:
+The first revision made this a validator that refused a record until the text
+passed. That was wrong twice over, and both were caught at the gate (O7):
 
-1. It matches a vague-stem pattern and carries nothing else: `continue`,
-   `carry on`, `keep going`, `finish (this|it|up)`, `more work`, `pick up where
-   …`, `resume`, `carry on with …` where the remainder is a bare noun phrase.
-2. It contains **no concrete anchor** — no path-like token, no
-   `identifier`-shaped token, no test or function name, no line or section
-   reference, no quoted string.
+- It measures **lexical form, not specificity**. "Keep going in `src/`" carries
+  an anchor and would have passed; "ask Russ whether the reserved block should
+  ship at all" carries none and would have failed — and the survey generates
+  parking records for exactly such decision-shaped threads.
+- Its errors are **systematic along the code/non-code axis**, not random. A
+  heuristic that is reliably unfair to one kind of thread is worse than one
+  that is noisy.
 
-It **passes** on any next action carrying at least one anchor and not consisting
-solely of a vague stem.
+Demoted to a trigger, both error directions cost the same thing: one extra
+question. A false positive asks about an already-concrete action; a false
+negative fails to ask about a vague one. Neither produces a wrong verdict about
+the human's words, and **the record is written either way**.
 
-### 3.3 The heuristic is disclosed, not hidden
+This also removes the gate. Nothing is refused, so constraint 6's
+override-on-the-record machinery does not engage — there is nothing to override.
 
-A heuristic gets this wrong in both directions, and pretending otherwise would
-be the overclaiming this epic exists to avoid. So:
+### 3.3 The anchor grammar, stated exactly
 
-- The failure message **names what was missing**, never merely "too vague": it
-  asks for a file, a test, or a first step.
-- The check is stated in the skill and the reference page, so a human can see
-  why their wording failed rather than guessing at a hidden rule.
+A next action **carries an anchor** when it contains at least one of:
 
-### 3.4 The override, on the record
-
-**Reprompt once, then defer to the human.** A first failure gets one reprompt
-naming what is missing. If the human gives the same answer again, the Coda
-**parks it anyway** and the record carries `next_action_flag: asked-override`.
-
-This is constraint 6 applied literally: no gate without an on-the-record human
-override, and never a bypass. The default stays firm because the evidence
-supports firmness; the human stays in charge because a sentinel that traps
-someone at the end of a session has become the thing it was built to prevent.
-
-The override is a *record* value, not a silence: a later reader can see that the
-specificity check fired and that the human overrode it.
-
-## 4. Contract Changes
-
-Two contracts owned elsewhere change here. Both are carved out explicitly rather
-than slipped in, per the promoted ARCH_DECISION that **a consumer never mutates
-the contract it consumes**. S2 is a consumer of both.
-
-This is the *second* worked instance of that decision (the first was
-`format-revision-per-stage-cost`), which its Rule-of-Three watch item asks to be
-recorded.
-
-### 4.1 Parking record: `next_action_flag` becomes an enum
-
-Owned by S1 (`reference/parking-record-format.md`).
-
-| Before | After |
+| Anchor | Pattern |
 | --- | --- |
-| `next_action_flag: asked` | `next_action_flag: asked \| asked-override` |
+| A path | a token containing `/` or a known file extension |
+| A code identifier | a token containing `_`, `::`, or `()`, or in `Some.Case` form |
+| A backticked span | anything inside `` ` `` |
+| A scenario or ticket id | a letter-digit token such as `B12`, `R4`, `#492` |
+| A line or section reference | `file:12`, `§3.2`, `line 40` |
 
-`asked` — the next action passed the specificity check.
-`asked-override` — it did not, and the human confirmed it anyway.
+Nothing else counts. In particular a bare English noun does **not** — `parser`
+is not an anchor, which is what makes `more work on the parser` trigger the
+question while `add the B12 fixture` does not.
 
-Both values still mean the next action came from the human. Neither is an
-inference, so constraint 3 is unaffected: this records *how the human answered*,
-never a judgement about them.
+The first revision also carried a vague-stem rule. It is dropped: any text
+consisting solely of a vague stem already carries no anchor, so the rule fired
+only on inputs the anchor test had already caught (O6).
 
-### 4.2 Reflection fragment: a new optional `Closed` field
+### 3.4 What the human sees
+
+On a trigger, one question that **names what is missing** — a file, a test, or a
+first step — never merely "too vague". Whatever the human answers next is
+parked, including the same words again.
+
+If the human repeats themselves, the record's `## Next action` section carries
+their answer plus a line in **their own voice** noting they were asked for a
+starting point and confirmed this was enough to go on.
+
+That line, not a frontmatter enum, is where the override lives. An
+`asked-override` flag would have been an agent-authored verdict on the human's
+wording, committed permanently and aggregable across records — a longitudinal
+account of how often someone's stopping answers were judged inadequate. Both of
+`sentinel-design`'s tests classify that as a record *about* the person, and the
+operational-state carve-out cannot rescue it because these records are committed
+and permanent (O5).
+
+### 3.5 The rule is disclosed
+
+§3.3's table is reproduced verbatim in `skills/coda/SKILL.md` and
+`reference/parking-record-format.md`, so a human who is asked can see exactly
+why. A check whose decisive term exists only in the implementation cannot be
+argued with, and this one is meant to be.
+
+## 4. Contract Change
+
+One contract owned elsewhere changes: the reflection fragment gains an optional
+field. The parking-record contract is **unchanged** (§2.2).
+
+### 4.1 Reflection fragment: a new optional `Closed` field
 
 Owned by `/reflect` and `scripts/lib/reflection-log-helpers.sh`.
 
@@ -205,6 +282,12 @@ Coda's invocation supplies it. The change is additive: `extract_field` resolves
 by name and `regenerate_log` concatenates fragments verbatim, so no existing
 fragment, parser, or archive path is affected.
 
+Because S2 is a consumer of this contract and not its owner, the change is
+carved out here explicitly rather than slipped in, per the promoted ARCH_DECISION
+that a consumer never mutates the contract it consumes. This is the second
+worked instance of that decision, which its Rule-of-Three watch item asks to be
+recorded.
+
 The alternative — a third record directory — was rejected at the design gate:
 the reflection fragment already *is* the session-scoped record, `/reflect`
 already runs inside the ritual, and a third schema would need its own
@@ -215,83 +298,124 @@ contract-ownership treatment for no gain.
 | File | Purpose |
 | --- | --- |
 | `agents/coda.agent.md` | `role: sentinel`, `tools: [Read, Glob, Grep, Bash]` — surveys and returns record content |
-| `skills/coda/SKILL.md` | the ritual, the evidence, the anti-patterns |
-| `commands/coda.md` | dispatches the agent, runs the validator, persists records after the human disposes |
-| `scripts/validate-next-action.sh` | the specificity check |
-| `hooks/scripts/parked-resume-check.sh` | `SessionStart` — surfaces open parking records |
+| `skills/coda/SKILL.md` | the ritual, the evidence, the anchor grammar, the anti-patterns |
+| `commands/coda.md` | dispatches the agent, asks for next actions, persists records; `/coda resume <record>` writes transitions |
+| `scripts/next-action-hint.sh` | the anchor check (a trigger, not a judge) |
+| `hooks/scripts/parked-resume-check.sh` | `SessionStart` — surfaces open records once per session |
+| `hooks/hooks.json` | registers the hook |
 
 **The agent holds no `Write`.** It returns parking-record content as a string;
 `/coda` persists it. That is the `cost-estimator` precedent and what keeps the
 Coda inside the sentinel category its own docs place it in.
 
+### 5.1 Why `/coda` is a command and not `/reflect --close`
+
+Recorded because the alternative is real and was rejected (O11).
+
+`/reflect --mine` is the established precedent for adding a mode rather than a
+surface, and folding the Coda in would have left one entry point and one owner
+for the fragment schema — dissolving §4.1's contract-ownership problem, since
+the field would then be added by its owner.
+
+It loses on trust shape. The Coda dispatches a `role: sentinel` agent that
+surveys and returns content and is forbidden to write; `/reflect` is a command
+whose final step commits, pushes, and merges. Putting a read-only sentinel
+inside a committing command muddles exactly the boundary S1 spent a slice
+making load-bearing.
+
+The objection's real worry — that the two commands drift until the boundary is
+folklore — is answered directly: both commands state when to reach for which.
+`/reflect` writes a learning. `/coda` closes a session, and calls `/reflect` as
+part of doing so.
+
 ## 6. Non-Goals
 
 - **No reimplementation of reflection.** The Coda calls `/reflect`.
-- **No changes to the Reservoir Warden.** The Coda may be *offered* when the
-  Warden's threshold is crossed and the human accepts its decide-your-stop
-  recommendation — never invoked automatically from it.
-- **No automatic invocation at all in this slice.** S3 wires the hard-stop
-  trigger. `/coda` is manual here.
-- **No new gates on the pipeline.** The ritual gates a session's ending, which
-  the human started, and always yields to the human.
+- **No changes to the Reservoir Warden**, its block, its hook, or its skill.
+  Whether to run `/coda` after the Warden recommends deciding a stop is the
+  **human's own move, mediated by no artefact**. Nothing offers it, nothing is
+  wired, and no file mentions the other. The first revision described an offer
+  pathway next to a non-goal forbidding its construction (O12).
+- **No automatic invocation.** S3 wires the hard-stop trigger; `/coda` is
+  manual here.
+- **No gates.** Nothing in this slice refuses, blocks, or requires a
+  disposition. The ritual can be stopped at any point by saying so.
 - **No claim about why the human stopped.** Records say a session closed and
   what was parked. Never why.
+- **No cap on ritual length.** One next action per live thread, asked in
+  sequence. Noted rather than solved: the cost scales with the mess found at
+  exactly the moment the human wants to stop. If that bites, batching is the
+  obvious answer and belongs in its own slice.
 
 ## 7. Acceptance Scenarios (TDAD)
 
-Prefixed **V** for the validator, **P** for parking records, **H** for the
+Prefixed **N** for the anchor check, **P** for parking records, **H** for the
 resume hook, and **A** for agent-verified ritual behaviour.
 
-### 7.1 Validator — `tdad_tests/layer0_deterministic/test-next-action.sh`
+### 7.1 Anchor check — `tdad_tests/layer0_deterministic/test-next-action.sh`
 
-- **V1 — vague stems rejected.** `continue work`, `carry on`, `keep going`,
-  `finish this`, `pick up where I left off`, `more work on the parser` each exit
-  non-zero.
-- **V2 — concrete actions accepted.** `implement the retry branch of slice 7's
-  error path, starting from the failing test in test_retry.py`,
-  `fix block_key's handling of a trailing comment in pact-blocks.sh:88`, and
-  `add the B12 fixture for a malformed Sync cadence block` each exit 0.
-- **V3 — the message names what is missing.** A rejection mentions a file, a
+The check exits 1 to mean *ask again*, never *reject*. These scenarios pin the
+grammar in §3.3, which the skill and reference page reproduce.
+
+- **N1 — no anchor triggers the question.** `continue work`, `carry on`,
+  `keep going`, `finish this`, `pick up where I left off`, and
+  `more work on the parser` each exit 1. A bare English noun is not an anchor.
+- **N2 — each anchor kind is recognised.** One case per row of §3.3's table:
+  a path (`src/parser.rs`), an identifier (`block_key()`), a backticked span,
+  a scenario id (`B12`), and a line reference (`pact-blocks.sh:88`) each exit 0.
+- **N3 — the message names what is missing.** A trigger mentions a file, a
   test, or a first step — never only "too vague".
-- **V4 — anchor without a stem passes.** `test_retry.py` alone passes: it is
-  terse but concrete, and the check is for specificity, not prose.
-- **V5 — stem with an anchor passes.** `continue the retry branch in
-  test_retry.py` passes — a vague stem is only fatal when nothing else is there.
-- **V6 — empty and whitespace-only rejected.**
+- **N4 — a terse anchor passes.** `test_retry.py` alone exits 0: terse but
+  concrete.
+- **N5 — a vague stem with an anchor passes.** `continue the retry branch in
+  test_retry.py` exits 0. This is a known false positive, disclosed in §3.2 —
+  and it costs nothing, because the check only decides whether to ask.
+- **N6 — empty and whitespace-only trigger the question.**
+- **N7 — exit 1 is not a failure.** The script exits 1 without writing to
+  stderr and without a non-zero-means-error message, so a caller cannot mistake
+  a trigger for a fault.
 
 ### 7.2 Parking records — `test-record-contracts.sh` (extended)
 
-- **P1 — the enum is documented.** `reference/parking-record-format.md` names
-  both `asked` and `asked-override` and says what each means.
-- **P2 — an override record is well-formed.** A fixture carrying
-  `next_action_flag: asked-override` satisfies every other field of the S1
-  contract.
-- **P3 — an overridden record is still open.** `records_open` returns it: an
-  override changes the flag, never the record's state.
+- **P1 — the contract is unchanged.** `next_action_flag` still documents
+  exactly one value, `asked`. S2 adds no enum value.
+- **P2 — an override reads as prose.** A fixture whose `## Next action` carries
+  a repeated answer plus a human-voice confirmation line satisfies every field
+  of the S1 contract, and its frontmatter is indistinguishable from any other
+  record.
+- **P3 — a resumed record supersedes its predecessor.** A `.resumed.md`
+  written by the resume path names its predecessor in `supersedes:`, and
+  `records_open` returns neither.
 
 ### 7.3 Resume hook — `tdad_tests/layer0_deterministic/test-parked-resume.sh`
 
 - **H1 — silent when nothing is parked.** Empty stdout, exit 0.
 - **H2 — silent when the directory does not exist.** Exit 0.
-- **H3 — surfaces an open record.** Output names the record and its next
-  action.
-- **H4 — a resumed record is not surfaced.** A record superseded by a
-  `.resumed.md` transition does not appear.
-- **H5 — exits 0 unconditionally**, including when the parked directory is
-  unreadable.
+- **H3 — surfaces an open record**, naming it and its next action.
+- **H4 — a resumed record is not surfaced.**
+- **H5 — once per session.** Given the hook has already fired for this session,
+  a second invocation with the same session id is silent. This is the scenario
+  that would have caught re-injection on every compact.
+- **H6 — a new session surfaces again.** A different session id gets the list.
+- **H7 — exits 0 unconditionally**, including when the parked directory is
+  unreadable and when `HOME` is unset.
 
 ### 7.4 Ritual — agent-verified, recorded in the skill
 
-- **A1** — the ritual runs its five steps in order, no reordering.
-- **A2** — a post-ritual work request is parked, not executed.
-- **A3** — a human who says plainly they want to continue gets the ritual
-  abandoned cleanly, not half-completed.
-- **A4** — the Coda writes no file itself; every record is persisted by the
+- **A1** — the four steps run in order: survey, park, closure summary and
+  reflection, close.
+- **A2** — thread grouping is proposed and confirmed, never decided alone.
+- **A3** — a `gh` failure is reported as `inferred`, never as an empty
+  `observed` result.
+- **A4** — a post-ritual work request is parked, not executed.
+- **A5** — a human who plainly says they want to continue gets the ritual
+  stopped, with an explicit statement of what was already written.
+- **A6** — the Coda writes no file itself; every record is persisted by the
   command after the human confirms.
 
 ## 8. Migration & Rollout
 
-Minor bump, 0.67.0 → 0.68.0 — a new agent, skill, command, and hook.
+Minor bump, 0.67.0 → 0.68.0 — a new agent, skill, command, script, and hook.
 
 Version locations: the five CI-checked ones plus the README plugin-table cell,
 and the README component counts (37 skills → 38, 16 agents → 17, 28 commands →
@@ -300,11 +424,15 @@ and the README component counts (37 skills → 38, 16 agents → 17, 28 commands
 Docs, same PR:
 
 - `how-to/closing-a-session.md` — the ritual, when to use it, what it writes
-- `reference/parking-record-format.md` — the `next_action_flag` enum (§4.1)
-- `reference/hooks.md` — the resume hook
-- `reference/agents.md`, `reference/commands.md`, `reference/skills.md` — entries
+- `reference/parking-record-format.md` — the anchor grammar and the prose-body
+  override convention (the field set is unchanged)
+- `reference/hooks.md` — the resume hook, including once-per-session firing
+- `reference/agents.md`, `reference/commands.md`, `reference/skills.md`
 - `explanation/sentinels.md` — roster 5 → 6
+- `skills/sentinel-design/SKILL.md` — the roster table, and the README
+  Sentinels section, both of which the skill's own step 5 requires be kept in
+  step with the roster
 
-No breaking changes. `next_action_flag` gains a value and loses none; the
-reflection `Closed` field is optional and additive; the resume hook is silent
-until a parking record exists.
+No breaking changes. The parking-record contract is untouched; the reflection
+`Closed` field is optional and additive; the resume hook is silent until a
+parking record exists.

--- a/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
@@ -1,11 +1,13 @@
 # Spec: Cadence Sentinels S2 — The Coda
 
-**Status:** Approved (revision 2, post-diaboli)
+**Status:** Approved (revision 3, post-cartographer)
 **Date:** 2026-08-09
 **Issue:** #492
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
 **Objections:** `docs/superpowers/objections/cadence-sentinels-s2-coda-design.md`
 — 12 objections, 11 accepted, 1 rejected on the record
+**Choice stories:** `docs/superpowers/stories/cadence-sentinels-s2-coda-design.md`
+— 8 stories, all accepted
 **Depends on:** S1 (#491, merged as 0.67.0) — the parking-record contract,
 `records_open`, and the pact file
 **Scope:** `ai-literacy-superpowers` plugin; one new agent, skill, command,
@@ -56,7 +58,13 @@ The same sequence every invocation, no reordering.
 | 3 | **Closure summary + reflection** | the `Closed` field, via `/reflect` |
 | 4 | **Close** | the session ends |
 
-**Why parking comes before reflection.** `/reflect` in this repository is not a
+**Why parking comes before reflection.** The portable reason first, because it
+holds in every repository: the `Closed` field names what was parked, and it can
+only do that if parking has already happened. A closure summary written before
+the parking it describes can assert a count and nothing else.
+
+The local reason makes the order non-negotiable *here*. `/reflect` in this
+repository is not a
 write-a-fragment-and-return operation: `HARNESS.md`'s *Reflections via PR
 workflow* constraint binds every invocation to `git checkout -b`, `gh pr
 create`, `gh pr merge --squash --delete-branch`, and `git pull` on main
@@ -66,10 +74,14 @@ enumerated — and then write parking records from wherever the merge left the
 tree. A closing ritual that rearranges your git state and blocks on CI is the
 most expensive way to stop yet designed.
 
-So parking completes while the tree is still where the human left it, and
-`/reflect` runs last. The reorder pays a second dividend: the `Closed` field is
-written *after* parking and can therefore name what was parked, which it could
-not when reflection came first.
+So parking completes — and is **committed** (§2.2) — while the tree is still
+where the human left it, and `/reflect` runs last.
+
+Downstream adopters who have not declared that constraint get a `/reflect` that
+commits directly to the current branch and moves nobody's tree. The order still
+holds for them, on the first reason. Stating which reason travels matters: a
+paragraph that reads as a workaround for someone else's CI is precisely the kind
+a maintainer reorders believing they are removing dead weight.
 
 **Divergence from the build spec, flagged for the PR.** The build spec fixed
 the sequence as survey → closure summary → reflection → park → close and said
@@ -96,11 +108,31 @@ PRs" because `gh` errored, flagged `observed`, is exactly the laundering of
 inference as observation constraint 3 exists to stop. When `gh` is unavailable
 the Coda says so; it never silently reports an empty result as an observation.
 
+**Flags are ritual-scoped.** They are shown to the human during the survey and
+do not travel into the record — parking records are handoffs, not provenance
+artefacts. Where provenance matters for a particular thread (a survey taken
+while `gh` was unavailable, say), it goes in the record's `## Context` prose,
+where the human can read it. This is stated so S5 inherits an answer: its
+consultation records *do* carry a per-voice `source_flag`, and the difference is
+deliberate rather than an accident of which slice was written first.
+
 **Thread grouping is `asked`, and this is the Coda's central epistemic act.**
 Nine modified files are an observation. That they constitute *two* threads
 rather than one or nine is a judgement — and it is the judgement that decides
-how many parking records exist and what each one says. The Coda proposes a
-grouping and the human confirms or regroups it. It does not decide.
+how many parking records exist and what each one says.
+
+**Propose and default-accept.** The Coda proposes a grouping; it stands unless
+the human changes it. The human can always overrule, which is what makes the
+flag `asked` rather than `inferred` — but the default costs a word rather than a
+partition.
+
+This is the plugin's own premise applied to its own ritual. The
+`reservoir-warden` exists because judgement degrades across a session, and this
+step lands at the moment the human has already decided they are finished.
+Demanding a full manual partition there would put the heaviest synthesis in the
+ritual on whoever is least equipped to do it — and the escape would be cheap and
+silent: group everything as one thread, answer once, and the handoff is worth
+nothing on exactly the sessions where it would have been worth most.
 
 ### 2.2 Park
 
@@ -116,6 +148,24 @@ prompting rule lives.
 every record. The first revision of this spec proposed an `asked-override`
 value; it was removed at the gate (O5), which means S2 consumes S1's contract
 without mutating it and the contract-ownership rule does not engage.
+
+**Records are committed here, at step 2, before `/reflect` runs.** This is not
+tidiness. `/reflect` stages `reflections/active/` and `REFLECTION_LOG.md` and
+nothing else (`commands/reflect.md:160`), then relocates the tree to `main`.
+Without an explicit commit at this step, the ritual would write parking records,
+publish a `Closed` field describing them, and leave the records themselves
+uncommitted in a tree that has just moved — the claim reaching `main` by design
+and the records it names reaching `main` by whatever the human happened to do
+next.
+
+**Retention: permanent and committed, stated rather than assumed.** A handoff
+another person may read is repository content, which is why these records live
+in the tree rather than beside the pact file. Two consequences follow and are
+accepted here rather than solved: the corpus grows as sessions × threads
+forever, and `records_open` iterates the whole directory on every call, so the
+session-start hook's cost tracks lifetime history rather than open work.
+Archival is deliberately not built in this slice — see issue #499. It needs its
+own spec and its own adversarial pass, because S1 owns the contract.
 
 ### 2.3 Closure summary and reflection
 
@@ -168,11 +218,34 @@ clear and compact (S1 §4.2), so an unguarded hook would re-inject the parked
 list mid-session, every compact, for the rest of the day. A hook that prints
 "still parked: implement the retry branch" while the human is deepest in
 something unrelated hands the thread back — which is the surface this epic
-exists to reduce, generated by the mechanism meant to reduce it. The hook writes
-a per-session marker under the S1 registry directory and stays silent if one
-already exists.
+exists to reduce, generated by the mechanism meant to reduce it. The guard keys off **S1's existing registry entry** rather than a new marker
+file: `started_at` is per-session and stable across compacts by design (S1's R2
+asserts exactly that), so the hook can tell a genuinely new session from a
+re-fire without writing anything.
 
-**Closing a record.** `/coda resume <record>` writes a `.resumed.md` transition
+That matters beyond convenience. A new per-session marker file in
+`~/.claude/sessions/` would have been a second file class in a directory another
+slice owns, inheriting its location guarantees without inheriting its retention
+contract — and the registry's only removal path is the lease pruner, which
+retires `*.json` by heartbeat and sweeps `*.tmp`. A marker in neither shape has
+no removal path and accumulates one per session for the life of the machine,
+against a carve-out whose second condition is *bounded* and whose own text warns
+that "a record with no expiry is an archive".
+
+**Closing a record is also asked, not only commanded.** When the ritual runs
+and open records exist, the Coda asks per record whether it is still live — the
+human is already in a closing conversation, so this costs them nothing extra,
+and a "no" writes the transition immediately.
+
+Without that, closure would depend entirely on someone remembering to run a
+command, and the corpus would only ever grow. Note the asymmetry this resolves:
+S1's registry is a *lease*, where forgetting costs nothing because entries
+expire; a parking record is the inverse, open by default until an act of
+bookkeeping closes it. The failure of forgetting is an undercount in one and an
+overcount in the other, and the overcount is the one a human sees at every
+session start.
+
+**Closing a record explicitly.** `/coda resume <record>` writes a `.resumed.md` transition
 naming its predecessor in `supersedes:`, exactly as the S1 contract specifies.
 S2 ships this because S1 assigned it here, and because without it
 `records_open` returns a monotonically growing set: session five surfaces the
@@ -230,10 +303,18 @@ A next action **carries an anchor** when it contains at least one of:
 | A backticked span | anything inside `` ` `` |
 | A scenario or ticket id | a letter-digit token such as `B12`, `R4`, `#492` |
 | A line or section reference | `file:12`, `§3.2`, `line 40` |
+| A decision | a question word, a named person, or `ask` / `decide` / `choose between` |
 
 Nothing else counts. In particular a bare English noun does **not** — `parser`
 is not an anchor, which is what makes `more work on the parser` trigger the
 question while `add the B12 fixture` does not.
+
+**The decision row exists because the other five are all artefacts of
+code-shaped work**, and this plugin's own work is mostly specs, prose, and
+decisions. Without it the table would tax the dominant kind of thread with an
+extra question at every close, from a published rule that reads as the house
+definition of a concrete next step. "Ask Russ whether the reserved block should
+ship at all" is a perfectly good next action and now reads as one.
 
 The first revision also carried a vague-stem rule. It is dropped: any text
 consisting solely of a vague stem already carries no anchor, so the rule fired
@@ -264,6 +345,11 @@ and permanent (O5).
 why. A check whose decisive term exists only in the implementation cannot be
 argued with, and this one is meant to be.
 
+Both copies carry the same framing sentence: **this is a trigger heuristic, and
+its complement is not "vague".** A next action that carries no anchor gets one
+question; it does not get a verdict, and it is not being called imprecise. The
+table says what makes the Coda *stop asking*, not what makes a next action good.
+
 ## 4. Contract Change
 
 One contract owned elsewhere changes: the reflection fragment gains an optional
@@ -274,8 +360,15 @@ field. The parking-record contract is **unchanged** (§2.2).
 Owned by `/reflect` and `scripts/lib/reflection-log-helpers.sh`.
 
 ```text
-- **Closed**: [what landed this session; what was parked, and how many]
+- **Closed**: [what landed this session; the filename of each record parked]
 ```
+
+**Filenames, not a count.** A count asserts that three threads were parked
+without saying which three, and nothing can check it. Naming the records makes
+the claim resolvable against `records_open` and gives a future reader a route
+from a reflection entry to the work it closed. The reflection log is the
+durable, published trace of a session's close; the one cross-artefact claim it
+makes should not be the one nothing can verify.
 
 Optional, and absent from every fragment `/reflect` writes on its own — only the
 Coda's invocation supplies it. The change is additive: `extract_field` resolves
@@ -371,6 +464,10 @@ grammar in §3.3, which the skill and reference page reproduce.
   test_retry.py` exits 0. This is a known false positive, disclosed in §3.2 —
   and it costs nothing, because the check only decides whether to ask.
 - **N6 — empty and whitespace-only trigger the question.**
+- **N8 — a decision anchor is recognised.** `ask Russ whether the reserved
+  block should ship at all` and `decide between the lease and the explicit
+  transition` each exit 0. This is the row that stops the grammar taxing the
+  plugin's own dominant kind of work.
 - **N7 — exit 1 is not a failure.** The script exits 1 without writing to
   stderr and without a non-zero-means-error message, so a caller cannot mistake
   a trigger for a fault.
@@ -399,6 +496,9 @@ grammar in §3.3, which the skill and reference page reproduce.
 - **H6 — a new session surfaces again.** A different session id gets the list.
 - **H7 — exits 0 unconditionally**, including when the parked directory is
   unreadable and when `HOME` is unset.
+- **H8 — no marker file is written.** After the hook runs, the registry
+  directory contains exactly the files it contained before. The guard reads
+  `started_at`; it does not leave residue in a directory S1 owns.
 
 ### 7.4 Ritual — agent-verified, recorded in the skill
 
@@ -412,6 +512,11 @@ grammar in §3.3, which the skill and reference page reproduce.
   stopped, with an explicit statement of what was already written.
 - **A6** — the Coda writes no file itself; every record is persisted by the
   command after the human confirms.
+- **A7** — parking records are committed before `/reflect` is invoked.
+- **A8** — the proposed thread grouping stands when the human says nothing, and
+  changes when they do.
+- **A9** — when open records exist at ritual time, each is asked about, and a
+  "no longer live" answer writes its transition.
 
 ## 8. Migration & Rollout
 

--- a/docs/superpowers/stories/cadence-sentinels-s2-coda-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s2-coda-design.md
@@ -1,0 +1,427 @@
+---
+spec: docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md
+date: 2026-08-09
+mode: spec
+cartographer_model: claude-opus-5[1m]
+stories:
+  - id: 1
+    lens: [consequences, defaults]
+    title: A record per thread, forever
+    disposition: accepted
+    disposition_rationale: "Retention stated on the record, mechanism deferred to issue #499. Records are permanent and committed because a handoff another person may read is repository content — but that is now a decision in the spec rather than a silence, along with the read-cost note that records_open tracks lifetime history rather than open work. Archival needs its own spec and its own adversarial pass, since S1 owns the contract."
+  - id: 2
+    lens: [coherence, alternatives]
+    title: Closure declared, never leased
+    disposition: accepted
+    disposition_rationale: "The surfacing becomes the closing affordance: the next /coda asks, per open record, whether it is still live. That is asked rather than inferred, costs the human nothing they were not already being asked at that moment, and stops the parked list being a corpus only an explicit command can ever shrink."
+  - id: 3
+    lens: [patterns, consequences]
+    title: The anchor grammar publishes an ontology
+    disposition: accepted
+    disposition_rationale: "A sixth anchor kind added — a decision: a question word, a named person, or ask/decide/choose between. The spec's own worked counter-example stops triggering. The reference page also reframes the table as a trigger heuristic whose complement is explicitly not 'vague', so the published grammar stops reading as the house definition of good work."
+  - id: 4
+    lens: [coherence, consequences]
+    title: Honesty flags die at the record
+    disposition: accepted
+    disposition_rationale: "Provenance moves into the ## Context prose, where the override already lives — no schema change and no contract question — and the spec states plainly that flags are ritual-scoped and records are not provenance artefacts. S5 then inherits an answer rather than reconstructing a precedent from a neighbour that went the other way."
+  - id: 5
+    lens: [forces, coherence]
+    title: The hardest judgement at the tiredest moment
+    disposition: accepted
+    disposition_rationale: "Propose-and-default-accept. The Coda's grouping stands unless the human changes it. Still asked in the sense that matters, since the human can always overrule, and it costs a depleted person one word instead of a partition. This is the plugin's own reservoir premise applied to its own ritual: the instrument that makes a moment safer should not add its heaviest work to that moment."
+  - id: 6
+    lens: [consequences, alternatives]
+    title: Closed names a count, not records
+    disposition: accepted
+    disposition_rationale: "The Coda commits the parking records BEFORE invoking /reflect, and Closed names the record filenames rather than a count. Verified at the gate: /reflect stages only reflections/active/ and REFLECTION_LOG.md, so without this the ritual writes records, relocates the tree to main, and leaves them behind uncommitted while publishing a claim about them."
+  - id: 7
+    lens: [coherence, defaults]
+    title: A Coda marker in S1's registry
+    disposition: accepted
+    disposition_rationale: "The guard keys off S1's existing entry — started_at is per-session and stable across compacts by design (R2) — so no new file class is created in another slice's directory. That removes the co-tenancy, the missing retention path, and the unbounded accumulation against a carve-out whose second condition is bounded."
+  - id: 8
+    lens: [defaults, consequences]
+    title: A repo's CI politics becomes ritual
+    disposition: accepted
+    disposition_rationale: "The portable reason leads: Closed can only name what parking produced, which holds in every repository. The PR-workflow constraint becomes the local fact that makes the order non-negotiable here rather than the headline justification. Without that ordering a downstream maintainer reads the paragraph as a workaround for someone else's CI, which is precisely when a fixed order gets quietly reordered."
+---
+
+# Choice stories — Cadence Sentinels S2: The Coda
+
+Eight stories from a spec that argues its explicit decisions unusually well.
+The ritual reorder, the demoted check, the prose-body override, the per-item
+flags, the once-per-session guard, the resume path, and the epithet narrowing
+are all adjudicated on the objection record and reasoned in the spec's own
+prose; none is restated here. These eight sit where that coverage stops: what
+the records look like as a corpus rather than as artefacts, what the anchor
+table teaches when read as a definition, where provenance stops travelling, and
+which of S2's decisions S3–S5 will inherit without being told they are
+inheriting anything.
+
+**Dispatcher verification note (2026-08-09).** Two citations were checked
+before recording. `commands/reflect.md:160` stages
+`reflections/active/ REFLECTION_LOG.md` only — no parking-record path — so the
+ritual's own reflection step does not commit the records the `Closed` field
+describes, and then relocates the tree to main (story #6). And
+`commands/reflect.md:131-133` enumerates exactly eight mandatory fields, so an
+absent optional ninth is undetectable there (story #6).
+
+## Story #1 — A record per thread, forever
+
+**Source:** spec §2.2, §2.5, §6 · **Lens:** consequences, defaults
+
+**Context.** The ritual writes one parking record per live thread, committed,
+append-only, closed by writing a second file rather than deleting the first. S2
+is the first producer for a directory S1 created and left empty.
+
+**Forces.** Per-thread granularity makes each next action self-contained and
+lets `records_open` answer "which threads" rather than "which sessions" —
+genuinely the right unit. Pulling the other way, the corpus grows as sessions ×
+threads, and a parked-then-resumed thread leaves at least two files behind
+permanently. §6 discloses the ritual's unbounded *length*; the same force at a
+longer time scale — the corpus's unbounded *size* — is not raised at all.
+
+**Options not taken.**
+
+- One record per session carrying a thread list. Fewer files, at the cost of
+  per-thread resume ergonomics.
+- Records outside the work tree, as S1 put the registry and the pact file, on
+  the same reasoning that a person's operational residue is not repository
+  content. S2 keeps them committed — defensible, since a handoff someone else
+  may read is repo content — but the spec never states the choice.
+- Adopt the reflection corpus's archival machinery from day one: `active/`
+  plus `archive/<YYYY>.md` and a weekly GC rule, which this repo already runs
+  and already specified.
+
+**Choice as written.** Per-thread, committed, permanent — with retention,
+archival, and GC all chosen by silence.
+
+**Consequences.** This is the repo's first committed corpus keyed to *moments*
+rather than to durable artefacts. Objections and stories grow one file per spec
+and stay relevant; a parking record's value drops to zero the moment its thread
+resumes, and it stays in the tree and in every clone regardless. Over months the
+directory becomes the densest available account of when work was left unfinished
+and how often — assembled from individually innocuous artefacts, which is the
+aggregation shape O5 refused at field level and which the spec does not
+re-examine at corpus level. Operationally, `records_open` scans and greps the
+whole directory on every session start, so read cost tracks lifetime history
+rather than open work; and the filename slug is the corpus's only human-readable
+index, with nobody in the spec assigned to author it.
+
+**Pattern.** An append-only log without a compaction story. The repo has solved
+this shape once already, for reflections, with the fragment/archive split and a
+GC rule — which makes the omission a decision to dispose of rather than an
+oversight to discover in six months.
+
+## Story #2 — Closure declared, never leased
+
+**Source:** spec §2.5, §7.2 P3 · **Lens:** coherence, alternatives · **Refs:** O9, #1
+
+**Context.** `/coda resume <record>` is the only thing that ever closes a
+parking record. The spec argues carefully for why the resume path must exist in
+this slice; it does not argue for why it is the only path.
+
+**Forces.** The BY/ABOUT boundary genuinely forbids the Coda from concluding a
+thread is finished — that would be an agent-authored claim about the person's
+work. Against that: *resuming work* and *declaring you resumed it* are different
+acts, and only the second is wired to anything. The spec resolves toward
+declaration and never states what keeps the declaration happening.
+
+**Options not taken.**
+
+- Make the surfacing the closing affordance: the hook already prints the open
+  list, and the next `/coda` could ask, per record, whether it is still live.
+  That is `asked`, honest, and costs a human nothing they were not already
+  being asked at that exact moment.
+- Give records a lease, as S1 gave registry entries: an untouched record ages
+  to a `stale` state. State-in-the-path already supports a third suffix.
+- Close implicitly on an observable signal — a commit touching the next
+  action's anchor path. Rejectable on honesty grounds, but it is the option the
+  anchor grammar quietly makes available and it is not weighed.
+
+**Choice as written.** Closure by explicit command, and by silence about
+everything else.
+
+**Consequences.** One epic now carries two opposite liveness models on one
+substrate. S1's registry is a lease: a session stays live only by renewing, and
+forgetting costs nothing because the lease expires. S2's corpus is the inverse —
+a thread stays open by default and only bookkeeping closes it. The failure of
+forgetting is opposite in each: the registry undercounts, the parked list
+overcounts, and the overcounting one is what a human sees at every session
+start. S3–S5 will each face this question, and whichever neighbour they read
+first supplies their default.
+
+**Pattern.** Lease-with-heartbeat-renewal against explicit lifecycle
+transition. Both are correct patterns; having both in one substrate with no
+stated rule for which applies is the coherence gap.
+
+## Story #3 — The anchor grammar publishes an ontology
+
+**Source:** spec §3.3, §3.4, §3.5 · **Lens:** patterns, consequences · **Refs:** O6, O7
+
+**Context.** §3.3 states five anchor kinds exactly, and §3.5 reproduces the
+table verbatim in the skill and the reference page so a human who is asked can
+see why.
+
+**Forces.** Arguability against reach. A rule whose decisive term lives only in
+the implementation cannot be argued with, and the spec is right to pay for
+publication. What it does not weigh is that publishing a rule also publishes a
+definition of *good*: this table becomes the only written statement in the
+plugin of what a concrete next action looks like, and all five kinds are
+artefacts of code-shaped work.
+
+**Options not taken.**
+
+- Publish the worked examples from §3.1 rather than the token grammar — same
+  arguability, and the implementation stays free to change.
+- Add a non-code anchor kind: a named person, a decision verb, a question. The
+  spec's own worked counter-example — "ask Russ whether the reserved block
+  should ship at all" — is a shape the grammar could recognise and does not.
+- Publish the table explicitly as a trigger heuristic whose complement is *not*
+  "vague". §3.4 nearly does this; the reference page does not carry the framing.
+
+**Choice as written.** Publish the token grammar verbatim, in two places, as
+the definition the human is entitled to argue with.
+
+**Consequences.** O7's systematic bias survives its own disposition, changed in
+kind rather than removed: demoted to a trigger it renders no verdict, but it
+still taxes one class of work with an extra question at closing time, now from a
+published table that reads as the house definition of a concrete next step. Two
+second-order effects. A human who reads the rule learns that backticking any
+phrase silences it, so the disclosure ships the bypass with the rule — harmless
+while the check only decides whether to ask, and worth knowing before any later
+slice tries to make an anchor load-bearing. And S3–S5 inherit this table as the
+epic's only vocabulary for specificity, in a plugin whose own work is mostly
+specs, prose, and decisions.
+
+**Pattern.** **Published Language** (Evans, *Domain-Driven Design*, 2003) — the
+same pattern S1's story #3 named for `Sync cadence`, with the same caveat: a
+published language is expensive to change. Here it is published in two documents
+and pinned by seven scenarios before a single record has been written against it.
+
+## Story #4 — Honesty flags die at the record
+
+**Source:** spec §2.1, §2.2, §4 · **Lens:** coherence, consequences · **Refs:** O4, O5
+
+**Context.** §2.1 replaces a blanket `observed` with per-item flags. §2.2 then
+writes records whose only honesty field is `next_action_flag: asked`, a constant
+fixed by S1's contract. The per-item flags exist in the ritual's conversation
+and nowhere afterwards.
+
+**Forces.** S1 §4.3 went to real trouble to make its flag a durable property of
+the count rather than of the reader, precisely so uncertainty is not disclosed
+to whoever read first and hidden from everyone after. S2's flags are the
+opposite shape — computed per survey, shown once, discarded at write time.
+Pulling the other way, S1 owns the parking-record contract and §4's own rule
+says a consumer does not mutate what it consumes: persisting provenance would
+have cost S2 a contract-owning slice. The spec takes the cheaper path without
+naming the trade.
+
+**Options not taken.**
+
+- Carve the contract slice. §4 demonstrates the move one section later for the
+  reflection fragment, so the spec plainly knows how.
+- Record provenance in the `## Context` prose, where §3.4 already puts the
+  override. No schema change, no contract question, and the human can see it.
+- State explicitly that flags are ritual-scoped and records are not provenance
+  artefacts, so S5 inherits an answer rather than a precedent.
+
+**Choice as written.** By silence. Nothing says the flags stop at the record,
+and nothing carries them across.
+
+**Consequences.** A thread surveyed while `gh` was unavailable produces a record
+indistinguishable from one surveyed cleanly; the honesty reaches the person
+present at the close and nobody after. The epic ends up with two contradictory
+precedents in the same directory tree: S1's consultation record carries a
+per-voice `source_flag`, so S5's records *will* persist provenance, while S2's
+will not. Worth noting which part of the record the flag does cover — the next
+action, the one thing that came from the human — while the `## Context`
+paragraph, a permanent committed agent-authored claim about the state of the
+work, carries no flag and is the part `sentinel-design`'s two tests were never
+run against.
+
+**Pattern.** — . The closest frame is lineage computed and then dropped: the
+survey derives provenance for the transform and discards it before the load.
+
+## Story #5 — The hardest judgement at the tiredest moment
+
+**Source:** spec §2.1, §6 · **Lens:** forces, coherence · **Refs:** O4, #4
+
+**Context.** Thread grouping is `asked`, and the spec names it "the Coda's
+central epistemic act": the Coda proposes a grouping and the human confirms or
+regroups. §6 declines to cap ritual length and notes the cost scales with the
+mess found, "at exactly the moment the human wants to stop".
+
+**Forces.** Constraint 3's honesty — the grouping is a judgement, so it cannot
+be flagged `observed` — against this plugin's own model of end-of-session
+capacity. The plugin ships a `reservoir-warden` whose entire premise is that
+judgement degrades across a session. The Coda places a synthesis task —
+partition N modified files into threads, then name and justify each — at the
+point the human has already decided they are finished. Both forces belong to
+this epic; the spec names one.
+
+**Options not taken.**
+
+- Propose-and-default-accept: the Coda's grouping stands unless the human
+  changes it. Still `asked` in the sense that matters — the human can always
+  overrule — and it costs a depleted person one word instead of a partition.
+- Flag the grouping `inferred` and let the resume path correct it. A disclosed
+  inference is not a laundered one, and the correction lands when the person is
+  fresh.
+- Group by an observable proxy — commit adjacency, directory, mtime — and ask
+  only about the residue that does not fall out cleanly.
+
+**Choice as written.** A full human partition, every session, uncapped, before
+any record can be written.
+
+**Consequences.** The grouping decision is where §6's unbounded ritual length
+actually comes from: the number of records, of next-action prompts, and of
+anchor-check triggers all fall out of it. Nothing refuses, so the escape is
+always available and cheap — a depleted human groups everything as one thread
+and writes one vague next action, the check asks once, and the answer is parked.
+The Coda therefore degrades toward a single low-value record rather than toward
+resistance, and it degrades hardest on exactly the sessions whose handoff would
+have been worth the most. S3 inherits this shape at the moment it makes the
+ritual fire on a trigger rather than on request.
+
+**Pattern.** — . Structurally this is the checklist paradox: the instrument that
+makes a moment safer adds work to that moment, and the work lands on whoever is
+least equipped to do it. The usual mitigation is to pre-compute the default and
+ask only for the correction.
+
+## Story #6 — Closed names a count, not records
+
+**Source:** spec §2, §2.3, §4.1 · **Lens:** consequences, alternatives · **Refs:** O1, O2, #4
+
+**Context.** The reorder makes `Closed` writable after parking, and its stated
+content is "what landed this session; what was parked, and how many". It is
+optional, free prose, supplied only by the Coda's invocation, and it travels
+into `REFLECTION_LOG.md` — a generated, committed, published aggregate.
+
+**Forces.** The field must be cheap and additive or it becomes a real change to
+a contract S2 does not own; it must also be the ritual's terminal cue, since
+closure needs an artefact. Cheapness won. What that bought — a field asserting
+that three threads were parked without saying which three — is not named as a
+cost.
+
+**Options not taken.**
+
+- Carry record filenames rather than a count, making the claim resolvable
+  against `records_open` and giving a future reader a route from a reflection
+  entry to the work it closed.
+- Carry only what landed, and let `records_open` answer what is parked.
+- Make the field mandatory in the Coda's fragment and extend `/reflect`'s
+  validation checkpoint, which enumerates exactly eight mandatory fields and
+  therefore cannot notice a missing ninth.
+
+**Choice as written.** Free prose, optional, unvalidated, carrying a count.
+
+**Consequences.** The reflection log becomes the durable, published trace of a
+session's close, and the one cross-artefact claim it makes is the one nothing
+can check. The reorder that made a truthful count possible is also what set the
+two artefacts on different durability paths: `/reflect` branches, commits,
+pushes, merges and pulls main while staging only `reflections/active/` and
+`REFLECTION_LOG.md`, so the parking records the field describes remain
+uncommitted in a tree the same command has just relocated to main. No step in
+this spec commits a parking record and no slice is assigned to — the claim
+reaches main by design, and the records it names reach main by whatever the
+human does next. Trusting `Closed` therefore means trusting the count, not the
+corpus.
+
+**Pattern.** — . The shape is a denormalised summary without referential
+integrity: a count held in one artefact about rows in another, with no key and
+no reconciliation path. The cheap fix — store the ids — stays cheap only until
+adopters hold fragments carrying the field.
+
+## Story #7 — A Coda marker in S1's registry
+
+**Source:** spec §2.5, §5 · **Lens:** coherence, defaults · **Refs:** O8, #2
+
+**Context.** The once-per-session guard is "a per-session marker under the S1
+registry directory" — `~/.claude/sessions/`, the machine-global store S1 built
+for the WIP Warden's count, and the worked example in `sentinel-design`'s
+operational-state carve-out.
+
+**Forces.** The marker must be per-session, survive a compact, and live outside
+every work tree; S1 built a directory with exactly those properties, so reuse is
+the cheapest correct answer. Pulling the other way, that directory is not
+general scratch space — it is a carve-out artefact permitted only while all four
+of `sentinel-design`'s conditions hold, and §4 of this very spec establishes
+that a consumer does not silently extend what another slice owns. The spec
+applies that discipline to the reflection fragment one section later and not to
+this.
+
+**Options not taken.**
+
+- Home the marker in the Coda's own state location, so the carve-out's four
+  conditions are evaluated on its own terms rather than inherited.
+- Key the guard off S1's existing entry: `started_at` is stable across compacts
+  by design (R2) and is already per-session, so no new file is needed.
+- Use the `source` field the hook receives and fire only on `startup` and
+  `resume` — the smaller of the two fixes O8 named, leaving no residue at all.
+
+**Choice as written.** A new file class in another slice's directory,
+established in one clause and tested only for its behaviour (H5, H6), never for
+its lifecycle.
+
+**Consequences.** The registry's only removal path is the lease pruner, which
+retires `*.json` by heartbeat and sweeps `*.tmp` older than the lease. An
+artefact in neither shape has no removal path, so markers accumulate one per
+session for the life of the machine — against a carve-out whose condition 2 is
+*bounded*, with its own note that "a record with no expiry is an archive, and an
+archive of where someone worked is a surveillance artefact whatever it was built
+for". S1 set the inherited default with the undeleted `.retired` marker; S2 is
+the second instance and the first that is one-file-per-session. The directory now
+has two owning slices and one documented purpose, and any future change to the
+registry's layout must account for a consumer S1 never knew about.
+
+**Pattern.** — . The frame is co-tenancy in a bounded store: a second writer
+inherits the store's location guarantees without inheriting its retention
+contract, and the retention contract is the part the carve-out turns on.
+
+## Story #8 — A repo's CI politics becomes ritual
+
+**Source:** spec §2, §5 · **Lens:** defaults, consequences · **Refs:** O1, #6
+
+**Context.** "The same sequence every invocation, no reordering." The order S2
+fixes — park before reflect — is derived primarily from this repository's
+`Reflections via PR workflow` constraint. The ritual ships in a plugin, and
+`commands/reflect.md:153` already branches: where that constraint is not
+declared, `/reflect` commits directly to the current branch and moves nobody's
+tree.
+
+**Forces.** A ritual with a stable order is one a person can learn, and fixing
+one is right. Against that, the order's headline justification is an
+environmental fact about a single adopter. The spec resolves toward a universal
+fixed order and never marks which of its two reasons travels and which does not.
+
+**Options not taken.**
+
+- Lead with the portable reason — `Closed` can only name what was parked if
+  parking precedes it, which holds in every repository — and state the git
+  reason second, as the local fact that makes the order non-negotiable *here*.
+- Make the order conditional on the constraint, mirroring the branch
+  `commands/reflect.md` already makes for the same constraint.
+- Take reflection out of the ritual entirely: the Coda emits the closure summary
+  and the human carries it into `/reflect` whenever they choose, which also
+  removes the ritual's dependency on a network round trip and a green CI run.
+
+**Choice as written.** One fixed order, justified primarily by a constraint most
+adopters will not have declared.
+
+**Consequences.** In this repository the record is excellent — §2 names the
+constraint, the command, and the line numbers. Downstream, that same paragraph
+reads as a workaround for someone else's CI, which is the precise condition
+under which a fixed order gets quietly reordered by a maintainer who believes
+they are removing dead weight. The portable justification does exist, but it
+appears second, in a sentence beginning "The reorder pays a second dividend" —
+phrasing that marks it as a bonus rather than as the load-bearing reason it
+becomes the moment the constraint is absent. This also sets the template for
+S3–S5: each will fix its own ritual against this repo's harness, and the epic
+has no convention for marking which parts of a ritual are environmental.
+
+**Pattern.** — . The frame is a workaround promoted to a rule: a sequence
+encodes an accidental property of one environment and is published as an
+essential one. The practical test, worth writing into `sentinel-design` if this
+story is promoted, is whether a ritual step's stated justification still reads as
+a justification in a repository that does not share the constraint.

--- a/tdad_tests/layer0_deterministic/test-next-action.sh
+++ b/tdad_tests/layer0_deterministic/test-next-action.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the next-action anchor check
+# (spec 2026-08-09-cadence-sentinels-s2-coda-design.md, §3; N1–N8).
+#
+# READ THE EXIT CODES CAREFULLY. This script is not a validator and exit 1 is
+# not a failure:
+#
+#     exit 0  -> the next action carries an anchor; do not ask again
+#     exit 1  -> no anchor found; ASK ONE MORE QUESTION
+#
+# The first revision of the spec made this a judge that refused to write a
+# parking record until the text passed. That was wrong twice. It measures
+# lexical form, not specificity — "keep going in src/" carries an anchor and
+# would have passed — and its errors run systematically along the code/non-code
+# axis, which is worse than noisy, because the Coda parks decision-shaped
+# threads by design.
+#
+# Demoted to a trigger, both error directions cost the same thing: one extra
+# question. The human always answers and the answer is always parked. That is
+# why N7 exists — a caller must not be able to mistake a trigger for a fault.
+#
+# §3.3's grammar is published verbatim in skills/coda/SKILL.md and
+# reference/parking-record-format.md, so a human who is asked can argue with it.
+# These scenarios are what keep those three copies honest.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+CHECK="$PLUGIN/scripts/next-action-hint.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$CHECK" ] || fail "anchor check not found at $CHECK"
+[ -x "$CHECK" ] || fail "anchor check is not executable: $CHECK"
+
+# asks <text> — true when the check would ask another question (exit 1).
+asks() {
+  set +e
+  "$CHECK" "$1" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  [ "$rc" -eq 1 ]
+}
+
+expect_ask() {
+  asks "$1" || fail "$2: expected a question for [$1], got none"
+}
+expect_quiet() {
+  asks "$1" && fail "$2: expected no question for [$1], got one" || true
+}
+
+# --- N1: no anchor triggers the question -------------------------------------
+# A bare English noun is not an anchor. "parser" naming a thing is not the same
+# as naming where to start.
+for t in \
+  "continue work" \
+  "carry on" \
+  "keep going" \
+  "finish this" \
+  "pick up where I left off" \
+  "more work on the parser"
+do
+  expect_ask "$t" "N1"
+done
+
+# --- N2: each anchor kind in §3.3's table is recognised ----------------------
+expect_quiet "rewrite src/parser.rs to split on the first delimiter" "N2 path"
+expect_quiet "fix block_key() so it trims only at the ends"          "N2 identifier"
+# shellcheck disable=SC2016  # literal backticks are the fixture — that is the anchor kind under test
+expect_quiet 'work through the `records_open` glob again'            "N2 backtick"
+expect_quiet "add the B12 fixture for a malformed block"             "N2 scenario id"
+expect_quiet "revisit pact-blocks.sh:88 and the heading rule"        "N2 line ref"
+
+# --- N8: the decision anchor ------------------------------------------------
+# The row that stops the grammar taxing this plugin's own dominant kind of
+# work. The other five kinds are all artefacts of code-shaped work; most of
+# what gets parked here is a spec, a piece of prose, or a decision.
+expect_quiet "ask Russ whether the reserved block should ship at all" "N8 question+person"
+expect_quiet "decide between the lease and the explicit transition"   "N8 decide"
+expect_quiet "choose between archiving and capping the corpus"        "N8 choose between"
+
+# --- N3: the question names what is missing ----------------------------------
+set +e
+msg="$("$CHECK" "continue work" 2>&1)"
+set -e
+echo "$msg" | grep -qiE 'file|test|first step' \
+  || fail "N3: the question must name a file, a test, or a first step. Got: $msg"
+echo "$msg" | grep -qiE 'too vague|invalid|rejected|error' \
+  && fail "N3: the question must not render a verdict on the wording. Got: $msg"
+
+# --- N4: a terse anchor passes ----------------------------------------------
+expect_quiet "test_retry.py" "N4"
+
+# --- N5: a vague stem with an anchor passes ----------------------------------
+# A known false positive, disclosed in §3.2 — and it costs nothing, because the
+# check only decides whether to ask.
+expect_quiet "continue the retry branch in test_retry.py" "N5"
+
+# --- N6: empty and whitespace-only trigger the question ----------------------
+expect_ask ""      "N6 empty"
+expect_ask "   "   "N6 spaces"
+
+# --- N7: a trigger is not an error -------------------------------------------
+# The caller reads exit 1 as "ask again". If the script also wrote to stderr or
+# used the vocabulary of failure, a caller — or a future maintainer — would
+# read it as a fault and start guarding against it.
+set +e
+stderr="$("$CHECK" "continue work" 2>&1 >/dev/null)"
+set -e
+[ -z "$stderr" ] || fail "N7: a trigger must write nothing to stderr. Got: $stderr"
+
+echo "PASS: next-action anchor check — triggers a question, never a verdict; all six anchor kinds recognised"

--- a/tdad_tests/layer0_deterministic/test-next-action.sh
+++ b/tdad_tests/layer0_deterministic/test-next-action.sh
@@ -46,7 +46,11 @@ expect_ask() {
   asks "$1" || fail "$2: expected a question for [$1], got none"
 }
 expect_quiet() {
-  asks "$1" && fail "$2: expected no question for [$1], got one" || true
+  # Written as if/then rather than `A && B || C`: that idiom is not if-then-else
+  # — C runs when A succeeds and B fails — and here B is `fail`, which exits.
+  if asks "$1"; then
+    fail "$2: expected no question for [$1], got one"
+  fi
 }
 
 # --- N1: no anchor triggers the question -------------------------------------

--- a/tdad_tests/layer0_deterministic/test-parked-resume.sh
+++ b/tdad_tests/layer0_deterministic/test-parked-resume.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the parked-resume SessionStart hook
+# (spec 2026-08-09-cadence-sentinels-s2-coda-design.md, §2.5; H1–H8).
+#
+# The hook surfaces still-open parking records once per session. H5 is the
+# scenario that carries the design: `SessionStart` fires on startup, resume,
+# clear and compact (established in S1 §4.2 and repeated in
+# session-registry-start.sh), so an unguarded hook would re-inject the parked
+# list into the middle of an unrelated working session, every compact, forever.
+#
+# That is not merely noisy. A parking record exists to release a thread's pull
+# so the person can stop holding it. Printing "still parked: implement the retry
+# branch" while they are deepest in something else hands the thread straight
+# back — the surface this epic exists to reduce, produced by the mechanism meant
+# to reduce it.
+#
+# H8 carries the other half. The guard keys off S1's existing registry entry
+# (`started_at`, per-session and stable across compacts by design) rather than
+# writing a marker file into a directory S1 owns. A marker would have inherited
+# that store's location guarantees without its retention contract: the pruner
+# retires `*.json` by heartbeat and sweeps `*.tmp`, so a file in neither shape
+# would accumulate one per session for the life of the machine.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+HOOK="$PLUGIN/hooks/scripts/parked-resume-check.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HOOK" ] || fail "resume hook not found at $HOOK"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_SESSIONS_DIR="$TMP/sessions"
+export CLAUDE_PARKED_DIR="$TMP/parked"
+mkdir -p "$CLAUDE_SESSIONS_DIR" "$CLAUDE_PARKED_DIR"
+
+# SessionStart carries a `source`: startup | resume | clear | compact.
+# The guard fires on startup only — that IS the once-per-session rule, and it
+# needs no stored marker and has no timing race.
+# Pass the literal `none` to omit the field entirely — `${2:-...}` would treat
+# an empty string as unset and silently substitute the default, which is
+# exactly the case the absent-source scenario needs to exercise.
+hook_input() {
+  if [ "${2-startup}" = "none" ]; then
+    printf '{"session_id":"%s","cwd":"%s"}' "$1" "$TMP"
+  else
+    printf '{"session_id":"%s","cwd":"%s","source":"%s"}' "$1" "$TMP" "${2-startup}"
+  fi
+}
+
+# run <session-id> [source] -> OUT, RC
+run() {
+  set +e
+  OUT="$(hook_input "$1" "${2-startup}" | bash "$HOOK" 2>/dev/null)"
+  RC=$?
+  set -e
+}
+
+# A session must exist in the registry for the guard to key off it.
+start_session() {
+  # shellcheck source=/dev/null
+  ( . "$PLUGIN/hooks/scripts/lib/session-registry-write.sh"; registry_touch "$1" "$TMP" )
+}
+
+park() {  # park <filename> <next action>
+  cat > "$CLAUDE_PARKED_DIR/$1" <<EOF
+---
+session: sess-x
+repo: $TMP
+created: 2026-08-09
+state: parked
+supersedes: null
+next_action_flag: asked
+---
+
+## Context
+
+A fixture thread.
+
+## Next action
+
+$2
+EOF
+}
+
+# --- H2: silent when the directory does not exist ----------------------------
+CLAUDE_PARKED_DIR="$TMP/nonexistent" run "sess-h2"
+[ "$RC" -eq 0 ] || fail "H2: must exit 0 when the parked directory is absent (got $RC)"
+[ -z "$OUT" ] || fail "H2: must be silent when the parked directory is absent. Got: $OUT"
+
+# --- H1: silent when nothing is parked ---------------------------------------
+start_session "sess-h1"
+run "sess-h1"
+[ "$RC" -eq 0 ] || fail "H1: must exit 0 with an empty parked directory (got $RC)"
+[ -z "$OUT" ] || fail "H1: must be silent with nothing parked. Got: $OUT"
+
+# --- H3: surfaces an open record, naming it and its next action --------------
+park "2026-08-08-retry-branch.md" "implement the retry branch, starting from test_retry.py"
+start_session "sess-h3"
+run "sess-h3"
+[ "$RC" -eq 0 ] || fail "H3: must exit 0 (got $RC)"
+echo "$OUT" | grep -qF "retry-branch" \
+  || fail "H3: output must name the record. Got: $OUT"
+echo "$OUT" | grep -qF "test_retry.py" \
+  || fail "H3: output must carry the next action. Got: $OUT"
+
+# --- H5: once per session ----------------------------------------------------
+# The scenario that carries the design. SessionStart re-fires on resume, clear
+# and compact; each of those must be silent, or the parked list is re-injected
+# into the middle of an unrelated working session for the rest of the day.
+for src in resume clear compact; do
+  run "sess-h3" "$src"
+  [ "$RC" -eq 0 ] || fail "H5: a $src firing must still exit 0 (got $RC)"
+  [ -z "$OUT" ] \
+    || fail "H5: a $src firing must be silent — only startup surfaces. Got: $OUT"
+done
+
+# An absent source must not be treated as startup. Unknown provenance is the
+# case where re-injection is possible, so the safe reading is 'stay quiet'.
+run "sess-h3" "none"
+[ -z "$OUT" ] || fail "H5: an absent source must not surface. Got: $OUT"
+
+# --- H6: a new session surfaces again ----------------------------------------
+start_session "sess-h6"
+run "sess-h6"
+echo "$OUT" | grep -qF "retry-branch" \
+  || fail "H6: a new startup must get the list. Got: $OUT"
+
+# --- H4: a resumed record is not surfaced ------------------------------------
+cat > "$CLAUDE_PARKED_DIR/2026-08-09-retry-branch.resumed.md" <<EOF
+---
+session: sess-y
+repo: $TMP
+created: 2026-08-09
+state: resumed
+supersedes: 2026-08-08-retry-branch.md
+next_action_flag: asked
+---
+
+## Context
+
+Resumed.
+
+## Next action
+
+Resumed — no further action pending.
+EOF
+start_session "sess-h4"
+run "sess-h4"
+echo "$OUT" | grep -qF "retry-branch" \
+  && fail "H4: a record superseded by a .resumed.md transition must not be surfaced. Got: $OUT"
+
+# --- H7: exits 0 unconditionally ---------------------------------------------
+blocked="$TMP/blocked"; : > "$blocked"
+CLAUDE_PARKED_DIR="$blocked/parked" run "sess-h7a"
+[ "$RC" -eq 0 ] || fail "H7: must exit 0 when the parked path is unusable (got $RC)"
+
+set +e
+OUT="$(hook_input "sess-h7b" | env -u HOME bash "$HOOK" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "H7: must exit 0 with HOME unset (got $RC)"
+
+set +e
+OUT="$(printf 'not json' | bash "$HOOK" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "H7: must exit 0 on unparseable stdin (got $RC)"
+
+# --- H8: no marker file is written -------------------------------------------
+# The guard reads S1's started_at. It must leave no residue in a directory
+# another slice owns and whose only removal path is the lease pruner.
+before="$(find "$CLAUDE_SESSIONS_DIR" -type f | sort)"
+start_session "sess-h8"
+mid="$(find "$CLAUDE_SESSIONS_DIR" -type f | sort)"
+run "sess-h8"; run "sess-h8"
+after="$(find "$CLAUDE_SESSIONS_DIR" -type f | sort)"
+[ "$mid" = "$after" ] \
+  || fail "H8: the hook must write no file into the registry directory.
+  before hook: $mid
+  after hook:  $after"
+[ "$before" != "$mid" ] || fail "H8: the fixture did not actually create a session entry"
+
+echo "PASS: parked-resume hook — surfaces once per session, honours transitions, writes nothing"

--- a/tdad_tests/layer0_deterministic/test-record-contracts.sh
+++ b/tdad_tests/layer0_deterministic/test-record-contracts.sh
@@ -99,4 +99,61 @@ if echo "$open" | grep -q "2026-08-01-retry-branch.md"; then
   fail "C3: a record named by a transition's supersedes must not be reported as open"
 fi
 
+# --- P1: S2 adds no value to the next_action_flag enum -----------------------
+# The first S2 revision proposed `asked-override`. It was removed at the gate:
+# a flag recording that a human's answer failed a check is an agent-authored
+# verdict about the person, permanent, committed and countable across records.
+# Keeping the enum at one value is what lets S2 consume S1's contract without
+# mutating it, so the consumer-never-mutates rule never engages.
+grep -qF 'asked-override' "$PARKING_REF" \
+  && fail "P1: the parking-record contract must not gain an override enum value — the override lives in the prose body"
+grep -qiE 'next_action_flag.*asked' "$PARKING_REF" \
+  || fail "P1: parking-record-format.md must still document next_action_flag: asked"
+
+# --- P1b: the anchor grammar is published, and framed as a trigger -----------
+# A check whose decisive term lives only in the implementation cannot be argued
+# with, and this one is meant to be.
+for kind in 'A path' 'A code identifier' 'A backticked span' 'A decision'; do
+  grep -qF "$kind" "$PARKING_REF" \
+    || fail "P1b: parking-record-format.md must publish the '$kind' anchor row"
+done
+grep -qiF 'complement is not' "$PARKING_REF" \
+  || fail "P1b: the reference page must frame the table as a trigger whose complement is not 'vague'"
+
+# --- P2: an override record is well-formed and unremarkable ------------------
+# Its frontmatter must be indistinguishable from any other record; the override
+# is prose the human authored and would recognise.
+p2="$FIX/2026-08-09-override-example.md"
+cat > "$p2" <<'EOF'
+---
+session: sess-p2
+repo: /tmp/toy
+created: 2026-08-09
+state: parked
+supersedes: null
+next_action_flag: asked
+---
+
+## Context
+
+A thread whose author was asked twice.
+
+## Next action
+
+continue work
+
+(Asked again for a starting point; confirmed this is enough to go on.)
+EOF
+grep -q 'next_action_flag: asked$' "$p2" \
+  || fail "P2: an override record's flag must be plain 'asked'"
+grep -qF 'Asked again for a starting point' "$p2" \
+  || fail "P2: the override must appear as prose in the body"
+
+# --- P3: an override record is still open ------------------------------------
+# An override changes nothing about the record's state.
+open_now=$(records_open "$FIX" | sort)
+echo "$open_now" | grep -qF "override-example" \
+  || fail "P3: an overridden record must still be reported open"
+rm -f "$p2"
+
 echo "PASS: record contracts — schemas published in reference pages, READMEs point not duplicate, open-record glob honours state-in-the-path"

--- a/tdad_tests/scenarios/agents/coda/read-only-boundary.md
+++ b/tdad_tests/scenarios/agents/coda/read-only-boundary.md
@@ -1,0 +1,67 @@
+---
+component: coda
+component_type: agent
+tier: structural
+---
+
+# Scenario: coda returns records and never writes them — tool boundary and charter
+
+## Given
+
+The `coda` agent (spec
+`docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md`)
+closes a session: it surveys what landed and what is still live, proposes a
+thread grouping, and drafts one parking record per thread.
+
+Every one of those outputs is durable content destined for a committed file —
+which is exactly why the agent must not be the thing that writes it. The
+`/coda` command persists what the agent returns, after the human confirms.
+That is the `cost-estimator` precedent, and it is what keeps the Coda inside
+the sentinel category rather than merely adjacent to it.
+
+## When
+
+The agent file at `ai-literacy-superpowers/agents/coda.agent.md` is read
+directly from the filesystem.
+
+## Then
+
+**Frontmatter:**
+
+- YAML frontmatter with `name: coda` and a non-empty `description`.
+- `role: sentinel`.
+- `tools` is exactly `Read, Glob, Grep, Bash` — **no `Write`, no `Edit`**.
+  `sentinel-integrity-check.sh` enforces this deterministically; the scenario
+  states *why* it is load-bearing rather than incidental.
+
+**Charter / body:**
+
+- Instructs the agent to read `skills/coda/SKILL.md` **first** and inherit its
+  grounding rather than re-derive it.
+- States that it returns parking-record content as a string and that the
+  command persists it.
+- States that `Bash` is for reading only — `git log`, `git status`,
+  `gh pr list`, `date` — never a mutation, a commit, or a `gh pr merge`.
+- Carries the per-item honesty table: commits and working-tree state
+  `observed`; `gh` reads `observed` on success and `inferred` on failure;
+  thread grouping `asked`.
+- States that thread grouping is proposed and **default-accepted** — it stands
+  unless the human changes it.
+- States that the next-action check **asks once more and never refuses**, and
+  that whatever the human answers is parked, including the same words again.
+- States the four things it never does: write a file, decide the session
+  should end, continue the ritual after being asked to stop, and record *why*
+  the human stopped.
+
+## Rubric
+
+Layer 1 structural scenario: every assertion is checkable by reading the agent
+file. It passes only when the tool list carries no write capability, the skill
+is read first, the honesty table is present with grouping flagged `asked`, and
+the never-refuse and never-record-why disciplines are both stated.
+
+## Notes
+
+Scope is the agent's structural shape. The anchor grammar's behaviour is
+covered deterministically by `tdad_tests/layer0_deterministic/test-next-action.sh`
+(N1–N8), and the ritual's step ordering by the command scenario.

--- a/tdad_tests/scenarios/commands/coda/ritual-order-and-persistence.md
+++ b/tdad_tests/scenarios/commands/coda/ritual-order-and-persistence.md
@@ -1,0 +1,66 @@
+---
+component: coda
+component_type: command
+tier: structural
+---
+
+# Scenario: /coda parks before it reflects, and commits before it does
+
+## Given
+
+`/coda` runs a four-step ritual: survey, park, closure summary and reflection,
+close.
+
+The order is not stylistic. `/reflect` in a repository declaring a
+*Reflections via PR workflow* constraint runs `git checkout -b`,
+`gh pr create`, `gh pr merge --squash --delete-branch` and `git pull` on
+`main`. Run before parking, it would move the working tree off the branch
+holding the uncommitted work the survey had just enumerated, and the ritual
+would then write parking records from wherever the merge left the tree.
+
+`/reflect` also stages only `reflections/active/` and `REFLECTION_LOG.md` — so
+records written but not committed at the park step would be left behind, in a
+tree that has just moved, while a `Closed` field describing them reaches
+`main`.
+
+## When
+
+The command file at `ai-literacy-superpowers/commands/coda.md` is read
+directly from the filesystem.
+
+## Then
+
+- Frontmatter with `name: coda` and a non-empty `description`.
+- The process states the four steps **in order**: survey, park, closure
+  summary and reflection, close.
+- Parking is step 2 and **precedes** the `/reflect` invocation.
+- The command states that parking records are **committed before `/reflect`
+  runs**, and gives the staging reason.
+- The command dispatches the `coda` agent and states that the agent holds no
+  `Write` and that the command persists what it returns.
+- The next-action step invokes `scripts/next-action-hint.sh` and documents
+  **exit 0 = move on, exit 1 = ask once more** — never reject. It instructs
+  the caller not to add a judgement of its own.
+- The repeated-answer path writes the human's own words plus a
+  human-voice confirmation line into `## Next action`; `next_action_flag`
+  stays `asked`.
+- A section states how to stop the ritual, and distinguishes *new work*
+  (parked) from *abandoning the ritual* (always the human's).
+- `/coda resume RECORD` writes a `.resumed.md` transition naming its
+  predecessor in `supersedes:`, and never edits or deletes the original.
+- A validation checkpoint reads the written records back against
+  `reference/parking-record-format.md`.
+- The command states when to reach for `/coda` versus `/reflect`.
+
+## Rubric
+
+Layer 1 structural scenario: checkable by reading the command file. It passes
+only when parking demonstrably precedes reflection, the commit-before-reflect
+instruction is present with its reason, the exit-1-means-ask semantics is
+documented, and the stop path distinguishes new work from abandonment.
+
+## Notes
+
+The ordering assertion is the load-bearing one. A future maintainer who reads
+the order as arbitrary and "tidies" it into the build spec's original sequence
+would reintroduce the failure this scenario exists to prevent.

--- a/tdad_tests/scenarios/skills/coda/anchor-grammar-and-anti-patterns.md
+++ b/tdad_tests/scenarios/skills/coda/anchor-grammar-and-anti-patterns.md
@@ -1,0 +1,73 @@
+---
+component: coda
+component_type: skill
+tier: structural
+---
+
+# Scenario: the coda skill publishes the anchor grammar and its anti-patterns
+
+## Given
+
+The `coda` skill is the authoritative grounding for the ritual. Two of its
+sections are contracts rather than prose.
+
+The **anchor grammar** is published so a human who is asked for a better next
+action can see exactly why and argue with it — a check whose decisive term
+lives only in the implementation cannot be argued with. It is reproduced
+verbatim in three places (the skill, `reference/parking-record-format.md`, and
+`scripts/next-action-hint.sh`), and drift between them silently changes what a
+person is told.
+
+The **anti-patterns** are what keep the ritual from becoming a gate on the
+person it is meant to serve.
+
+## When
+
+The skill file at `ai-literacy-superpowers/skills/coda/SKILL.md` is read
+directly from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: coda` with a description naming the ritual, the anchor
+grammar, and the anti-patterns.
+
+**The ritual:** four steps in order, with the reason parking precedes
+reflection stated — the portable reason (`Closed` can only name what parking
+produced) **first**, and the PR-workflow constraint as the local fact behind
+it.
+
+**The survey:** a per-item flag table, with thread grouping flagged `asked`
+and described as the central epistemic act, and grouping stated as
+propose-and-default-accept.
+
+**The anchor grammar:** all six kinds present — path, code identifier,
+backticked span, scenario or ticket id, line or section reference, and
+**decision**. The decision row's rationale is stated: the other five are
+artefacts of code-shaped work.
+
+**The framing sentence:** the table is described as a trigger heuristic whose
+complement is **not** "vague", and as saying what makes the Coda stop asking
+rather than what makes a next action good.
+
+**The evidence comments:** at least one `<!-- evidence: ... -->` comment
+grounding the next-action question, naming specificity as the active
+ingredient. Language discipline holds throughout — no "addiction", no
+"dopamine".
+
+**The anti-patterns section** names at least: refusing a next action, deciding
+the grouping alone, recording why the human stopped, continuing after being
+asked to stop, writing a file from the agent, and surfacing parked records
+more than once a session.
+
+## Rubric
+
+Layer 1 structural scenario: checkable by reading the skill. It passes only
+when all six anchor kinds are present, the not-"vague" framing is stated, the
+evidence comment is present, and all six anti-patterns are named.
+
+## Notes
+
+The three-way duplication of the anchor grammar is a known cost, accepted
+because publication is what makes the rule arguable. This scenario is one of
+the two guards on that drift; `test-next-action.sh` N1–N8 is the other, and it
+pins the behaviour the table describes.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -70,6 +70,10 @@ BASH_TEST_SCRIPTS = [
     "test-pact-blocks",
     "test-session-registry",
     "test-record-contracts",
+    # Cadence Sentinels S2 — the Coda's ritual. RED until S2 ships
+    # scripts/next-action-hint.sh and hooks/scripts/parked-resume-check.sh.
+    "test-next-action",
+    "test-parked-resume",
 ]
 
 


### PR DESCRIPTION
Closes #492. Second slice of **The Cadence Sentinels** epic (#491–#497). Depends on S1, merged as 0.67.0.

An agentic session has no terminal cue — no compile, no deploy, no colleague standing up to leave. So sessions end by attrition, the open threads keep their pull because nothing wrote down where they were, and the next session opens cold.

`/coda` is the deliberate alternative: **survey → park → closure summary and reflection → close.**

## What's here

- **`/coda`** and **`/coda resume RECORD`** — the ritual, and the transition that closes a parked thread.
- **`coda` agent** — `role: sentinel`, read-only. Returns record content; the command persists it. Sentinel roster 5 → 6.
- **`scripts/next-action-hint.sh`** — decides whether to ask *once more* for a starting point. It never refuses.
- **`hooks/scripts/parked-resume-check.sh`** — surfaces open records at session start, once.
- **19 new Layer-0 scenarios**, three mutation-tested guards, 18/18 suite green.

## Divergence from the build spec — please read

**The ritual order changed.** The build spec fixed it as survey → closure summary → reflection → park → close, and said "no reordering". That order is unshippable here.

`/reflect` in this repo runs `git checkout -b` → `gh pr create` → `gh pr merge --squash --delete-branch` → `git pull` on main (`commands/reflect.md:159–173`), and `HARNESS.md:413` binds that to *every* invocation. As step 3 it would move the working tree off the branch holding the uncommitted work the survey had just enumerated — then write parking records from wherever the merge left the tree. A closing ritual that rearranges your git state and blocks on CI is the most expensive way to stop yet designed.

Parking now completes and commits while the tree is still where you left it, and `/reflect` runs last.

## What the gates caught

| Gate | Outcome |
|---|---|
| Diaboli (spec) | 12 objections — 11 accepted, 1 rejected on the record |
| Choice Cartographer | 8 stories, all accepted |

**Two dispositions made the slice smaller rather than larger** — worth noting, because the instinct is usually the opposite:

- The override moved from a frontmatter enum into the record's prose, in your own voice. `next_action_flag` stays `asked`, so **S2 no longer changes S1's contract at all** and the consumer-never-mutates rule stops applying.
- The next-action check was demoted from judge to **reprompt trigger**. It decides only whether to *ask*; you always answer, and the answer is always parked. So there's no gate — and constraint 6's override machinery isn't needed, because there's nothing to override.

**The cartographer's sharpest find:** `/reflect` stages only `reflections/active/` and `REFLECTION_LOG.md`. Without an explicit commit at the park step, the ritual would have written parking records, published a `Closed` field describing them, and left them uncommitted in a tree it had just relocated to main.

**One design correction worth flagging:** thread grouping is now *propose-and-default-accept* rather than a full manual partition. This plugin ships a warden premised on judgement degrading across a session, and this step lands after you've decided you're finished. Demanding the ritual's heaviest synthesis there put it on whoever was least equipped — with a cheap silent escape (group everything as one thread, answer vaguely) that would have gutted exactly the handoffs worth most.

## Constitutional notes

- The **anchor grammar** gained a sixth row — a decision: a question word, a named person, `ask`/`decide`/`choose between`. The other five are all artefacts of code-shaped work, and this plugin's own work is mostly specs, prose, and decisions. Published in the skill and the reference page, framed explicitly as a trigger whose complement is **not** "vague".
- The resume hook fires on `startup` only and **writes nothing**. A marker file in `~/.claude/sessions/` would have inherited S1's location guarantees without its retention contract and accumulated one file per session forever — against a carve-out whose second condition is *bounded*.
- Flags are **ritual-scoped**: shown during the survey, not carried into records. Parking records are handoffs, not provenance artefacts. Stated so S5 inherits an answer rather than a precedent, since its consultation records *do* carry `source_flag`.

## Records

- Spec (revision 3): `docs/superpowers/specs/2026-08-09-cadence-sentinels-s2-coda-design.md`
- Objections: `docs/superpowers/objections/cadence-sentinels-s2-coda-design.md`
- Choice stories: `docs/superpowers/stories/cadence-sentinels-s2-coda-design.md`

## Follow-up raised

**#499** — parking-record archival. The corpus grows as sessions × threads with no compaction story, and `records_open` scans the whole directory on every session start. Retention is now stated in the spec rather than left silent; the mechanism is deferred, because S1 owns the contract and it needs its own adversarial pass.

Version: 0.67.0 → 0.68.0.