### PR TITLE
Cadence Sentinels S3 — the Mast: the gauge, and the ritual that unblocks the epic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Russ Miles"
   },
   "version": "0.4.0",
-  "plugin_version": "0.68.0",
+  "plugin_version": "0.69.0",
   "description": "Marketplace listing for the ai-literacy-superpowers Copilot plugin — provides easy install and canonical plugin metadata.",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
       "name": "ai-literacy-superpowers",
       "source": "./ai-literacy-superpowers",
       "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
-      "version": "0.68.0"
+      "version": "0.69.0"
     },
     {
       "name": "model-cards",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 0.69.0 — 2026-08-10
+
+### Cadence Sentinels S3 — the Mast
+
+The pact-keeper: the gauge that reads the limits you set for yourself, and the
+ritual that brings them into existence.
+
+- **`/mast tune`** is the only sanctioned path that creates or amends
+  `~/.claude/pacts.md`. **This unblocks the epic** — S1 shipped a template no
+  path authored, so until now the pact file did not exist and every sentinel was
+  permanently in observe-only.
+- **It is an editor, not only an author.** It reads your current values back as
+  each question's context — not as defaults — and `/mast tune budgets` scopes an
+  edit to one block. Without that, changing one number meant re-running the
+  whole ritual, and the cheapest path to a small edit was the file itself.
+- **It asks the stop hour first**, then offers to stop there: a useful pact in
+  one question. It proposes nothing as a default, and every block is skippable.
+- **It says what nothing reads yet before asking** — `Sync cadence` entirely,
+  three of `Session WIP`'s keys, `notification_policy_after_stop`,
+  `daily_cost_ceiling`. Disclosing for one block and not the others would have
+  had people authoring a first pact under two regimes without being told.
+- **`/mast` recites before it measures.** A pact nobody reads is not a pact, so
+  the report leads with your own declared words and annotates after.
+- **It refuses to estimate.** `hard_stop_hour` is `observed`; `focus_blocks` and
+  `sessions_per_day` are `inferred`; `daily_cost_ceiling` is **not observable**.
+  A fabricated spend figure against a real ceiling would make someone stop, or
+  not stop, on a number nobody measured.
+- **The weather check discloses its own blind spot.** It notes a budget tuned
+  today; a pact hand-edited outside Tune never moves the stamp and is invisible
+  to it. The build spec called for a CI check on `Budgets` diffs, which is
+  impossible now that pacts are never committed — flagged, and replaced with a
+  note that says what it misses rather than one that overclaims.
+- **`lib/pact-write.sh`** — the write surface, sourceable by commands and hooks
+  only, matching S1's read/write split. It derives the mandatory clauses from
+  the template rather than restating them, replaces a block instead of appending
+  a second (a duplicate heading is silently unread), stamps `Budgets` only, and
+  preserves the preamble.
+- **A validation checkpoint** after every write, per the repo convention for
+  commands producing structured output that downstream consumers parse. Its
+  absence would otherwise surface later and silently, as sentinels dropping to
+  observe-only.
+- **Boundary notices and the hard stop are #501**, split out at the spec gate.
+- **9 new Layer-0 scenarios**; sentinels 6 → 7.
+
 ## 0.68.0 — 2026-08-09
 
 ### Cadence Sentinels S2 — the Coda

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Lint Markdown](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/Habitat-Thinking/ai-literacy-superpowers/actions/workflows/lint-markdown.yml)
 [![Marketplace](https://img.shields.io/badge/Marketplace-v0.4.0-4682B4?style=flat-square)](.claude-plugin/marketplace.json)
-[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.68.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
+[![ai-literacy-superpowers](https://img.shields.io/badge/ai--literacy--superpowers-v0.69.0-4682B4?style=flat-square)](ai-literacy-superpowers/)
 [![model-cards](https://img.shields.io/badge/model--cards-v0.1.0-4682B4?style=flat-square)](model-cards/)
 [![diagnostic-legibility](https://img.shields.io/badge/diagnostic--legibility-v0.11.0-4682B4?style=flat-square)](diagnostic-legibility/)
-[![Skills](https://img.shields.io/badge/Skills-38-2E8B57?style=flat-square)](#skills-38)
-[![Agents](https://img.shields.io/badge/Agents-17-2E8B57?style=flat-square)](#agents-17)
-[![Commands](https://img.shields.io/badge/Commands-29-2E8B57?style=flat-square)](#commands-29)
+[![Skills](https://img.shields.io/badge/Skills-39-2E8B57?style=flat-square)](#skills-39)
+[![Agents](https://img.shields.io/badge/Agents-18-2E8B57?style=flat-square)](#agents-18)
+[![Commands](https://img.shields.io/badge/Commands-30-2E8B57?style=flat-square)](#commands-30)
 [![Harness](https://img.shields.io/badge/Harness-31%2F32_enforced-4682B4?style=flat-square)](HARNESS.md)
 [![Harness Health](https://img.shields.io/badge/Harness_Health-Healthy-2E8B57?style=flat-square)](observability/snapshots/2026-07-21-snapshot.md)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai/claude-code)
@@ -28,7 +28,7 @@ New to the project? Start with [ONBOARDING.md](ONBOARDING.md) or browse the [doc
 
 | Plugin | Version | What it does | Docs |
 | ------ | ------- | ------------ | ---- |
-| **`ai-literacy-superpowers`** | v0.68.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **38 skills, 17 agents, 29 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
+| **`ai-literacy-superpowers`** | v0.69.0 | The flagship. Harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops. **39 skills, 18 agents, 30 commands.** | [docs](docs/plugins/ai-literacy-superpowers/index.md) |
 | **`model-cards`** | v0.1.0 | Researches and authors Mitchell-extended model cards from a model name. Tiered source strategy (provider docs → HuggingFace → arXiv → web), refusal-on-unconfirmed-existence honesty rule. | [docs](docs/plugins/model-cards/index.md) |
 | **`diagnostic-legibility`** | v0.11.0 | Hosts agents accountable for maintaining human understanding. Ships the `diagnostic-legibility` agent — builds and self-challenges two models of a codebase scope (architectural moving parts and domain concepts) via a five-question retained-challenge cycle, then cross-checks the two collections against each other via a five-question per-direction cycle. The `/diagnose` command surfaces the mutually-corrected models on demand as a readable report. The `ConceptualPipelineMap` template adds a standalone, presentation-agnostic flow-perspective data model; the agent's `scope-resolution` mode answers "what does my task touch?"; its `pipeline` mode traces control flow within that bound and cross-checks all three collections; the `/pipeline-map "<task>"` command renders the task-scoped map as a self-contained HTML flowchart (pinned, SHA-verified Mermaid inlined; no CDN); and `--predict-change` adds an opt-in change-site prediction (which stages the task will modify and where it will insert new ones), disclosed as a prediction, never a directive. | [docs](docs/plugins/diagnostic-legibility/index.md) |
 
@@ -158,7 +158,7 @@ This plugin works with both Claude Code and GitHub Copilot CLI from the same rep
 
 The remaining sections of this README document the **`ai-literacy-superpowers`** plugin in detail. For `model-cards`, see [its README](model-cards/README.md) and [its docs](docs/plugins/model-cards/index.md).
 
-### Skills (38)
+### Skills (39)
 
 Code quality, harness engineering, and governance knowledge that agents read when working in your codebase.
 
@@ -199,7 +199,7 @@ Code quality, harness engineering, and governance knowledge that agents read whe
 | cognitive-reservoir | Watches the human verifier the harness cannot verify — four observable proxies, observed/inferred/asked confidence discipline, disjunctive thresholds, the decide-your-stop-first principle, and the honesty rule separating contested science (ego depletion, hungry judges) from the robust basis (vigilance decrement, switching cost); advisory-only, never a fatigue score |
 | sentinel-design | Defines the sentinel agent category — the three-part signature (S1 read-only, S2 advisory-to-human, S3 explicit honesty rule), the near-miss gallery (why code-reviewer and harness-auditor don't qualify), the honesty-rule-before-detection-logic discipline, and the three anti-patterns (scoring the human, persisting human-state records, gating automatically) |
 
-### Agents (17)
+### Agents (18)
 
 A coordinated team that handles the full development lifecycle. It
 splits into two families: **sentinels**, whose object of care is the
@@ -258,7 +258,7 @@ The [decision-discipline triad](docs/plugins/ai-literacy-superpowers/explanation
 | assessor | AI literacy assessment — scans repo, asks questions, applies fixes, recommends workflow changes | Read + Write |
 | governance-auditor | Governance specialist — semantic drift analysis, debt inventory, three-frame alignment | Read + limited Write |
 
-### Commands (29)
+### Commands (30)
 
 | Command | What it does |
 | ------- | ------------ |

--- a/ai-literacy-superpowers/.claude-plugin/plugin.json
+++ b/ai-literacy-superpowers/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-literacy-superpowers",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "The AI Literacy framework's complete development workflow — harness engineering, agent orchestration, literate programming, CUPID code review, compound learning, and the three enforcement loops",
   "author": {
     "name": "Russ Miles"

--- a/ai-literacy-superpowers/agents/mast.agent.md
+++ b/ai-literacy-superpowers/agents/mast.agent.md
@@ -1,0 +1,95 @@
+---
+name: mast
+description: Use on demand via /mast to read the pact a human authored for themselves — reports each budget key with an observed/inferred/asked flag, refuses to estimate spend it cannot see, notes when a budget was tuned today, and recites the pact's own words rather than only measuring against them; read-only by design and never a gate
+tools: [Read, Glob, Grep, Bash]
+role: sentinel
+---
+
+# Mast Agent
+
+You read the pact a person set for themselves in advance, and you tell them
+what it says and where they stand against it.
+
+A limit set in the moment you are about to breach it does not hold — you will
+simply move it, because the thing you want at 18:00 is to keep working. So the
+pact is authored in clear weather, and your job is to bring it back into view
+later, honestly.
+
+You never stop anything. You never estimate anything you cannot see.
+
+## Your first action
+
+Read the `mast` skill in full:
+
+```text
+ai-literacy-superpowers/skills/mast/SKILL.md
+```
+
+It carries the two modes, the clear-weather rule and its honest limits, the
+flag discipline, and the anti-patterns. Inherit your grounding from it — do not
+re-derive it here.
+
+## Trust boundary
+
+You hold no `Write` and no `Edit`. You never author or amend the pact file;
+`/mast tune` does that, through a write library you must not source.
+
+`Bash` is for reading only — `date`, and `pact-blocks.sh` for parsing. Never
+`pact-write.sh`, never a mutation of any kind.
+
+## Recite first, measure second
+
+A pact nobody reads is not a pact. Re-reading it *is* the intervention, so lead
+with the human's own declared words and annotate them afterwards.
+
+Do not open with a table of what you cannot see.
+
+## The flags, and what they cost
+
+| Key | Flag |
+| --- | --- |
+| `hard_stop_hour` | `observed` — the clock is past it or not |
+| `focus_blocks` | `inferred` — the clock being inside a block is not the same as having spent it working |
+| `sessions_per_day` | `inferred` — the registry is a lease over live sessions, not a day's log |
+| `daily_cost_ceiling` | **not observable** |
+
+Say what you could not see rather than omitting it. A row missing from your
+report reads as a row that was fine.
+
+**Never estimate spend.** Nothing in this plugin observes it. A fabricated
+figure against a real ceiling is the worst output available — it would make a
+person stop, or not stop, on a number nobody measured. If the human declared
+`not observable`, that is the honest value and you report it as declared.
+
+Only one of four keys ever moves. That is the price of not fabricating the
+other three, and it is the right price.
+
+## The weather note, and its blind spot
+
+If `authored_at` is today, say so — this pact has not been lived with yet, and
+that is worth a line when it asks something of the person tonight.
+
+**Say what the note cannot see, in the same breath.** It detects a budget
+*tuned* today. A pact hand-edited outside `/mast tune` never moves the stamp
+and is invisible to this check, permanently. A check that claims coverage it
+lacks is worse than one that claims none, because the human learns to read its
+silence as an all-clear.
+
+It is a note, never a gate.
+
+## Offer the door
+
+If no `Budgets` block is declared, say the project has not opted in and **offer
+`/mast tune`**. Do not manufacture a read.
+
+The pact file does not exist until someone authors it, and `/mast tune` is the
+only path that does. A human who does not know the command has no way in.
+
+## What you never do
+
+- **Never write a file**, and never source the write library.
+- **Never estimate**, especially spend.
+- **Never gate.** The weather note, a missing block, a malformed block — all of
+  these are reports, and none changes what the human may do next.
+- **Never judge the pact.** A stop hour is not too late or too early. It is
+  theirs.

--- a/ai-literacy-superpowers/commands/mast.md
+++ b/ai-literacy-superpowers/commands/mast.md
@@ -1,0 +1,129 @@
+---
+name: mast
+description: Read the pact you set for yourself, or author one. Read mode recites your declared budget and says where you stand against it, with each key flagged for what can honestly be seen. Tune mode is the only sanctioned path that creates or amends the pact file.
+---
+
+# /mast [read | tune [BLOCK]]
+
+A limit you set in advance holds. A limit you set at the moment you are about
+to breach it does not. `/mast` is what brings the first kind back into view.
+
+Mode defaults to `read`. Nothing here gates anything.
+
+## When to use
+
+- **Read** — any time you want to see the pact you made, and where you stand.
+- **Tune** — to author a pact for the first time, or to change one.
+
+## Read mode
+
+### 1. Check for a pact
+
+Source `hooks/scripts/lib/pact-blocks.sh` and check `block_state 'Budgets'`.
+
+If it is `absent`, say the project has not opted in and **offer Tune mode**.
+Do not manufacture a read.
+
+That offer matters more than it looks: the pact file does not exist until
+someone authors it, `/mast tune` is the only path that does, and a human who
+does not know the command has no way in.
+
+If it is `malformed`, say which mandatory clause is missing, then continue in
+observe-only. Malformed is never a gate.
+
+### 2. Dispatch the mast agent
+
+Pass the project root. The agent reads the `mast` skill, parses the block, and
+returns the report.
+
+The agent is `role: sentinel`, holds no `Write`, and must never source
+`pact-write.sh`.
+
+### 3. Present it — recital first
+
+Lead with the human's own declared words. Annotate afterwards.
+
+A pact nobody reads is not a pact; re-reading it *is* the intervention. Opening
+with a table of what cannot be measured turns a gauge into an inventory of the
+plugin's limits.
+
+Then the flags: `hard_stop_hour` observed, `focus_blocks` and
+`sessions_per_day` inferred, `daily_cost_ceiling` not observable — each with a
+word on what could not be seen. **Never estimate spend.**
+
+If `authored_at` is today, add the weather note **with its blind spot in the
+same breath**: it sees a budget tuned today; a pact hand-edited outside `/mast
+tune` never moves the stamp and is invisible to it.
+
+## Tune mode
+
+The only sanctioned path that writes the pact file.
+
+### 1. Read what is already there
+
+If a pact exists, read each current value so you can ask with it as context —
+*your line is 18:30; what should it be?*
+
+**That is not a proposed default.** What you are showing is the human's own
+prior authorship, not the template's illustration. Never offer the template's
+numbers.
+
+`/mast tune budgets` scopes the ritual to one block.
+
+### 2. Ask the stop hour first
+
+`hard_stop_hour` is the one key a person can answer cold, and the one that
+carries the point. Ask it, then **offer to stop there** — a useful two-line
+pact in one question.
+
+Offer the remaining keys; do not march through them.
+
+### 3. Say what nothing reads yet — before asking
+
+- `Sync cadence` — reserved entirely; nothing reads it.
+- `Session WIP` — only `stale_after_hours` is read today. The rest waits for
+  the WIP Warden.
+- `notification_policy_after_stop` — declared intent; nothing here enforces it.
+- `daily_cost_ceiling` — declared, never checkable.
+
+Every block is skippable. An undeclared block is not an incomplete pact.
+
+### 4. Compose, show, then write
+
+Build the block from the answers and **show it before writing**. Take accept /
+edit / abort.
+
+Per-value confirmation alone is not enough: the mandatory clause, the reserved
+marker and the stamps are what decide whether the block reads as `declared`,
+and the human never authored them.
+
+On accept, source `hooks/scripts/lib/pact-write.sh` and call:
+
+```bash
+pact_write_block "Budgets" "$body_file"
+```
+
+The writer derives the clause from the template, replaces rather than appends,
+stamps `Budgets` only, and preserves the preamble.
+
+### 5. Validation checkpoint
+
+Read the block back and check it:
+
+1. `block_state` returns `declared`
+2. The mandatory clause is present (match whitespace-normalised — the clause's
+   words are the interface, its line breaks are not)
+3. Every value the human gave reads back through `block_key`, including
+   colon-bearing times and comma-separated ranges
+4. Exactly one heading exists for the block
+
+Fix deviations in place. A malformed write is otherwise discovered later and
+silently, as every sentinel drops to observe-only with no line saying why.
+
+## What this command never does
+
+- **Never scaffolds a pact.** Nothing is written until a human answers.
+- **Never proposes a default.** Authorship is the active ingredient.
+- **Never estimates.** Especially not spend.
+- **Never gates.** Absent, malformed, tuned-today — all reports.
+- **Never judges the pact.** A stop hour is not too late. It is theirs.

--- a/ai-literacy-superpowers/hooks/scripts/lib/pact-write.sh
+++ b/ai-literacy-superpowers/hooks/scripts/lib/pact-write.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Strict mode, applied only when this file is EXECUTED. `return` succeeds
+# solely inside a sourced context, so the `set` is skipped when a command
+# sources us — `set` mutates the CALLER's shell, and a library must not impose
+# -e/-u/-o pipefail on whatever sourced it.
+(return 0 2>/dev/null) || set -euo pipefail
+# pact-write.sh — the write surface of the pact file.
+#
+# Spec: docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md §5.5
+# Tests: tdad_tests/layer0_deterministic/test-pact-write.sh (T1–T9)
+#
+# COMMANDS AND HOOKS ONLY. A `role: sentinel` agent must never source this
+# file — that is the whole reason it is separate from pact-blocks.sh, which a
+# sentinel may source freely. S1 made the same split for the registry, and
+# `sentinel-design` promoted the rule out of it: a read surface a sentinel may
+# source, a write surface it may not. The frontmatter check cannot see a
+# `.sh` file, so the boundary holds by what an agent can reach.
+#
+# Why this library exists at all. The first draft of S3 shipped no shell: the
+# write path was six numbered rules for a model to follow in a command file.
+# That did not survive its own acceptance scenarios — T1–T9 are Layer-0
+# deterministic tests, and there is nothing deterministic to test when the
+# writer is prose. Either the round trip was not real or the writer was.
+#
+# THE READER AND THE WRITER ARE ONE CONTRACT. Whatever this emits,
+# `block_state` must call `declared`. Getting that wrong fails in the quietest
+# possible way: the block reads `malformed`, every consumer drops to
+# observe-only per S1's Null Object contract, and nothing tells the human which
+# sentence is missing. T1 is the guard.
+
+_PW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PW_TEMPLATE="$_PW_DIR/../../../templates/pacts.md"
+
+# _pw_pact_file — the file being written. Mirrors pact-blocks.sh's resolution
+# so the writer and the reader never disagree about which file they mean.
+_pw_pact_file() {
+  printf '%s' "${CLAUDE_PACTS_FILE:-$HOME/.claude/pacts.md}"
+}
+
+# _pw_template_prose <heading> — the prose a block must carry, lifted from the
+# shipped template: everything after the block's value lines, up to the next
+# heading.
+#
+# DERIVED, NEVER RESTATED. The mandatory clauses and the reserved marker are
+# matched literally by the reader, so a copy in this file would agree with it
+# only by coincidence of wording — and the promoted decision is that harness
+# artefacts derive from the source of truth rather than pinning a copy of it.
+# T9 is the test: change the template, and what this emits changes with no
+# edit here.
+_pw_template_prose() {
+  local heading="$1"
+  [ -f "$_PW_TEMPLATE" ] || return 0
+  awk -v want="$heading" '
+    /^#{1,6}[[:space:]]+/ {
+      title = $0
+      sub(/^#+[[:space:]]+/, "", title)
+      if (inblock) { exit }
+      if (title == want) { inblock = 1 }
+      next
+    }
+    inblock && /^[[:space:]]*-[[:space:]]/ { next }   # value lines come from the caller
+    inblock { print }
+  ' "$_PW_TEMPLATE"
+}
+
+# _pw_trim_blanks — collapse leading and trailing blank lines from stdin.
+_pw_trim_blanks() {
+  awk 'NF { blank = 0; buf = buf sep $0; sep = "\n"; next }
+       { if (buf != "") sep = sep "\n" }
+       END { if (buf != "") print buf }'
+}
+
+# pact_write_block <heading> <body-file> — replace the block, or append it if
+# absent. The body file holds the caller's value lines and nothing else.
+#
+# REPLACE, NEVER APPEND-A-SECOND. `_block_span` exits at the next known
+# heading, so a duplicate `## Budgets` is silently unread: the human's newly
+# tuned values become invisible with no error anywhere. T5 is the guard.
+#
+# Everything outside the replaced block survives, including the template's
+# editing guidance and any other declared block (T8).
+pact_write_block() {
+  local heading="$1" body_file="$2" file tmp prose stamped
+  file="$(_pw_pact_file)"
+  mkdir -p "$(dirname "$file")" 2>/dev/null || return 1
+  [ -f "$file" ] || _pw_seed_file "$file"
+
+  prose="$(_pw_template_prose "$heading")"
+
+  # The stamps live in Budgets only, where S1's grammar defines them. Stamping
+  # every block would leave "when was this pact authored" a per-block fact with
+  # no rule for combining them (T6).
+  stamped=""
+  if [ "$heading" = "Budgets" ]; then
+    stamped="- authored_at: $(date -u +%Y-%m-%d)
+- authored_via: tune"
+  fi
+
+  # Written as if-blocks, not `[ -n "$x" ] && printf ...` chains: an empty
+  # value makes such a chain return non-zero, and the whole group is guarded by
+  # `|| return 1` — so an absent optional would read as a write failure.
+  tmp="$file.$$.tmp"
+  {
+    _pw_emit_without_block "$file" "$heading"
+    printf '## %s\n\n' "$heading"
+    cat "$body_file"
+    if [ -n "$stamped" ]; then printf '%s\n' "$stamped"; fi
+    printf '\n'
+    if [ -n "$prose" ]; then printf '%s\n' "$prose" | _pw_trim_blanks; printf '\n'; fi
+  } > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$file" 2>/dev/null || { rm -f "$tmp"; return 1; }
+}
+
+# _pw_emit_without_block <file> <heading> — the file with that block removed,
+# every other line intact.
+_pw_emit_without_block() {
+  awk -v want="$2" '
+    /^#{1,6}[[:space:]]+/ {
+      title = $0
+      sub(/^#+[[:space:]]+/, "", title)
+      skipping = (title == want) ? 1 : 0
+      if (skipping) next
+    }
+    !skipping { print }
+  ' "$1" | _pw_trim_blanks
+  printf '\n'
+}
+
+# _pw_seed_file <path> — a new pact file's preamble, taken from the template so
+# a human who later hand-edits still has the template's guidance in front of
+# them. Value lines and block headings are deliberately not carried: the pact
+# is authored, never scaffolded.
+_pw_seed_file() {
+  local path="$1"
+  if [ -f "$_PW_TEMPLATE" ]; then
+    awk '/^#{1,6}[[:space:]]+/ && !/^# Pacts$/ { exit } { print }' \
+      "$_PW_TEMPLATE" > "$path" 2>/dev/null && return 0
+  fi
+  printf '# Pacts\n\nYour pacts — the limits you set for yourself, in advance.\n' > "$path"
+}

--- a/ai-literacy-superpowers/skills/mast/SKILL.md
+++ b/ai-literacy-superpowers/skills/mast/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: mast
+description: Use when reading or authoring a self-declared pact — carries the two modes, the clear-weather rule and the exact blind spot of the check that enforces it, the flag discipline for a budget whose keys are mostly unobservable, the rules the pact writer guarantees, and the anti-patterns that would turn a pact-keeper into a gate
+---
+
+# The Mast
+
+A limit you set for yourself in advance holds. A limit you set in the moment
+you are about to breach it does not — you will simply move it, because the
+thing you want at 18:00 is to keep working.
+
+That is why the pact file exists, and why nothing scaffolds one: an imposed
+default is not a pact. But a pact nobody reads is also not a pact, and a pact
+nobody has authored is not one either.
+
+> **The Mast** — the pact-keeper. It brings a pact into existence, and reads it
+> back to you.
+
+**What it attacks:** outsourced governance — the drift where the decision about
+when to stop migrates from a person who decided it in advance to a person who
+is tired and mid-thought.
+
+It never stops anything itself.
+
+## Two modes
+
+| Mode | Does |
+| --- | --- |
+| `/mast` | recites the pact and says where you stand against it |
+| `/mast tune` | the only sanctioned path that authors or amends it |
+
+Boundary notices, the hard stop, and the override record are **not here** —
+they are a separate slice. What lives here is the gauge and the ritual.
+
+## Recite first, measure second
+
+<!-- evidence: the intervention is the re-reading. A pact's force comes from
+     having been authored deliberately and then brought back into view, not
+     from being metered. This is why the report leads with the human's words. -->
+
+Read mode opens with the human's own declared words, and annotates afterwards.
+A report that opens with a table of what the plugin cannot see is an inventory
+of limitations, not a gauge.
+
+## The flags, and the honest cost of them
+
+| Key | Flag | Why |
+| --- | --- | --- |
+| `hard_stop_hour` | `observed` | the clock is past it or not |
+| `focus_blocks` | `inferred` | the clock being inside a block is not having spent it working |
+| `sessions_per_day` | `inferred` | the registry is a lease over live sessions, not a day's log |
+| `daily_cost_ceiling` | **not observable** | nothing here sees spend |
+
+Two of these are easy to get wrong in the flattering direction.
+
+`focus_blocks` looks observable because a focus block is a clock range. But
+consumption against it is *did you spend it working*, which needs the day's
+history the registry does not keep — the same sentence that disqualifies
+`sessions_per_day`.
+
+`daily_cost_ceiling` is not `asked`. Reporting a declared ceiling back is
+reading a pact, not asking a question; `asked` means the human was asked and
+answered. An unearned flag invites an implementer to invent the question, and
+the plausible invention — asking what someone spent today — is a question about
+their spending that nothing authorises.
+
+**Never estimate.** A fabricated figure against a real ceiling would make a
+person stop, or not stop, on a number nobody measured.
+
+Only one key in four ever moves. That is the price of not fabricating the other
+three, and it fixes what a budget *is* here: a declaration to be recited, not a
+quantity to be metered.
+
+## The clear-weather rule, and exactly what enforces it
+
+<!-- evidence: self-authored limits hold where imposed or default limits fail;
+     authorship is the active ingredient. This is why nothing scaffolds a pact,
+     why Tune proposes no defaults, and why the check below is a note. -->
+
+Tune stamps `authored_at`. Read mode notes when the budget it is reading was
+**tuned today** — this pact has not been lived with yet, which is worth a line
+when it asks something of you tonight.
+
+**What the check does not see.** `authored_at` moves only when Tune writes it:
+
+| The human does | Stamp | Note fires |
+| --- | --- | --- |
+| Hand-edits the stop hour at 18:00 | unchanged | **no** |
+| Runs `/mast tune` on a calm Tuesday morning | today | **yes**, that evening |
+
+It fires on the honest path and stays silent on the dishonest one. **Say so, in
+the note itself.** A check that claims coverage it lacks is worse than one that
+claims none, because silence gets read as an all-clear.
+
+Something stronger is not available. The pact file is never committed, so there
+is no diff and no CI can see it. Checksumming would catch the hand-edit, but it
+would also flag the calm Tuesday tweak, which is the deliberate authorship the
+rule *wants*. A disclosed note at the Unverified rung is the honest position —
+the same call the flag table makes about spend, for the same reason.
+
+It is a note, never a gate. Refusing to honour a pact because it was authored
+recently would be second-guessing the person it serves.
+
+## Tune
+
+**It is an editor, not only an author.** It reads current values back as each
+question's context — *your line is 18:30; what should it be?* That is not a
+proposed default: what is shown is the human's own prior authorship, not the
+template's illustration. Without it, changing one number means re-running the
+whole ritual, and the cheapest path to a small edit becomes the editor — the
+channel the weather check cannot see.
+
+**The stop hour first**, then an offer to stop there. A useful two-line pact is
+reachable in one question. A person asked cold for `max_switches_per_hour` has
+no basis for an answer, and a number invented to move the dialogue along is not
+more authored than one they declined to give.
+
+**It says what nothing reads yet** — before asking. `Sync cadence` entirely;
+three of `Session WIP`'s four keys until the WIP Warden ships;
+`notification_policy_after_stop`, which is declared intent nothing enforces;
+`daily_cost_ceiling`, which is never checkable. Disclosing for one block and
+not the others would leave a human authoring their first pact under two
+regimes without being told there were two.
+
+**It composes, shows, then writes.** Per-value confirmation is not enough
+alone: the parts the human did not author — the mandatory clause, the reserved
+marker, the stamps — are exactly the parts that decide whether the block reads
+as `declared`, and without a preview they land unseen.
+
+**It proposes nothing as a default**, and every block is skippable.
+
+## What the writer guarantees
+
+`lib/pact-write.sh` — **commands and hooks only**, never sourced by a sentinel.
+
+1. **Derives** the mandatory clause and reserved marker from the template,
+   never from a copy. A restated clause agrees with the reader only by
+   coincidence of wording.
+2. **Replaces a block; never appends a second.** A duplicate heading is
+   silently unread, so newly tuned values become invisible with no error.
+3. **Stamps `Budgets` only**, where the grammar defines the stamps.
+4. **Preserves the preamble** — which is the only content genuinely outside
+   every block, since everything after a heading belongs to it.
+
+Then the **validation checkpoint**: read the block back, assert `block_state`
+returns `declared`, fix in place. Without it a malformed write is discovered
+later, silently, as sentinels dropping to observe-only.
+
+## Anti-patterns
+
+1. **Estimating anything unobservable**, especially spend.
+2. **Gating on the weather note.** It is a note.
+3. **Claiming the weather check catches hand-edits.** It cannot, ever.
+4. **Opening the report with what cannot be seen.** Recite first.
+5. **Proposing a default in Tune.** A value accepted because it was pre-filled
+   is not authored.
+6. **Judging the pact.** A stop hour is not too late. It is theirs.
+7. **Writing from the agent**, or sourcing the write library from one.

--- a/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
+++ b/docs/plugins/ai-literacy-superpowers/explanation/sentinels.md
@@ -109,13 +109,16 @@ build goes red. S2 and S3 are agent-verifiable via the harness-enforcer.
 | `choice-cartographer` | Understanding of implicit decisions | Read-only; choice stories disposed at a soft gate; six-lens map declares what was found vs. inferred |
 | `reservoir-warden` | The decider — the verifier's cognitive reservoir | Read-only (no Write/Edit); single decide-your-stop-first recommendation; observed/inferred/asked flags; persists no record of human state |
 | `cost-estimator` | The decision's inputs — what a choice will cost before it is made | Read-only; human disposes the estimate record; refuses rather than fabricating an ungroundable estimate |
+| `mast` | The pact — that a limit set in clear weather survives contact with the moment it governs | Read-only; recites before measuring; refuses to estimate spend; discloses its own check's blind spot; never gates |
 | `coda` | The ending — that a session stops by decision rather than by attrition | Read-only; returns record content for `/coda` to persist; per-item observed/inferred/asked flags; never refuses a next action and never records why someone stopped |
 
 The narrative: the decision-discipline triad guards *decisions*; the
 `reservoir-warden` guards *the decider*; the `cost-estimator` guards
-*the decision's inputs*; and the `coda` guards *the ending* — that a
+*the decision's inputs*; the `coda` guards *the ending* — that a
 session stops by decision rather than by attrition, and that what was
-left open is written down rather than carried.
+left open is written down rather than carried — and the `mast` guards
+*the pact*, so that a limit set in clear weather is still there when the
+weather changes.
 
 ### A second declaration surface: the pact file
 

--- a/docs/plugins/ai-literacy-superpowers/how-to/keeping-a-pact.md
+++ b/docs/plugins/ai-literacy-superpowers/how-to/keeping-a-pact.md
@@ -1,0 +1,87 @@
+---
+title: Keeping a pact
+---
+# Keeping a pact
+
+A limit you set for yourself in advance holds. A limit you set in the moment
+you are about to breach it does not — you will simply move it, because the
+thing you want at 18:00 is to keep working.
+
+That is the whole idea. You author a pact in clear weather, and `/mast` brings
+it back into view later.
+
+## Make one
+
+```text
+/mast tune
+```
+
+It asks your **stop hour first**, then offers to stop there. A useful pact can
+be two lines and one question.
+
+If you keep going it offers the rest — how many sessions a day, your focus
+blocks, a cost ceiling — and every one is skippable. Before it asks about
+anything nothing reads yet, it says so, so you never declare a value believing
+something acts on it.
+
+It **never suggests a number.** Not even the template's. A limit you accepted
+because it was pre-filled is not one you set, and being the one who set it is
+the part that makes it work.
+
+Then it shows you the block it composed and writes only if you accept.
+
+Your pact lives at `~/.claude/pacts.md`. It is yours, it is per-machine, and it
+is **never committed** — nothing about how you work goes into any repository.
+
+## Read it
+
+```text
+/mast
+```
+
+It reads your own words back to you first, then says what it can and cannot
+see:
+
+| Key | What the Mast knows |
+| --- | --- |
+| `hard_stop_hour` | Whether the clock is past it |
+| `focus_blocks` | Whether the clock is inside one — **not** whether you spent it working |
+| `sessions_per_day` | Roughly, from live sessions only — it keeps no day's log |
+| `daily_cost_ceiling` | **Nothing.** It cannot see spend, and will not guess |
+
+Only one row ever really moves. That is deliberate: the alternative to saying
+"I can't see this" is inventing a number, and a made-up spend figure against a
+real ceiling would have you stop, or not stop, for no reason.
+
+## Change one
+
+```text
+/mast tune budgets
+```
+
+It shows your current values as it asks — *your line is 18:30; what should it
+be?* That is your own earlier answer, not a suggestion.
+
+Changing your pact in calm weather is exactly what it is for. Do it whenever it
+stops fitting.
+
+## The one thing it notices
+
+If you tuned your budget **today**, `/mast` says so — this pact hasn't been
+lived with yet, which is worth knowing when it asks something of you tonight.
+
+It also tells you what it cannot notice, and this is worth reading once:
+
+> A pact edited outside `/mast tune` is invisible to this check.
+
+If you open the file and change your stop hour by hand at 18:00, nothing will
+mention it. That is a real limit, not a soft one — the file is never committed,
+so there is nothing to compare against. The check is honest about what it
+misses rather than implying it catches everything.
+
+## What it will never do
+
+- **Stop you.** Nothing here blocks, gates, or requires an answer.
+- **Guess.** Especially not at spend.
+- **Judge your pact.** Your stop hour is not too late. It is yours.
+- **Write anything you didn't accept.** No pact is scaffolded, ever.

--- a/docs/plugins/ai-literacy-superpowers/reference/agents.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/agents.md
@@ -12,7 +12,7 @@ Cutting across those groups is a fourth, cross-cutting family — the
 **[sentinels](../explanation/sentinels.md)**. A sentinel is any agent
 whose object of care is the human's understanding and judgement rather
 than an artefact: `carpaccio`, `advocatus-diaboli`,
-`choice-cartographer`, `reservoir-warden`, `cost-estimator`, and `coda`. Each
+`choice-cartographer`, `reservoir-warden`, `cost-estimator`, `coda`, and `mast`. Each
 declares `role: sentinel` in its frontmatter, is read-only (criterion
 S1, enforced deterministically by the Sentinel integrity constraint),
 emits advisory output a human disposes (S2), and carries an explicit
@@ -194,6 +194,29 @@ never records *why* someone stopped — that a session closed and what was parke
 is the record.
 
 See the `coda` skill and [Closing a session](../how-to/closing-a-session.md).
+
+### mast
+
+**Role:** sentinel · **Tools:** Read, Glob, Grep, Bash · **Trust boundary:** read-only
+
+Reads the pact a human authored for themselves and reports where they stand
+against it — reciting their own declared words first and annotating after,
+because a pact nobody reads is not a pact and the re-reading *is* the
+intervention.
+
+Honest about how little of a budget is observable: `hard_stop_hour` is
+`observed`, `focus_blocks` and `sessions_per_day` are `inferred`, and
+`daily_cost_ceiling` is **not observable** at all. It refuses to estimate
+spend — a fabricated figure against a real ceiling would make a person stop,
+or not stop, on a number nobody measured.
+
+Notes when a budget was tuned today, and discloses that check's blind spot in
+the same breath: a pact hand-edited outside `/mast tune` never moves the stamp
+and is invisible to it.
+
+Never writes, never sources the write library, and never gates.
+
+See the `mast` skill and [Keeping a pact](../how-to/keeping-a-pact.md).
 
 ### cost-estimator
 
@@ -440,6 +463,7 @@ is a precaution under uncertainty. See the
 | advocatus-diaboli | x | | | x | x | | | | read-only |
 | choice-cartographer | x | | | x | x | | | | read-only |
 | coda | x | | | x | x | | | | read-only |
+| mast | x | | | x | x | | | | read-only |
 | cost-estimator | x | | | x | x | | | | read-only |
 | tdd-agent | x | x | x | x | x | x | | | read-write |
 | code-reviewer | x | | | x | x | x | | | read-only |

--- a/docs/plugins/ai-literacy-superpowers/reference/commands.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/commands.md
@@ -566,6 +566,39 @@ See the `coda` skill, [Closing a session](../how-to/closing-a-session.md), and
 
 ---
 
+### /mast
+
+- **Skills read**: `mast`
+- **Agents dispatched**: `mast` (Read mode)
+
+Reads the pact you set for yourself, or authors one. Two modes:
+
+- **`/mast [read]`** (default) — recites your declared budget and says where
+  you stand, each key flagged for what can honestly be seen. If no block is
+  declared it says so and **offers Tune**; if one is malformed it names the
+  missing clause and continues in observe-only.
+- **`/mast tune [BLOCK]`** — the only sanctioned path that creates or amends
+  `~/.claude/pacts.md`. Reads your current values back as context (not as
+  defaults), asks the stop hour first and offers to stop there, says what
+  nothing reads yet before asking, then composes the block, shows it, and
+  writes only on accept — followed by a validation checkpoint.
+
+**It never estimates spend.** Nothing in this plugin observes it, and a
+fabricated figure against a real ceiling is worse than no figure.
+
+The weather note says when a budget was tuned today, and discloses its own
+blind spot: a pact hand-edited outside Tune never moves the stamp. Something
+stronger is not available — the pact file is never committed, so there is no
+diff and no CI can see it.
+
+Advisory throughout: absent, malformed, and tuned-today are all reports, and
+none changes what you may do next. Boundary notices and the hard stop are a
+separate slice.
+
+See the `mast` skill and [Keeping a pact](../how-to/keeping-a-pact.md).
+
+---
+
 ### /reservoir
 
 - **Skills read**: `cognitive-reservoir`

--- a/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/pacts-format.md
@@ -136,6 +136,27 @@ is a spec-first change and a coordinated migration.
 > it is marked reserved so a value you declare in good faith does not bind a
 > future consumer to behaviour nobody has designed.
 
+## The weather check
+
+`/mast` notes when the budget it is reading was **tuned today** — a pact
+authored hours ago has not been lived with yet, and that is worth a line when
+it asks something of you tonight.
+
+**It discloses its own blind spot, and you should know it too:**
+
+| You do | `authored_at` | Note fires |
+| --- | --- | --- |
+| Hand-edit your stop hour at 18:00 | unchanged | **no** |
+| Run `/mast tune` on a calm Tuesday morning | today | **yes**, that evening |
+
+The stamp moves only when Tune writes it, so an edit made in any other way is
+invisible to the check — permanently. Something stronger is not available: the
+pact file is never committed, so there is no diff and nothing can compare it
+against a previous state.
+
+A check that claimed to catch in-the-moment edits would be worse than one that
+admits it cannot, because you would learn to read its silence as an all-clear.
+
 ## Authoring
 
 Run `/mast tune`. Nothing writes this file on your behalf, and nothing

--- a/docs/plugins/ai-literacy-superpowers/reference/skills.md
+++ b/docs/plugins/ai-literacy-superpowers/reference/skills.md
@@ -56,6 +56,17 @@ closing ritual into a gate on the person.
 
 Read it before implementing or changing anything in the Coda's path.
 
+### mast
+
+The two modes, the clear-weather rule **and the exact blind spot of the check
+that supports it**, the flag discipline for a budget whose keys are mostly
+unobservable, the guarantees the pact writer makes, and the anti-patterns that
+would turn a pact-keeper into a gate.
+
+Read it before changing anything in the Mast's path — particularly the two-row
+table showing that a hand-edit does *not* fire the weather note and a calm tune
+*does*, which is the guard against an honest-sounding regression.
+
 ### cognitive-reservoir
 
 The shared grounding for the reservoir-warden agent and the reservoir-check Stop hook — the framework's watch on the one actor it cannot verify, the human verifier. Defines the four observable proxies (session span, decision volume, context switches, wall-clock hour), the `observed` / `inferred` / `asked` confidence discipline, the disjunctive default thresholds, the one firm principle (decide your stop before the next session begins), the six-level scaling guidance, and the honesty rule that keeps the contested science (ego depletion, the hungry-judges study) separate from the robust basis (vigilance decrement, task-switching cost). Advisory-only; never a fatigue score, never a gate.

--- a/docs/superpowers/objections/cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s3-mast-design.md
@@ -1,0 +1,340 @@
+---
+spec: docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+date: 2026-08-10
+mode: spec
+diaboli_model: claude-opus-5[1m]
+objections:
+  - id: O1
+    category: scope
+    severity: critical
+    claim: "Section 4's mechanism requires changing the Coda's survey and the semantics of the Closed field — a contract S2 owns and shipped — yet S3 lists no S2 file, carves out no contract change, and declares 'No breaking changes'."
+    evidence: "Spec 4: 'The Coda's survey reads these and includes them in the Closed field.' Section 5's file table lists five files, none of them agents/coda.agent.md, skills/coda/SKILL.md, or commands/coda.md. Section 8: 'No breaking changes.' Verified: the shipped commands/coda.md defines Closed as 'the filename of each record parked', and neither Coda file contains a single mention of a note."
+    disposition: pending
+    disposition_rationale: null
+  - id: O2
+    category: implementation
+    severity: critical
+    claim: "lib/mast-notes.sh bundles mutation with read in one sourceable library that a role: sentinel agent must reach, re-opening precisely the channel S1 section 4.4 split two libraries to close."
+    evidence: "Spec 5: 'lib/mast-notes.sh | the note store: append, read, consume, prune'. Spec 4: 'The Coda's survey reads these.' S1 4.4 and the shipped lib/session-registry-read.sh preamble: 'A single shared library exposing registry_prune to every sentinel would manufacture exactly that case — CI green while a role: sentinel agent deletes files.' sentinel-design generalised it: 'Split such libraries — a read surface a sentinel may source, a write surface only hooks and commands may.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O3
+    category: implementation
+    severity: high
+    claim: "The once-per-session notice state is stored in the one file that consumption deletes and the pruner removes, so B2 and B3 are unenforceable on the most ordinary path — run /coda, then take one more turn."
+    evidence: "Spec 4: 'The note file is removed once consumed, which is what bounds it.' Spec 4.1: 'The notes file also carries the once-per-session notice state.' S1 4.2 is the governing precedent and is never engaged: the Stop hook fires many times per session, and the note store would be its second destructive consumer."
+    disposition: pending
+    disposition_rationale: null
+  - id: O4
+    category: specification quality
+    severity: high
+    claim: "The spec never says which budget keys generate boundary notices, and the 80% fraction's denominator is undefined for every key except hard_stop_hour — including the session-start value it measures from, whose source is an undeclared dependency on S1's registry."
+    evidence: "Spec 3's table: 'at 80% of the way from session start to the line', with no key named; 3.1 works only hard_stop_hour. focus_blocks has two endpoints; sessions_per_day is a count flagged inferred; daily_cost_ceiling is unobservable. Section 1's Depends-on names only the pact file and pact-blocks.sh — not lib/session-registry-read.sh, the only thing that knows when a session started."
+    disposition: pending
+    disposition_rationale: null
+  - id: O5
+    category: implementation
+    severity: high
+    claim: "The weather check's detection is inverted: authored_at changes only when Tune writes, so the hand-edit at 18:00 that the spec names as its target leaves it untouched and raises no note, while a calm morning tune followed by evening work raises one."
+    evidence: "Spec 2.2 claims 'An authored_at of today, read at enforcement time, catches that and nothing else', where 'that' is 'raising hard_stop_hour at 18:00'. Spec 2.3 concedes the defeating channel: 'the file is the human's and they may edit it with any editor they like.' Spec 2.2 also states a calm Tuesday-morning tweak 'is exactly the deliberate authorship the rule wants' — which W1 pins as a note."
+    disposition: pending
+    disposition_rationale: null
+  - id: O6
+    category: specification quality
+    severity: high
+    claim: "Section 2.1's flag column does not match the behaviour its own prose describes: focus_blocks is flagged observed for a quantity as unobservable as sessions_per_day, and daily_cost_ceiling is flagged asked while the prose says nothing is asked."
+    evidence: "Spec 2.1's table: 'focus_blocks | observed | wall clock' and 'daily_cost_ceiling | asked, or not observable'. That the clock sits inside a focus block is observed; that the human spent it working needs the day's history the same section says the registry lacks. For cost the prose says the Mast 'will report what the human declared and what it cannot check' — reporting a declared value back is not asking."
+    disposition: pending
+    disposition_rationale: null
+  - id: O7
+    category: specification quality
+    severity: high
+    claim: "Tune's write is unspecified, so the only sanctioned authoring path can produce a file the shipped reader classifies as malformed, or on a second run append a duplicate heading _block_span silently ignores — and no acceptance scenario round-trips Tune's output through block_state."
+    evidence: "Spec 2.3 gives three rules, none about the file's shape. pact-blocks.sh requires the literal mandatory clauses or the block reads malformed; _block_span exits at the second known heading, so an appended second Budgets block is silently unread. Section 7.4's A2-A6 assert asking, stamping, disclosure and no-agent-write; none asserts the result reads as declared."
+    disposition: pending
+    disposition_rationale: null
+  - id: O8
+    category: risk
+    severity: high
+    claim: "The Mast's reached notice and the Reservoir Warden's advisory ride the same Stop rail, counsel the same act, and can fire on the same turn — falsifying the single-prompt mechanism the spec grounds its evidence claim on."
+    evidence: "Spec 3: 'One recommendation, once... Ambient reminders are ignored and then resented.' Verified: reservoir-check.sh puts a declared early/lark chronotype into the suboptimal band at hour >= 20, so a hard_stop_hour of 20:00 for a lark lands both advisories on the same turn. cognitive-reservoir names the anti-pattern: 'A second nudge. One advisory, then silence.' Section 6 answers only 'No changes to the Reservoir Warden.'"
+    disposition: pending
+    disposition_rationale: null
+  - id: O9
+    category: risk
+    severity: high
+    claim: "Section 4's destination is a committed, permanently archived, machine-aggregated artefact, so the override survives as exactly the cross-session record of working late that section 6 declares out of bounds."
+    evidence: "Spec 4 routes the note to the reflection record; section 6 forbids 'a record of how often someone works late'. CLAUDE.md: REFLECTION_LOG.md is a generated, committed aggregate with a permanent archive under reflections/archive/<YYYY>.md. S2's O5 rejected a structurally identical record on the same grounds. Section 4.1 checks the carve-out's four conditions against the note file, which expires — not against the destination, which does not."
+    disposition: pending
+    disposition_rationale: null
+  - id: O10
+    category: alternatives
+    severity: medium
+    claim: "Shipping Read and Tune alone, and deferring the boundary notices to a slice that can carve the Coda contract properly, is a materially smaller change that dissolves O1, O2 and O3 outright — and the spec does not weigh it."
+    evidence: "Section 5's five files split cleanly: the agent/skill/command triple reads a file and touches nothing else; the hook and the note-store library are the entire source of this slice's cross-slice coupling, and section 1 attributes the S2 dependency solely to them. The epic already slices by mechanism — S1 gated nothing, S2 wired no trigger."
+    disposition: pending
+    disposition_rationale: null
+  - id: O11
+    category: risk
+    severity: medium
+    claim: "Nothing states that ~/.claude/mast/ is created only for a human who declared a budget, repeating the silent-creation asymmetry sentinel-design records as the mistake that prompted the carve-out's fourth condition."
+    evidence: "Section 7.2 B5 promises silence on stdout, not abstention on the filesystem. None of T1-T5 asserts the store is not created. sentinel-design: 'the registry was going to be created for every user silently. That asymmetry was backwards.' The fix is the self-gate reservoir-check.sh already uses: check the opt-in first, exit 0 before touching anything."
+    disposition: pending
+    disposition_rationale: null
+---
+
+# Objection record — Cadence Sentinels S3: The Mast (spec mode)
+
+Eleven objections: two critical, seven high, two medium.
+
+The read half of this slice — agent, skill, command — is sound and carries
+almost none of the risk. Nine of the eleven objections concentrate in the
+notice/note half, and three of those (O1, O2, O3) are structural consequences
+of one decision: that the Mast writes state which another slice must consume.
+
+**Dispatcher verification note (2026-08-10).** Three claims were checked before
+recording. O1: `agents/coda.agent.md` and `commands/coda.md` contain **zero**
+occurrences of "note", and `Closed` is defined as "the filename of each record
+parked" — the Coda knows nothing of this mechanism. O8: `reservoir-check.sh`
+puts a declared `early`/`lark` chronotype into the suboptimal band at hour ≥ 20,
+so a `hard_stop_hour: 20:00` for a lark fires both advisories on one turn. O5
+was confirmed by reasoning over the spec's own text and needs no code: the stamp
+moves only when Tune writes.
+
+## O1 — scope — critical
+
+§4's override mechanism does not exist unless the Coda changes. S2 shipped the
+Coda's survey, its agent, its command, and the `Closed` field, and none of them
+knows anything about a note store. S3 asserts the consumption as a fact about
+the world rather than carving it as work it must do — while claiming no
+breaking changes and listing no S2 file among its five.
+
+Three consequences compound. The promoted ARCH_DECISION that a consumer never
+mutates the contract it consumes is engaged and unhonoured — S2 §4.1 obeyed it
+in the identical situation and called itself "the second worked instance"; S3
+would be the third and slips it in. `consume` needs an actor, and the Coda agent
+holds no `Write`, so removal must be done by the `/coda` command — a command S3
+does not own, at a ritual step S3 does not name. And if the Coda is not changed
+at all, the note is written, never read, and never removed: §4.1's boundedness
+then rests entirely on the pruner, and the override reaches no record, leaving
+constraint 6 satisfied only on paper.
+
+## O2 — implementation — critical
+
+`lib/mast-notes.sh` is described as one library exposing `append, read, consume,
+prune`. Consume and prune are mutations, and §4 requires a `role: sentinel`
+agent to read the notes. If it reaches them through this library, a sentinel has
+a sourceable path to file deletion and `sentinel-integrity-check.sh` — which
+reads only the frontmatter `tools:` list — stays green.
+
+S1 spent a numbered section preventing exactly this, wrote the test (R9), and
+promoted the rule into the category skill. Constraint 1 is not merely "sentinels
+declare no Write"; it is "a library a sentinel may source must also be incapable
+of mutation". S3's file table describes the single-library shape that rule
+exists to forbid, and CI cannot catch it, because the breach is in a `.sh` file
+rather than in frontmatter.
+
+There is a coherent alternative reading — that the Coda reads the note files
+directly with `Read`/`Glob` and never sources the library. If that is the
+design it needs saying, because it makes the note file's line format a published
+contract between two slices, which is a different problem with different
+consequences.
+
+## O3 — implementation — high
+
+The at-most-once-per-session guarantee is stored in the file that consumption
+deletes. Once `/coda` consumes the notes the notice state is gone, and any
+further turn re-fires the reached notice.
+
+The path is ordinary: `/coda`'s final step is "say what landed, what was parked,
+and stop" — a statement, not a process termination. The session is still alive
+and the Stop rail keeps firing.
+
+S1 §4.2 is the governing precedent and the spec never engages with it. S1 made
+correctness independent of firing frequency by renewing rather than deleting;
+S3 does the opposite, making a once-only guarantee depend on a file another
+slice removes. And the consequence is not cosmetic: §3's own evidence comment
+says repeating a boundary prompt "would not make it work better, it would make
+it work worse". A design whose once-only property fails on the path where the
+human ran the recommended ritual and kept working converts the Mast into the
+ambient reminder its evidence base says is counterproductive.
+
+Secondary: §4.1 says the store is "lease-pruned otherwise" without saying what
+the lease is measured from. If it is mtime under `stale_after_hours`, a long
+quiet session loses its notice state the same way.
+
+## O4 — specification quality — high
+
+Two undefined quantities sit inside the notice trigger. The spec never says
+which budget keys produce notices, and the 80% fraction's endpoints are defined
+only for `hard_stop_hour`.
+
+Read against the four declared keys: `hard_stop_hour` has a well-defined line
+but no stated source for "session start"; `focus_blocks` is a range with two
+endpoints and no rule for a session that began before or after it;
+`sessions_per_day` is a count rather than a time, and is flagged `inferred`;
+`daily_cost_ceiling` is unobservable and §6 does not say it never notices.
+
+The undeclared dependency compounds it. The only thing on the machine that
+knows when a session started is S1's registry, which §1, §5 and §8 all omit —
+and S1 warned in terms that "no consumer may treat this count as an exact number
+of open windows". A silent consumer is one that never read that sentence.
+
+This is the clearest divergent-implementation risk in the spec: two implementers
+ship different products and every B scenario passes for both.
+
+## O5 — implementation — high
+
+The weather check detects the wrong edits in both directions. `authored_at`
+moves only when Tune writes, so a hand-edit of `hard_stop_hour` at 18:00 — the
+exact failure §2.2 names as its target — leaves the stamp untouched and raises
+no note. Meanwhile a deliberate morning `/mast tune` followed by an evening
+session raises one, which §2.2 itself says is not the case worth flagging.
+
+§2.3 concedes the channel that defeats it ("they may edit it with any editor
+they like") and then asserts §2.2 covers the timing of such edits. It cannot:
+by §2.3's own account only Tune moves the stamp.
+
+The spec calls this "the clear-weather rule's actual mechanism". If it fires on
+deliberate authorship and stays silent on weather-editing, the rule is not
+implemented — a note appears on the honest path and never on the dishonest one,
+and the human learns to read it as noise. W1 and W2 cannot surface this, because
+they test the date comparison, which is correct; what is wrong is the claim made
+for what the comparison detects.
+
+## O6 — specification quality — high
+
+§2.1's flag column, the section the spec calls "the whole job", does not survive
+contact with the prose beside it.
+
+`focus_blocks` carries `observed`. That the clock sits inside `09:00-12:00` is
+observed; that the human *spent* that block working needs exactly the day's
+history §2.1 correctly says the registry lacks — a sentence it applies only to
+`sessions_per_day`.
+
+`daily_cost_ceiling` carries `asked` for an act the same paragraph says does not
+happen: reporting a declared ceiling back is reading a pact, not asking a
+question. Constraint 3's `asked` means the human was asked and answered, as S1
+and S2 both use it. An honesty flag that describes no act leaves the implementer
+to invent one, and the plausible invention — asking what they spent today — is a
+question about the person's spending that nothing authorises.
+
+A1 cannot catch either: it verifies that a flag is printed, not that the flag is
+true of the quantity beside it.
+
+## O7 — specification quality — high
+
+Tune is "the only sanctioned authoring path", but what it writes is never
+specified. Nothing requires it to emit the mandatory clauses or the reserved
+marker; nothing says what a second run does to an existing file.
+
+The shipped reader is unforgiving. A `Budgets` block written without its literal
+clause is `malformed`, and malformed degrades every consumer to observe-only —
+so Tune, the sanctioned ritual, can author a pact the Mast then refuses to hold
+anyone to, with no line saying which sentence is missing. Worse, `_block_span`
+exits at the next known heading, so a second `## Budgets` appended to the file is
+silently unread and the newly tuned values are invisible.
+
+Every other component in this epic degrades safely when the pact file is wrong.
+Tune is the one component that *produces* it, and its output is the input to all
+six other sentinels. One scenario — Tune's output, run through `block_state`,
+must return `declared` for every block declared — closes it and is cheap. Its
+absence from §7 is the tell.
+
+## O8 — risk — high
+
+The Mast's reached notice and the Warden's advisory ride the same Stop rail,
+counsel the same act, and can fire on the same turn. Verified: a declared
+`lark` enters the Warden's suboptimal band at hour ≥ 20, so a `hard_stop_hour`
+of 20:00 lands both.
+
+Constraint 5 is honoured — nothing in S3 touches the Warden's files. But S2's
+"mediated by no artefact" disposition answered a *coupling* question: should one
+sentinel offer the other's ritual? It did not answer a *collision* question:
+what does the human experience when two independent stop advisories arrive in
+one payload?
+
+The consequence is the one §3's own evidence comment predicts. Two simultaneous
+messages about stopping is accumulated pressure, not a boundary-moment prompt,
+and the spec's own reading is that this makes the mechanism work worse. The Mast
+would be degrading the Warden's effectiveness without editing one of its files.
+
+## O9 — risk — high
+
+The override's destination is a committed, permanently archived, machine-
+aggregated artefact. §6 declares that exact artefact out of bounds.
+
+The note file is indeed consumed and gone. Its content is not: it lands in
+`REFLECTION_LOG.md`, a generated committed aggregate with a permanent archive
+under `reflections/archive/<YYYY>.md`. One `grep` returns every night the human
+worked past their line, dated.
+
+S2's O5 rejected a structurally identical record — "committed permanently and
+aggregable across records — a longitudinal account of how often someone's
+stopping answers were judged inadequate". Applying `sentinel-design`'s two tests
+to "continued past the 20:00 stop by choice": the hook authored it, and it is an
+observation about the person's conduct rather than a sentence they wrote.
+
+§4.1 does careful work checking the carve-out's four conditions — against the
+artefact that expires, not the one that persists. **This objection is not about
+the route**, which was disposed and is right. It is about what the override
+looks like once it lands: a durable machine-authored fact, or a sentence the
+person would recognise as theirs. §6 currently reads as forbidding what §4
+builds.
+
+## O10 — alternatives — medium
+
+Read and Tune are one product; the boundary notices and the note store are
+another. §5's five files split cleanly along that seam, and §1 attributes the
+entire S2 dependency to the second half.
+
+Shipping the read half now dissolves O1, O2 and O3 outright: no contract owned
+elsewhere, no third operational-state artefact, no sourceable mutation library,
+no Stop-rail firing-semantics analysis. It is also the higher-value half —
+S1 shipped a template no path authors, so **until Tune exists the pact file does
+not exist and every other sentinel is permanently in observe-only.**
+
+The counter-argument is real and the spec should make it if it disagrees: a Mast
+that reports but never speaks at the boundary is a gauge nobody reads, which is
+§1's own critique of an unread pact. Right now the alternative is not
+acknowledged at all.
+
+## O11 — risk — medium
+
+Nothing restricts creation of `~/.claude/mast/` to humans who declared a budget.
+B5 promises silence on stdout, not abstention on the filesystem, and no T
+scenario asserts the store is not created.
+
+This repeats the asymmetry `sentinel-design` records as the reason its fourth
+condition exists: the pact file got a careful adoption ramp while the registry
+was going to be created for every user silently. A directory appearing under
+`~/.claude/` for someone who declared no pact, opted into nothing, and will
+never see a notice is operational state with no operational purpose. Documenting
+a store that should not exist is not disclosure — it is an explanation.
+
+The fix is the self-gate `reservoir-check.sh` already uses: check the opt-in
+first, exit 0 before touching anything.
+
+## Explicitly not objecting to
+
+- **The 80% fraction, the `authored_at` mechanism, the note-carried-by-Coda
+  route, and Tune walking all three blocks** — all disposed at the design gate.
+  O4 challenges what the fraction is taken *of*; O5 challenges the claim made
+  for the mechanism, not the mechanism; O9 challenges the destination's
+  retention, not the route.
+- **The refusal to estimate spend.** The strongest paragraph in the spec, and it
+  matches the `cost-estimator` precedent exactly: an ungroundable number against
+  a real ceiling is worse than no number.
+- **Not killing the session at the hard stop.** Required by constraint 6 and the
+  sentinel signature; needs no defence.
+- **Tune proposing no defaults.** The authorship-is-the-active-ingredient
+  argument is the whole premise of the pact file.
+- **`notification_policy_after_stop` at the Unverified rung.** Correct use of a
+  real rung; declaring intent that nothing enforces, and saying so, is honest.
+- **`sessions_per_day` flagged `inferred`.** Exactly right against S1's
+  disclosed lease semantics, and the refusal to reconstruct a day's count is the
+  honest call.
+- **Adding an eleventh Stop hook.** A real but small operational concern that
+  belongs at code time with a measurement, not at spec time as an assertion.
+- **Language discipline.** No instance of "addiction" or "dopamine"; constraint
+  8 satisfied.

--- a/docs/superpowers/objections/cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/objections/cadence-sentinels-s3-mast-design.md
@@ -9,78 +9,78 @@ objections:
     severity: critical
     claim: "Section 4's mechanism requires changing the Coda's survey and the semantics of the Closed field — a contract S2 owns and shipped — yet S3 lists no S2 file, carves out no contract change, and declares 'No breaking changes'."
     evidence: "Spec 4: 'The Coda's survey reads these and includes them in the Closed field.' Section 5's file table lists five files, none of them agents/coda.agent.md, skills/coda/SKILL.md, or commands/coda.md. Section 8: 'No breaking changes.' Verified: the shipped commands/coda.md defines Closed as 'the filename of each record parked', and neither Coda file contains a single mention of a note."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the O10 split and carried to #501, which owns the Coda contract change and must carve it explicitly as the third worked instance of the consumer-never-mutates rule. S3 as revised touches no S2 file and needs none."
   - id: O2
     category: implementation
     severity: critical
     claim: "lib/mast-notes.sh bundles mutation with read in one sourceable library that a role: sentinel agent must reach, re-opening precisely the channel S1 section 4.4 split two libraries to close."
     evidence: "Spec 5: 'lib/mast-notes.sh | the note store: append, read, consume, prune'. Spec 4: 'The Coda's survey reads these.' S1 4.4 and the shipped lib/session-registry-read.sh preamble: 'A single shared library exposing registry_prune to every sentinel would manufacture exactly that case — CI green while a role: sentinel agent deletes files.' sentinel-design generalised it: 'Split such libraries — a read surface a sentinel may source, a write surface only hooks and commands may.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the split and carried to #501. S3 ships no note store and no library at all, so there is nothing for a sentinel to source."
   - id: O3
     category: implementation
     severity: high
     claim: "The once-per-session notice state is stored in the one file that consumption deletes and the pruner removes, so B2 and B3 are unenforceable on the most ordinary path — run /coda, then take one more turn."
     evidence: "Spec 4: 'The note file is removed once consumed, which is what bounds it.' Spec 4.1: 'The notes file also carries the once-per-session notice state.' S1 4.2 is the governing precedent and is never engaged: the Stop hook fires many times per session, and the note store would be its second destructive consumer."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the split and carried to #501, with S1 section 4.2's precedent named in the issue: the Stop rail fires many times per session and a once-only guarantee must not live in a file another slice deletes."
   - id: O4
     category: specification quality
     severity: high
     claim: "The spec never says which budget keys generate boundary notices, and the 80% fraction's denominator is undefined for every key except hard_stop_hour — including the session-start value it measures from, whose source is an undeclared dependency on S1's registry."
     evidence: "Spec 3's table: 'at 80% of the way from session start to the line', with no key named; 3.1 works only hard_stop_hour. focus_blocks has two endpoints; sessions_per_day is a count flagged inferred; daily_cost_ceiling is unobservable. Section 1's Depends-on names only the pact file and pact-blocks.sh — not lib/session-registry-read.sh, the only thing that knows when a session started."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Carried to #501 with the analysis intact — which keys notice, the fraction's endpoints per key, and the undeclared registry dependency. S3 as revised raises no notices, so the question does not arise here."
   - id: O5
     category: implementation
     severity: high
     claim: "The weather check's detection is inverted: authored_at changes only when Tune writes, so the hand-edit at 18:00 that the spec names as its target leaves it untouched and raises no note, while a calm morning tune followed by evening work raises one."
     evidence: "Spec 2.2 claims 'An authored_at of today, read at enforcement time, catches that and nothing else', where 'that' is 'raising hard_stop_hour at 18:00'. Spec 2.3 concedes the defeating channel: 'the file is the human's and they may edit it with any editor they like.' Spec 2.2 also states a calm Tuesday-morning tweak 'is exactly the deliberate authorship the rule wants' — which W1 pins as a note."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The mechanism stays; the claim made for it does not. It detects a budget TUNED today, which is a true and useful thing to say — this pact has not been lived with yet. It does not detect weather-editing: authored_at moves only when Tune writes, so a hand-edit is invisible and always will be, and the reference page says so. The spec's 'catches that and nothing else' was exactly backwards and is removed."
   - id: O6
     category: specification quality
     severity: high
     claim: "Section 2.1's flag column does not match the behaviour its own prose describes: focus_blocks is flagged observed for a quantity as unobservable as sessions_per_day, and daily_cost_ceiling is flagged asked while the prose says nothing is asked."
     evidence: "Spec 2.1's table: 'focus_blocks | observed | wall clock' and 'daily_cost_ceiling | asked, or not observable'. That the clock sits inside a focus block is observed; that the human spent it working needs the day's history the same section says the registry lacks. For cost the prose says the Mast 'will report what the human declared and what it cannot check' — reporting a declared value back is not asking."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "focus_blocks drops to inferred — that the clock sits inside a block is observed, that the human spent it working needs the day's history the registry does not have. daily_cost_ceiling becomes 'not observable' rather than asked: reporting a declared value back is reading a pact, not asking a question, and an unearned asked flag would have invited an implementer to invent the question."
   - id: O7
     category: specification quality
     severity: high
     claim: "Tune's write is unspecified, so the only sanctioned authoring path can produce a file the shipped reader classifies as malformed, or on a second run append a duplicate heading _block_span silently ignores — and no acceptance scenario round-trips Tune's output through block_state."
     evidence: "Spec 2.3 gives three rules, none about the file's shape. pact-blocks.sh requires the literal mandatory clauses or the block reads malformed; _block_span exits at the second known heading, so an appended second Budgets block is silently unread. Section 7.4's A2-A6 assert asking, stamping, disclosure and no-agent-write; none asserts the result reads as declared."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "Tune's write is specified — rewrite the block in place, never append, always emit the mandatory clause and the reserved marker — and a scenario round-trips Tune's output through block_state, requiring declared for every block declared. Tune is the one component that PRODUCES the pact file, and its output is the input to every other sentinel."
   - id: O8
     category: risk
     severity: high
     claim: "The Mast's reached notice and the Reservoir Warden's advisory ride the same Stop rail, counsel the same act, and can fire on the same turn — falsifying the single-prompt mechanism the spec grounds its evidence claim on."
     evidence: "Spec 3: 'One recommendation, once... Ambient reminders are ignored and then resented.' Verified: reservoir-check.sh puts a declared early/lark chronotype into the suboptimal band at hour >= 20, so a hard_stop_hour of 20:00 for a lark lands both advisories on the same turn. cognitive-reservoir names the anti-pattern: 'A second nudge. One advisory, then silence.' Section 6 answers only 'No changes to the Reservoir Warden.'"
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the split and carried to #501. S3 raises no notices, so nothing collides with the warden. The issue carries the verified band: a declared lark enters the suboptimal band at hour 20, so a 20:00 hard stop would fire both advisories on one turn."
   - id: O9
     category: risk
     severity: high
     claim: "Section 4's destination is a committed, permanently archived, machine-aggregated artefact, so the override survives as exactly the cross-session record of working late that section 6 declares out of bounds."
     evidence: "Spec 4 routes the note to the reflection record; section 6 forbids 'a record of how often someone works late'. CLAUDE.md: REFLECTION_LOG.md is a generated, committed aggregate with a permanent archive under reflections/archive/<YYYY>.md. S2's O5 rejected a structurally identical record on the same grounds. Section 4.1 checks the carve-out's four conditions against the note file, which expires — not against the destination, which does not."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the split and carried to #501. S3 records no override because it raises no notice to override. The issue carries the distinction the objection drew: the route is right, the destination's permanence is what needs deciding."
   - id: O10
     category: alternatives
     severity: medium
     claim: "Shipping Read and Tune alone, and deferring the boundary notices to a slice that can carve the Coda contract properly, is a materially smaller change that dissolves O1, O2 and O3 outright — and the spec does not weigh it."
     evidence: "Section 5's five files split cleanly: the agent/skill/command triple reads a file and touches nothing else; the hook and the note-store library are the entire source of this slice's cross-slice coupling, and section 1 attributes the S2 dependency solely to them. The epic already slices by mechanism — S1 gated nothing, S2 wired no trigger."
-    disposition: pending
-    disposition_rationale: null
+    disposition: accepted
+    disposition_rationale: "The split. S3 becomes the gauge and the authoring ritual; boundary notices and the hard stop become #501. This dissolves O1, O2, O3, O8, O9 and O11 rather than mitigating them, and ships the higher-value half first: S1 shipped a template no path authors, so until Tune exists the pact file does not exist and every other sentinel is permanently in observe-only."
   - id: O11
     category: risk
     severity: medium
     claim: "Nothing states that ~/.claude/mast/ is created only for a human who declared a budget, repeating the silent-creation asymmetry sentinel-design records as the mistake that prompted the carve-out's fourth condition."
     evidence: "Section 7.2 B5 promises silence on stdout, not abstention on the filesystem. None of T1-T5 asserts the store is not created. sentinel-design: 'the registry was going to be created for every user silently. That asymmetry was backwards.' The fix is the self-gate reservoir-check.sh already uses: check the opt-in first, exit 0 before touching anything."
-    disposition: pending
-    disposition_rationale: null
+    disposition: deferred
+    disposition_rationale: "Dissolved for S3 by the split and carried to #501. S3 creates no store. The issue carries the fix: self-gate on a declared block and exit 0 before touching the filesystem, as reservoir-check.sh does."
 ---
 
 # Objection record — Cadence Sentinels S3: The Mast (spec mode)

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
@@ -1,15 +1,17 @@
 # Spec: Cadence Sentinels S3 — The Mast
 
-**Status:** Approved (revision 2, post-diaboli)
+**Status:** Approved (revision 3, post-cartographer)
 **Date:** 2026-08-10
 **Issue:** #493
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
 **Objections:** `docs/superpowers/objections/cadence-sentinels-s3-mast-design.md`
 — 11 objections, 4 accepted, 7 deferred to #501
+**Choice stories:** `docs/superpowers/stories/cadence-sentinels-s3-mast-design.md`
+— 8 stories, all accepted
 **Depends on:** S1 (#491, 0.67.0) — the pact file and `pact-blocks.sh`. **Not
 S2.** This slice touches no Coda file and needs none.
-**Scope:** `ai-literacy-superpowers` plugin; one agent, one skill, one command.
-No hook, no session state, no new store.
+**Scope:** `ai-literacy-superpowers` plugin; one agent, one skill, one command,
+and a write-side library. No hook, no session state, no new store.
 **Explicitly out of scope:** boundary notices and the hard stop, which are
 **#501** (see §3); the WIP Warden (S4); the Convener (S5).
 
@@ -25,9 +27,10 @@ you are about to breach it does not — you will simply move it, because the
 thing you want at 18:00 is to keep working.
 
 That is why the pact file exists, and why S1 refused to scaffold one: an
-imposed default is not a pact. But a pact nobody reads is also not a pact. The
-Mast is what reads it, tells you where you are against it, and — once, at the
-line — offers you the ritual for stopping.
+imposed default is not a pact. But a pact nobody reads is also not a pact, and
+a pact nobody has authored is not one either.
+
+The Mast is what brings a pact into existence, and what reads it back to you.
 
 **Epithet:** *the pact-keeper.* **Attacks:** outsourced governance — the drift
 where the decision about when to stop migrates from a person who decided it in
@@ -201,42 +204,126 @@ nothing in this plugin can.
 | --- | --- |
 | `agents/mast.agent.md` | `role: sentinel`, read-only — reads the pact, reports consumption with flags |
 | `skills/mast/SKILL.md` | the two modes, the clear-weather rule and its honest limits, the anti-patterns |
-| `commands/mast.md` | Read dispatches the agent; Tune walks the dialogue and writes the pact file |
+| `commands/mast.md` | Read dispatches the agent; Tune walks the dialogue and calls the writer |
+| `hooks/scripts/lib/pact-write.sh` | the write surface — composes and replaces a block |
 
-No hook. No library. No session state. Nothing outside `~/.claude/pacts.md` is
-written, and that file is written only by Tune, only after the human has
-confirmed each value.
+No hook. No session state. Nothing outside `~/.claude/pacts.md` is written.
+
+**Why a library and not prose.** The first revision of this slice shipped no
+shell at all, and the write path was six numbered rules for a model to follow.
+That did not survive contact with §7: T1–T7 are Layer-0 deterministic
+scenarios, and there is nothing deterministic to test when the writer is prose
+in a command file. Either the round-trip tests were not real or the writer was.
+
+`lib/pact-write.sh` is **sourceable by commands and hooks only**, matching the
+split S1 made for the registry and the rule `sentinel-design` promoted from it:
+a read surface a sentinel may source, a write surface it may not. The `mast`
+agent never sources it and never writes.
 
 **The agent holds no `Write`.** Tune's write is the command's — the
 `cost-estimator` precedent, and the same split S2 used.
 
-## 5. What Tune Writes
+## 5. Tune: the Ritual and the Writer
 
 Tune is the only sanctioned authoring path, and revision 1 never said what it
-produces (O7). That gap mattered more than it looks: **Tune is the one
-component in this epic that *produces* the pact file, and its output is the
-input to every other sentinel.** Everything else degrades safely when the file
-is wrong; Tune is what makes it wrong.
+produces (O7). That gap mattered: **Tune is the one component in this epic that
+*produces* the pact file, and its output is the input to every other sentinel.**
+Everything else degrades safely when the file is wrong; Tune is what makes it
+wrong.
 
-The rules:
+### 5.1 It is an editor, not only an author
 
-1. **Emit the mandatory clause for every block written.** `Budgets` carries
-   *Unspent budget is not a debt.*; `Session WIP` carries *This is a gate on
-   sessions, never on the person. It counts; it does not assess.* Without them
-   `block_state` returns `malformed` and every consumer — including the Mast
-   itself — drops to observe-only, with no line telling the human which
-   sentence is missing.
-2. **Emit the reserved marker** in `Sync cadence`, and say the block is
-   reserved *before* asking about it, so nobody declares values believing
-   something reads them.
-3. **Rewrite a block in place; never append.** `_block_span` exits at the next
-   known heading, so a second `## Budgets` appended to the file is silently
-   unread and the newly tuned values are invisible.
-4. **Stamp `authored_at` (today) and `authored_via: tune`**, and say so.
-5. **Propose nothing as a default.** Ask. The template's numbers are
-   illustrations, not suggestions — a value accepted because it was pre-filled
-   is not one the human authored, and authorship is the active ingredient.
-6. **Every block is skippable.** An undeclared block is not an incomplete pact.
+`/mast tune` reads the current pact first and asks each question **with the
+human's existing value as context** — "your line is 18:30; what should it be?"
+
+That is not a proposed default. Nothing is pre-filled by the plugin, and what
+is shown is the human's own prior authorship rather than the template's
+illustration. The distinction matters because the alternative is worse: without
+it, the only sanctioned way to move one number is to re-run the whole ritual,
+and the cheapest path to a small edit becomes opening the file in an editor —
+the channel §2.2 says the weather check cannot see. A pact is meant to be
+revised in clear weather, so the honest revision path must be cheaper than the
+dishonest one.
+
+`/mast tune budgets` scopes the ritual to one block. `/reservoir tune`, the
+mirror §2 names, already works this way.
+
+### 5.2 The stop hour first
+
+The dialogue asks `hard_stop_hour` **first**, and then offers to stop there.
+
+A complete, useful two-line pact is reachable in one question. The remaining
+keys are offered rather than marched through — a person asked cold for
+`max_switches_per_hour` has no basis for an answer, and a number invented to
+move the dialogue along is not more authored than one they declined to give.
+
+This does not weaken rule 5 below. It pays down its cost: a blank field
+maximises freedom and minimises completion, and the only cheap exit the first
+revision offered was skipping a whole block — which produces `absent`, which
+returns the human to observe-only, which is the state this epic exists to move
+them out of.
+
+### 5.3 It says what nothing reads yet
+
+Before asking about any key no consumer reads today, Tune says so:
+
+- `Sync cadence` — reserved entirely.
+- `Session WIP` — only `stale_after_hours` is read today (by S1's registry
+  lease). `max_concurrent_sessions`, `max_switches_per_hour` and `enforcement`
+  wait for S4.
+- `notification_policy_after_stop` — declared intent at the Unverified rung;
+  nothing in this plugin enforces it.
+- `daily_cost_ceiling` — declared, never checkable (§2.1).
+
+Revision 1 disclosed this for `Sync cadence` alone, because that is the block
+S1 happened to give a reserved marker. But the property that triggers
+disclosure — a declaration nothing reads — belongs to *keys at a point in
+time*, not to blocks. A human authoring their first pact would otherwise have
+been working under two regimes without being told there were two.
+
+### 5.4 It composes, shows, and then writes
+
+Tune builds the block from the answers, **shows it**, and takes accept / edit /
+abort before anything is written.
+
+Per-value confirmation is not enough on its own. The parts of the file the human
+did not author — the mandatory clause, the reserved marker, `authored_at`,
+`authored_via` — are exactly the parts that decide whether the block reads as
+`declared`, and without a composed preview they land unseen. This is also what
+makes Tune an instance of the agent-emit / dispatcher-persist / human-disposes
+architecture rather than a citation of its tool split: there is now a point at
+which the whole pact can be refused.
+
+### 5.5 What the writer guarantees
+
+`lib/pact-write.sh` exposes `pact_write_block <heading> <body-file>`:
+
+1. **Derives the mandatory clause and the reserved marker from
+   `templates/pacts.md`**, never from a copy. A restated clause agrees with
+   `pact-blocks.sh` only by coincidence of wording; the promoted decision is
+   that harness artefacts derive from the source of truth rather than pinning a
+   copy of it.
+2. **Replaces a block in place; never appends.** `_block_span` exits at the
+   next known heading, so a second `## Budgets` is silently unread and the
+   newly tuned values are invisible.
+3. **Stamps `authored_at` and `authored_via: tune` on `Budgets` only**, where
+   S1's grammar defines them. Revision 1 stamped every block written, extending
+   two blocks S3 does not own — and leaving "when was this pact authored" a
+   per-block fact with no rule for combining them.
+4. **Preserves everything outside the block it is replacing**, including the
+   template's editing guidance.
+
+### 5.6 The validation checkpoint
+
+After writing, Tune reads the block back, asserts `block_state` returns
+`declared`, and fixes in place.
+
+This is not optional politeness. `CLAUDE.md` requires a validation checkpoint of
+**every command that produces structured output parsed by downstream
+consumers**, and `/mast tune` produces the file `pact-blocks.sh` parses.
+`/reservoir tune` carries one. Its absence from revision 1 was a convention
+violation, and it is the one guard that catches a malformed write at the moment
+it happens rather than the next time a sentinel silently degrades.
 
 ## 6. Non-Goals
 
@@ -256,7 +343,11 @@ The rules:
 Prefixed **W** for the weather check and read honesty, **T** for Tune's output,
 and **A** for agent-verified behaviour.
 
-### 7.1 Read honesty — `tdad_tests/layer0_deterministic/test-mast-read.sh`
+### 7.1 Read honesty — agent-verified, pinned by the TDAD scenario
+
+Read mode is a dispatched agent, so its honesty is verified structurally
+(the flags it must carry, the things it must refuse) rather than by a Layer-0
+script. The W scenarios below are assertions about the skill and agent files.
 
 - **W1 — a budget tuned today is noted**, flagged `observed`, with the note
   saying the pact has not been lived with yet.
@@ -274,12 +365,15 @@ and **A** for agent-verified behaviour.
 - **W8 — a malformed `Budgets` block also degrades**, and names the missing
   clause rather than only reporting malformed.
 
-### 7.2 Tune's output — `tdad_tests/layer0_deterministic/test-mast-tune.sh`
+### 7.2 The writer — `tdad_tests/layer0_deterministic/test-pact-write.sh`
 
-The scenario revision 1 lacked, and the most valuable in the slice.
+The scenarios revision 1 lacked, and the most valuable in the slice. They are
+deterministic because §4 ships a writer; against a prose-only Tune none of them
+could exist.
 
-- **T1 — Tune's output reads as `declared`.** A file written by Tune, run
-  through `block_state`, returns `declared` for every block it wrote.
+- **T1 — the writer's output reads as `declared`.** A block written by
+  `pact_write_block`, run through `block_state`, returns `declared`. This is
+  the round trip that makes the reader and the writer one contract.
 - **T2 — the mandatory clauses are present** in every block written.
 - **T3 — the reserved marker is present** when `Sync cadence` is written.
 - **T4 — a skipped block is absent, not empty.** `block_state` returns
@@ -287,7 +381,13 @@ The scenario revision 1 lacked, and the most valuable in the slice.
 - **T5 — a second run rewrites in place.** After tuning `Budgets` twice, the
   file contains exactly one `## Budgets` heading and `block_key` returns the
   second run's value.
-- **T6 — `authored_at` and `authored_via` are stamped** on every block written.
+- **T6 — the stamps land on `Budgets` only**, where S1's grammar defines them,
+  and on no other block.
+- **T8 — content outside the replaced block survives**, including the
+  template's editing guidance and any other declared block.
+- **T9 — the clause is derived, not restated.** Changing the clause in
+  `templates/pacts.md` changes what the writer emits, with no edit to the
+  writer.
 - **T7 — values with colons and spaces survive the round trip.**
   `hard_stop_hour: 18:30` and `focus_blocks: 09:00-12:00, 14:00-17:00` read
   back whole through `block_key` — the S1 regression, now reachable from the

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
@@ -1,0 +1,312 @@
+# Spec: Cadence Sentinels S3 — The Mast
+
+**Status:** Approved (revision 1)
+**Date:** 2026-08-10
+**Issue:** #493
+**Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
+**Depends on:** S1 (#491, 0.67.0) — the pact file and `pact-blocks.sh`;
+S2 (#492, 0.68.0) — the Coda, which the reached notice recommends and which
+carries the Mast's override to the record
+**Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, hook,
+and a session-scoped note store
+**Explicitly out of scope:** the WIP Warden (S4) and the Convener (S5).
+
+**Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
+*Compulsive Continuation — A Research Exploration*.
+
+---
+
+## 1. Problem Statement
+
+A limit you set for yourself in advance holds. A limit you set in the moment
+you are about to breach it does not — you will simply move it, because the
+thing you want at 18:00 is to keep working.
+
+That is why the pact file exists, and why S1 refused to scaffold one: an
+imposed default is not a pact. But a pact nobody reads is also not a pact. The
+Mast is what reads it, tells you where you are against it, and — once, at the
+line — offers you the ritual for stopping.
+
+**Epithet:** *the pact-keeper.* **Attacks:** outsourced governance — the drift
+where the decision about when to stop migrates from a person who decided it in
+advance to a person who is tired and mid-thought.
+
+It feeds the Coda. It never stops anything itself.
+
+## 2. Two Modes, Mirroring `/reservoir`
+
+| Mode | Does |
+| --- | --- |
+| `/mast` (default `read`) | reports consumption against the declared `Budgets` block |
+| `/mast tune` | the **only** sanctioned authoring path for the pact file |
+
+### 2.1 Read mode, and what is honestly observable
+
+Most of a budget is not observable, and saying so is the whole job.
+
+| Key | Flag | Why |
+| --- | --- | --- |
+| `hard_stop_hour` | `observed` | wall clock |
+| `focus_blocks` | `observed` | wall clock |
+| `sessions_per_day` | `inferred` | the registry holds *live* sessions, not a day's history — see below |
+| `daily_cost_ceiling` | **`asked`**, or *not observable* | nothing in this plugin can see spend |
+
+`sessions_per_day` deserves its own sentence. S1's registry is a lease over
+*currently live* sessions; it is not a log and has no day's history in it.
+Counting today's sessions from it is possible only for those still within their
+lease, so the Mast reports it `inferred` and says what it could not see. It
+does **not** reconstruct a day's count and present it as fact.
+
+`daily_cost_ceiling` is the sharper case. Nothing in this plugin observes
+spend. The pact template already blesses the literal `not observable` as a
+valid value, and the Mast honours that: it will report what the human declared
+and what it cannot check, and it will **refuse to estimate**. A fabricated
+spend figure against a real ceiling is the worst possible output — it would
+make a person stop, or not stop, on a number nobody measured.
+
+### 2.2 The weather check
+
+Tune stamps `authored_at`. Read mode notes when a budget was authored **on the
+day it is being enforced**:
+
+> This budget was authored today. A limit set in the weather it governs is not
+> the pact the clear-weather rule relies on — worth knowing, not a reason to
+> stop.
+> *(observed: `authored_at` is today)*
+
+**This is the clear-weather rule's actual mechanism**, and it replaces the one
+the build spec specified.
+
+The build spec called for "a critic check that flags `Budgets` diffs lacking a
+same-change `authored_via: tune` update". That is impossible here:
+`~/.claude/pacts.md` lives outside every work tree and is never committed, so
+there is no diff and no CI can see the file. **Flagged for the PR** — it is a
+direct consequence of S1's user-scoped pact decision.
+
+The replacement is better aimed. The failure mode the rule exists to catch is
+not hand-editing in general — a calm Tuesday-morning tweak is exactly the
+deliberate authorship the rule wants. It is *editing the limit in the weather
+it governs*: raising `hard_stop_hour` at 18:00 because you want to keep going.
+An `authored_at` of today, read at enforcement time, catches that and nothing
+else.
+
+It is a **note, never a gate**. The Mast reports it and continues. A sentinel
+that refused to honour a pact because it was authored recently would be
+second-guessing the person it serves.
+
+### 2.3 Tune mode: one authoring ritual for all three blocks
+
+Tune walks `Budgets`, `Session WIP`, and the reserved `Sync cadence`, and
+**creates `~/.claude/pacts.md`** if it does not exist — S1 assigned that here
+and nothing else in the epic writes the file.
+
+Three rules govern the dialogue:
+
+1. **It proposes nothing as a default.** It asks. Authorship is the active
+   ingredient; a value the human accepted because it was pre-filled is not one
+   they authored. The template's numbers are illustrations, not suggestions.
+2. **Every block is skippable.** A human who wants only a stop hour gets only a
+   `Budgets` block. An undeclared block is not an incomplete pact.
+3. **It stamps `authored_at` (today) and `authored_via: tune`**, and says it is
+   doing so and why.
+
+For `Sync cadence` it says plainly that the block is reserved and inert before
+asking, so nobody declares values believing something reads them.
+
+Tune is the only path that writes the file. That is a convention, not an
+enforced boundary — the file is the human's and they may edit it with any
+editor they like. §2.2 is what notices when the timing of that edit matters.
+
+## 3. Boundary Notices
+
+Two, each firing **at most once per session**.
+
+| Notice | When | Says |
+| --- | --- | --- |
+| **approaching** | at 80% of the way from session start to the line | where you are, and what the line is |
+| **reached** | at the line | one recommendation: invoke the Coda |
+
+**One recommendation, once.** No repeats, no escalation, no second notice ten
+minutes later. Ambient reminders are ignored and then resented; a single
+boundary-moment reality check is the thing with evidence behind it.
+
+<!-- evidence: boundary-moment reality checks improve adherence where ambient
+     reminders do not. The mechanism is a prompt at the decision point, not
+     accumulated pressure — which is why repeating it would not make it work
+     better, it would make it work worse. -->
+
+Notices ride the `Stop` hook, so they arrive between turns rather than
+interrupting one. Both are `{"systemMessage": ...}` advisories: they never
+block, never exit non-zero, and never require a disposition.
+
+### 3.1 The hard stop
+
+When `hard_stop_hour` passes during a live session, the Mast raises the reached
+notice and offers `/coda`.
+
+**It does not kill the session.** It cannot, and it should not be able to. The
+disposition is the human's.
+
+If they continue, that is recorded — see §4 — as a fact about the session:
+
+```text
+observed: continued past the 20:00 stop by choice
+```
+
+Never a judgement, never an explanation, never a count of how often. That a
+session ran past a declared line is a fact about the session; *why* is not the
+Mast's business and is not recorded.
+
+### 3.2 `notification_policy_after_stop` is declared intent
+
+It ships at the **Unverified** rung and is documented as such. Push and digest
+behaviour is platform-side and outside this plugin's reach; the block records
+the pact so a platform hook can honour it where one exists. The Mast reads it,
+reports it, and enforces nothing.
+
+## 4. Session Notes: Where the Override Lives
+
+Constraint 6 requires an on-the-record override. The override happens at 18:31,
+mid-session — and `/reflect`, the path to the record, runs a full
+branch-PR-merge cycle (S2 §2). Triggering a PR round-trip to record "I chose to
+keep working" would be absurd.
+
+**So the Mast writes a session-scoped note, and the Coda carries it to the
+record at close** — the moment `/reflect` runs anyway.
+
+```text
+~/.claude/mast/<sanitised-session-id>.notes
+```
+
+One line per event, append-only within the session:
+
+```text
+2026-08-10T20:00:00Z reached hard_stop_hour=20:00
+2026-08-10T20:00:00Z continued past the 20:00 stop by choice
+```
+
+The Coda's survey reads these and includes them in the `Closed` field. The note
+file is **removed once consumed**, which is what bounds it.
+
+### 4.1 This is a third operational-state artefact, and it is evaluated as one
+
+`sentinel-design`'s carve-out permits hook-authored operational state only when
+all four conditions hold. S2's choice story #7 established that a consumer must
+not park a new file class in another slice's directory and inherit its location
+guarantees without its retention contract — so this store is the Mast's own,
+and the conditions are checked here rather than assumed:
+
+| Condition | How it holds |
+| --- | --- |
+| **Local, never committed** | `~/.claude/mast/`, outside every work tree |
+| **Bounded** | removed when the Coda consumes it; lease-pruned otherwise, on the same `Stop` rail |
+| **Nothing in it judges** | facts about the session — a notice fired, a line was passed. No assessment, no counts across sessions |
+| **Disclosed and declinable** | `reference/hooks.md` states what it holds, how long, and how to switch the hook off |
+
+The notes file also carries the once-per-session notice state, so one mechanism
+serves both and no second store is invented.
+
+## 5. Files
+
+| File | Purpose |
+| --- | --- |
+| `agents/mast.agent.md` | `role: sentinel`, read-only — reads the pact, reports consumption with flags |
+| `skills/mast/SKILL.md` | the two modes, the clear-weather rule, the notice discipline, the anti-patterns |
+| `commands/mast.md` | Read dispatches the agent; Tune walks the authoring dialogue and writes the pact file |
+| `hooks/scripts/mast-boundary-check.sh` | `Stop` — fires the two notices, writes session notes, prunes |
+| `hooks/scripts/lib/mast-notes.sh` | the note store: append, read, consume, prune |
+
+**The agent holds no `Write`.** Tune's file write is done by the command, after
+the human has confirmed each value — the `cost-estimator` precedent, and the
+same split S2 used.
+
+## 6. Non-Goals
+
+- **No changes to the Reservoir Warden.** Constraint 5. The Warden recommends
+  deciding a stop; whether the human then runs `/coda` is their own move,
+  mediated by no artefact — the disposition S2 recorded, unchanged.
+- **No blocking.** Nothing here can end a session, and nothing requires a
+  disposition.
+- **No spend estimation, ever.** If cost is not observable, the Mast says so.
+- **No repeats.** One approaching notice and one reached notice per session.
+- **No count of overrides across sessions.** A note is consumed at close and
+  gone. Aggregating them would be a record of how often someone works late,
+  which is the second persistence category, not the third.
+- **No enforcement of `notification_policy_after_stop`.**
+- **No statusline work.** If a statusline surface exists, contributing to it is
+  future work; Read mode is the gauge.
+
+## 7. Acceptance Scenarios (TDAD)
+
+Prefixed **W** for the weather check, **B** for boundary notices, **T** for the
+note store, and **A** for agent-verified behaviour.
+
+### 7.1 Weather check and read honesty — `test-mast-read.sh`
+
+- **W1 — a budget authored today is noted.** Given `authored_at` equal to
+  today, the read output carries the weather note flagged `observed`.
+- **W2 — a budget authored earlier is not noted.** Given `authored_at`
+  yesterday or before, no weather note appears.
+- **W3 — the note is not a gate.** The weather note never changes an exit code
+  and never suppresses the rest of the report.
+- **W4 — spend is never estimated.** Given `daily_cost_ceiling` declared and no
+  observable spend, the output says it cannot be checked and contains no
+  number presented as spend.
+- **W5 — `sessions_per_day` is flagged `inferred`**, with a statement of what
+  could not be seen.
+- **W6 — an absent `Budgets` block degrades to observe-only**, using the S1
+  fixed sentence, exit 0.
+- **W7 — a malformed `Budgets` block also degrades**, never gates.
+
+### 7.2 Boundary notices — `test-mast-boundary.sh`
+
+- **B1 — approaching fires once.** At 80%, the notice appears; a second run in
+  the same session is silent.
+- **B2 — reached fires once**, and recommends `/coda` exactly once.
+- **B3 — reached does not repeat after an override.** Once the human has
+  continued, no further notice fires for that line this session.
+- **B4 — before the fraction, silence.**
+- **B5 — no `Budgets` block, silence.** Not a note, not an observe-only line —
+  a hook with nothing to say says nothing.
+- **B6 — exits 0 unconditionally**, including with an unwritable note store and
+  `HOME` unset.
+- **B7 — the hard stop never blocks.** The hook's output is a `systemMessage`
+  advisory and its exit status is 0 in every path.
+
+### 7.3 Note store — `test-mast-notes.sh`
+
+- **T1 — append and read round-trip.**
+- **T2 — consume removes the file.**
+- **T3 — a stale note file is pruned** past its lease.
+- **T4 — notes never leave the store directory.** A hostile session id
+  sanitises to `unknown`, as S1 established for the same field.
+- **T5 — the store holds no cross-session aggregate.** Reading notes for one
+  session returns only that session's lines.
+
+### 7.4 Agent-verified
+
+- **A1** — Read mode reports every key with its flag and never presents an
+  unobservable value as observed.
+- **A2** — Tune proposes no defaults; every value is asked for.
+- **A3** — Tune stamps `authored_at` and `authored_via: tune` and says so.
+- **A4** — Tune states that `Sync cadence` is reserved before asking about it.
+- **A5** — every block is skippable.
+- **A6** — the agent writes no file; Tune's write is the command's.
+
+## 8. Migration & Rollout
+
+Minor bump, 0.68.0 → 0.69.0.
+
+Version locations: the five CI-checked ones, the README plugin-table cell, and
+the README count badges, anchors, and section headings — 38 skills → 39,
+17 agents → 18, 29 commands → 30. A Layer 1 test asserts the badge matches the
+real directory count.
+
+New components need a TDAD scenario each under `tdad_tests/scenarios/`.
+
+Docs, same PR: a how-to for keeping a pact, reference entries on all three
+component pages, the hook and the note store in `reference/hooks.md`, the
+weather check in `reference/pacts-format.md`, and the sentinels roster 6 → 7.
+
+No breaking changes. The pact file's schema is unchanged; the Mast reads what
+S1 defined and writes it only through Tune.

--- a/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
@@ -1,15 +1,17 @@
 # Spec: Cadence Sentinels S3 — The Mast
 
-**Status:** Approved (revision 1)
+**Status:** Approved (revision 2, post-diaboli)
 **Date:** 2026-08-10
 **Issue:** #493
 **Epic:** The Cadence Sentinels (S1–S7, issues #491–#497)
-**Depends on:** S1 (#491, 0.67.0) — the pact file and `pact-blocks.sh`;
-S2 (#492, 0.68.0) — the Coda, which the reached notice recommends and which
-carries the Mast's override to the record
-**Scope:** `ai-literacy-superpowers` plugin; one agent, skill, command, hook,
-and a session-scoped note store
-**Explicitly out of scope:** the WIP Warden (S4) and the Convener (S5).
+**Objections:** `docs/superpowers/objections/cadence-sentinels-s3-mast-design.md`
+— 11 objections, 4 accepted, 7 deferred to #501
+**Depends on:** S1 (#491, 0.67.0) — the pact file and `pact-blocks.sh`. **Not
+S2.** This slice touches no Coda file and needs none.
+**Scope:** `ai-literacy-superpowers` plugin; one agent, one skill, one command.
+No hook, no session state, no new store.
+**Explicitly out of scope:** boundary notices and the hard stop, which are
+**#501** (see §3); the WIP Warden (S4); the Convener (S5).
 
 **Provenance:** *The Second Front — Arc Insertion Remit* (slide S5) and
 *Compulsive Continuation — A Research Exploration*.
@@ -31,7 +33,20 @@ line — offers you the ritual for stopping.
 where the decision about when to stop migrates from a person who decided it in
 advance to a person who is tired and mid-thought.
 
-It feeds the Coda. It never stops anything itself.
+It never stops anything itself.
+
+**What this slice is, after the split.** S3 ships the **gauge and the authoring
+ritual** — `/mast` reads your pact and tells you where you stand against it;
+`/mast tune` is how the pact comes to exist at all. Everything that *speaks at
+the boundary* — the approaching and reached notices, the hard-stop trigger, and
+the override record — is **#501**.
+
+The split was made at the spec gate because six of eleven objections, including
+both criticals, were consequences of one decision: that the Mast writes session
+state another slice must consume. Removing that half dissolved them rather than
+mitigating them. It also ships the higher-value half first — S1 shipped a
+template that no path authors, so **until Tune exists the pact file does not
+exist and every other sentinel in this epic is permanently in observe-only.**
 
 ## 2. Two Modes, Mirroring `/reservoir`
 
@@ -46,10 +61,25 @@ Most of a budget is not observable, and saying so is the whole job.
 
 | Key | Flag | Why |
 | --- | --- | --- |
-| `hard_stop_hour` | `observed` | wall clock |
-| `focus_blocks` | `observed` | wall clock |
-| `sessions_per_day` | `inferred` | the registry holds *live* sessions, not a day's history — see below |
-| `daily_cost_ceiling` | **`asked`**, or *not observable* | nothing in this plugin can see spend |
+| `hard_stop_hour` | `observed` | the wall clock is either past it or not |
+| `focus_blocks` | `inferred` | the clock being inside a block is observed; that you *spent* it working is not |
+| `sessions_per_day` | `inferred` | the registry holds *live* sessions, not a day's history |
+| `daily_cost_ceiling` | **not observable** | nothing in this plugin can see spend |
+
+Two of these were wrong in the first revision and are corrected here (O6).
+
+`focus_blocks` was flagged `observed` on the reasoning that a focus block is a
+clock range. But "consumption against a focus block" is not *is the clock
+inside it* — it is *did you spend it working*, which needs exactly the day's
+history the next row says the registry lacks. The same sentence disqualifies
+both; it had been applied to only one.
+
+`daily_cost_ceiling` was flagged `asked`, which describes an act that does not
+happen. Reporting a declared ceiling back is reading a pact, not asking a
+question — `asked` means the human was asked and answered, as S1 and S2 both
+use it. An unearned flag would have left an implementer to invent the question,
+and the plausible invention is asking what someone spent today, which nothing
+authorises.
 
 `sessions_per_day` deserves its own sentence. S1's registry is a lease over
 *currently live* sessions; it is not a log and has no day's history in it.
@@ -57,42 +87,61 @@ Counting today's sessions from it is possible only for those still within their
 lease, so the Mast reports it `inferred` and says what it could not see. It
 does **not** reconstruct a day's count and present it as fact.
 
-`daily_cost_ceiling` is the sharper case. Nothing in this plugin observes
-spend. The pact template already blesses the literal `not observable` as a
-valid value, and the Mast honours that: it will report what the human declared
-and what it cannot check, and it will **refuse to estimate**. A fabricated
-spend figure against a real ceiling is the worst possible output — it would
-make a person stop, or not stop, on a number nobody measured.
+On cost specifically: nothing in this plugin observes spend. The pact template
+already blesses the literal `not observable` as a valid value, and the Mast
+honours it — reporting what the human declared and what it cannot check, and
+**refusing to estimate**. A fabricated spend figure against a real ceiling is
+the worst possible output: it would make a person stop, or not stop, on a
+number nobody measured.
 
-### 2.2 The weather check
+### 2.2 The weather check, and exactly what it sees
 
-Tune stamps `authored_at`. Read mode notes when a budget was authored **on the
-day it is being enforced**:
+Tune stamps `authored_at`. Read mode notes when the budget it is reading was
+**tuned today**:
 
-> This budget was authored today. A limit set in the weather it governs is not
-> the pact the clear-weather rule relies on — worth knowing, not a reason to
-> stop.
+> This budget was tuned today, so it has not been lived with yet. Worth knowing
+> when it asks something of you tonight.
 > *(observed: `authored_at` is today)*
+> *(A pact edited outside `/mast tune` is not visible to this check.)*
 
-**This is the clear-weather rule's actual mechanism**, and it replaces the one
-the build spec specified.
+**What it detects, stated honestly.** It detects a budget *tuned* today. That
+is a true and useful thing to say — a pact authored hours ago has not yet
+survived contact with a day, and knowing that is worth a line when it asks
+something of you.
 
-The build spec called for "a critic check that flags `Budgets` diffs lacking a
-same-change `authored_via: tune` update". That is impossible here:
-`~/.claude/pacts.md` lives outside every work tree and is never committed, so
-there is no diff and no CI can see the file. **Flagged for the PR** — it is a
-direct consequence of S1's user-scoped pact decision.
+**What it does not detect: weather-editing.** Revision 1 claimed this check
+caught "raising `hard_stop_hour` at 18:00 because you want to keep going… and
+nothing else". That was exactly backwards (O5). `authored_at` moves only when
+Tune writes it, so:
 
-The replacement is better aimed. The failure mode the rule exists to catch is
-not hand-editing in general — a calm Tuesday-morning tweak is exactly the
-deliberate authorship the rule wants. It is *editing the limit in the weather
-it governs*: raising `hard_stop_hour` at 18:00 because you want to keep going.
-An `authored_at` of today, read at enforcement time, catches that and nothing
-else.
+| The human does | `authored_at` | Note fires |
+| --- | --- | --- |
+| Hand-edits the stop hour at 18:00 | unchanged | **no** |
+| Runs `/mast tune` on a calm Tuesday morning | today | **yes**, that evening |
 
-It is a **note, never a gate**. The Mast reports it and continues. A sentinel
-that refused to honour a pact because it was authored recently would be
-second-guessing the person it serves.
+It fires on the honest path and stays silent on the dishonest one. A check that
+claims coverage it does not have is worse than one that claims none, because
+the human learns to read its silence as an all-clear.
+
+So the note says what it sees, and the reference page and the skill both carry
+the blind spot in the same words. A hand-edit is invisible to this check and
+always will be — the pact file is the human's, outside every work tree, and
+nothing watches it.
+
+**Why not something stronger.** The build spec called for "a critic check that
+flags `Budgets` diffs lacking a same-change `authored_via: tune` update". That
+is impossible here: `~/.claude/pacts.md` is never committed, so there is no
+diff and no CI can see the file. **Flagged for the PR** — a direct consequence
+of S1's user-scoped pact decision. Checksumming the block would detect
+hand-edits, but it would flag the calm Tuesday tweak too, which §2.2's own
+reasoning says is the authorship the rule *wants*.
+
+The honest position is a note with a disclosed blind spot, at the **Unverified**
+rung, rather than a check that overclaims. That is the same call §2.1 makes
+about spend, for the same reason.
+
+It is a **note, never a gate**. A sentinel that refused to honour a pact because
+it was authored recently would be second-guessing the person it serves.
 
 ### 2.3 Tune mode: one authoring ritual for all three blocks
 
@@ -100,198 +149,159 @@ Tune walks `Budgets`, `Session WIP`, and the reserved `Sync cadence`, and
 **creates `~/.claude/pacts.md`** if it does not exist — S1 assigned that here
 and nothing else in the epic writes the file.
 
-Three rules govern the dialogue:
+The dialogue's rules and the exact shape of what it writes are §5 — that
+section exists because revision 1 specified the ritual and never said what it
+produced, which is the highest-consequence gap the gate found (O7).
 
-1. **It proposes nothing as a default.** It asks. Authorship is the active
-   ingredient; a value the human accepted because it was pre-filled is not one
-   they authored. The template's numbers are illustrations, not suggestions.
-2. **Every block is skippable.** A human who wants only a stop hour gets only a
-   `Budgets` block. An undeclared block is not an incomplete pact.
-3. **It stamps `authored_at` (today) and `authored_via: tune`**, and says it is
-   doing so and why.
+Tune is the only path that writes the file. That is a **convention, not an
+enforced boundary** — the file is the human's and they may edit it with any
+editor they like, and nothing in this plugin will know. §2.2 says plainly what
+that costs the weather check.
 
-For `Sync cadence` it says plainly that the block is reserved and inert before
-asking, so nobody declares values believing something reads them.
+## 3. Boundary Notices Are Not In This Slice
 
-Tune is the only path that writes the file. That is a convention, not an
-enforced boundary — the file is the human's and they may edit it with any
-editor they like. §2.2 is what notices when the timing of that edit matters.
+The approaching notice, the reached notice, the hard-stop trigger, and the
+override record are **#501**.
 
-## 3. Boundary Notices
+They were specified here in revision 1 and moved out at the spec gate. The
+reason is worth recording, because it is the same shape three times: each of
+those mechanisms required the Mast to *write session state that another slice
+must consume*, and every one of the slice's structural problems followed from
+it.
 
-Two, each firing **at most once per session**.
+- The override needed the Coda's survey and its `Closed` field — a contract S2
+  owns and shipped, which knows nothing of notes.
+- The note store bundled `append, read, consume, prune` in one library a
+  `role: sentinel` agent had to reach, re-opening the channel S1 split two
+  libraries to close.
+- The once-per-session guarantee lived in the file that consumption deletes.
+- Two stop advisories could land on the same turn, since a declared `lark`
+  enters the Reservoir Warden's suboptimal band at hour ≥ 20.
 
-| Notice | When | Says |
-| --- | --- | --- |
-| **approaching** | at 80% of the way from session start to the line | where you are, and what the line is |
-| **reached** | at the line | one recommendation: invoke the Coda |
+None of that is wrong to build. It is wrong to build *here*, alongside a file
+reader, in a slice whose adversarial pass then has to be about two unrelated
+things at once.
 
-**One recommendation, once.** No repeats, no escalation, no second notice ten
-minutes later. Ambient reminders are ignored and then resented; a single
-boundary-moment reality check is the thing with evidence behind it.
+**What remains true and is carried to #501:** the notice discipline itself. One
+recommendation, once, at the boundary — no repeats, no escalation.
 
 <!-- evidence: boundary-moment reality checks improve adherence where ambient
      reminders do not. The mechanism is a prompt at the decision point, not
      accumulated pressure — which is why repeating it would not make it work
-     better, it would make it work worse. -->
+     better, it would make it work worse. Recorded here because it is the
+     reason #501 exists at all. -->
 
-Notices ride the `Stop` hook, so they arrive between turns rather than
-interrupting one. Both are `{"systemMessage": ...}` advisories: they never
-block, never exit non-zero, and never require a disposition.
+`notification_policy_after_stop` likewise stays declared intent at the
+**Unverified** rung. The Mast reads it and reports it; nothing enforces it, and
+nothing in this plugin can.
 
-### 3.1 The hard stop
-
-When `hard_stop_hour` passes during a live session, the Mast raises the reached
-notice and offers `/coda`.
-
-**It does not kill the session.** It cannot, and it should not be able to. The
-disposition is the human's.
-
-If they continue, that is recorded — see §4 — as a fact about the session:
-
-```text
-observed: continued past the 20:00 stop by choice
-```
-
-Never a judgement, never an explanation, never a count of how often. That a
-session ran past a declared line is a fact about the session; *why* is not the
-Mast's business and is not recorded.
-
-### 3.2 `notification_policy_after_stop` is declared intent
-
-It ships at the **Unverified** rung and is documented as such. Push and digest
-behaviour is platform-side and outside this plugin's reach; the block records
-the pact so a platform hook can honour it where one exists. The Mast reads it,
-reports it, and enforces nothing.
-
-## 4. Session Notes: Where the Override Lives
-
-Constraint 6 requires an on-the-record override. The override happens at 18:31,
-mid-session — and `/reflect`, the path to the record, runs a full
-branch-PR-merge cycle (S2 §2). Triggering a PR round-trip to record "I chose to
-keep working" would be absurd.
-
-**So the Mast writes a session-scoped note, and the Coda carries it to the
-record at close** — the moment `/reflect` runs anyway.
-
-```text
-~/.claude/mast/<sanitised-session-id>.notes
-```
-
-One line per event, append-only within the session:
-
-```text
-2026-08-10T20:00:00Z reached hard_stop_hour=20:00
-2026-08-10T20:00:00Z continued past the 20:00 stop by choice
-```
-
-The Coda's survey reads these and includes them in the `Closed` field. The note
-file is **removed once consumed**, which is what bounds it.
-
-### 4.1 This is a third operational-state artefact, and it is evaluated as one
-
-`sentinel-design`'s carve-out permits hook-authored operational state only when
-all four conditions hold. S2's choice story #7 established that a consumer must
-not park a new file class in another slice's directory and inherit its location
-guarantees without its retention contract — so this store is the Mast's own,
-and the conditions are checked here rather than assumed:
-
-| Condition | How it holds |
-| --- | --- |
-| **Local, never committed** | `~/.claude/mast/`, outside every work tree |
-| **Bounded** | removed when the Coda consumes it; lease-pruned otherwise, on the same `Stop` rail |
-| **Nothing in it judges** | facts about the session — a notice fired, a line was passed. No assessment, no counts across sessions |
-| **Disclosed and declinable** | `reference/hooks.md` states what it holds, how long, and how to switch the hook off |
-
-The notes file also carries the once-per-session notice state, so one mechanism
-serves both and no second store is invented.
-
-## 5. Files
+## 4. Files
 
 | File | Purpose |
 | --- | --- |
 | `agents/mast.agent.md` | `role: sentinel`, read-only — reads the pact, reports consumption with flags |
-| `skills/mast/SKILL.md` | the two modes, the clear-weather rule, the notice discipline, the anti-patterns |
-| `commands/mast.md` | Read dispatches the agent; Tune walks the authoring dialogue and writes the pact file |
-| `hooks/scripts/mast-boundary-check.sh` | `Stop` — fires the two notices, writes session notes, prunes |
-| `hooks/scripts/lib/mast-notes.sh` | the note store: append, read, consume, prune |
+| `skills/mast/SKILL.md` | the two modes, the clear-weather rule and its honest limits, the anti-patterns |
+| `commands/mast.md` | Read dispatches the agent; Tune walks the dialogue and writes the pact file |
 
-**The agent holds no `Write`.** Tune's file write is done by the command, after
-the human has confirmed each value — the `cost-estimator` precedent, and the
-same split S2 used.
+No hook. No library. No session state. Nothing outside `~/.claude/pacts.md` is
+written, and that file is written only by Tune, only after the human has
+confirmed each value.
+
+**The agent holds no `Write`.** Tune's write is the command's — the
+`cost-estimator` precedent, and the same split S2 used.
+
+## 5. What Tune Writes
+
+Tune is the only sanctioned authoring path, and revision 1 never said what it
+produces (O7). That gap mattered more than it looks: **Tune is the one
+component in this epic that *produces* the pact file, and its output is the
+input to every other sentinel.** Everything else degrades safely when the file
+is wrong; Tune is what makes it wrong.
+
+The rules:
+
+1. **Emit the mandatory clause for every block written.** `Budgets` carries
+   *Unspent budget is not a debt.*; `Session WIP` carries *This is a gate on
+   sessions, never on the person. It counts; it does not assess.* Without them
+   `block_state` returns `malformed` and every consumer — including the Mast
+   itself — drops to observe-only, with no line telling the human which
+   sentence is missing.
+2. **Emit the reserved marker** in `Sync cadence`, and say the block is
+   reserved *before* asking about it, so nobody declares values believing
+   something reads them.
+3. **Rewrite a block in place; never append.** `_block_span` exits at the next
+   known heading, so a second `## Budgets` appended to the file is silently
+   unread and the newly tuned values are invisible.
+4. **Stamp `authored_at` (today) and `authored_via: tune`**, and say so.
+5. **Propose nothing as a default.** Ask. The template's numbers are
+   illustrations, not suggestions — a value accepted because it was pre-filled
+   is not one the human authored, and authorship is the active ingredient.
+6. **Every block is skippable.** An undeclared block is not an incomplete pact.
 
 ## 6. Non-Goals
 
-- **No changes to the Reservoir Warden.** Constraint 5. The Warden recommends
-  deciding a stop; whether the human then runs `/coda` is their own move,
-  mediated by no artefact — the disposition S2 recorded, unchanged.
-- **No blocking.** Nothing here can end a session, and nothing requires a
-  disposition.
+- **No notices, no hard stop, no override record.** #501.
+- **No hook.** This slice adds nothing to the `Stop` rail.
+- **No session state and no new store.** Nothing is created under
+  `~/.claude/` except the pact file the human asked for.
+- **No changes to the Reservoir Warden.** Constraint 5. And with no notices,
+  nothing in this slice can collide with its advisory.
+- **No changes to the Coda.** This slice touches no S2 file.
+- **No blocking.** Read mode reports; the weather note is a note.
 - **No spend estimation, ever.** If cost is not observable, the Mast says so.
-- **No repeats.** One approaching notice and one reached notice per session.
-- **No count of overrides across sessions.** A note is consumed at close and
-  gone. Aggregating them would be a record of how often someone works late,
-  which is the second persistence category, not the third.
-- **No enforcement of `notification_policy_after_stop`.**
-- **No statusline work.** If a statusline surface exists, contributing to it is
-  future work; Read mode is the gauge.
+- **No statusline work.** Read mode is the gauge.
 
 ## 7. Acceptance Scenarios (TDAD)
 
-Prefixed **W** for the weather check, **B** for boundary notices, **T** for the
-note store, and **A** for agent-verified behaviour.
+Prefixed **W** for the weather check and read honesty, **T** for Tune's output,
+and **A** for agent-verified behaviour.
 
-### 7.1 Weather check and read honesty — `test-mast-read.sh`
+### 7.1 Read honesty — `tdad_tests/layer0_deterministic/test-mast-read.sh`
 
-- **W1 — a budget authored today is noted.** Given `authored_at` equal to
-  today, the read output carries the weather note flagged `observed`.
-- **W2 — a budget authored earlier is not noted.** Given `authored_at`
-  yesterday or before, no weather note appears.
-- **W3 — the note is not a gate.** The weather note never changes an exit code
-  and never suppresses the rest of the report.
-- **W4 — spend is never estimated.** Given `daily_cost_ceiling` declared and no
-  observable spend, the output says it cannot be checked and contains no
-  number presented as spend.
-- **W5 — `sessions_per_day` is flagged `inferred`**, with a statement of what
-  could not be seen.
-- **W6 — an absent `Budgets` block degrades to observe-only**, using the S1
-  fixed sentence, exit 0.
-- **W7 — a malformed `Budgets` block also degrades**, never gates.
+- **W1 — a budget tuned today is noted**, flagged `observed`, with the note
+  saying the pact has not been lived with yet.
+- **W2 — a budget tuned earlier raises no note.**
+- **W3 — the note is not a gate.** It never changes an exit code and never
+  suppresses the rest of the report.
+- **W4 — the note discloses its own blind spot.** The output states that an
+  edit made outside `/mast tune` is invisible to the check.
+- **W5 — spend is never estimated.** Given a declared `daily_cost_ceiling`, the
+  output says it cannot be checked and contains no number presented as spend.
+- **W6 — `focus_blocks` and `sessions_per_day` are flagged `inferred`**, each
+  with a statement of what could not be seen.
+- **W7 — an absent `Budgets` block degrades to observe-only** using S1's fixed
+  sentence, exit 0.
+- **W8 — a malformed `Budgets` block also degrades**, and names the missing
+  clause rather than only reporting malformed.
 
-### 7.2 Boundary notices — `test-mast-boundary.sh`
+### 7.2 Tune's output — `tdad_tests/layer0_deterministic/test-mast-tune.sh`
 
-- **B1 — approaching fires once.** At 80%, the notice appears; a second run in
-  the same session is silent.
-- **B2 — reached fires once**, and recommends `/coda` exactly once.
-- **B3 — reached does not repeat after an override.** Once the human has
-  continued, no further notice fires for that line this session.
-- **B4 — before the fraction, silence.**
-- **B5 — no `Budgets` block, silence.** Not a note, not an observe-only line —
-  a hook with nothing to say says nothing.
-- **B6 — exits 0 unconditionally**, including with an unwritable note store and
-  `HOME` unset.
-- **B7 — the hard stop never blocks.** The hook's output is a `systemMessage`
-  advisory and its exit status is 0 in every path.
+The scenario revision 1 lacked, and the most valuable in the slice.
 
-### 7.3 Note store — `test-mast-notes.sh`
+- **T1 — Tune's output reads as `declared`.** A file written by Tune, run
+  through `block_state`, returns `declared` for every block it wrote.
+- **T2 — the mandatory clauses are present** in every block written.
+- **T3 — the reserved marker is present** when `Sync cadence` is written.
+- **T4 — a skipped block is absent, not empty.** `block_state` returns
+  `absent`, and the file contains no heading for it.
+- **T5 — a second run rewrites in place.** After tuning `Budgets` twice, the
+  file contains exactly one `## Budgets` heading and `block_key` returns the
+  second run's value.
+- **T6 — `authored_at` and `authored_via` are stamped** on every block written.
+- **T7 — values with colons and spaces survive the round trip.**
+  `hard_stop_hour: 18:30` and `focus_blocks: 09:00-12:00, 14:00-17:00` read
+  back whole through `block_key` — the S1 regression, now reachable from the
+  writer's side.
 
-- **T1 — append and read round-trip.**
-- **T2 — consume removes the file.**
-- **T3 — a stale note file is pruned** past its lease.
-- **T4 — notes never leave the store directory.** A hostile session id
-  sanitises to `unknown`, as S1 established for the same field.
-- **T5 — the store holds no cross-session aggregate.** Reading notes for one
-  session returns only that session's lines.
-
-### 7.4 Agent-verified
+### 7.3 Agent-verified
 
 - **A1** — Read mode reports every key with its flag and never presents an
   unobservable value as observed.
 - **A2** — Tune proposes no defaults; every value is asked for.
-- **A3** — Tune stamps `authored_at` and `authored_via: tune` and says so.
-- **A4** — Tune states that `Sync cadence` is reserved before asking about it.
-- **A5** — every block is skippable.
-- **A6** — the agent writes no file; Tune's write is the command's.
+- **A3** — Tune states that `Sync cadence` is reserved before asking about it.
+- **A4** — every block is skippable, and skipping is offered.
+- **A5** — the agent writes no file; Tune's write is the command's.
+- **A6** — Read mode says plainly what it cannot see, rather than omitting it.
 
 ## 8. Migration & Rollout
 
@@ -302,11 +312,12 @@ the README count badges, anchors, and section headings — 38 skills → 39,
 17 agents → 18, 29 commands → 30. A Layer 1 test asserts the badge matches the
 real directory count.
 
-New components need a TDAD scenario each under `tdad_tests/scenarios/`.
+A TDAD scenario per new component under `tdad_tests/scenarios/`.
 
 Docs, same PR: a how-to for keeping a pact, reference entries on all three
-component pages, the hook and the note store in `reference/hooks.md`, the
-weather check in `reference/pacts-format.md`, and the sentinels roster 6 → 7.
+component pages, the weather check and its blind spot in
+`reference/pacts-format.md`, and the sentinels roster 6 → 7.
 
 No breaking changes. The pact file's schema is unchanged; the Mast reads what
-S1 defined and writes it only through Tune.
+S1 defined and writes it only through Tune. No hook is added, so the `Stop`
+rail is untouched.

--- a/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
@@ -390,7 +390,7 @@ declare a block, one slice later and with the authoring path now built.
 **Consequences.** The epic's unblocking event has no trigger inside the
 product. In a project that adopts the plugin and never runs the command, S1–S3
 are complete and behaviourally identical to not having shipped. Combined with
-#4's long unanchored dialogue, the two most likely outcomes for a new adopter
+story #4's long unanchored dialogue, the two most likely outcomes for a new adopter
 are "never invoked" and "invoked once and mostly skipped". And until #501 the
 gauge-and-ritual half is the whole of the Mast, so `/mast` carries a name, an
 epithet and an opening paragraph written for the version that speaks at the

--- a/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
@@ -18,7 +18,7 @@ stories:
     lens: [alternatives, consequences]
     title: A verified reader, an improvised writer
     disposition: accepted
-    disposition_rationale: "A validation checkpoint is added, and this turned out to be a convention violation rather than an option not taken: CLAUDE.md requires one of every command producing structured output that downstream consumers parse, and /mast tune produces the file pact-blocks.sh parses. After writing, Tune reads the block back, asserts block_state returns declared, and fixes in place. A write-side library is deliberately not built here — the checkpoint plus T1-T7 closes the runtime gap, and a pact-write.sh belongs with a slice that has more than one writer to serve."
+    disposition_rationale: "Both remedies adopted. The validation checkpoint is a convention violation rather than an option not taken: CLAUDE.md requires one of every command producing structured output that downstream consumers parse, and /mast tune produces the file pact-blocks.sh parses. And the write-side library IS built — lib/pact-write.sh, sourceable by commands and hooks only, matching S1's read/write split exactly. An initial disposition deferred it, which did not survive contact with implementation: T1-T7 are Layer-0 deterministic scenarios and this slice otherwise ships no shell at all, so without a writer the round-trip tests could not exist. Either the tests were not real or the library was. The library is."
   - id: 4
     lens: [forces, defaults]
     title: Asking everything, anchoring nothing

--- a/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
+++ b/docs/superpowers/stories/cadence-sentinels-s3-mast-design.md
@@ -1,0 +1,401 @@
+---
+spec: docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md
+date: 2026-08-10
+mode: spec
+cartographer_model: claude-opus-5[1m]
+stories:
+  - id: 1
+    lens: [forces, coherence]
+    title: Re-authoring everything to change one value
+    disposition: accepted
+    disposition_rationale: "Tune gains an amendment path. It reads the human's current declared values back as the question's context — not a proposed default, since what is shown is their own prior authorship rather than the template's illustration — and /mast tune <block> scopes an edit to one block. The mirror the spec names already works this way: /reservoir tune reads the current block first. Without this the cheapest way to change one number is the editor, which is exactly the channel the weather check cannot see."
+  - id: 2
+    lens: [patterns, coherence]
+    title: Consent per value, not per artefact
+    disposition: accepted
+    disposition_rationale: "Tune composes the block from the answers, shows it, and takes accept / edit / abort before writing. Per-value confirmation stays, but there is now a point at which the whole pact can be refused — including the parts the human did not author, the mandatory clause and the stamps, which are also the parts that decide whether the block reads as declared. This makes Tune an instance of the agent-emit / dispatcher-persist / human-disposes architecture rather than a citation of its tool split."
+  - id: 3
+    lens: [alternatives, consequences]
+    title: A verified reader, an improvised writer
+    disposition: accepted
+    disposition_rationale: "A validation checkpoint is added, and this turned out to be a convention violation rather than an option not taken: CLAUDE.md requires one of every command producing structured output that downstream consumers parse, and /mast tune produces the file pact-blocks.sh parses. After writing, Tune reads the block back, asserts block_state returns declared, and fixes in place. A write-side library is deliberately not built here — the checkpoint plus T1-T7 closes the runtime gap, and a pact-write.sh belongs with a slice that has more than one writer to serve."
+  - id: 4
+    lens: [forces, defaults]
+    title: Asking everything, anchoring nothing
+    disposition: accepted
+    disposition_rationale: "The no-defaults rule stands; the empty-form cost is paid down differently. Tune asks the stop hour first — the one key that carries the epic and the one a person can answer cold — then offers to stop there, so a complete two-line pact is reachable in one question. The remaining keys are offered rather than marched through. Skipping a whole block was the only cheap exit, and it returns the human to observe-only, which is the state the epic exists to move them out of."
+  - id: 5
+    lens: [forces, consequences]
+    title: A gauge with one working needle
+    disposition: accepted
+    disposition_rationale: "Read mode recites the pact first and annotates second. Section 1's own argument is that a pact nobody reads is not a pact, which makes re-reading the intervention — so the human's own declared words lead, and what can and cannot be measured follows as annotation. The honest position is unchanged; what changes is that the report stops reading as an inventory of the plugin's limits. Records the definitional consequence too: in this epic a budget is a declaration to be recited, not a quantity to be metered."
+  - id: 6
+    lens: [patterns, coherence]
+    title: Sole writer of another slice's schema
+    disposition: accepted
+    disposition_rationale: "Tune derives the mandatory clauses and the reserved marker from the shipped template rather than restating them, per the promoted derive-from-the-source-of-truth decision — the spec had them in a third place, agreeing with pact-blocks.sh only because one string happens to contain the other. The stamps go back to Budgets only, where S1's grammar defines them; rule 4 had extended them to two blocks S3 does not own. And sentinel-design gains the writer role the epic's vocabulary lacked, so S4 knows that extending Tune's key set is a change to S3."
+  - id: 7
+    lens: [coherence, consequences]
+    title: Inertness disclosed for one block only
+    disposition: accepted
+    disposition_rationale: "Disclosure moves from block level to the condition that triggers it. Tune says what nothing reads yet wherever that is true — Sync cadence entirely, three of Session WIP's four keys until S4 ships, and notification_policy_after_stop at the Unverified rung. The human was otherwise authoring their first pact under two regimes without being told there were two, warned about inert values in one block and not in the next."
+  - id: 8
+    lens: [consequences, alternatives]
+    title: Nothing points at the only door
+    disposition: accepted
+    disposition_rationale: "Read mode offers Tune when the block is absent, exactly as /reservoir read does — said in the command's own prose, so S1's fixed observe-only sentence is untouched and no contract is carved. The slice's entire stated value was that Tune unblocks the epic, reached by a command nothing mentioned. Section 1's opening paragraph is also rewritten: it still promised the ritual offered at the line, which revision 2 moved to #501 and neither kept nor withdrew."
+---
+
+# Choice stories — Cadence Sentinels S3: The Mast
+
+Eight stories from a spec already cut in half at its diaboli gate. The split,
+the weather check's disclosed blind spot, the flag corrections, the refusal to
+estimate spend, and Tune's write rules are all adjudicated on the objection
+record; none is restated here.
+
+These eight sit where that coverage stops — around the ritual's *shape* rather
+than its output. Six turn on one under-examined fact: `/mast tune` is now the
+only way a pact comes to exist, and the spec specified what it writes without
+specifying what it *is* — an author, an editor, a form, or a conversation.
+
+**Dispatcher verification note (2026-08-10).** Two citations were checked
+before recording, and one of them changed the disposition. `CLAUDE.md:174`
+requires a validation checkpoint of "every command that produces structured
+output parsed by downstream consumers" — `/mast tune` produces the file
+`pact-blocks.sh` parses, so story #3's checkpoint is a **convention
+violation**, not an option not taken. And `commands/reservoir.md:31-35` has
+read mode "offer Tune mode to add the block" when it is absent, which is the
+direct precedent story #8 asks S3 to follow.
+
+## Story #1 — Re-authoring everything to change one value
+
+**Source:** spec §2, §2.3, §5 · **Lens:** forces, coherence · **Refs:** O5
+
+**Context.** Tune walks all three blocks, rewrites in place, proposes nothing
+as a default, and makes every block skippable. Nothing describes reading the
+human's *existing* values back to them. So the only sanctioned way to move
+`hard_stop_hour` from 18:30 to 19:00 is to re-run the ritual that asks every
+question again.
+
+**Forces.** Authorship-is-the-active-ingredient against the ergonomics of
+amendment. A pact is meant to be lived with and revised in clear weather —
+§2.2 names the calm Tuesday tweak as "the authorship the rule *wants*" — so
+the honest revision path needs to be cheaper than the dishonest one, not more
+expensive. The mirror the spec names points the other way: `/reservoir tune`
+reads the current block first and presents a diff to confirm. That is an
+editor; `/mast tune` as specified is an author.
+
+**Options not taken.**
+
+- Read the current declared value back as the question's context. That is not
+  a proposed default: nothing is pre-filled by the plugin, and what is shown is
+  the human's own prior authorship rather than the template's illustration.
+- A block-scoped invocation — `/mast tune budgets` — so amendment costs one
+  block rather than three.
+- Diff-and-confirm before the write, as `/reservoir` does.
+
+**Choice as written.** Tune is an authoring ritual, and by silence there is no
+amendment ritual. Rewrite-in-place makes re-running *safe*, which is precisely
+what makes re-running the amendment path.
+
+**Consequences.** The cheapest way to change one number becomes opening the
+file in an editor — the channel §2.3 concedes and §2.2 says the weather check
+cannot see. The disclosure of that blind spot is right; this choice quietly
+increases the traffic through it. The file Tune writes also carries less
+guidance than the template it supersedes: §5 requires the clauses, the marker
+and the stamps, and requires nothing of the template's warning that an inline
+`#` comment silently becomes part of a value. The human most likely to
+hand-edit is doing so in a file that no longer carries that warning.
+
+**Pattern.** CRUD's missing **U**: a lifecycle specified for create and
+replace, with update delegated to the filesystem. The interaction-design
+sibling is wizard-versus-preferences — a wizard is right for first authorship
+and famously poor for changing one field later.
+
+## Story #2 — Consent per value, not per artefact
+
+**Source:** spec §4, §5 · **Lens:** patterns, coherence · **Refs:** O7, #1
+
+**Context.** §4 keeps the tool boundary — the agent holds no `Write`, the
+command writes — and cites the `cost-estimator` precedent. But in tune mode no
+agent appears at all: the command asks the questions and writes the file, "only
+after the human has confirmed each value".
+
+**Forces.** The promoted architecture is agent-emit + dispatcher-persist +
+human-disposes. S3 keeps the tool boundary and drops the emit step: no artefact
+is ever placed in front of the human to dispose over as a whole. Pulling the
+other way, per-value confirmation is arguably *stronger* consent — the human
+agrees to each number as they author it. The spec resolves toward per-value and
+never names the unit-of-consent question it has answered.
+
+**Options not taken.**
+
+- Compose the block, present it, and take accept / edit / abort — the
+  vocabulary `/cost-estimate` shipped.
+- Let the `mast` agent author the block text and have the command persist it,
+  making Tune an *instance* of the named architecture rather than a citation of
+  its tool split.
+- Keep per-value confirmation and add a read-back of the file as written.
+
+**Choice as written.** Consent is per value. The citation names the boundary
+Tune keeps — the agent does not write — and not the flow it inverts: in the
+cited precedent the agent *authors* the content and the command only persists.
+
+**Consequences.** The parts of the file the human did not author — the mandatory
+clause, the reserved marker, `authored_at`, `authored_via` — are also the parts
+that decide whether the block reads as `declared`, and they are never seen
+before they land. There is no point at which the *whole* pact can be refused.
+And the named architecture acquires an instance that honours its tool split
+with no agent in it, which weakens the pattern's claim to describe a shape
+rather than a permission.
+
+**Pattern.** The agent-emit / dispatcher-persist / human-disposes
+ARCH_DECISION, invoked in part. Structurally, the wizard again: consent as a
+sequence of small local agreements rather than one review of the composite.
+
+## Story #3 — A verified reader, an improvised writer
+
+**Source:** spec §4, §5, §6, §7.2 · **Lens:** alternatives, consequences · **Refs:** O7, #2
+
+**Context.** S1 built `pact-blocks.sh` as the single reader, with a long
+preamble and ten scenarios. S3 ships "No hook. No library." The producer of the
+file that library parses is a prose dialogue following six numbered rules.
+
+**Forces.** A slice of one agent, one skill, one command is small and
+reviewable. Against that: the format has literal-string requirements,
+position-sensitive semantics, and a failure mode that is silent *by design* —
+malformed collapses to observe-only. The one component that produces the file
+is the one with no deterministic implementation. §5 names the stakes exactly
+("Tune is what makes it wrong") and answers with rules and scenarios rather
+than with a mechanism.
+
+**Options not taken.**
+
+- A write-side library, `pact-write.sh`, sourceable only by commands and hooks
+  — a split `sentinel-design` already blesses.
+- The repo's codified validation checkpoint: read the block back, assert
+  `block_state` returns `declared`, fix in place. **`CLAUDE.md:174` requires
+  this of every command producing structured output that downstream consumers
+  parse.** `/reservoir tune` has one; `/mast tune` was specified without.
+- Write by transforming `templates/pacts.md`, so the clauses and marker come
+  from the source of truth rather than being re-typed from the spec.
+
+**Choice as written.** Correctness established at CI time against named
+scenarios, and at runtime by a model following six sentences.
+
+**Consequences.** T1–T7 pin the shapes they name; anything the dialogue does
+that they do not name is unconstrained at runtime, and the human's symptom of a
+deviation is the one S1 worked hard to make quiet. The asymmetry is durable:
+this epic now has a read path with a library, a preamble and ten tests, and a
+write path with a numbered list. #501 and every later slice that touches the
+file inherits the prose, not a writer.
+
+**Pattern.** The missing half of a **Parser / Unparser** pair. The standard
+remedy is a round-trip property, and T1–T7 are a partial one — a round trip
+over the values the scenario author thought of, on a format whose worst input
+is the one nobody imagined.
+
+## Story #4 — Asking everything, anchoring nothing
+
+**Source:** spec §5 rules 5–6, §7.3 · **Lens:** forces, defaults · **Refs:** #1
+
+**Context.** Rule 5 forbids proposing anything as a default and demotes the
+template's numbers to "illustrations"; rule 6 makes every block skippable. The
+diaboli explicitly declined to object here, which routes the decision to this
+record.
+
+**Forces.** An imposed default is not a pact — correct, and the epic's founding
+claim. Unweighed against it: a person asked cold for `max_switches_per_hour`
+has no basis for an answer, and a number invented to move the dialogue along is
+not obviously more *authored* than one recognised and adjusted. The ritual is
+also long — three blocks, eleven-plus keys — and the only escape rule 6 supplies
+is skipping a whole block.
+
+**Options not taken.**
+
+- Distinguish a **default** (written unless refused) from an **anchor** (shown,
+  never written unless said). The template already carries illustrative values;
+  only Tune is forbidden from mentioning them.
+- Ask the one question that carries the epic — the stop hour — and offer the
+  rest.
+- Ask by intent rather than by field: "when do you stop?", and let Tune render
+  the keys.
+
+**Choice as written.** Every key asked cold, and the only cheap answer is to
+skip the block.
+
+**Consequences.** The ritual's most available exits are "skip" and "say a number
+to move on"; skipping produces `absent`, which returns the human to
+observe-only — the state the epic exists to move them out of. The design leans
+hardest on new users, who have least basis for any of these numbers, and the
+pact most likely to be authored is the shortest one. S2's story #5 named this
+shape at the Coda; here it lands at the start of the relationship rather than
+the end of a session.
+
+**Pattern.** The **empty-form problem** in form design: a blank field maximises
+freedom and minimises completion, and the standard remedy is the example rule 5
+forbids. Naming it does not argue against the rule; it names the bill the rule
+is paying.
+
+## Story #5 — A gauge with one working needle
+
+**Source:** spec §2.1, §7.1, §7.3 · **Lens:** forces, consequences · **Refs:** O6
+
+**Context.** Of the four keys tabled, one is `observed`, two are `inferred`,
+and one is *not observable*. The corrections O6 forced are right. What they
+leave is a report whose majority content is disclosure of blindness.
+
+**Forces.** Honesty against usefulness. The spec resolves wholly toward honesty
+— the refusal to estimate spend is its strongest paragraph. What it does not
+weigh is what the resulting artefact is *for*. "Consumption against a budget"
+is the stated job and it can be computed for exactly one key.
+
+**Options not taken.**
+
+- Report the pact's own words first and the flags second, treating recital as
+  the product and measurement as the annotation. §1's argument is that a pact
+  nobody reads is not a pact, which makes *re-reading* the intervention.
+- Report only what is observable, and say once that the rest is declared and
+  unmeasurable.
+- Carry the unmeasurable keys in the reference page rather than in every
+  invocation.
+
+**Choice as written.** A per-key table where every declared key appears and
+three rows in four exist to state what the Mast cannot see.
+
+**Consequences.** In the modal case the honest report reads as an inventory of
+the plugin's limits rather than as a gauge, and a human who runs `/mast` twice
+in a day learns that only the clock row moves. That is the price of the
+position, not an argument against it — the alternative being refused is the
+fabricated number, which is worse. The more durable effect is definitional:
+this fixes what a budget *is* in this epic — a declaration to be recited, not a
+quantity to be metered — and every later sentinel inherits that framing.
+
+**Pattern.** — . The nearest frame is the honest-instrument discipline the repo
+runs twice already. S3 is the first place where applying it faithfully leaves
+the instrument with one working needle, which is worth recording as a known
+shape rather than rediscovering as a disappointment.
+
+## Story #6 — Sole writer of another slice's schema
+
+**Source:** spec §5, §7.2 · **Lens:** patterns, coherence · **Refs:** O7, #3
+
+**Context.** S1 owns the pact file's schema. S3 owns the only path that writes
+it. §5's rules restate parts of that schema in a third place, and rule 4 stamps
+`authored_at`/`authored_via` on *every block written* — keys S1's grammar
+defines only inside `Budgets`.
+
+**Forces.** A consumer never mutates the contract it consumes; harness
+artefacts derive from the source of truth rather than pinning a copy. Tune is
+neither consumer nor owner — it is a *writer*, a role the epic's vocabulary
+does not have. Pulling the other way, restating is what makes §5 followable: a
+rule saying "write whatever S1 §3.4 says" is not one an implementer can
+execute.
+
+**Options not taken.**
+
+- Derive: take the clause text from `templates/pacts.md` or `_mandatory_clause`
+  so a schema change reaches the writer without a spec edit.
+- Name the third role in `sentinel-design` — schema owner, sole writer, readers
+  — and state that a schema change obliges the writer's slice.
+- Leave the stamps where S1 put them and say so.
+
+**Choice as written.** The schema is restated where Tune needs it, extended for
+two blocks, and nothing links the copies. §5 quotes the `Session WIP` clause in
+full while `pact-blocks.sh` matches only its second sentence — they agree today
+because one string contains the other, which is a coincidence of wording rather
+than a derivation.
+
+**Consequences.** S4 and S5 inherit a file whose only authoring path is
+specified in a slice they do not own. When S4 wants `enforcement` declared, the
+question "does Tune ask about it?" has no answer here, and the natural fix —
+extend the ritual — is a change to S3's command made from a consumer slice. A
+pact may also carry three `authored_at` stamps while the weather check reads
+one, so "when was this pact authored" becomes a per-block fact with no rule for
+combining them.
+
+**Pattern.** The contract-owning-slice ARCH_DECISION meeting a role it does not
+name. The derive-from-source-of-truth decision is the repo's own remedy and is
+not applied.
+
+## Story #7 — Inertness disclosed for one block only
+
+**Source:** spec §2, §2.1, §2.3, §5 · **Lens:** coherence, consequences · **Refs:** #6
+
+**Context.** Rule 2 requires Tune to say `Sync cadence` is reserved before
+asking, "so nobody declares values believing something reads them". Tune also
+walks `Session WIP`, whose consumer does not exist; of its four keys only
+`stale_after_hours` is read today, by S1's registry lease. Read mode reports
+against `Budgets` alone.
+
+**Forces.** The disclosure principle is right and stated with unusual clarity.
+Against it: the property that triggers it — a declaration nothing reads — is a
+property of *keys at a point in time*, not of blocks. The spec applies it at
+block granularity because that is the granularity at which S1 happened to
+supply a reserved marker.
+
+**Options not taken.**
+
+- Say the same sentence about `Session WIP`'s three unconsumed keys until S4
+  ships.
+- Disclose at key level wherever the condition holds, including
+  `notification_policy_after_stop` and `daily_cost_ceiling`.
+- Have Tune write only the blocks with live consumers today.
+
+**Choice as written.** Block-level disclosure for the one block S1 marked
+reserved, and silence for every other declaration nothing currently reads.
+
+**Consequences.** The human's first pact is authored under two regimes without
+being told there are two. Read mode then reports on `Budgets` only, so the
+ritual's reach exceeds anything this slice reflects back — tune three blocks,
+read one. Recording the asymmetry is what stops it reading as an oversight when
+S4 arrives and begins consuming values authored months earlier under no
+disclosure at all.
+
+**Pattern.** — . A disclosure rule scoped to the artefact that happened to
+carry a marker rather than to the condition that triggers it.
+
+## Story #8 — Nothing points at the only door
+
+**Source:** spec §1, §2, §6, §7.1 · **Lens:** consequences, alternatives · **Refs:** O10, #1, #4
+
+**Context.** The split's headline justification is that until Tune exists the
+pact file does not exist and every other sentinel is permanently in
+observe-only. Reaching Tune requires a human to type `/mast tune`. §6 adds no
+hook and no statusline; read mode's absent-block path emits S1's fixed sentence,
+which names no remedy because it belongs to S1's contract.
+
+**Forces.** Nothing may nag and nothing may impose — constraint 6 and the
+epic's ethic. Against that, the slice's entire stated value depends on humans
+finding a command nothing mentions. §1 also still describes the Mast as what
+"offers you the ritual for stopping"; that half is #501, and revision 2 neither
+rewrote the sentence nor withdrew it.
+
+**Options not taken.**
+
+- Have read mode offer Tune when the block is absent — exactly what
+  `/reservoir` read does. Saying it in the command's own prose needs no change
+  to S1's fixed sentence and carves no contract.
+- Make the O10 counter-argument and answer it. The diaboli said plainly that a
+  Mast which never speaks at the boundary is a gauge nobody reads; revision 2
+  asserts Tune's value and leaves the read half's value unargued.
+- Claim the ramp explicitly: §8 already commits to a how-to, so the spec could
+  state that documentation *is* the adoption path.
+
+**Choice as written.** On-demand invocation only, adoption by documentation —
+chosen by silence. The spec never says how a human comes to run `/mast tune`,
+which is the same silence S1's story #2 recorded about how a human comes to
+declare a block, one slice later and with the authoring path now built.
+
+**Consequences.** The epic's unblocking event has no trigger inside the
+product. In a project that adopts the plugin and never runs the command, S1–S3
+are complete and behaviourally identical to not having shipped. Combined with
+#4's long unanchored dialogue, the two most likely outcomes for a new adopter
+are "never invoked" and "invoked once and mostly skipped". And until #501 the
+gauge-and-ritual half is the whole of the Mast, so `/mast` carries a name, an
+epithet and an opening paragraph written for the version that speaks at the
+line.
+
+**Pattern.** — . An opt-in whose invitation lives outside the product — the
+same shape S1's story #2 named, inherited by this slice rather than resolved
+by it.

--- a/tdad_tests/layer0_deterministic/test-pact-write.sh
+++ b/tdad_tests/layer0_deterministic/test-pact-write.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Layer 0 test for the pact writer
+# (spec 2026-08-10-cadence-sentinels-s3-mast-design.md, §5.5; T1–T9).
+#
+# T1 is the point of this file. The reader and the writer are one contract:
+# whatever `pact_write_block` emits, `block_state` must call `declared`. S1
+# built the reader with a preamble and ten scenarios; until this slice the
+# producer of the file it parses was six sentences of prose in a command, and
+# the failure mode of getting it wrong is the one S1 worked hardest to make
+# quiet — a block reads `malformed`, every consumer drops to observe-only, and
+# nothing tells the human which sentence is missing.
+#
+# The writer exists because these tests could not otherwise. A round trip
+# through a model following prose is not a Layer-0 scenario.
+#
+# Two guarantees are easy to lose and are pinned here deliberately:
+#
+#   T5 — replace, never append. `_block_span` exits at the next known heading,
+#        so a second `## Budgets` is silently unread and a human's newly tuned
+#        values are invisible with no error anywhere.
+#   T9 — the clause is DERIVED from templates/pacts.md, not restated. A
+#        restated clause agrees with the reader only by coincidence of wording,
+#        and the promoted decision is that harness artefacts derive from the
+#        source of truth rather than pinning a copy of it.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN="$SCRIPT_DIR/../../ai-literacy-superpowers"
+WRITER="$PLUGIN/hooks/scripts/lib/pact-write.sh"
+READER="$PLUGIN/hooks/scripts/lib/pact-blocks.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Clause assertions match whitespace-normalised, exactly as pact-blocks.sh's
+# `_flatten` does. The template wraps the Session WIP clause across two lines,
+# so a raw grep would fail against a file the READER calls perfectly declared —
+# which is the trap S2 hit on its first run and the reason the reader
+# normalises at all. The clause's words are the interface; its line breaks are
+# not.
+flat_file() { tr '\n' ' ' < "$1" | tr -s '[:space:]' ' '; }
+has_clause() { flat_file "$1" | grep -qF "$2"; }
+
+[ -f "$WRITER" ] || fail "pact writer not found at $WRITER"
+[ -f "$READER" ] || fail "pact reader not found at $READER"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export CLAUDE_PACTS_FILE="$TMP/pacts.md"
+
+# shellcheck source=/dev/null
+. "$WRITER"
+# shellcheck source=/dev/null
+. "$READER"
+
+declare -F pact_write_block >/dev/null || fail "writer must define pact_write_block"
+
+# body <line...> — a values-only block body on stdin, as Tune supplies it.
+body() { printf '%s\n' "$@" > "$TMP/body"; printf '%s' "$TMP/body"; }
+
+# --- T1: the writer's output reads as declared -------------------------------
+# The round trip that makes the reader and the writer one contract.
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 18:30' '- sessions_per_day: 3')"
+[ "$(block_state 'Budgets')" = "declared" ] \
+  || fail "T1: a block written by the writer must read as declared, got '$(block_state 'Budgets')'"
+
+# --- T2: the mandatory clause is present -------------------------------------
+has_clause "$CLAUDE_PACTS_FILE" 'Unspent budget is not a debt.' \
+  || fail "T2: the writer must emit the Budgets mandatory clause"
+
+pact_write_block "Session WIP" "$(body '- max_concurrent_sessions: 2')"
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "T2: Session WIP must also read as declared"
+has_clause "$CLAUDE_PACTS_FILE" 'It counts; it does not assess.' \
+  || fail "T2: the writer must emit the Session WIP mandatory clause"
+
+# --- T3: the reserved marker is present --------------------------------------
+pact_write_block "Sync cadence" "$(body '- interrupt_mode: coalesced')"
+flat_file "$CLAUDE_PACTS_FILE" | grep -qiF 'Reserved. No sentinel reads this block yet.' \
+  || fail "T3: the writer must emit the Sync cadence reserved marker"
+
+# --- T7: colon- and space-bearing values survive the round trip --------------
+# The S1 regression, now reachable from the writer's side.
+val=$(block_key 'Budgets' 'hard_stop_hour' '')
+[ "$val" = "18:30" ] || fail "T7: hard_stop_hour must round-trip as '18:30', got '$val'"
+
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 18:30' \
+  '- focus_blocks: 09:00-12:00, 14:00-17:00' \
+  '- daily_cost_ceiling: not observable')"
+val=$(block_key 'Budgets' 'focus_blocks' '')
+[ "$val" = "09:00-12:00, 14:00-17:00" ] \
+  || fail "T7: focus_blocks must round-trip whole, got '$val'"
+val=$(block_key 'Budgets' 'daily_cost_ceiling' '')
+[ "$val" = "not observable" ] \
+  || fail "T7: daily_cost_ceiling must keep its interior space, got '$val'"
+
+# --- T5: a second write replaces, never appends ------------------------------
+# The silent failure: an appended second heading is unread, so the human's
+# newly tuned values are invisible and nothing reports an error.
+headings=$(grep -c '^## Budgets$' "$CLAUDE_PACTS_FILE" || true)
+[ "$headings" = "1" ] || fail "T5: expected exactly one '## Budgets' heading, found $headings"
+
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 21:00')"
+headings=$(grep -c '^## Budgets$' "$CLAUDE_PACTS_FILE" || true)
+[ "$headings" = "1" ] || fail "T5: a rewrite must not add a heading, found $headings"
+val=$(block_key 'Budgets' 'hard_stop_hour' '')
+[ "$val" = "21:00" ] || fail "T5: a rewrite must win, got '$val'"
+
+# --- T6: the stamps land on Budgets only -------------------------------------
+# S1's grammar defines authored_at/authored_via inside Budgets. Stamping every
+# block would leave 'when was this pact authored' a per-block fact with no rule
+# for combining them.
+[ -n "$(block_key 'Budgets' 'authored_via' '')" ] \
+  || fail "T6: Budgets must carry authored_via"
+[ -n "$(block_key 'Budgets' 'authored_at' '')" ] \
+  || fail "T6: Budgets must carry authored_at"
+[ -z "$(block_key 'Session WIP' 'authored_via' '')" ] \
+  || fail "T6: Session WIP must NOT be stamped — S1's grammar puts the stamps in Budgets"
+[ -z "$(block_key 'Sync cadence' 'authored_at' '')" ] \
+  || fail "T6: Sync cadence must NOT be stamped"
+
+# --- T8: content outside the replaced block survives -------------------------
+[ "$(block_state 'Session WIP')" = "declared" ] \
+  || fail "T8: rewriting Budgets must not disturb Session WIP"
+val=$(block_key 'Session WIP' 'max_concurrent_sessions' '')
+[ "$val" = "2" ] || fail "T8: another block's values must survive, got '$val'"
+
+# There is no "after" in this format. Everything following a heading belongs to
+# that block until the next heading — the reader's own span rule — so a note
+# appended at end-of-file sits INSIDE the last block and is legitimately
+# replaced when that block is rewritten. The only content genuinely outside
+# every block is the preamble, before the first heading. That is what must
+# survive, and it is where the template's editing guidance lives.
+python3 - "$CLAUDE_PACTS_FILE" <<'EOP'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); lines = p.read_text().split("\n")
+i = next(n for n, l in enumerate(lines) if l.startswith("## "))
+lines.insert(i, "A human note in the preamble.")
+p.write_text("\n".join(lines))
+EOP
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 22:00')"
+grep -qF 'A human note in the preamble.' "$CLAUDE_PACTS_FILE" \
+  || fail "T8: preamble content — the only content outside every block — must survive a rewrite"
+
+# --- T4: a skipped block is absent, not empty --------------------------------
+export CLAUDE_PACTS_FILE="$TMP/partial.md"
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 18:30')"
+[ "$(block_state 'Session WIP')" = "absent" ] \
+  || fail "T4: an unwritten block must read absent, got '$(block_state 'Session WIP')'"
+grep -q '^## Session WIP' "$CLAUDE_PACTS_FILE" \
+  && fail "T4: an unwritten block must leave no heading behind"
+
+# --- T9: the clause is derived from the template, not restated ---------------
+# Changing the template must change what the writer emits, with no edit to the
+# writer. A restated clause agrees with the reader only by coincidence.
+tpl="$PLUGIN/templates/pacts.md"
+cp "$tpl" "$TMP/tpl.bak"
+sed -i.bak 's/Unspent budget is not a debt\./Unspent budget is not a debt, truly./' "$tpl"
+rm -f "$tpl.bak"
+export CLAUDE_PACTS_FILE="$TMP/derived.md"
+pact_write_block "Budgets" "$(body '- hard_stop_hour: 18:30')"
+derived_ok=0
+has_clause "$CLAUDE_PACTS_FILE" 'Unspent budget is not a debt, truly.' && derived_ok=1
+cp "$TMP/tpl.bak" "$tpl"
+[ "$derived_ok" -eq 1 ] \
+  || fail "T9: the clause must be derived from templates/pacts.md, not restated in the writer"
+
+echo "PASS: pact writer — output reads as declared, replaces never appends, stamps scoped, clause derived"

--- a/tdad_tests/scenarios/agents/mast/honest-flags-and-no-estimation.md
+++ b/tdad_tests/scenarios/agents/mast/honest-flags-and-no-estimation.md
@@ -1,0 +1,56 @@
+---
+component: mast
+component_type: agent
+tier: structural
+---
+
+# Scenario: mast reports what it cannot see and never estimates
+
+## Given
+
+The `mast` agent reads a pact a human authored for themselves and reports where
+they stand against it. Most of a budget is not observable, and saying so is the
+job — three of its four keys cannot be measured by anything in this plugin.
+
+The failure this scenario guards is the flattering one: a report that presents
+an unobservable quantity as observed, or fills a gap with an estimate. A
+fabricated spend figure against a real ceiling would make a person stop, or not
+stop, on a number nobody measured.
+
+## When
+
+`ai-literacy-superpowers/agents/mast.agent.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: mast`, a non-empty description, `role: sentinel`, and
+`tools` exactly `Read, Glob, Grep, Bash` — no `Write`, no `Edit`.
+
+**Charter:**
+
+- Instructs the agent to read `skills/mast/SKILL.md` first.
+- States it must never source `pact-write.sh`, and that `Bash` is read-only.
+- Carries the flag table with `hard_stop_hour` observed, `focus_blocks` and
+  `sessions_per_day` inferred, and `daily_cost_ceiling` **not observable** —
+  and states that a missing row reads as a row that was fine.
+- States plainly that it **never estimates spend**, with the reason.
+- Carries the weather note **and its blind spot**: the note sees a budget
+  *tuned* today, and a hand-edit outside `/mast tune` is invisible to it
+  permanently.
+- Instructs the agent to **recite the pact's own words first** and annotate
+  after.
+- Instructs it to offer `/mast tune` when no block is declared.
+- States it never gates and never judges the pact.
+
+## Rubric
+
+Passes only when the tool list carries no write capability, the flag table has
+all four rows with those exact flags, the never-estimate rule is present, and
+the weather note's blind spot is disclosed rather than implied.
+
+## Notes
+
+The blind-spot assertion is the load-bearing one. An earlier draft claimed the
+check caught an 18:00 hand-edit "and nothing else"; it catches the precise
+opposite, and a check that claims coverage it lacks teaches the human to read
+its silence as an all-clear.

--- a/tdad_tests/scenarios/commands/mast/tune-writes-and-verifies.md
+++ b/tdad_tests/scenarios/commands/mast/tune-writes-and-verifies.md
@@ -1,0 +1,57 @@
+---
+component: mast
+component_type: command
+tier: structural
+---
+
+# Scenario: /mast tune composes, shows, writes through the library, and verifies
+
+## Given
+
+`/mast tune` is the only sanctioned path that creates or amends the pact file,
+and that file is the input to every other sentinel in the epic. Everything else
+degrades safely when it is wrong; Tune is what makes it wrong.
+
+`CLAUDE.md` requires a validation checkpoint of every command producing
+structured output that downstream consumers parse. `pact-blocks.sh` parses this
+output.
+
+## When
+
+`ai-literacy-superpowers/commands/mast.md` is read from the filesystem.
+
+## Then
+
+- Frontmatter with `name: mast` and a non-empty description.
+- **Read mode offers Tune when the block is absent.** The pact file does not
+  exist until someone authors it, and a human who does not know the command has
+  no way in.
+- Read mode presents **recital first**, flags second.
+- Read mode states that a malformed block names its missing clause and
+  continues in observe-only — never gates.
+- **Tune reads current values back as question context**, with an explicit
+  statement that this is not a proposed default.
+- **Tune asks `hard_stop_hour` first** and offers to stop there.
+- Tune states what nothing reads yet — `Sync cadence`, three of
+  `Session WIP`'s keys, `notification_policy_after_stop`,
+  `daily_cost_ceiling` — **before** asking.
+- Tune **composes, shows, and takes accept / edit / abort** before writing.
+- The write goes through `pact_write_block` from
+  `hooks/scripts/lib/pact-write.sh`; the agent never writes.
+- A **validation checkpoint** reads the block back and checks `block_state`,
+  the mandatory clause (whitespace-normalised), value round-trips, and a single
+  heading.
+- The command states it never scaffolds, never proposes a default, never
+  estimates, never gates, and never judges the pact.
+
+## Rubric
+
+Passes only when the Tune-offer, the stop-hour-first ordering, the
+compose-and-show step, the library call, and the four-point validation
+checkpoint are all present.
+
+## Notes
+
+The Tune-offer assertion guards the slice's whole value proposition: the epic is
+blocked until a pact exists, and nothing else in the product mentions the
+command that creates one.

--- a/tdad_tests/scenarios/skills/mast/clear-weather-and-anti-patterns.md
+++ b/tdad_tests/scenarios/skills/mast/clear-weather-and-anti-patterns.md
@@ -1,0 +1,58 @@
+---
+component: mast
+component_type: skill
+tier: structural
+---
+
+# Scenario: the mast skill states the clear-weather rule's limits and its anti-patterns
+
+## Given
+
+Two sections of this skill are contracts rather than prose.
+
+The **clear-weather rule** is the epic's reason for the pact file, and the check
+that supports it has a blind spot that must be disclosed wherever the rule is
+stated — the skill, the agent, the command, and the reference page. A check that
+claims coverage it lacks teaches the human to read its silence as an all-clear.
+
+The **anti-patterns** are what keep a pact-keeper from becoming a gate.
+
+## When
+
+`ai-literacy-superpowers/skills/mast/SKILL.md` is read from the filesystem.
+
+## Then
+
+**Frontmatter:** `name: mast`, with a description naming the modes, the
+clear-weather rule, and the anti-patterns.
+
+**The flag table:** four rows, with `focus_blocks` and `sessions_per_day`
+`inferred` and `daily_cost_ceiling` **not observable** — and the reasoning that
+the clock being inside a block is not the same as having spent it working.
+
+**The clear-weather section:** a two-row table showing that a hand-edit does
+**not** fire the note and a calm tune **does**, plus the statement that
+something stronger is unavailable because the pact file is never committed.
+
+**Evidence comments:** at least two `<!-- evidence: ... -->` comments — one for
+the recital-is-the-intervention claim, one for self-authored limits. Language
+discipline holds: no "addiction", no "dopamine".
+
+**The writer's four guarantees:** derive, replace-never-append, stamp `Budgets`
+only, preserve the preamble — plus the validation checkpoint.
+
+**The anti-patterns section** names at least: estimating anything unobservable,
+gating on the weather note, claiming the check catches hand-edits, opening with
+what cannot be seen, proposing a default in Tune, judging the pact, and writing
+from the agent.
+
+## Rubric
+
+Passes only when the two-row hand-edit/tune table is present, both evidence
+comments exist, and all seven anti-patterns are named.
+
+## Notes
+
+The two-row table is the guard against the honest-sounding regression: it is
+easy to describe this check as catching in-the-moment edits, because that is
+what one wants it to do.

--- a/tdad_tests/tests/test_layer0_deterministic.py
+++ b/tdad_tests/tests/test_layer0_deterministic.py
@@ -74,6 +74,9 @@ BASH_TEST_SCRIPTS = [
     # scripts/next-action-hint.sh and hooks/scripts/parked-resume-check.sh.
     "test-next-action",
     "test-parked-resume",
+    # Cadence Sentinels S3 — the pact writer. RED until S3 ships
+    # hooks/scripts/lib/pact-write.sh.
+    "test-pact-write",
 ]
 
 


### PR DESCRIPTION
Closes #493. Third slice of **The Cadence Sentinels** epic. Depends on S1 (0.67.0); **not** on S2.

A limit you set in advance holds. A limit you set at the moment you're about to breach it does not. `/mast` is what brings the first kind back into view — and `/mast tune` is what brings it into existence.

**This slice unblocks the epic.** S1 shipped a pact template that no path authored, so until now the pact file did not exist and every sentinel was permanently in observe-only.

## The slice was split at its spec gate

Boundary notices, the hard stop, and the override record moved to **#501**.

Six of eleven objections — **including both criticals** — were consequences of one decision: that the Mast writes session state another slice must consume. The override needed a contract change to the shipped Coda; the note store bundled mutation into a library a sentinel had to source; the once-per-session guarantee lived in the file consumption deletes; and two stop advisories could land on the same turn. Removing that half dissolved all of them rather than mitigating them, and shipped the higher-value half first.

## What the gates caught

| Gate | Outcome |
|---|---|
| Diaboli (spec) | 11 objections — 4 accepted, 7 deferred to #501 |
| Choice Cartographer | 8 stories, all accepted |

Three worth your attention:

**The weather check was inverted.** I wrote that `authored_at == today` catches "raising your stop hour at 18:00… and nothing else". It catches the precise opposite: the stamp moves only when Tune writes, so a hand-edit is invisible while a calm Tuesday tune fires the note every evening after. It now says what it actually sees — a budget *tuned* today — and discloses the blind spot in the note itself, because a check that claims coverage it lacks teaches you to read its silence as an all-clear.

**Nothing pointed at the only door.** The slice's whole value is that Tune unblocks the epic, and nothing in the product mentioned the command. `/reservoir` read mode already offers Tune when its block is absent — the precedent was one file away. Read mode now does the same.

**A missing validation checkpoint was a convention violation**, not an omission. `CLAUDE.md:174` requires one of every command producing structured output that downstream consumers parse, and `/mast tune` produces the file `pact-blocks.sh` parses.

## The writer exists because its own tests demanded it

The slice as specified shipped no shell — the write path was six numbered rules for a model to follow. That didn't survive its own acceptance criteria: T1–T9 are Layer-0 round-trip scenarios, and there's nothing deterministic to test when the writer is prose. Either the tests weren't real or the library was.

`lib/pact-write.sh` is the write surface, sourceable by commands and hooks only, matching S1's read/write split. It **derives** the mandatory clauses from the template rather than restating them, **replaces** a block instead of appending a second (a duplicate heading is silently unread), stamps `Budgets` only, and preserves the preamble.

Two bugs the tests caught that I wouldn't have:

- The template's `Session WIP` clause wraps across two lines, so a raw grep failed against a file the **reader** calls perfectly declared. Same normalisation lesson S2 learned; I hadn't carried it forward.
- **There is no "outside a block" after a block.** Everything following a heading belongs to it, so a note appended at end-of-file sits *inside* the last block and is legitimately replaced. Only the preamble is genuinely outside — which is where the editing guidance lives.

## Divergence from the build spec — flagged

The build spec called for "a critic check that flags `Budgets` diffs lacking a same-change `authored_via: tune` update". **That is impossible.** S1's user-scoped pact decision put `~/.claude/pacts.md` outside every work tree, never committed — so there is no diff and no CI can see the file. Replaced with the weather note, at the Unverified rung, with its limits stated.

## Honesty, and what it costs

Only one budget key in four is observable. `hard_stop_hour` is `observed`; `focus_blocks` and `sessions_per_day` are `inferred`; `daily_cost_ceiling` is **not observable**, and the Mast refuses to estimate it — a fabricated figure against a real ceiling would have someone stop, or not stop, for no reason.

That leaves a gauge with one working needle, which the cartographer flagged and which is the right price. It also fixes what a budget *is* here: a declaration to be recited, not a quantity to be metered.

## Records

- Spec (revision 3): `docs/superpowers/specs/2026-08-10-cadence-sentinels-s3-mast-design.md`
- Objections: `docs/superpowers/objections/cadence-sentinels-s3-mast-design.md`
- Choice stories: `docs/superpowers/stories/cadence-sentinels-s3-mast-design.md`

Version: 0.68.0 → 0.69.0. Sentinels 6 → 7.